### PR TITLE
Do not name files with file names reserved for autorest

### DIFF
--- a/src/CodeGeneratorGo.cs
+++ b/src/CodeGeneratorGo.cs
@@ -65,17 +65,19 @@ namespace AutoRest.Go
 
             // by convention the methods in the method group with an empty
             // name go into the client template so skip them here.
-            HashSet<string> ReservedFiles = new HashSet<string>();
-            ReservedFiles.Add("models");
-            ReservedFiles.Add("client");
-            ReservedFiles.Add("version");
+            HashSet<string> ReservedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase){
+                "models",
+                "client",
+                "version",
+            };
 
             foreach (var methodGroup in codeModel.MethodGroups.Where(mg => !string.IsNullOrEmpty(mg.Name)))
             {
-                if (ReservedFiles.Contains(methodGroup.Name.Value.ToLowerInvariant()))
+                if (ReservedFiles.Contains(methodGroup.Name.Value))
                 {
                     methodGroup.Name += "group";
                 }
+                ReservedFiles.Add(methodGroup.Name);
                 var methodGroupTemplate = new MethodGroupTemplate
                 {
                     Model = methodGroup

--- a/src/CodeGeneratorGo.cs
+++ b/src/CodeGeneratorGo.cs
@@ -65,7 +65,8 @@ namespace AutoRest.Go
 
             // by convention the methods in the method group with an empty
             // name go into the client template so skip them here.
-            HashSet<string> ReservedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase){
+            HashSet<string> ReservedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
                 "models",
                 "client",
                 "version",

--- a/src/CodeGeneratorGo.cs
+++ b/src/CodeGeneratorGo.cs
@@ -8,6 +8,7 @@ using AutoRest.Go.Templates;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace AutoRest.Go
 {
@@ -64,8 +65,17 @@ namespace AutoRest.Go
 
             // by convention the methods in the method group with an empty
             // name go into the client template so skip them here.
+            HashSet<string> ReservedFiles = new HashSet<string>();
+            ReservedFiles.Add("models");
+            ReservedFiles.Add("client");
+            ReservedFiles.Add("version");
+
             foreach (var methodGroup in codeModel.MethodGroups.Where(mg => !string.IsNullOrEmpty(mg.Name)))
             {
+                if (ReservedFiles.Contains(methodGroup.Name.Value.ToLowerInvariant()))
+                {
+                    methodGroup.Name += "group";
+                }
                 var methodGroupTemplate = new MethodGroupTemplate
                 {
                     Model = methodGroup


### PR DESCRIPTION
Some of the new swaggers happens to have a method group called `version`.
PTAL
@jhendrixMSFT @marstr 