### PR TITLE
Refactor model EnumTypeGo.

### DIFF
--- a/src/Decorators/v1/EnumTypeGoDecorator.cs
+++ b/src/Decorators/v1/EnumTypeGoDecorator.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Utilities;
+using AutoRest.Go.Model;
+
+namespace AutoRest.Go.Decorators.v1
+{
+    public class EnumTypeGoDecorator : EnumTypeGo
+    {
+        /// <summary>
+        /// Returns true if all the values for this enum are unique.
+        /// </summary>
+        public bool HasUniqueNames { get; }
+
+        public EnumTypeGoDecorator(EnumTypeGo etg, bool hasUniqueNames)
+        {
+            this.LoadFrom(etg);
+            HasUniqueNames = hasUniqueNames;
+        }
+    }
+}

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -315,32 +315,6 @@ namespace AutoRest.Go
                 || sequenceType != null;
         }
 
-        public static string GetEmptyCheck(this IModelType type, string valueReference, bool asEmpty = true)
-        {
-            if (type is PrimaryTypeGo)
-            {
-                return (type as PrimaryTypeGo).GetEmptyCheck(valueReference, asEmpty);
-            }
-            else if (type is SequenceTypeGo)
-            {
-                return (type as SequenceTypeGo).GetEmptyCheck(valueReference, asEmpty);
-            }
-            else if (type is DictionaryTypeGo)
-            {
-                return (type as DictionaryTypeGo).GetEmptyCheck(valueReference, asEmpty);
-            }
-            else if (type is EnumTypeGo)
-            {
-                return (type as EnumTypeGo).GetEmptyCheck(valueReference, asEmpty);
-            }
-            else
-            {
-                return string.Format(asEmpty
-                                        ? "{0} == nil"
-                                        : "{0} != nil", valueReference);
-            }
-        }
-
         /// <summary>
         /// Add imports for a type.
         /// </summary>

--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -57,7 +57,7 @@ namespace AutoRest.Go.Model
 
         public EnumType DiscriminatorEnum;
 
-        public string DiscriminatorEnumValue => (DiscriminatorEnum as EnumTypeGo).Constants.FirstOrDefault(c => c.Value.Equals(SerializedName)).Key;
+        public string DiscriminatorEnumValue => DiscriminatorEnum.Values.FirstOrDefault(c => c.SerializedName.Equals(SerializedName)).Name;
 
         public CompositeTypeGo()
         {

--- a/src/Model/EnumTypeGo.cs
+++ b/src/Model/EnumTypeGo.cs
@@ -1,24 +1,18 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Linq;
 using AutoRest.Core.Model;
 using AutoRest.Core.Utilities;
+using System.Linq;
 
 namespace AutoRest.Go.Model
 {
     public class EnumTypeGo : EnumType
     {
-        public bool HasUniqueNames { get; set; }
-
         public EnumTypeGo()
         {
             // the default value for unnamed enums is "enum"
             Name.OnGet += v => v == "enum" ? "string" : v;
-
-            // Assume members have unique names
-            HasUniqueNames = true;
         }
 
         public EnumTypeGo(EnumType source) : this()
@@ -26,30 +20,15 @@ namespace AutoRest.Go.Model
             this.LoadFrom(source);
         }
 
-        public string GetEmptyCheck(string valueReference, bool asEmpty)
-        {
-            return string.Format(asEmpty
-                                    ? "len(string({0})) == 0"
-                                    : "len(string({0})) > 0", valueReference);
-        }
-
+        /// <summary>
+        /// Returns true if this enum has a name (swagger supports "anonymous" enums).
+        /// </summary>
         public bool IsNamed => Name != "string" && Values.Any();
 
-        public IDictionary<string, string> Constants
-        {
-            get
-            {
-                var constants = new Dictionary<string, string>();
-                Values
-                    .ForEach(v =>
-                    {
-                        constants.Add(HasUniqueNames ? v.Name : Name + v.Name, v.SerializedName);
-                    });
-
-                return constants;
-            }
-        }
-
-        public string Documentation { get; set; }
+        /// <summary>
+        /// Gets the doc string for this enum type.
+        /// Since swagger doesn't let you define a description for enums we make one up.
+        /// </summary>
+        public string Documentation => $"{Name} enumerates the values for {Name.FixedValue.ToPhrase()}.";
     }
 }

--- a/src/Model/ParameterGo.cs
+++ b/src/Model/ParameterGo.cs
@@ -110,6 +110,39 @@ namespace AutoRest.Go.Model
                     : $"{s}",
                 value);
         }
