### PR TITLE
TestGetUnderflowDateTimeRFC1123 changed due to changes in Go1.8

### DIFF
--- a/.gulp/gulpfile.iced
+++ b/.gulp/gulpfile.iced
@@ -22,7 +22,7 @@ task 'init', "" ,(done)->
 # Run language-specific tests:
 task 'test', "", ['regenerate'], (done) ->
   process.env.GOPATH = "#{basefolder}/test"
-  await execute "glide up",               { cwd: './test/src/tests' }, defer code, stderr, stdout
+  await execute "glide install",               { cwd: './test/src/tests' }, defer code, stderr, stdout
   await execute "go fmt ./generated/...", { cwd: './test/src/tests' }, defer code, stderr, stdout
   await execute "go run ./runner.go",     { cwd: './test/src/tests' }, defer code, stderr, stdout
   done();

--- a/test/src/tests/acceptancetests/datetimerfc1123grouptest/body-datetime-rfc1123_test.go
+++ b/test/src/tests/acceptancetests/datetimerfc1123grouptest/body-datetime-rfc1123_test.go
@@ -39,6 +39,7 @@ func (s *DateTimeRfc1123GroupSuite) TestGetNullDateTimeRFC1123(c *chk.C) {
 func (s *DateTimeRfc1123GroupSuite) TestGetUnderflowDateTimeRFC1123(c *chk.C) {
 	res, err := datetimerfc1123Client.GetUnderflow()
 	c.Assert(err, chk.NotNil)
+	c.Assert(err, chk.ErrorMatches, ".*day out of range.*")
 }
 
 func (s *DateTimeRfc1123GroupSuite) TestGetOverflowDateTimeRFC1123(c *chk.C) {

--- a/test/src/tests/acceptancetests/datetimerfc1123grouptest/body-datetime-rfc1123_test.go
+++ b/test/src/tests/acceptancetests/datetimerfc1123grouptest/body-datetime-rfc1123_test.go
@@ -37,7 +37,7 @@ func (s *DateTimeRfc1123GroupSuite) TestGetNullDateTimeRFC1123(c *chk.C) {
 }
 
 func (s *DateTimeRfc1123GroupSuite) TestGetUnderflowDateTimeRFC1123(c *chk.C) {
-	res, err := datetimerfc1123Client.GetUnderflow()
+	_, err := datetimerfc1123Client.GetUnderflow()
 	c.Assert(err, chk.NotNil)
 	c.Assert(err, chk.ErrorMatches, ".*day out of range.*")
 }

--- a/test/src/tests/acceptancetests/datetimerfc1123grouptest/body-datetime-rfc1123_test.go
+++ b/test/src/tests/acceptancetests/datetimerfc1123grouptest/body-datetime-rfc1123_test.go
@@ -36,13 +36,10 @@ func (s *DateTimeRfc1123GroupSuite) TestGetNullDateTimeRFC1123(c *chk.C) {
 	c.Assert(res.Value, chk.IsNil)
 }
 
-/*
-func (s *DateTimeRfc1123GroupSuite) TestGetGetUnderflowDateTimeRFC1123(c *chk.C) {
+func (s *DateTimeRfc1123GroupSuite) TestGetUnderflowDateTimeRFC1123(c *chk.C) {
 	res, err := datetimerfc1123Client.GetUnderflow()
-	c.Assert(err, chk.IsNil)
-	t1, _ := time.Parse(time.RFC1123, "Tue, 00 Jan 0000 00:00:00 GMT")
-	c.Assert((*res.Value).Time, chk.DeepEquals, t1)
-}  @fearthecowboy disabled -- change in underlying go behavior */
+	c.Assert(err, chk.NotNil)
+}
 
 func (s *DateTimeRfc1123GroupSuite) TestGetOverflowDateTimeRFC1123(c *chk.C) {
 	_, err := datetimerfc1123Client.GetOverflow()


### PR DESCRIPTION
replay of https://github.com/Azure/autorest/pull/2492