### PR TITLE
Adding parameter `user-agent`

### DIFF
--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -23,18 +23,21 @@ namespace AutoRest.Go.Model
 
         public string UserAgent
         {
-            get {
+            get
+            {
                 if (SpecifiedUserAgent == null) {
                     return DefaultUserAgent;
                 }
                 return SpecifiedUserAgent;
             }
-            set {
+            set
+            {
                 SpecifiedUserAgent = value;
             }
         }
         private string DefaultUserAgent{
-            get {
+            get
+            {
                 return $"Azure-SDK-For-Go/{Version} arm-{Namespace}/{ApiVersion}";
             }
         }

--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -25,9 +25,20 @@ namespace AutoRest.Go.Model
         {
             get
             {
-                return $"Azure-SDK-For-Go/{Version} arm-{Namespace}/{ApiVersion}";
+                _userAgent.Value();
             }
         }
+        private Lazy<string> _userAgent = new Lazy<string>(() => {
+            var specifiedUserAgent = Settings.Instance.Host?.GetValue<string>("user-agent");
+
+            string retval;
+            if null == specifiedUserAgent {
+                retval = $"Azure-SDK-For-Go/{Version} arm-{Namespace}/{ApiVersion}";
+            } else {
+                retval = specifiedUserAgent;
+            }
+            return retval;
+        });
 
         public CodeModelGo()
         {

--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -23,7 +23,24 @@ namespace AutoRest.Go.Model
 
         public string UserAgent
         {
+            get {
+                if (SpecifiedUserAgent == null) {
+                    return DefaultUserAgent;
+                }
+                return SpecifiedUserAgent;
+            }
+            set {
+                SpecifiedUserAgent = value;
+            }
+        }
+        private string DefaultUserAgent{
+            get {
+                return $"Azure-SDK-For-Go/{Version} arm-{Namespace}/{ApiVersion}";
+            }
+        }
+        private string SpecifiedUserAgent {
             get;
+            set;
         }
 
         public CodeModelGo()
@@ -31,12 +48,7 @@ namespace AutoRest.Go.Model
             NextMethodUndefined = new List<IModelType>();
             PagedTypes = new Dictionary<IModelType, string>();
             Version = FormatVersion(Settings.Instance.PackageVersion);
-            var specifiedUserAgent = Settings.Instance.Host?.GetValue<string>("user-agent").Result;
-            if (specifiedUserAgent == null) {
-                UserAgent = $"Azure-SDK-For-Go/{Version} arm-{Namespace}/{ApiVersion}";
-            } else {
-                UserAgent = specifiedUserAgent;
-            }
+            SpecifiedUserAgent = Settings.Instance.Host?.GetValue<string>("user-agent").Result;
         }
 
         public override string Namespace

--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -23,28 +23,20 @@ namespace AutoRest.Go.Model
 
         public string UserAgent
         {
-            get
-            {
-                _userAgent.Value();
-            }
+            get;
         }
-        private Lazy<string> _userAgent = new Lazy<string>(() => {
-            var specifiedUserAgent = Settings.Instance.Host?.GetValue<string>("user-agent");
-
-            string retval;
-            if null == specifiedUserAgent {
-                retval = $"Azure-SDK-For-Go/{Version} arm-{Namespace}/{ApiVersion}";
-            } else {
-                retval = specifiedUserAgent;
-            }
-            return retval;
-        });
 
         public CodeModelGo()
         {
             NextMethodUndefined = new List<IModelType>();
             PagedTypes = new Dictionary<IModelType, string>();
             Version = FormatVersion(Settings.Instance.PackageVersion);
+            var specifiedUserAgent = Settings.Instance.Host?.GetValue<string>("user-agent").Result;
+            if (specifiedUserAgent == null) {
+                UserAgent = $"Azure-SDK-For-Go/{Version} arm-{Namespace}/{ApiVersion}";
+            } else {
+                UserAgent = specifiedUserAgent;
+            }
         }
 
         public override string Namespace


### PR DESCRIPTION
Adding this parameter will allow for the person generating a package to
have a User Agent other than `Azure-SDK-for-Go/{Version}
arm-{Namespace}/{ApiVersion}`.

However, by default the behavior will still the same to prevent breaking
other tools.