+
+        public string GetEmptyCheck(string valueReference, bool asEmpty = true)
+        {
+            if (ModelType is PrimaryTypeGo)
+            {
+                return (ModelType as PrimaryTypeGo).GetEmptyCheck(valueReference, asEmpty);
+            }
+            else if (ModelType is SequenceTypeGo)
+            {
+                return (ModelType as SequenceTypeGo).GetEmptyCheck(valueReference, asEmpty);
+            }
+            else if (ModelType is DictionaryTypeGo)
+            {
+                return (ModelType as DictionaryTypeGo).GetEmptyCheck(valueReference, asEmpty);
+            }
+            else if (ModelType is EnumTypeGo)
+            {
+                return GetEnumEmptyCheck(valueReference, asEmpty);
+            }
+            else
+            {
+                return string.Format(asEmpty
+                                        ? "{0} == nil"
+                                        : "{0} != nil", valueReference);
+            }
+        }
+
+        private string GetEnumEmptyCheck(string valueReference, bool asEmpty)
+        {
+            return string.Format(asEmpty
+                                    ? "len(string({0})) == 0"
+                                    : "len(string({0})) > 0", valueReference);
+        }
     }
 
     public static class ParameterGoExtensions

--- a/src/Templates/v1/EnumTemplate.cshtml
+++ b/src/Templates/v1/EnumTemplate.cshtml
@@ -1,9 +1,15 @@
-﻿@using System.Linq
-@using AutoRest.Go
+﻿@using AutoRest.Go
+@using System.Collections.Generic
+@using System.Linq
 
-@inherits AutoRest.Core.Template<AutoRest.Go.Model.EnumTypeGo>
+@inherits AutoRest.Core.Template<AutoRest.Go.Decorators.v1.EnumTypeGoDecorator>
 @{
-    var constants = Model.Constants.Keys.OrderBy(v => v);
+    var constants = new Dictionary<string, string>();
+    foreach (var val in Model.Values)
+    {
+        constants.Add(Model.HasUniqueNames ? val.Name : Model.Name + val.Name, val.SerializedName);
+    }
+
     var modelName = CodeNamerGo.Instance.CamelCase(Model.Name);
     var modelPhrase = Model.Name.FixedValue.ToPhrase();
 }
