### PR TITLE
Make tests run faster.

### DIFF
--- a/test/src/tests/acceptancetests/arraygrouptest/body-array_test.go
+++ b/test/src/tests/acceptancetests/arraygrouptest/body-array_test.go
@@ -29,6 +29,7 @@ var seven, eight, nine = "seven", "eight", "nine"
 
 func getArrayClient() ArrayClient {
 	c := NewArrayClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/booleangrouptest/body-boolean_test.go
+++ b/test/src/tests/acceptancetests/booleangrouptest/body-boolean_test.go
@@ -19,6 +19,7 @@ var boolClient = getBooleanClient()
 
 func getBooleanClient() BoolGroupClient {
 	c := NewBoolGroupClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/bytegrouptest/body-byte_test.go
+++ b/test/src/tests/acceptancetests/bytegrouptest/body-byte_test.go
@@ -20,6 +20,7 @@ var byteClient = getByteClient()
 
 func getByteClient() GroupClient {
 	c := NewGroupClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/complexgrouptest/body-complex_test.go
+++ b/test/src/tests/acceptancetests/complexgrouptest/body-complex_test.go
@@ -31,48 +31,56 @@ var complexPolymorphicRecursiveClient = getPolymorphismRecursiveClient()
 
 func getArrayComplexClient() ArrayClient {
 	c := NewArrayClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getBasicOperationsClient() BasicClient {
 	c := NewBasicClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getDictionaryComplexClient() DictionaryClient {
 	c := NewDictionaryClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getPrimitiveClient() PrimitiveClient {
 	c := NewPrimitiveClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getInheritanceClient() InheritanceClient {
 	c := NewInheritanceClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getPolymorphismClient() PolymorphismClient {
 	c := NewPolymorphismClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getReadOnlyClient() ReadonlypropertyClient {
 	c := NewReadonlypropertyClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getPolymorphismRecursiveClient() PolymorphicrecursiveClient {
 	c := NewPolymorphicrecursiveClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/custombaseurlgrouptest/custom-baseurl_test.go
+++ b/test/src/tests/acceptancetests/custombaseurlgrouptest/custom-baseurl_test.go
@@ -18,6 +18,7 @@ var custombaseuriClient = getCustomBaseURIClient()
 
 func getCustomBaseURIClient() PathsClient {
 	c := NewWithoutDefaults("host:3000")
+	c.RetryDuration = 1
 	return PathsClient{ManagementClient: c}
 }
 

--- a/test/src/tests/acceptancetests/dategrouptest/body-date_test.go
+++ b/test/src/tests/acceptancetests/dategrouptest/body-date_test.go
@@ -21,6 +21,7 @@ var dateClient = getDateClient()
 
 func getDateClient() GroupClient {
 	c := NewGroupClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/datetimegrouptest/body-datetime_test.go
+++ b/test/src/tests/acceptancetests/datetimegrouptest/body-datetime_test.go
@@ -19,6 +19,7 @@ var datetimeClient = getDateTimeClient()
 
 func getDateTimeClient() DatetimeClient {
 	c := NewDatetimeClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/datetimerfc1123grouptest/body-datetime-rfc1123_test.go
+++ b/test/src/tests/acceptancetests/datetimerfc1123grouptest/body-datetime-rfc1123_test.go
@@ -21,6 +21,7 @@ var datetimerfc1123Client = getDateTimeRFC1123Client()
 
 func getDateTimeRFC1123Client() Datetimerfc1123Client {
 	c := NewDatetimerfc1123Client()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/dictionarygrouptest/body-dictionary_test.go
+++ b/test/src/tests/acceptancetests/dictionarygrouptest/body-dictionary_test.go
@@ -28,6 +28,7 @@ var seven, eight, nine = "seven", "eight", "nine"
 
 func getDictionaryClient() DictionaryClient {
 	c := NewDictionaryClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/durationgrouptest/body-duration_test.go
+++ b/test/src/tests/acceptancetests/durationgrouptest/body-duration_test.go
@@ -20,6 +20,7 @@ var durationClient = getDurationClient()
 
 func getDurationClient() DurationClient {
 	c := NewDurationClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/filegrouptest/body-file_test.go
+++ b/test/src/tests/acceptancetests/filegrouptest/body-file_test.go
@@ -22,6 +22,7 @@ var filesClient = getFileClient()
 
 func getFileClient() FilesClient {
 	c := NewFilesClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/formdatagrouptest/body-formdata_test.go
+++ b/test/src/tests/acceptancetests/formdatagrouptest/body-formdata_test.go
@@ -20,6 +20,7 @@ var formdataClient = getFormdataClient()
 
 func getFormdataClient() FormdataClient {
 	c := NewFormdataClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/headergrouptest/headergroup_test.go
+++ b/test/src/tests/acceptancetests/headergrouptest/headergroup_test.go
@@ -24,6 +24,7 @@ var headerClient = getHeaderClient()
 
 func getHeaderClient() HeaderClient {
 	c := NewHeaderClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/httpInfrastructuregrouptest/httpInfrastructure_test.go
+++ b/test/src/tests/acceptancetests/httpInfrastructuregrouptest/httpInfrastructure_test.go
@@ -32,24 +32,28 @@ var httpMultipleResponsesClient = getHTTPMultipleResponsesClient()
 
 func getHTTPSuccessClient() HTTPSuccessClient {
 	c := NewHTTPSuccessClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getHTTPFailureClient() HTTPFailureClient {
 	c := NewHTTPFailureClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getHTTPClientFailureClient() HTTPClientFailureClient {
 	c := NewHTTPClientFailureClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getHTTPRetryClient() HTTPRetryClient {
 	c := NewHTTPRetryClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	c.RetryDuration = 3 * time.Second
 	return c
@@ -57,18 +61,21 @@ func getHTTPRetryClient() HTTPRetryClient {
 
 func getHTTPRedirectClient() HTTPRedirectsClient {
 	c := NewHTTPRedirectsClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getHTTPServerFailureClient() HTTPServerFailureClient {
 	c := NewHTTPServerFailureClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getHTTPMultipleResponsesClient() MultipleResponsesClient {
 	c := NewMultipleResponsesClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/integergrouptest/body-integer_test.go
+++ b/test/src/tests/acceptancetests/integergrouptest/body-integer_test.go
@@ -22,6 +22,7 @@ var intClient = getIntegerClient()
 
 func getIntegerClient() IntGroupClient {
 	c := NewIntGroupClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/modelflatteninggrouptest/model-flattening_test.go
+++ b/test/src/tests/acceptancetests/modelflatteninggrouptest/model-flattening_test.go
@@ -20,6 +20,7 @@ var modelflatteningClient = getmodelflatteningClient()
 
 func getmodelflatteningClient() ManagementClient {
 	c := New()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/morecustombaseurigrouptest/more-custom-base-uri_test.go
+++ b/test/src/tests/acceptancetests/morecustombaseurigrouptest/more-custom-base-uri_test.go
@@ -18,6 +18,7 @@ var custombaseuriClient = getMoreCustomBaseURIClient()
 
 func getMoreCustomBaseURIClient() PathsClient {
 	c := NewWithoutDefaults("test12", "host:3000")
+	c.RetryDuration = 1
 	return PathsClient{ManagementClient: c}
 }
 

--- a/test/src/tests/acceptancetests/numbergrouptest/body-number_test.go
+++ b/test/src/tests/acceptancetests/numbergrouptest/body-number_test.go
@@ -22,6 +22,7 @@ var numberClient = getNumberClient()
 
 func getNumberClient() NumberClient {
 	c := NewNumberClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/paginggrouptest/paging_test.go
+++ b/test/src/tests/acceptancetests/paginggrouptest/paging_test.go
@@ -21,6 +21,7 @@ var clientID = "client-id"
 
 func getPagingClient() PagingClient {
 	c := NewPagingClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/requiredoptionalgrouptest/required-optional_test.go
+++ b/test/src/tests/acceptancetests/requiredoptionalgrouptest/required-optional_test.go
@@ -22,12 +22,14 @@ var implicitClient = getRequiredImplicitTestClient()
 
 func getRequiredExplicitTestClient() ExplicitClient {
 	c := NewExplicitClient("", "", nil)
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getRequiredImplicitTestClient() ImplicitClient {
 	c := NewImplicitClient("", "", nil)
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/stringgrouptest/body-string_test.go
+++ b/test/src/tests/acceptancetests/stringgrouptest/body-string_test.go
@@ -27,12 +27,14 @@ var enumClient = getEnumClient()
 
 func getStringClient() GroupClient {
 	c := NewGroupClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getEnumClient() EnumClient {
 	c := NewEnumClient()
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/urlgrouptest/url_test.go
+++ b/test/src/tests/acceptancetests/urlgrouptest/url_test.go
@@ -30,18 +30,21 @@ var pathItemClient = getPathItemsClient()
 
 func getPathItemsClient() PathItemsClient {
 	c := NewPathItemsClient("globalStringPath", "globalStringQuery")
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getQueryClient() QueriesClient {
 	c := NewQueriesClient("globalStringPath", "globalStringQuery")
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
 func getPathClient() PathsClient {
 	c := NewPathsClient("globalStringPath", "globalStringQuery")
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }

--- a/test/src/tests/acceptancetests/validationgrouptest/validation_test.go
+++ b/test/src/tests/acceptancetests/validationgrouptest/validation_test.go
@@ -19,6 +19,7 @@ var validationClient = getValidationClient()
 
 func getValidationClient() ManagementClient {
 	c := New("abc123")
+	c.RetryDuration = 1
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }


### PR DESCRIPTION
Some tests send failures to test retries.  The default retry delay is 30
seconds which makes total test time way too long (the default 30 second
delay should be investigated separately).  Set the retry duration to one
second so tests execute faster.