### PR TITLE
Auth File support

### DIFF
--- a/src/CodeNamerGo.cs
+++ b/src/CodeNamerGo.cs
@@ -28,7 +28,7 @@ namespace AutoRest.Go
 
         public virtual IEnumerable<string> AutorestImports => new string[] { PrimaryTypeGo.GetImportLine(package: "github.com/Azure/go-autorest/autorest") };
 
-        public virtual IEnumerable<string> AuthImports => new string[] { PrimaryTypeGo.GetImportLine(package: "github.com/Azure/go-autorest/autorest/utils") };
+        public virtual IEnumerable<string> AuthImports => new string[] { PrimaryTypeGo.GetImportLine(package: "github.com/Azure/go-autorest/autorest/azure/auth") };
 
         public virtual IEnumerable<string> StandardImports => new string[] 
         { 

--- a/src/CodeNamerGo.cs
+++ b/src/CodeNamerGo.cs
@@ -28,6 +28,8 @@ namespace AutoRest.Go
 
         public virtual IEnumerable<string> AutorestImports => new string[] { PrimaryTypeGo.GetImportLine(package: "github.com/Azure/go-autorest/autorest") };
 
+        public virtual IEnumerable<string> AuthImports => new string[] { PrimaryTypeGo.GetImportLine(package: "github.com/Azure/go-autorest/autorest/utils") };
+
         public virtual IEnumerable<string> StandardImports => new string[] 
         { 
             PrimaryTypeGo.GetImportLine(package: "github.com/Azure/go-autorest/autorest/azure"), 

--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -72,7 +72,7 @@ namespace AutoRest.Go.Model
                 {
                     imports.UnionWith(clientMg.Imports);
                 }
-                if (AddCredentials)
+                if (AddCredentials && !IsCustomBaseUri)
                 {
                     imports.UnionWith(CodeNamerGo.Instance.AuthImports);
                 }

--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -235,14 +235,14 @@ namespace AutoRest.Go.Model
                     parameters.Add("authentication.BaseURI");
                     foreach (var p in NonDefaultProperties)
                     {
-                        var name = p.Name;
-                        switch (name.ToLower())
+                        var name = p.Name.ToLower();
+                        switch (name)
                         {
                             case "subscriptionid":
-                                parameters.Add("authentication.File[\"subscriptionId\"]");
+                                parameters.Add("authentication.SubscriptionID");
                                 break;
                             case "tenantid":
-                                parameters.Add("authentication.File[\"tenantId\"]");
+                                parameters.Add("authentication.TenantID");
                                 break;
                             default:
                                 parameters.Add(p.Name.Value.ToSentence());

--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -225,7 +225,7 @@ namespace AutoRest.Go.Model
             }
         }
 
-        public string AuthParameters
+        public string HelperAuthParameters
         {
             get
             {
@@ -244,6 +244,51 @@ namespace AutoRest.Go.Model
                             case "tenantid":
                                 parameters.Add("auth.File[\"tenantId\"]");
                                 break;
+                            default:
+                                parameters.Add(p.Name.Value.ToSentence());
+                                break;
+                        }
+                    }
+                    return string.Join(", ", parameters);
+                }
+                return null;
+            }
+        }
+
+        public string AuthParameters
+        {
+            get
+            {
+                if (AddCredentials)
+                {
+                    var parameters = new List<string>();
+                    foreach (var p in NonDefaultProperties)
+                    {
+                        if (!(p.Name.EqualsIgnoreCase("subscriptionid") || p.Name.EqualsIgnoreCase("tenantid")))
+                        {
+                            parameters.Add(string.Format(
+                                (p.IsRequired || p.ModelType.CanBeEmpty() ? "{0} {1}" : "{0} *{1}"),
+                                p.Name.Value.ToSentence(), p.ModelType.Name));
+                        }
+                    }
+                    return string.Join(", ", parameters);
+                }
+                return null;
+            }
+        }
+
+        public string ClientHelperAuthParameters
+        {
+            get
+            {
+                if (AddCredentials)
+                {
+                    var parameters = new List<string>();
+                    foreach (var p in NonDefaultProperties)
+                    {
+                        if (!(p.Name.EqualsIgnoreCase("subscriptionid") || p.Name.EqualsIgnoreCase("tenantid")))
+                        {
+                            parameters.Add(p.Name.Value.ToSentence());
                         }
                     }
                     return string.Join(", ", parameters);

--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -232,17 +232,17 @@ namespace AutoRest.Go.Model
                 if (AddCredentials)
                 {
                     var parameters = new List<string>();
-                    parameters.Add("auth.BaseURI");
+                    parameters.Add("authentication.BaseURI");
                     foreach (var p in NonDefaultProperties)
                     {
                         var name = p.Name;
                         switch (name.ToLower())
                         {
                             case "subscriptionid":
-                                parameters.Add("auth.File[\"subscriptionId\"]");
+                                parameters.Add("authentication.File[\"subscriptionId\"]");
                                 break;
                             case "tenantid":
-                                parameters.Add("auth.File[\"tenantId\"]");
+                                parameters.Add("authentication.File[\"tenantId\"]");
                                 break;
                             default:
                                 parameters.Add(p.Name.Value.ToSentence());

--- a/src/Model/MethodGroupGo.cs
+++ b/src/Model/MethodGroupGo.cs
@@ -27,6 +27,7 @@ namespace AutoRest.Go.Model
         public string HelperGlobalDefaultParameters;
         public string ConstGlobalDefaultParameters;
         public IEnumerable<string> Imports { get; private set; }
+        public bool AddCredentials;
 
         public MethodGroupGo(string name) : base(name)
         {
@@ -68,7 +69,7 @@ namespace AutoRest.Go.Model
             GlobalDefaultParameters = cmg.GlobalDefaultParameters;
             HelperGlobalDefaultParameters = cmg.HelperGlobalDefaultParameters;
             ConstGlobalDefaultParameters = cmg.ConstGlobalDefaultParameters;
-
+            AddCredentials = cmg.AddCredentials;
 
 
             //Imports

--- a/src/Model/MethodGroupGo.cs
+++ b/src/Model/MethodGroupGo.cs
@@ -28,6 +28,8 @@ namespace AutoRest.Go.Model
         public string ConstGlobalDefaultParameters;
         public IEnumerable<string> Imports { get; private set; }
         public bool AddCredentials;
+        public string AuthParameters;
+        public string HelperAuthParameters;
 
         public MethodGroupGo(string name) : base(name)
         {
@@ -70,6 +72,8 @@ namespace AutoRest.Go.Model
             HelperGlobalDefaultParameters = cmg.HelperGlobalDefaultParameters;
             ConstGlobalDefaultParameters = cmg.ConstGlobalDefaultParameters;
             AddCredentials = cmg.AddCredentials;
+            HelperAuthParameters = cmg.ClientHelperAuthParameters;
+            AuthParameters = cmg.AuthParameters;
 
 
             //Imports

--- a/src/Templates/MethodGroupTemplate.cshtml
+++ b/src/Templates/MethodGroupTemplate.cshtml
@@ -58,6 +58,18 @@ func New@(Model.ClientName)(@(Model.GlobalParameters)) @(Model.ClientName) {
     }
     </text>
     @EmptyLine
+
+    @if (Model.AddCredentials)
+    {
+    @WrapComment("// ", string.Format("New{0}WithAuthFile creates an instance of the {0} client.", Model.ClientName))
+    <text>
+    func New@(Model.ClientName)WithAuthFile() (@(Model.ClientName), error) {
+        c, err := NewWithAuthFile()
+        return @(Model.ClientName){c}, err
+    }
+    </text>
+    @EmptyLine
+    }
 }
 
 @foreach (var method in methods)

--- a/src/Templates/MethodGroupTemplate.cshtml
+++ b/src/Templates/MethodGroupTemplate.cshtml
@@ -63,8 +63,8 @@ func New@(Model.ClientName)(@(Model.GlobalParameters)) @(Model.ClientName) {
     {
     @WrapComment("// ", string.Format("New{0}WithAuthFile creates an instance of the {0} client.", Model.ClientName))
     <text>
-    func New@(Model.ClientName)WithAuthFile() (@(Model.ClientName), error) {
-        c, err := NewWithAuthFile()
+    func New@(Model.ClientName)WithAuthFile(@(Model.AuthParameters)) (@(Model.ClientName), error) {
+        c, err := NewWithAuthFile(@(Model.HelperAuthParameters))
         return @(Model.ClientName){c}, err
     }
     </text>

--- a/src/Templates/ServiceClientTemplate.cshtml
+++ b/src/Templates/ServiceClientTemplate.cshtml
@@ -93,6 +93,23 @@ func New(@(Model.GlobalParameters))@(Model.BaseClient) {
         }
     }
     </text>
+
+    @if (Model.AddCredentials)
+    {
+    @WrapComment("// ", string.Format("NewWithAuthFile creates an instance of the {0} client.", Model.BaseClient))
+    <text>
+    func NewWithAuthFile() (c @(Model.BaseClient), err error) {
+        auth, err := utils.GetTokenFromAuthFile(DefaultBaseURI)
+        if err != nil {
+            return
+        }
+        c = NewWithBaseURI(@(Model.AuthParameters))
+        c.Authorizer = auth.Authorizer
+        return
+    }
+    </text>
+    @EmptyLine
+    }
 }
 else
 {

--- a/src/Templates/ServiceClientTemplate.cshtml
+++ b/src/Templates/ServiceClientTemplate.cshtml
@@ -98,12 +98,12 @@ func New(@(Model.GlobalParameters))@(Model.BaseClient) {
     {
     @WrapComment("// ", string.Format("NewWithAuthFile creates an instance of the {0} client.", Model.BaseClient))
     <text>
-    func NewWithAuthFile() (c @(Model.BaseClient), err error) {
+    func NewWithAuthFile(@(Model.AuthParameters)) (c @(Model.BaseClient), err error) {
         auth, err := utils.GetTokenFromAuthFile(DefaultBaseURI)
         if err != nil {
             return
         }
-        c = NewWithBaseURI(@(Model.AuthParameters))
+        c = NewWithBaseURI(@(Model.HelperAuthParameters))
         c.Authorizer = auth.Authorizer
         return
     }

--- a/src/Templates/ServiceClientTemplate.cshtml
+++ b/src/Templates/ServiceClientTemplate.cshtml
@@ -99,12 +99,12 @@ func New(@(Model.GlobalParameters))@(Model.BaseClient) {
     @WrapComment("// ", string.Format("NewWithAuthFile creates an instance of the {0} client.", Model.BaseClient))
     <text>
     func NewWithAuthFile(@(Model.AuthParameters)) (c @(Model.BaseClient), err error) {
-        authentication, err := auth.GetTokenFromAuthFile(DefaultBaseURI)
+        authentication, err := auth.GetClientSetup(DefaultBaseURI)
         if err != nil {
             return
         }
         c = NewWithBaseURI(@(Model.HelperAuthParameters))
-        c.Authorizer = authentication.Authorizer
+        c.Authorizer = authentication
         return
     }
     </text>

--- a/src/Templates/ServiceClientTemplate.cshtml
+++ b/src/Templates/ServiceClientTemplate.cshtml
@@ -99,12 +99,12 @@ func New(@(Model.GlobalParameters))@(Model.BaseClient) {
     @WrapComment("// ", string.Format("NewWithAuthFile creates an instance of the {0} client.", Model.BaseClient))
     <text>
     func NewWithAuthFile(@(Model.AuthParameters)) (c @(Model.BaseClient), err error) {
-        auth, err := utils.GetTokenFromAuthFile(DefaultBaseURI)
+        authentication, err := auth.GetTokenFromAuthFile(DefaultBaseURI)
         if err != nil {
             return
         }
         c = NewWithBaseURI(@(Model.HelperAuthParameters))
-        c.Authorizer = auth.Authorizer
+        c.Authorizer = authentication.Authorizer
         return
     }
     </text>


### PR DESCRIPTION
Matching generated code for https://github.com/Azure/go-autorest/pull/174
Code also handles the case in which global paramaters that should be located on methods are part of clients.
I am using an autorest flag that we have never used, that looked good for what I am doing here: `add-credentials`.
PTAL @jhendrixMSFT @marstr 