@@ -16,11 +22,11 @@ type @Model.Name string
 {
 <text>
 const (
-@foreach (var c in constants)
+@foreach (var c in constants.Keys.OrderBy(v => v))
 {
     <text>
 @WrapComment("// ", string.Format("{0} specifies the {1} state for {2}.", CodeNamerGo.Instance.GetEnumMemberName(c), c.ToPhrase(), modelPhrase))
-@(CodeNamerGo.Instance.GetEnumMemberName(c)) @(Model.Name) = "@(Model.Constants[c])"
+@(CodeNamerGo.Instance.GetEnumMemberName(c)) @(Model.Name) = "@(constants[c])"
     </text>
 }
 )

--- a/src/Templates/v1/MethodTemplate.cshtml
+++ b/src/Templates/v1/MethodTemplate.cshtml
@@ -129,7 +129,7 @@ func (client @(Model.Owner)) @(Model.PreparerMethodName)(@(Model.MethodParameter
     @:@(Model.QueryMap)
     foreach (var p in Model.OptionalQueryParameters)
     {
-    @:if @(p.ModelType.GetEmptyCheck(p.GetParameterName(),false)) {
+    @:if @(p.GetEmptyCheck(p.GetParameterName(),false)) {
         @:@(p.AddToMap("queryParameters"))
     @:}
     }
@@ -150,7 +150,7 @@ func (client @(Model.Owner)) @(Model.PreparerMethodName)(@(Model.MethodParameter
 @if (Model.BodyParameter != null && !Model.BodyParameter.IsRequired)
 {
 <text>
-    if @(Model.BodyParameter.ModelType.GetEmptyCheck(Model.BodyParameter.Name, false)) {
+    if @(Model.BodyParameter.GetEmptyCheck(Model.BodyParameter.Name, false)) {
         preparer = autorest.DecoratePreparer(preparer,
                             @(string.Format("autorest.WithJSON({0})", Model.BodyParameter.Name)))
     }
@@ -160,7 +160,7 @@ func (client @(Model.Owner)) @(Model.PreparerMethodName)(@(Model.MethodParameter
 @foreach (var p in Model.OptionalHeaderParameters)
 {
 <text>
-    if @(p.ModelType.GetEmptyCheck(p.GetParameterName(), false)) {
+    if @(p.GetEmptyCheck(p.GetParameterName(), false)) {
         preparer = autorest.DecoratePreparer(preparer,
                             @(string.Format("autorest.WithHeader(\"{0}\",autorest.String({1}))",
                             p.SerializedName, p.GetParameterName())))

--- a/src/Templates/v1/ModelsTemplate.cshtml
+++ b/src/Templates/v1/ModelsTemplate.cshtml
@@ -1,16 +1,42 @@
-﻿@using System;
+﻿@using AutoRest.Core.Utilities
+@using AutoRest.Go
+@using AutoRest.Go.Decorators.v1
+@using AutoRest.Go.Model
+@using AutoRest.Go.Templates.v1
+@using System;
 @using System.Collections.Generic;
 @using System.Linq;
 
-@using AutoRest.Go
-@using AutoRest.Core.Model
-@using AutoRest.Go.Model
-@using AutoRest.Go.Templates.v1
-@using AutoRest.Core.Utilities
-
 @inherits AutoRest.Core.Template<AutoRest.Go.Model.CodeModelGo>
 @{
-    var imports = Model.ModelImports;
+    // Ensure all enumerated type values have the simplest possible unique names
+    // -- The code assumes that all public type names are unique within the client and that the values
+    //    of an enumerated type are unique within that type. To safely promote the enumerated value name
+    //    to the top-level, it must not conflict with other existing types. If it does, prepending the
+    //    value name with the (assumed to be unique) enumerated type name will make it unique.
+
+    // First, collect all type names (since these cannot change)
+    var topLevelNames = new HashSet<string>();
+    foreach (var mt in Model.ModelTypes)
+    {
+        topLevelNames.Add(mt.Name);
+    }
+
+    // Then, note each enumerated type with one or more conflicting values and collect the values from
+    // those enumerated types without conflicts.  do this on a sorted list to ensure consistent naming
+    var conflicts = new HashSet<EnumTypeGo>();
+    foreach (var em in Model.EnumTypes.Cast<EnumTypeGo>().OrderBy(etg => etg.Name.Value))
+    {
+        if (em.Values.Where(v => topLevelNames.Contains(v.Name) || CodeNamerGo.Instance.UserDefinedNames.Contains(v.Name)).Any())
+        {
+            conflicts.Add(em);
+        }
+        else
+        {
+            topLevelNames.UnionWith(em.Values.Select(ev => ev.Name));
+        }
+    }
+
     var enums = Model.EnumTypes.Cast<EnumTypeGo>().ToList();
     enums.Sort(delegate(EnumTypeGo lhs, EnumTypeGo rhs) { return lhs.Name.FixedValue.CompareTo(rhs.Name); });
 
@@ -23,10 +49,10 @@ package @Model.Namespace
 
 @EmptyLine
 
-@if (!imports.IsNullOrEmpty())
+@if (!Model.ModelImports.IsNullOrEmpty())
 {
 @:import (
-foreach (var import in imports)
+foreach (var import in Model.ModelImports)
 {
     @:@(import)
 }
@@ -35,7 +61,7 @@ foreach (var import in imports)
 }
 
 @foreach (var e in enums) {
-@:@(Include(new EnumTemplate(), e))
+@:@(Include(new EnumTemplate(), new EnumTypeGoDecorator(e, !conflicts.Contains(e))))
 @EmptyLine
 @:
 }

--- a/src/TransformerGo.cs
+++ b/src/TransformerGo.cs
@@ -130,43 +130,6 @@ namespace AutoRest.Go
                     v.Name = CodeNamer.Instance.GetEnumMemberName(v.Name);
                 }
             }
-
-            // Ensure all enumerated type values have the simplest possible unique names
-            // -- The code assumes that all public type names are unique within the client and that the values
-            //    of an enumerated type are unique within that type. To safely promote the enumerated value name
-            //    to the top-level, it must not conflict with other existing types. If it does, prepending the
-            //    value name with the (assumed to be unique) enumerated type name will make it unique.
-
-            // First, collect all type names (since these cannot change)
-            var topLevelNames = new HashSet<string>();
-            cmg.ModelTypes
-                .ForEach(mt => topLevelNames.Add(mt.Name));
-
-            // Then, note each enumerated type with one or more conflicting values and collect the values from
-            // those enumerated types without conflicts.  do this on a sorted list to ensure consistent naming
-            cmg.EnumTypes.Cast<EnumTypeGo>().OrderBy(etg => etg.Name.Value)
-                .ForEach(em =>
-                {
-                    if (em.Values.Where(v => topLevelNames.Contains(v.Name) || CodeNamerGo.Instance.UserDefinedNames.Contains(v.Name)).Count() > 0)
-                    {
-                        em.HasUniqueNames = false;
-                    }
-                    else
-                    {
-                        em.HasUniqueNames = true;
-                        topLevelNames.UnionWith(em.Values.Select(ev => ev.Name).ToList());
-                    }
-                });
-
-            // add documentation comment if there aren't any
-            cmg.EnumTypes.Cast<EnumTypeGo>()
-                .ForEach(em =>
-                {
-                    if (string.IsNullOrEmpty(em.Documentation))
-                    {
-                        em.Documentation = string.Format("{0} enumerates the values for {1}.", em.Name, em.Name.FixedValue.ToPhrase());
-                    }
-                });
         }
 
         private void TransformModelTypes(CodeModelGo cmg)


### PR DESCRIPTION
Removed template-specific code from EnumTypeGo.  Most of the code was
for ensuring enum names are unique in a v1-specific way so it was moved
out of the transformer and into the views.
Small refactoring of GetEmptyCheck(), more to do there.
Sorted import statements.