### PR TITLE
Discriminator

### DIFF
--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -327,7 +327,7 @@ namespace AutoRest.Go
         public static bool ShouldBeSyntheticType(this IModelType type)
         {            
             return (type is PrimaryType || type is SequenceType || type is DictionaryType || type is EnumType || 
-                (type is CompositeTypeGo && (type as CompositeTypeGo).IsPolymorphicResponse()));
+                (type is CompositeType && (type as CompositeTypeGo).IsPolymorphicResponse()));
         }
 
         /// <summary>

--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -192,7 +192,7 @@ namespace AutoRest.Go.Model
         public void AddImports(HashSet<string> imports)
         {
             Properties.ForEach(p => p.ModelType.AddImports(imports));
-            if (BaseIsPolymorphic && !IsPolymorphic)
+            if (IsPolymorphic)
             {
                 imports.Add("\"encoding/json\"");
                 imports.Add("\"errors\"");

--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -207,11 +207,15 @@ namespace AutoRest.Go.Model
         }
 
         public bool IsPolymorphicResponse() {
-            if (BaseIsPolymorphic && BaseModelType != null)
+            if (IsPolymorphic && IsResponseType)
+            {
+                return true;
+            }
+            if (BaseModelType != null && BaseIsPolymorphic)
             {
                 return (BaseModelType as CompositeTypeGo).IsPolymorphicResponse();
             }
-            return IsPolymorphic && IsResponseType;
+            return false;
         }
 
         /// <summary>

--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -57,7 +57,7 @@ namespace AutoRest.Go.Model
 
         public EnumTypeGo DiscriminatorEnum;
 
-        public string DiscriminatorEnumValue => (DiscriminatorEnum as EnumTypeGo).Constants.FirstOrDefault(c => c.Value.Equals(SerializedName)).Key;
+        public string DiscriminatorEnumValue => (DiscriminatorEnum as EnumTypeGo).Values.FirstOrDefault(v => v.SerializedName.Equals(SerializedName)).Name;
 
         public CompositeTypeGo()
         {

--- a/src/Model/EnumTypeGo.cs
+++ b/src/Model/EnumTypeGo.cs
@@ -16,9 +16,6 @@ namespace AutoRest.Go.Model
         {
             // the default value for unnamed enums is "enum"
             Name.OnGet += v => v == "enum" ? "string" : v;
-
-            // Assume members have unique names		
-            HasUniqueNames = true;
         }
 
         public EnumTypeGo(EnumType source) : this()
@@ -30,21 +27,6 @@ namespace AutoRest.Go.Model
         /// Returns true if this enum has a name (swagger supports "anonymous" enums).
         /// </summary>
         public bool IsNamed => Name != "string" && Values.Any();
-
-        public IDictionary<string, string> Constants
-        {
-            get
-            {
-                var constants = new Dictionary<string, string>();
-                Values
-                    .ForEach(v =>
-                    {
-                        constants.Add(HasUniqueNames ? v.Name : Name + v.Name, v.SerializedName);
-                    });
-
-                return constants;
-            }
-        }
 
         /// <summary>
         /// Gets the doc string for this enum type.

--- a/src/Templates/EnumTemplate.cshtml
+++ b/src/Templates/EnumTemplate.cshtml
@@ -4,7 +4,6 @@
 
 @inherits AutoRest.Core.Template<AutoRest.Go.Model.EnumTypeGo>
 @{
-    var constants = Model.Constants.Keys.OrderBy(v => v);
     var modelName = CodeNamerGo.Instance.CamelCase(Model.Name);
     var modelPhrase = Model.Name.FixedValue.ToPhrase();
 }
@@ -13,15 +12,15 @@
 type @Model.Name string
 
 @EmptyLine
-@if (constants.Any())
+@if (Model.Values.Any())
 {
 <text>
 const (
-@foreach (var c in constants)
+@foreach (var v in Model.Values.OrderBy(v => v.Name))
 {
     <text>
-@WrapComment("// ", string.Format("{0} specifies the {1} state for {2}.", CodeNamerGo.Instance.GetEnumMemberName(c), c.ToPhrase(), modelPhrase))
-@(CodeNamerGo.Instance.GetEnumMemberName(c)) @(Model.Name) = "@(Model.Constants[c])"
+@WrapComment("// ", string.Format("{0} specifies the {1} state for {2}.", CodeNamerGo.Instance.GetEnumMemberName(v.Name), v.Name.ToPhrase(), modelPhrase))
+@(CodeNamerGo.Instance.GetEnumMemberName(v.Name)) @(Model.Name) = "@(v.SerializedName)"
     </text>
 }
 )

--- a/src/Templates/ModelTemplate.cshtml
+++ b/src/Templates/ModelTemplate.cshtml
@@ -112,13 +112,27 @@ func (@(Model.Name.FixedValue.ToShortName()) @(Model.Name)) As@(st.Name)() (*@(s
 func (@(Model.Name.FixedValue.ToShortName()) *@(Model.Name)) UnmarshalJSON(body []byte) error {
     @if (Model.IsWrapperType)
     {
+        @if (Model.BaseType is SequenceType)
+        {
+    @:@((Model.BaseType as SequenceTypeGo).ElementType.Name.FixedValue.ToShortName()), err := unmarshal@((Model.BaseType as SequenceTypeGo).ElementType.Name)Array(body)
+        }
+        else
+        {
+    @:@(Model.BaseType.Name.FixedValue.ToShortName()), err := unmarshal@(Model.BaseType.Name)(body)
+        }
     <text>
-    @(Model.BaseType.Name.FixedValue.ToShortName()), err := unmarshal@(Model.BaseType.Name)(body)
 	if err != nil {
 		return err
 	}
-    @(Model.Name.FixedValue.ToShortName()).Value = @(Model.BaseType.Name.FixedValue.ToShortName())
     </text>
+        @if (Model.BaseType is SequenceType)
+        {
+    @:@(Model.Name.FixedValue.ToShortName()).Value = &@((Model.BaseType as SequenceTypeGo).ElementType.Name.FixedValue.ToShortName())
+        }
+        else
+        {
+    @:@(Model.Name.FixedValue.ToShortName()).Value = @(Model.BaseType.Name.FixedValue.ToShortName())
+        }
     }
     else
     {

--- a/src/TransformerGo.cs
+++ b/src/TransformerGo.cs
@@ -79,7 +79,7 @@ namespace AutoRest.Go
             {
                 if (mt.IsPolymorphic)
                 {
-                    var values  = new List<EnumValue>();
+                    var values = new List<EnumValue>();
                     foreach (var dt in (mt as CompositeTypeGo).DerivedTypes)
                     {
                         var ev = new EnumValue();
@@ -110,6 +110,7 @@ namespace AutoRest.Go
                     {
                         (mt as CompositeTypeGo).DiscriminatorEnum = (cmg.Add(New<EnumType>(new{
                             Name = nameAlreadyExists ? string.Format("{0}{1}", mt.PolymorphicDiscriminator, mt.Name) :  mt.PolymorphicDiscriminator,
+                            // how to add values ensuring they dont get repeated across the SDK?
                             Values = values,
                         })) as EnumTypeGo);
                     }
@@ -176,7 +177,6 @@ namespace AutoRest.Go
             }
 
             // Find all methods that returned paged results
-
             cmg.Methods.Cast<MethodGo>()
                 .Where(m => m.IsPageable).ToList()
                 .ForEach(m =>

--- a/src/TransformerGo.cs
+++ b/src/TransformerGo.cs
@@ -156,6 +156,17 @@ namespace AutoRest.Go
                     topLevelNames.UnionWith(em.Values.Select(ev => ev.Name));
                 }
             }
+
+            var modelList = new List<EnumValue>();
+            foreach (var em in cmg.EnumTypes.OrderBy(etg => etg.Name.Value))
+            {
+                foreach (var v in em.Values)
+                {
+                    v.Name = CodeNamerGo.Instance.GetUnique(v.Name, v, cmg.ModelTypes, modelList);
+                    modelList.Add(v);
+                }
+            }
+
         }
 
         private void TransformModelTypes(CodeModelGo cmg)
@@ -295,8 +306,6 @@ namespace AutoRest.Go
                         var name = exported is IModelType
                                         ? (exported as IModelType).Name
                                         : (exported as Method).Name;
-
-                        Logger.Instance.Log(Category.Warning, string.Format(CultureInfo.InvariantCulture, Resources.StutteringName, name));
 
                         name = name.Value.TrimPackageName(cmg.Namespace);
 

--- a/src/TransformerGo.cs
+++ b/src/TransformerGo.cs
@@ -110,7 +110,6 @@ namespace AutoRest.Go
                     {
                         (mt as CompositeTypeGo).DiscriminatorEnum = (cmg.Add(New<EnumType>(new{
                             Name = nameAlreadyExists ? string.Format("{0}{1}", mt.PolymorphicDiscriminator, mt.Name) :  mt.PolymorphicDiscriminator,
-                            // how to add values ensuring they dont get repeated across the SDK?
                             Values = values,
                         })) as EnumTypeGo);
                     }
@@ -147,7 +146,10 @@ namespace AutoRest.Go
             {
                 if (em.Values.Where(v => topLevelNames.Contains(v.Name) || CodeNamerGo.Instance.UserDefinedNames.Contains(v.Name)).Any())
                 {
-                    em.HasUniqueNames = false;
+                    foreach (var v in em.Values)
+                    {
+                        v.Name = em.Name + v.Name;
+                    }
                 }
                 else
                 {
@@ -288,7 +290,6 @@ namespace AutoRest.Go
 
             if (stutteringTypes.Any())
             {
-                Logger.Instance.Log(Category.Warning, string.Format(CultureInfo.InvariantCulture, Resources.NamesStutter, stutteringTypes.Count()));
                 stutteringTypes.ForEach(exported =>
                     {
                         var name = exported is IModelType


### PR DESCRIPTION
Fixing tiny little bugs regarding the discriminator extension:

- Enum values are no longer duplicated on the SDK.
- Arrays of polymorphic structs are correctly unmarshalled.
- Json package is imported anytime there are polymorphic structs.
- Also deleted loggers because they are noisy and, in my opinion, they don't provide the most interesting info.

PTAL @jhendrixMSFT @marstr  @vladbarosan 