### PR TITLE
Pageable operations rewrite.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   },
   "homepage": "https://github.com/Azure/autorest.go/blob/master/README.md",
   "devDependencies": {
-    "@microsoft.azure/autorest.testserver": "^1.9.0",
-    "autorest": "^2.0.0",
+    "autorest": "^2.0.4203",
     "coffee-script": "^1.11.1",
     "dotnet-sdk-2.0.0": "^1.4.4",
     "gulp": "^3.9.1",
@@ -46,6 +45,7 @@
     "shx": "^0.2.2",
     "through2-parallel": "^0.1.3",
     "yargs": "^8.0.2",
+    "@microsoft.azure/autorest.testserver": "^2.3.9",
     "yarn": "^1.0.2"
   },
   "dependencies": {

--- a/src/CodeNamerGo.cs
+++ b/src/CodeNamerGo.cs
@@ -397,7 +397,39 @@ namespace AutoRest.Go
         public string GetFutureTypeName(MethodGo method)
         {
             // operation group + method name is guaranteed to be unique
-            return $"{method.Group}{method.Name}Future";
+            return GetFutureTypeName($"{method.Group}{method.Name}");
+        }
+
+        /// <summary>
+        /// Returns a future type name constructed from the specified prefix string.
+        /// </summary>
+        /// <param name="prefix">The prefix string.</param>
+        /// <returns>The future type name.</returns>
+        public string GetFutureTypeName(string prefix)
+        {
+            return $"{prefix}Future";
+        }
+
+        /// <summary>
+        /// Returns the page type name for the specified method, which is the type to
+        /// be returned from the method (this is applicable to paged operations).
+        /// </summary>
+        /// <param name="method">The paged operation.</param>
+        /// <returns>The name of the type to be returned from the specified method.</returns>
+        public string GetPageTypeName(MethodGo method)
+        {
+            return $"{method.MethodReturnType}Page";
+        }
+
+        /// <summary>
+        /// Returns the iterator type name for the specified paged type, which is the type to
+        /// be returned from the "list all" method (this is applicable to paged operations).
+        /// </summary>
+        /// <param name="pageType">The page type.</param>
+        /// <returns>The name of the type to be returned from the "list all" method.</returns>
+        public string GetIteratorTypeName(PageTypeGo pageType)
+        {
+            return $"{pageType.ContentType.Name}Iterator";
         }
 
         /// <summary>

--- a/src/CodeNamerGo.cs
+++ b/src/CodeNamerGo.cs
@@ -394,7 +394,7 @@ namespace AutoRest.Go
         /// </summary>
         /// <param name="method">The long-running operation.</param>
         /// <returns>The name of the type to be returned from the specified method.</returns>
-        public string GetFutureTypeName(MethodGo method)
+        internal string GetFutureTypeName(MethodGo method)
         {
             // operation group + method name is guaranteed to be unique
             return GetFutureTypeName($"{method.Group}{method.Name}");
@@ -405,7 +405,7 @@ namespace AutoRest.Go
         /// </summary>
         /// <param name="prefix">The prefix string.</param>
         /// <returns>The future type name.</returns>
-        public string GetFutureTypeName(string prefix)
+        internal string GetFutureTypeName(string prefix)
         {
             return $"{prefix}Future";
         }
@@ -416,7 +416,7 @@ namespace AutoRest.Go
         /// </summary>
         /// <param name="method">The paged operation.</param>
         /// <returns>The name of the type to be returned from the specified method.</returns>
-        public string GetPageTypeName(MethodGo method)
+        internal string GetPageTypeName(MethodGo method)
         {
             return $"{method.MethodReturnType}Page";
         }
@@ -427,7 +427,7 @@ namespace AutoRest.Go
         /// </summary>
         /// <param name="pageType">The page type.</param>
         /// <returns>The name of the type to be returned from the "list all" method.</returns>
-        public string GetIteratorTypeName(PageTypeGo pageType)
+        internal string GetIteratorTypeName(PageTypeGo pageType)
         {
             return $"{pageType.ContentType.Name}Iterator";
         }

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -385,7 +385,7 @@ namespace AutoRest.Go
         /// </summary>
         /// <param name="ctg">The type to convert from.</param>
         /// <returns>The type converted to a page type.</returns>
-        public static PageTypeGo UnwrapPageType(this CompositeTypeGo ctg)
+        internal static PageTypeGo UnwrapPageType(this CompositeTypeGo ctg)
         {
             PageTypeGo result;
             if (ctg is FutureTypeGo ftg)

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -388,13 +388,13 @@ namespace AutoRest.Go
         public static PageTypeGo UnwrapPageType(this CompositeTypeGo ctg)
         {
             PageTypeGo result;
-            if (ctg is FutureTypeGo)
+            if (ctg is FutureTypeGo ftg)
             {
-                result = ctg.Cast<FutureTypeGo>().ResultType.Cast<PageTypeGo>();
+                result = ftg.ResultType.Cast<PageTypeGo>();
             }
-            else if (ctg is PageTypeGo)
+            else if (ctg is PageTypeGo ptg)
             {
-                result = ctg.Cast<PageTypeGo>();
+                result = ptg;
             }
             else
             {
@@ -410,21 +410,21 @@ namespace AutoRest.Go
         /// <returns>The zero-init expression.</returns>
         public static string GetZeroInitExpression(this IModelType type)
         {
-            if (type is CompositeTypeGo)
+            if (type is CompositeTypeGo ctg)
             {
-                return type.Cast<CompositeTypeGo>().ZeroInitExpression;
+                return ctg.ZeroInitExpression;
             }
-            else if (type is EnumTypeGo)
+            else if (type is EnumTypeGo etg)
             {
-                return type.Cast<EnumTypeGo>().ZeroInitExpression;
+                return etg.ZeroInitExpression;
             }
-            else if (type is PrimaryTypeGo)
+            else if (type is PrimaryTypeGo ptg)
             {
-                return type.Cast<PrimaryTypeGo>().ZeroInitExpression;
+                return ptg.ZeroInitExpression;
             }
-            else if (type is DictionaryTypeGo)
+            else if (type is DictionaryTypeGo dtg)
             {
-                return type.Cast<DictionaryTypeGo>().ZeroInitExpression;
+                return dtg.ZeroInitExpression;
             }
             throw new NotImplementedException($"GetZeroInitExpression for type {type} NYI");
         }

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -113,6 +113,10 @@ namespace AutoRest.Go
             return WordSplitPattern.Split(value).Where(s => !string.IsNullOrEmpty(s)).ToArray();
         }
 
+        /// <summary>
+        /// Creates a string from the first letter in each word.
+        /// E.g. "SomeTypeName" would generate the string "stn".
+        /// </summary>
         public static string ToShortName(this string longName)
         {
             var initials = from word in longName.ToWords()
@@ -122,7 +126,16 @@ namespace AutoRest.Go
         }
 
         /// <summary>
-        /// This method checks if MethodGroupName is plural of package name.
+        /// Creates a string from the first letter in each word.
+        /// E.g. "SomeTypeName" would generate the string "stn".
+        /// </summary>
+        public static string ToShortName(this Fixable<string> longName)
+        {
+            return longName.ToString().ToShortName();
+        }
+
+        /// <summary>
+        /// This method checks if MethodGroupName is plural of package name. 
         /// It returns false for packages not listed in dictionary 'plural'.
         /// Example, group EventHubs in package EventHub.
         /// Refactor -> Namer, but also could be used by the CodeModelTransformer
@@ -363,6 +376,57 @@ namespace AutoRest.Go
         public static T Cast<T>(this IModelType type)
         {
             return (T)type;
+        }
+
+        /// <summary>
+        /// Converts the specified composite type into a page type.
+        /// If the type specified is a future it will "unwrap" the page type from it.
+        /// Throws if the specified type is not a future or page type.
+        /// </summary>
+        /// <param name="ctg">The type to convert from.</param>
+        /// <returns>The type converted to a page type.</returns>
+        public static PageTypeGo UnwrapPageType(this CompositeTypeGo ctg)
+        {
+            PageTypeGo result;
+            if (ctg is FutureTypeGo)
+            {
+                result = ctg.Cast<FutureTypeGo>().ResultType.Cast<PageTypeGo>();
+            }
+            else if (ctg is PageTypeGo)
+            {
+                result = ctg.Cast<PageTypeGo>();
+            }
+            else
+            {
+                throw new InvalidCastException("supplied object is not a FutureTypeGo or PageTypeGo");
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Returns an expression for zero-initializing the specified type.
+        /// </summary>
+        /// <param name="type">The type for which to create a zero-init expression.</param>
+        /// <returns>The zero-init expression.</returns>
+        public static string GetZeroInitExpression(this IModelType type)
+        {
+            if (type is CompositeTypeGo)
+            {
+                return type.Cast<CompositeTypeGo>().ZeroInitExpression;
+            }
+            else if (type is EnumTypeGo)
+            {
+                return type.Cast<EnumTypeGo>().ZeroInitExpression;
+            }
+            else if (type is PrimaryTypeGo)
+            {
+                return type.Cast<PrimaryTypeGo>().ZeroInitExpression;
+            }
+            else if (type is DictionaryTypeGo)
+            {
+                return type.Cast<DictionaryTypeGo>().ZeroInitExpression;
+            }
+            throw new NotImplementedException($"GetZeroInitExpression for type {type} NYI");
         }
 
         /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -106,8 +106,6 @@ namespace AutoRest.Go.Model
 
         public string DiscriminatorEnumValue => DiscriminatorEnum.Values.FirstOrDefault(v => v.SerializedName.Equals(SerializedName)).Name;
 
-        public string PreparerMethodName => $"{Name}Preparer";
-
         public bool IsWrapperType { get; }
 
         public IModelType BaseType { get; }

--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -18,16 +18,9 @@ namespace AutoRest.Go.Model
     public class CompositeTypeGo : CompositeType
     {
         /// <summary>
-        ///True if the type is returned by a method
+        /// True if the type is returned by a method
         /// </summary>
         public bool IsResponseType;
-
-        /// <summary>
-        /// Name of the field containing the URL used to retrieve the next result set (null or empty if the model is not paged).
-        /// </summary>
-        public string NextLink;
-
-        public bool PreparerNeeded = false;
 
         public EnumTypeGo DiscriminatorEnum;
 
@@ -221,7 +214,8 @@ namespace AutoRest.Go.Model
                 null;
         }
 
-        public bool IsPolymorphicResponse() {
+        public bool IsPolymorphicResponse()
+        {
             if (IsPolymorphic && IsResponseType)
             {
                 return true;
@@ -284,11 +278,6 @@ namespace AutoRest.Go.Model
                 }
                 else
                 {
-                    // NextLinks might have differences in casing, but they need to be consistent
-                    if (property.Name.EqualsIgnoreCase(NextLink))
-                    {
-                        property.Name = NextLink;
-                    }
                     indented.AppendFormat("{0} *{1} {2}\n", property.Name, property.ModelType.Name, property.JsonTag());
                 }
             }
@@ -320,6 +309,10 @@ namespace AutoRest.Go.Model
         }
 
         /// <summary>
+        /// Gets the expression for a zero-initialized composite type.
+        /// </summary>
+        public string ZeroInitExpression => $"{Name}{{}}";
+
         /// If PolymorphicDiscriminator is set, makes sure we have a PolymorphicDiscriminator property.
         /// </summary>
         private void AddPolymorphicPropertyIfNecessary()

--- a/src/Model/DictionaryTypeGo.cs
+++ b/src/Model/DictionaryTypeGo.cs
@@ -58,5 +58,10 @@ namespace AutoRest.Go.Model
         {
             return ValueType.GetHashCode();
         }
+
+        /// <summary>
+        /// Gets the expression for a zero-initialized dictionary type.
+        /// </summary>
+        public string ZeroInitExpression => $"{FieldNameFormat}{{}}";
     }
 }

--- a/src/Model/EnumTypeGo.cs
+++ b/src/Model/EnumTypeGo.cs
@@ -33,5 +33,10 @@ namespace AutoRest.Go.Model
         /// Since swagger doesn't let you define a description for enums we make one up.
         /// </summary>
         public string Documentation => $"{Name} enumerates the values for {Name.FixedValue.ToPhrase()}.";
+
+        /// <summary>
+        /// Gets the expression for a zero-initialized enum.
+        /// </summary>
+        public string ZeroInitExpression => "\"\"";
     }
 }

--- a/src/Model/FutureTypeGo.cs
+++ b/src/Model/FutureTypeGo.cs
@@ -9,7 +9,7 @@ namespace AutoRest.Go.Model
     /// <summary>
     /// Represents a future, which is the return type for long-running operations.
     /// </summary>
-    class FutureTypeGo : CompositeTypeGo
+    internal class FutureTypeGo : CompositeTypeGo
     {
         /// <summary>
         /// Creates a new future type for the specified method.

--- a/src/Model/IteratorTypeGo.cs
+++ b/src/Model/IteratorTypeGo.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Model;
+using AutoRest.Core.Utilities;
+using AutoRest.Extensions.Azure;
+using AutoRest.Go;
+using System;
+using System.Linq;
+
+namespace AutoRest.Go.Model
+{
+    /// <summary>
+    /// An abstraction for seamlessly iterating over a pageable collection.
+    /// </summary>
+    public class IteratorTypeGo : CompositeTypeGo
+    {
+        /// <summary>
+        /// Creates a new iterator type for the specified pageable type.
+        /// </summary>
+        /// <param name="method">The pageable type that requires an iterator.</param>
+        public IteratorTypeGo(PageTypeGo pageType) : base(CodeNamerGo.Instance.GetIteratorTypeName(pageType))
+        {
+            PageType = pageType;
+            Documentation = $"Provides access to a complete listing of {PageType.ElementType.Name} values.";
+        }
+
+        /// <summary>
+        /// Gets the PageTypeGo type associated with this iterator.
+        /// </summary>
+        public PageTypeGo PageType { get; }
+
+        /// <summary>
+        /// Gets the name of the indexer field used to track the current value.
+        /// </summary>
+        public string IndexField => "i";
+
+        /// <summary>
+        /// Gets the name of the page field that contains the current page of values.
+        /// </summary>
+        public string PageField => "page";
+
+        public override string Fields()
+        {
+            return $"    {IndexField} int\n    {PageField} {PageType.Name}";
+        }
+    }
+}

--- a/src/Model/IteratorTypeGo.cs
+++ b/src/Model/IteratorTypeGo.cs
@@ -13,7 +13,7 @@ namespace AutoRest.Go.Model
     /// <summary>
     /// An abstraction for seamlessly iterating over a pageable collection.
     /// </summary>
-    public class IteratorTypeGo : CompositeTypeGo
+    internal class IteratorTypeGo : CompositeTypeGo
     {
         /// <summary>
         /// Creates a new iterator type for the specified pageable type.

--- a/src/Model/LroPagedResponseGo.cs
+++ b/src/Model/LroPagedResponseGo.cs
@@ -10,7 +10,7 @@ namespace AutoRest.Go.Model
     /// This is a bit of a hack as the "list all" method isn't part of the code model and doing
     /// it this way was the path of least resistance (we should fix this eventually).
     /// </summary>
-    class LroPagedResponseGo : Response
+    internal class LroPagedResponseGo : Response
     {
         public LroPagedResponseGo(FutureTypeGo returnType, FutureTypeGo listAllReturnType, IModelType headers) : base(returnType, headers)
         {

--- a/src/Model/LroPagedResponseGo.cs
+++ b/src/Model/LroPagedResponseGo.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Model;
+
+namespace AutoRest.Go.Model
+{
+    /// <summary>
+    /// Represents a response from a long-running operation that's also a paged operation.
+    /// This is a bit of a hack as the "list all" method isn't part of the code model and doing
+    /// it this way was the path of least resistance (we should fix this eventually).
+    /// </summary>
+    class LroPagedResponseGo : Response
+    {
+        public LroPagedResponseGo(FutureTypeGo returnType, FutureTypeGo listAllReturnType, IModelType headers) : base(returnType, headers)
+        {
+            ListAllReturnType = listAllReturnType;
+        }
+
+        /// <summary>
+        /// Gets the future type to be returned from the "list all" method.
+        /// </summary>
+        public FutureTypeGo ListAllReturnType { get; }
+    }
+}

--- a/src/Model/MethodGo.cs
+++ b/src/Model/MethodGo.cs
@@ -199,22 +199,15 @@ namespace AutoRest.Go.Model
 
         public string ResponderMethodName => $"{Name}Responder";
 
-        public string ListAllMethodName => $"{Name}All";
+        public string ListCompleteMethodName => $"{Name}Complete";
 
-        public string HelperInvocationParameters(bool complete)
+        public string HelperInvocationParameters()
         {
             var invocationParams = new List<string> { "ctx" };
 
             foreach (ParameterGo p in LocalParameters)
             {
-                if (p.Name.EqualsIgnoreCase("nextlink") && complete)
-                {
-                    invocationParams.Add(string.Format("*list.{0}", p.Name));
-                }
-                else
-                {
-                    invocationParams.Add(p.Name);
-                }
+                invocationParams.Add(p.Name);
             }
             return string.Join(", ", invocationParams);
         }

--- a/src/Model/MethodGroupGo.cs
+++ b/src/Model/MethodGroupGo.cs
@@ -82,6 +82,10 @@ namespace AutoRest.Go.Model
                     {
                         mg.ReturnType.Body.AddImports(imports);
                     }
+                    if (mg.IsNextMethod)
+                    {
+                        imports.UnionWith(CodeNamerGo.Instance.PageableImports);
+                    }
                 });
 
             foreach (var p in cmg.Properties)

--- a/src/Model/PageTypeGo.cs
+++ b/src/Model/PageTypeGo.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Model;
+using AutoRest.Core.Utilities;
+using AutoRest.Extensions.Azure;
+using AutoRest.Go;
+using System;
+using System.Linq;
+
+namespace AutoRest.Go.Model
+{
+    /// <summary>
+    /// Represents a response from a pageable operation.
+    /// </summary>
+    public class PageTypeGo : CompositeTypeGo
+    {
+        /// <summary>
+        /// Creates a new pageable type for the specified response type.
+        /// </summary>
+        /// <param name="method">The method that will return a pageable type.</param>
+        public PageTypeGo(MethodGo method) : base(CodeNamerGo.Instance.GetPageTypeName(method))
+        {
+            if (!method.IsPageable)
+            {
+                throw new InvalidOperationException($"method {method.Owner}.{method.Name} is not a pageable operation");
+            }
+
+            CodeModel = method.CodeModel;
+            ContentType = (CompositeTypeGo)method.ReturnType.Body;
+            ElementType = ContentType.Properties.Where(p => p.ModelType is SequenceTypeGo).FirstOrDefault().ModelType.Cast<SequenceTypeGo>().ElementType;
+            Documentation = $"Contains a page of {ElementType.Name} values.";
+            PreparerNeeded = !method.NextMethodExists(CodeModel.Methods.Cast<MethodGo>());
+
+            var pageableExtension = method.Extensions[AzureExtensions.PageableExtension] as Newtonsoft.Json.Linq.JContainer;
+            NextLink = CodeNamerGo.Instance.GetPropertyName((string)pageableExtension["nextLinkName"]);
+            if (string.IsNullOrWhiteSpace(NextLink))
+            {
+                throw new InvalidOperationException($"method {method.Owner}.{method.Name} contains a null nextLinkName so it shouldn't be treated as a pageable operation");
+            }
+            ItemName = CodeNamerGo.Instance.GetPropertyName((string)pageableExtension["itemName"] ?? "value");
+
+            IteratorType = new IteratorTypeGo(this);
+        }
+
+        /// <summary>
+        /// Gets the value of the x-ms-pageable:nextLinkName property.
+        /// </summary>
+        public string NextLink { get; }
+
+        /// <summary>
+        /// Gets the value of the x-ms-pageable:itemName property.
+        /// </summary>
+        public string ItemName { get; }
+
+        /// <summary>
+        /// Gets true if this response type needs a preparer to retrieve the next page of results.
+        /// This is false if the swagger explicitly defines a next operation (i.e. x-ms-pageable:operationName).
+        /// </summary>
+        public bool PreparerNeeded { get; }
+
+        /// <summary>
+        /// Gets the underlying type returned from the pageable operation (i.e. the wrapper around the array).
+        /// </summary>
+        public CompositeTypeGo ContentType { get; }
+
+        /// <summary>
+        /// Gets the element type, i.e. the type in the arrary.
+        /// </summary>
+        public IModelType ElementType { get; }
+
+        /// <summary>
+        /// Gets the name of the preparer method used to prepare the request for retrieving the next page of results.
+        /// </summary>
+        public string PreparerMethodName => $"{ContentType.Name.ToCamelCase()}Preparer";
+
+        /// <summary>
+        /// Gets the iterator type associated with this paged type.
+        /// </summary>
+        public IteratorTypeGo IteratorType { get; }
+
+        /// <summary>
+        /// Gets the name of the next results function field.
+        /// </summary>
+        public string FnFieldName => "fn";
+
+        /// <summary>
+        /// Gets the name of the results field.
+        /// </summary>
+        public string ResultFieldName => ContentType.Name.ToShortName();
+
+        public override string Fields()
+        {
+            return $"    {FnFieldName} func({ContentType.Name}) ({ContentType.Name}, error)\n    {ResultFieldName} {ContentType.Name}";
+        }
+
+        public override bool Equals(object other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            var asMyType = other as PageTypeGo;
+            if (asMyType == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+            return string.Compare(Name, asMyType.Name, StringComparison.Ordinal) == 0;
+        }
+
+        public override int GetHashCode()
+        {
+            return Name.GetHashCode();
+        }
+    }
+}

--- a/src/Model/PageTypeGo.cs
+++ b/src/Model/PageTypeGo.cs
@@ -13,7 +13,7 @@ namespace AutoRest.Go.Model
     /// <summary>
     /// Represents a response from a pageable operation.
     /// </summary>
-    public class PageTypeGo : CompositeTypeGo
+    internal class PageTypeGo : CompositeTypeGo
     {
         /// <summary>
         /// Creates a new pageable type for the specified response type.
@@ -101,17 +101,17 @@ namespace AutoRest.Go.Model
                 return false;
             }
 
-            var asMyType = other as PageTypeGo;
-            if (asMyType == null)
-            {
-                return false;
-            }
-
             if (ReferenceEquals(this, other))
             {
                 return true;
             }
-            return string.Compare(Name, asMyType.Name, StringComparison.Ordinal) == 0;
+
+            if (other is PageTypeGo asMyType)
+            {
+                return string.Compare(Name, asMyType.Name, StringComparison.Ordinal) == 0;
+            }
+
+            return false;
         }
 
         public override int GetHashCode()

--- a/src/Model/ParameterGo.cs
+++ b/src/Model/ParameterGo.cs
@@ -180,6 +180,18 @@ namespace AutoRest.Go.Model
                                    ? "{0} == nil || len({0}) == 0"
                                    : "{0} != nil && len({0}) > 0", valueReference);
         }
+
+        /// <summary>
+        /// Returns true if two parameters are semantically equivalent.
+        /// The names match (excluding casing) and the types are identical.
+        /// </summary>
+        /// <param name="lhs">Left-hand side to compare against.</param>
+        /// <param name="rhs">Right-hand side to compare with.</param>
+        /// <returns>True if the two are semantically equal.</returns>
+        public static bool Match(ParameterGo lhs, ParameterGo rhs)
+        {
+            return lhs.Name.EqualsIgnoreCase(rhs.Name) && lhs.ModelTypeName.Equals(rhs.ModelTypeName);
+        }
     }
 
     public static class ParameterGoExtensions

--- a/src/Model/PrimaryTypeGo.cs
+++ b/src/Model/PrimaryTypeGo.cs
@@ -124,7 +124,8 @@ namespace AutoRest.Go.Model
             }
         }
 
-        public static string GetImportLine(string package, string alias = default(string)) {
+        public static string GetImportLine(string package, string alias = default(string))
+        {
             var builder = new StringBuilder();
             if(!string.IsNullOrEmpty(alias)){
                 builder.Append(alias);
@@ -135,6 +136,56 @@ namespace AutoRest.Go.Model
             builder.Append(package);
             builder.Append('"');
             return builder.ToString();
+        }
+
+        /// <summary>
+        /// Gets the expression for a zero-initialized primary type.
+        /// </summary>
+        public string ZeroInitExpression
+        {
+            get
+            {
+                switch (KnownPrimaryType)
+                {
+                    case KnownPrimaryType.ByteArray:
+                        return "nil";
+
+                    case KnownPrimaryType.Boolean:
+                        return "false";
+
+                    case KnownPrimaryType.Date:
+                        return "date.Date{}";
+
+                    case KnownPrimaryType.DateTime:
+                        return "date.Time{}";
+
+                    case KnownPrimaryType.DateTimeRfc1123:
+                        return "date.TimeRFC1123{}";
+
+                    case KnownPrimaryType.Double:
+                    case KnownPrimaryType.Decimal:
+                    case KnownPrimaryType.Int:
+                    case KnownPrimaryType.Long:
+                        return "0";
+
+                    case KnownPrimaryType.Base64Url:
+                    case KnownPrimaryType.String:
+                        return "\"\"";
+
+                    case KnownPrimaryType.Object:
+                        return "map[string]interface{}{}";
+
+                    case KnownPrimaryType.UnixTime:
+                        return "date.UnixTime{}";
+
+                    case KnownPrimaryType.Uuid:
+                        return "uuid.UUID{}";
+
+                    default:
+                        throw new NotImplementedException($"ZeroInitExpression for primary type {KnownPrimaryType} NYI");
+
+                }
+            }
         }
     }
 }

--- a/src/Templates/MethodTemplate.cshtml
+++ b/src/Templates/MethodTemplate.cshtml
@@ -42,7 +42,7 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
         if lastResult.@nextLinkField == nil || len(to.String(lastResult.@nextLinkField)) < 1 {
             return @returnType{}, nil
         }
-        return client.@(nextMethod.Name)( @Model.HelperInvocationParameters(false), *lastResult.@nextLinkField )
+        return client.@(nextMethod.Name)( @Model.HelperInvocationParameters(), *lastResult.@nextLinkField )
     }
     </text>
     }
@@ -51,7 +51,7 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
     @:result.@fnField = client.@(Model.NextMethodName)
     }
 }
-    req, err := client.@(Model.PreparerMethodName)(@(Model.HelperInvocationParameters(false)))
+    req, err := client.@(Model.PreparerMethodName)(@(Model.HelperInvocationParameters()))
     if err != nil {
         err = @(Model.AutorestError("Failure preparing request"))
         return
@@ -291,13 +291,13 @@ func (client @(Model.Owner)) @(Model.NextMethodName)(lastResults @Model.LastResu
     }
 <text>
 @EmptyLine
-// @(Model.ListAllMethodName) enumerates all values, automatically crossing page boundaries as required.
-func (client @(Model.Owner)) @(Model.ListAllMethodName)(@(Model.MethodParametersSignature)) (result @resultTypeName, err error) {
+// @(Model.ListCompleteMethodName) enumerates all values, automatically crossing page boundaries as required.
+func (client @(Model.Owner)) @(Model.ListCompleteMethodName)(@(Model.MethodParametersSignature)) (result @resultTypeName, err error) {
     @if (Model.IsLongRunningOperation())
     {
     <text>
     var future @Model.MethodReturnType
-    future, err = client.@(Model.Name)(@(Model.HelperInvocationParameters(false)))
+    future, err = client.@(Model.Name)(@(Model.HelperInvocationParameters()))
     result.Future = future.Future
     result.req = future.req
     </text>
@@ -305,7 +305,7 @@ func (client @(Model.Owner)) @(Model.ListAllMethodName)(@(Model.MethodParameters
     else
     {
     <text>
-    result.page, err = client.@(Model.Name)(@(Model.HelperInvocationParameters(false)))
+    result.page, err = client.@(Model.Name)(@(Model.HelperInvocationParameters()))
     </text>
     }
     return

--- a/src/Templates/MethodTemplate.cshtml
+++ b/src/Templates/MethodTemplate.cshtml
@@ -62,7 +62,7 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
 <text>
     result, err = client.@(Model.SenderMethodName)(req)
     if err != nil {
-        err = @(Model.AutorestError("Failure sending request", "resp", "result.Response()"))
+        err = @(Model.AutorestError("Failure sending request", "result.Response()"))
         return
     }
 </text>
@@ -156,25 +156,30 @@ func (client @(Model.Owner)) @(Model.PreparerMethodName)(@(Model.MethodParameter
 }
 
 @{
-    var senderRetType = "*http.Response";
+    var senderRetSig = "*http.Response, error";
     if (Model.IsLongRunningOperation())
     {
-        senderRetType = Model.MethodReturnType;
+        senderRetSig = $"future {Model.MethodReturnType}, err error";
     }
 }
 
 @EmptyLine
 // @(Model.SenderMethodName) sends the @(Model.Name) request. The method will close the
 // http.Response Body if it receives an error.
-func (client @(Model.Owner)) @(Model.SenderMethodName)(req *http.Request) (@senderRetType, error) {
+func (client @(Model.Owner)) @(Model.SenderMethodName)(req *http.Request) (@senderRetSig) {
 @if (Model.IsLongRunningOperation())
 {
 <text>
     sender := autorest.DecorateSender(client, @Model.SendDecorators.EmitAsArguments())
-    future := azure.NewFuture(req)
-    _, err := future.Done(sender)
-    f := @(senderRetType){Future: future, req: req}
-    return f, err
+    future.Future = azure.NewFuture(req)
+    future.req = req
+    _, err = future.Done(sender)
+    if err != nil {
+        return
+    }
+    err = autorest.Respond(future.Response(),
+        azure.WithErrorUnlessStatusCode(@(string.Join(",", Model.ResponseCodes.ToArray()))))
+    return
 </text>
 }
 else

--- a/src/Templates/MethodTemplate.cshtml
+++ b/src/Templates/MethodTemplate.cshtml
@@ -42,7 +42,7 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
         if lastResult.@nextLinkField == nil || len(to.String(lastResult.@nextLinkField)) < 1 {
             return @returnType{}, nil
         }
-        return client.@(nextMethod.Name)( @Model.HelperInvocationParameters(), *lastResult.@nextLinkField )
+        return client.@(nextMethod.Name)( @Model.NextMethodInvocationParameters($"*lastResult.{nextLinkField}") )
     }
     </text>
     }

--- a/src/Templates/MethodTemplate.cshtml
+++ b/src/Templates/MethodTemplate.cshtml
@@ -18,7 +18,7 @@
 </text>
 }
 
-func (client @(Model.Owner)) @(Model.MethodSignature) (@Model.MethodReturnSignature()) {
+func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@Model.MethodReturnSignature()) {
 @if ((Model.CodeModel as CodeModelGo).ShouldValidate && !Model.ParameterValidations.IsNullOrEmpty())
 {
 <text>
@@ -29,8 +29,29 @@ func (client @(Model.Owner)) @(Model.MethodSignature) (@Model.MethodReturnSignat
 @EmptyLine
 </text>
 }
-
-    req, err := client.@(Model.PreparerMethodName)(@(Model.HelperInvocationParameters(complete: false)))
+@if (Model.IsPageable && !Model.IsLongRunningOperation() && !Model.IsNextMethod)
+{
+    var fnField = Model.ReturnType.Body.Cast<CompositeTypeGo>().UnwrapPageType().FnFieldName;
+    var nextMethod = Model.NextMethod;
+    if (nextMethod != null)
+    {
+        var returnType = nextMethod.MethodReturnType;
+        var nextLinkField = Model.ReturnType.Body.Cast<CompositeTypeGo>().UnwrapPageType().NextLink;
+    <text>
+    result.@fnField = func(lastResult @returnType) (@returnType, error) {
+        if lastResult.@nextLinkField == nil || len(to.String(lastResult.@nextLinkField)) < 1 {
+            return @returnType{}, nil
+        }
+        return client.@(nextMethod.Name)( @Model.HelperInvocationParameters(false), *lastResult.@nextLinkField )
+    }
+    </text>
+    }
+    else
+    {
+    @:result.@fnField = client.@(Model.NextMethodName)
+    }
+}
+    req, err := client.@(Model.PreparerMethodName)(@(Model.HelperInvocationParameters(false)))
     if err != nil {
         err = @(Model.AutorestError("Failure preparing request"))
         return
@@ -56,7 +77,7 @@ else
         return
     }
 @EmptyLine
-    result, err = client.@(Model.ResponderMethodName)(resp)
+    @(Model.ResponseAssignTarget), err = client.@(Model.ResponderMethodName)(resp)
     if err != nil {
         err = @(Model.AutorestError("Failure responding to request", "resp"))
     }
@@ -169,6 +190,36 @@ else
 // @(Model.ResponderMethodName) handles the response to the @(Model.Name) request. The method always
 // closes the http.Response Body.
 func (client @(Model.Owner)) @(Model.ResponderMethodName)(resp *http.Response) (@Model.ResponderReturnSignature()) {
+@if (Model.IsLongRunningOperation() && Model.IsPageable)
+{
+    var pageType = Model.ReturnType.Body.Cast<CompositeTypeGo>().UnwrapPageType();
+<text>
+    result.@(pageType.ResultFieldName), err = client.@(Model.ResponderMethodName.ToCamelCase())(resp)
+    result.@(pageType.FnFieldName) = client.@(Model.NextMethodName)
+</text>
+}
+else
+{
+<text>
+    @if (Model.ReturnValue().Body.IsStreamType())
+    {
+    @:result.Value = &resp.Body
+    }
+    err = autorest.Respond(
+        @(Model.RespondDecorators.EmitAsArguments()))
+
+    @(Model.Response(true))
+</text>
+}
+    return
+}
+
+@if (Model.IsLongRunningOperation() && Model.IsPageable)
+{
+    var pageType = Model.ReturnType.Body.Cast<CompositeTypeGo>().UnwrapPageType();
+<text>
+@EmptyLine
+func (client @(Model.Owner)) @(Model.ResponderMethodName.ToCamelCase())(resp *http.Response) (result @pageType.ContentType.Name, err error) {
     @if (Model.ReturnValue().Body.IsStreamType())
     {
     @:result.Value = &resp.Body
@@ -179,42 +230,50 @@ func (client @(Model.Owner)) @(Model.ResponderMethodName)(resp *http.Response) (
     @(Model.Response(true))
     return
 }
+</text>
+}
 
 @if (Model.IsPageable && !Model.NextAlreadyDefined)
 {
-    var lastResTypyeName = Model.ReturnValue().Body.Name;
-    var preparerName = Model.ReturnValue().Body.Cast<CompositeTypeGo>().PreparerMethodName;
+    var preparerName = Model.ReturnValue().Body.Cast<CompositeTypeGo>().UnwrapPageType().PreparerMethodName;
     if (Model.IsLongRunningOperation())
     {
-        lastResTypyeName = Model.ReturnValue().Body.Cast<FutureTypeGo>().ResultTypeName;
-        preparerName = $"{lastResTypyeName}Preparer";
+        preparerName = $"{Model.LastResultsTypeName().ToCamelCase()}Preparer";
     }
 <text>
 @EmptyLine
 // @(Model.NextMethodName) retrieves the next set of results, if any.
-func (client @(Model.Owner)) @(Model.NextMethodName)(lastResults @lastResTypyeName) (@Model.MethodReturnSignature()) {
+func (client @(Model.Owner)) @(Model.NextMethodName)(lastResults @Model.LastResultsTypeName()) (@Model.NextMethodReturnSignature()) {
     req, err := lastResults.@(preparerName)()
     if err != nil {
-        return result, @(Model.AutorestError("Failure preparing next results request"))
+        return result, @(Model.AutorestError("Failure preparing next results request", null, null, Model.NextMethodName))
     }
     if req == nil {
         return
     }
     @if (Model.IsLongRunningOperation())
     {
-    @:return client.@(Model.SenderMethodName)(req)
+    <text>
+    var resp *http.Response
+    resp, err = autorest.SendWithSender(client, req,
+        autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+    if err != nil {
+        return result, @(Model.AutorestError("Failure sending next results request", "resp", null, Model.NextMethodName))
+    }
+    return client.@(Model.ResponderMethodName.ToCamelCase())(resp)
+    </text>
     }
     else
     {
     <text>
     resp, err := client.@(Model.SenderMethodName)(req)
     if err != nil {
-        @(Model.Response(false))
-        return result, @(Model.AutorestError("Failure sending next results request", "resp"))
+        @(Model.Response(true))
+        return result, @(Model.AutorestError("Failure sending next results request", "resp", null, Model.NextMethodName))
     }
     result, err = client.@(Model.ResponderMethodName)(resp)
     if err != nil {
-        err = @(Model.AutorestError("Failure responding to next results request", "resp"))
+        err = @(Model.AutorestError("Failure responding to next results request", "resp", null, Model.NextMethodName))
     }
     return
     </text>
@@ -223,62 +282,33 @@ func (client @(Model.Owner)) @(Model.NextMethodName)(lastResults @lastResTypyeNa
 </text>
 }
 
-@if (Model.IsPageable && !Model.IsNextMethod && Model.ListElement != null)
+@if (Model.IsPageable && !Model.IsNextMethod)
 {
+    var resultTypeName = Model.ReturnType.Body.Cast<CompositeTypeGo>().UnwrapPageType().IteratorType.Name;
+    if (Model.IsLongRunningOperation())
+    {
+        resultTypeName = ((LroPagedResponseGo)Model.ReturnType).ListAllReturnType.Name;
+    }
 <text>
 @EmptyLine
-// @(Model.ListCompleteMethodName) gets all elements from the list without paging.
-func (client @(Model.Owner)) @(Model.ListCompleteMethodName)(@(Model.MethodParametersSignature)) @(Model.MethodReturnSignatureComplete) {
-    resultChan := make(chan @((Model.ListElement.ModelType as SequenceTypeGo).GetElement))
-    errChan := make(chan error, 1)
-    go func() {
-        defer func() {
-			close(resultChan)
-			close(errChan)
-		}()
-        list, err := client.@(Model.Name)(@(Model.HelperInvocationParameters(complete: false)))
-        if err != nil {
-            errChan @("<-") err
-            return
-        }
-        if list.@(Model.ListElement.Name) != nil {
-            for _, item := range *list.@(Model.ListElement.Name) {
-                select {
-                case @("<-") ctx.Done():
-                    errChan @("<-") ctx.Err()
-                    return
-                case resultChan @("<-") item:
-                    // Intentionally left blank
-                }
-            }
-        }
-        for list.@(Model.NextLink) != nil {
-    @if (Model.NextAlreadyDefined)
+// @(Model.ListAllMethodName) enumerates all values, automatically crossing page boundaries as required.
+func (client @(Model.Owner)) @(Model.ListAllMethodName)(@(Model.MethodParametersSignature)) (result @resultTypeName, err error) {
+    @if (Model.IsLongRunningOperation())
     {
-          @:list, err = client.@(Model.NextOperationName)(@(Model.NextMethod.HelperInvocationParameters(complete: true)))
+    <text>
+    var future @Model.MethodReturnType
+    future, err = client.@(Model.Name)(@(Model.HelperInvocationParameters(false)))
+    result.Future = future.Future
+    result.req = future.req
+    </text>
     }
     else
     {
-          @:list, err = client.@(Model.NextMethodName)(list)
+    <text>
+    result.page, err = client.@(Model.Name)(@(Model.HelperInvocationParameters(false)))
+    </text>
     }
-            if err != nil {
-                errChan @("<-") err
-                return
-            }
-            if list.@(Model.ListElement.Name) != nil {
-                for _, item := range *list.@(Model.ListElement.Name) {
-                    select {
-                        case @("<-") ctx.Done():
-                            errChan @("<-") ctx.Err()
-                            return
-                        case resultChan @("<-") item:
-                            // Intentionally left blank
-                    }
-                }
-            }
-        }
-    }()
-    return resultChan, errChan
+    return
 }
 </text>
 }

--- a/src/Templates/ModelTemplate.cshtml
+++ b/src/Templates/ModelTemplate.cshtml
@@ -76,8 +76,41 @@ func unmarshal@(Model.GetInterfaceName())Array(body []byte) ([]@(Model.GetInterf
 }
 else
 {
-@WrapComment("// ", $"{Model.Name} {Model.Documentation.ToSentence()}")
+    @if (Model is PageTypeGo)
+    {
+        var pageType = Model as PageTypeGo;
+        var itemName = pageType.ItemName;
+        var contentType = pageType.ContentType.Name;
+        var receiverVar = contentType.FixedValue.ToShortName();
+
     <text>
+@EmptyLine
+// IsEmpty returns true if the ListResult contains no values.
+func (@receiverVar @contentType) IsEmpty() bool {
+    return @(receiverVar).@itemName == nil || len(*@(receiverVar).@itemName) == 0
+}
+@EmptyLine
+    </text>
+        if (pageType.PreparerNeeded)
+        {
+        <text>
+// @(pageType.PreparerMethodName) prepares a request to retrieve the next set of results.
+// It returns nil if no more results exist.
+func (@receiverVar @contentType) @(pageType.PreparerMethodName)() (*http.Request, error) {
+    if @(receiverVar).@(pageType.NextLink) == nil || len(to.String(@(receiverVar).@(pageType.NextLink))) < 1 {
+        return nil, nil
+    }
+    return autorest.Prepare(&http.Request{},
+    autorest.AsJSON(),
+    autorest.AsGet(),
+    autorest.WithBaseURL(to.String( @(receiverVar).@(pageType.NextLink))));
+}
+@EmptyLine
+        </text>
+        }
+    }
+<text>
+@WrapComment("// ", $"{Model.Name} {Model.Documentation.ToSentence()}")
 type @(Model.Name) struct {
     @(Model.AddHTTPResponse())
     @(Model.Fields())
@@ -178,6 +211,11 @@ func (@(Model.Name.FixedValue.ToShortName()) *@(Model.Name)) UnmarshalJSON(body 
     var v *json.RawMessage
         @foreach (var p in Model.AllProperties)
         {
+            if (p.ModelType is DictionaryTypeGo && ((DictionaryTypeGo)p.ModelType).SupportsAdditionalProperties)
+            {
+                // TODO: codegen for this scenario is broken
+                continue;
+            }
         <text>
     @EmptyLine
     v = m["@(p.SerializedName)"]
@@ -219,20 +257,83 @@ func (@(Model.Name.FixedValue.ToShortName()) *@(Model.Name)) UnmarshalJSON(body 
 </text>
 }
 
-@if (!string.IsNullOrEmpty(Model.NextLink) && Model.PreparerNeeded)
+@if (Model is PageTypeGo)
 {
+    var pageType = (PageTypeGo)Model;
+    var itemName = pageType.ItemName;
+    var itemType = pageType.ElementType.Name;
 <text>
 @EmptyLine
-// @(Model.PreparerMethodName) prepares a request to retrieve the next set of results. It returns
-// nil if no more results exist.
-func (client @(Model.Name)) @(Model.PreparerMethodName)() (*http.Request, error) {
-    if client.@(Model.NextLink) == nil || len(to.String(client.@(Model.NextLink))) <= 0 {
-        return nil, nil
+// Next advances to the next page of values.  If there was an error making
+// the request the page does not advance and the error is returned.
+func (page * @Model.Name) Next() error {
+    next, err := page.@(pageType.FnFieldName)(page.@pageType.ResultFieldName)
+    if err != nil {
+        return err
     }
-    return autorest.Prepare(&http.Request{},
-        autorest.AsJSON(),
-        autorest.AsGet(),
-        autorest.WithBaseURL(to.String(client.@(Model.NextLink))));
+    page.@pageType.ResultFieldName = next
+    return nil
+}
+
+// NotDone returns true if the page enumeration should be started or is not yet complete.
+func (page @Model.Name) NotDone() bool {
+    return !page.@(pageType.ResultFieldName).IsEmpty()
+}
+
+// Response returns the raw server response from the last page request.
+func (page @Model.Name) Response() autorest.Response {
+    return page.@(pageType.ResultFieldName).Response
+}
+
+// Values returns the slice of values for the current page or nil if there are no values.
+func (page @Model.Name) Values() []@(itemType) {
+    if page.@(pageType.ResultFieldName).IsEmpty() {
+        return nil
+    }
+    return *page.@(pageType.ResultFieldName).@itemName
+}
+</text>
+}
+
+@if (Model is IteratorTypeGo)
+{
+    var iterType = (IteratorTypeGo)Model;
+    var itemType = iterType.PageType.ElementType;
+    var itemTypeName = iterType.PageType.ElementType.Name;
+<text>
+// Next advances to the next value.  If there was an error making
+// the request the iterator does not advance and the error is returned.
+func (iter * @Model.Name) Next() error {
+    iter.@(iterType.IndexField)++
+    if iter.@(iterType.IndexField) < len(iter. @(iterType.PageField).Values()) {
+        return nil
+    }
+    err := iter.@(iterType.PageField).Next()
+    if err != nil {
+        iter. @(iterType.IndexField)--
+        return err
+    }
+    iter.@(iterType.IndexField) = 0
+    return nil
+}
+
+// NotDone returns true if the enumeration should be started or is not yet complete.
+func (iter @Model.Name) NotDone() bool {
+    return iter.@(iterType.PageField).NotDone() && iter.@(iterType.IndexField) < len(iter. @(iterType.PageField).Values())
+}
+
+// Response returns the raw server response.
+func (iter @Model.Name) Response() autorest.Response {
+    return iter.@(iterType.PageField).Response()
+}
+
+// Value returns the current value or a zero-initialized value if the
+// iterator has advanced beyond the end of the collection.
+func (iter @Model.Name) Value() @(itemTypeName) {
+    if !iter.@(iterType.PageField).NotDone() {
+        return @itemType.GetZeroInitExpression()
+    }
+    return iter.@(iterType.PageField).Values()[iter.@(iterType.IndexField)]
 }
 </text>
 }
@@ -240,26 +341,36 @@ func (client @(Model.Name)) @(Model.PreparerMethodName)() (*http.Request, error)
 @if (Model is FutureTypeGo)
 {
     var ftg = Model as FutureTypeGo;
+    var resultVar = ftg.ResultTypeName.ToShortName();
+    var resultVarTarget = resultVar;
+    if (ftg.ResultType is IteratorTypeGo)
+    {
+        resultVarTarget = $"{resultVarTarget}.{ftg.ResultType.Cast<IteratorTypeGo>().PageField}";
+    }
 <text>
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future @Model.Name) Result(client @ftg.ClientTypeName) (@ftg.ResultTypeName, error) {
-    done, err := future.Done(client)
+func (future @Model.Name) Result(client @ftg.ClientTypeName) (@resultVar @ftg.ResultTypeName, err error) {
+    var done bool
+    done, err = future.Done(client)
     if err != nil {
-        return @ftg.ResultTypeName{}, err
+        return
     }
     if !done {
-        return @ftg.ResultTypeName{}, autorest.NewError("@(Model.CodeModel.Namespace).@Model.Name", "Result", "asynchronous operation has not completed")
+        return @resultVar, autorest.NewError("@(Model.CodeModel.Namespace).@Model.Name", "Result", "asynchronous operation has not completed")
     }
     if future.PollingMethod() == azure.PollingLocation {
-        return client.@(ftg.ResponderMethodName)(future.Response())
+        @resultVarTarget, err = client.@(ftg.ResponderMethodName)(future.Response())
+        return
     }
-    resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+    var resp *http.Response
+    resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
         autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
     if err != nil {
-        return @ftg.ResultTypeName{}, err
+        return
     }
-    return client.@(ftg.ResponderMethodName)(resp)
+    @resultVarTarget, err = client.@(ftg.ResponderMethodName)(resp)
+    return
 }
 </text>
 }

--- a/src/Templates/ModelTemplate.cshtml
+++ b/src/Templates/ModelTemplate.cshtml
@@ -281,8 +281,8 @@ func (page @Model.Name) NotDone() bool {
 }
 
 // Response returns the raw server response from the last page request.
-func (page @Model.Name) Response() autorest.Response {
-    return page.@(pageType.ResultFieldName).Response
+func (page @Model.Name) Response() @pageType.ContentType.Name {
+    return page.@(pageType.ResultFieldName)
 }
 
 // Values returns the slice of values for the current page or nil if there are no values.
@@ -322,8 +322,8 @@ func (iter @Model.Name) NotDone() bool {
     return iter.@(iterType.PageField).NotDone() && iter.@(iterType.IndexField) < len(iter. @(iterType.PageField).Values())
 }
 
-// Response returns the raw server response.
-func (iter @Model.Name) Response() autorest.Response {
+// Response returns the raw server response from the last page request.
+func (iter @Model.Name) Response() @iterType.PageType.ContentType.Name {
     return iter.@(iterType.PageField).Response()
 }
 

--- a/src/Templates/ModelsTemplate.cshtml
+++ b/src/Templates/ModelsTemplate.cshtml
@@ -11,7 +11,7 @@
     var enums = Model.EnumTypes.Cast<EnumTypeGo>().ToList();
     enums.Sort((lhs, rhs) => lhs.Name.FixedValue.CompareTo(rhs.Name));
 
-    var modelTypes = Model.ModelTypes.Cast<CompositeTypeGo>().Union(Model.FutureTypes).ToList();
+    var modelTypes = Model.ModelTypes.Cast<CompositeTypeGo>().ToList();
     modelTypes.Sort((x, y) => x.Name.Value.CompareTo(y.Name.Value));
 }
 package @Model.Namespace

--- a/test/src/tests/acceptancetests/paginggrouptest/paging_test.go
+++ b/test/src/tests/acceptancetests/paginggrouptest/paging_test.go
@@ -39,7 +39,7 @@ func (s *PagingGroupSuite) TestGetMultiplePages(c *chk.C) {
 
 	// Get all!
 	count = 0
-	for iter, err := pagingClient.GetMultiplePagesAll(context.Background(), clientID, nil, nil); iter.NotDone(); err = iter.Next() {
+	for iter, err := pagingClient.GetMultiplePagesComplete(context.Background(), clientID, nil, nil); iter.NotDone(); err = iter.Next() {
 		c.Assert(err, chk.IsNil)
 		c.Assert(iter.Value().Properties, chk.NotNil)
 		count++
@@ -69,7 +69,7 @@ func (s *PagingGroupSuite) TestGetOdataMultiplePages(c *chk.C) {
 	c.Assert(count, chk.Equals, 10)
 
 	count = 0
-	for iter, err := pagingClient.GetOdataMultiplePagesAll(context.Background(), clientID, nil, nil); iter.NotDone(); err = iter.Next() {
+	for iter, err := pagingClient.GetOdataMultiplePagesComplete(context.Background(), clientID, nil, nil); iter.NotDone(); err = iter.Next() {
 		c.Assert(err, chk.IsNil)
 		c.Assert(iter.Value().Properties, chk.NotNil)
 		count++
@@ -90,7 +90,7 @@ func (s *PagingGroupSuite) TestGetMultiplePagesWithOffset(c *chk.C) {
 	c.Assert(id, chk.Equals, int32(110))
 
 	count = 0
-	for iter, err := pagingClient.GetMultiplePagesWithOffsetAll(context.Background(), 100, clientID, nil, nil); iter.NotDone(); err = iter.Next() {
+	for iter, err := pagingClient.GetMultiplePagesWithOffsetComplete(context.Background(), 100, clientID, nil, nil); iter.NotDone(); err = iter.Next() {
 		c.Assert(err, chk.IsNil)
 		c.Assert(iter.Value().Properties, chk.NotNil)
 		count++
@@ -108,7 +108,7 @@ func (s *PagingGroupSuite) TestGetMultiplePagesRetryFirst(c *chk.C) {
 	c.Assert(count, chk.Equals, 10)
 
 	count = 0
-	for iter, err := pagingClient.GetMultiplePagesRetryFirstAll(context.Background()); iter.NotDone(); err = iter.Next() {
+	for iter, err := pagingClient.GetMultiplePagesRetryFirstComplete(context.Background()); iter.NotDone(); err = iter.Next() {
 		c.Assert(err, chk.IsNil)
 		c.Assert(iter.Value().Properties, chk.NotNil)
 		count++
@@ -126,7 +126,7 @@ func (s *PagingGroupSuite) TestGetMultiplePagesRetrySecond(c *chk.C) {
 	c.Assert(count, chk.Equals, 10)
 
 	count = 0
-	for iter, err := pagingClient.GetMultiplePagesRetrySecondAll(context.Background()); iter.NotDone(); err = iter.Next() {
+	for iter, err := pagingClient.GetMultiplePagesRetrySecondComplete(context.Background()); iter.NotDone(); err = iter.Next() {
 		c.Assert(err, chk.IsNil)
 		c.Assert(iter.Value().Properties, chk.NotNil)
 		count++
@@ -140,7 +140,7 @@ func (s *PagingGroupSuite) TestGetSinglePagesFailure(c *chk.C) {
 	c.Assert(page.Response().StatusCode, chk.Equals, http.StatusBadRequest)
 
 	count := 0
-	for iter, err := pagingClient.GetSinglePagesFailureAll(context.Background()); iter.NotDone(); err = iter.Next() {
+	for iter, err := pagingClient.GetSinglePagesFailureComplete(context.Background()); iter.NotDone(); err = iter.Next() {
 		c.Assert(err, chk.IsNil)
 		c.Assert(iter.Value().Properties, chk.NotNil)
 		count++
@@ -157,7 +157,7 @@ func (s *PagingGroupSuite) TestGetMultiplePagesFailure(c *chk.C) {
 	//c.Assert(page.Response().StatusCode, chk.Equals, http.StatusBadRequest)
 
 	count := 0
-	for iter, err := pagingClient.GetMultiplePagesFailureAll(context.Background()); err == nil; err = iter.Next() {
+	for iter, err := pagingClient.GetMultiplePagesFailureComplete(context.Background()); err == nil; err = iter.Next() {
 		c.Assert(err, chk.IsNil)
 		c.Assert(iter.Value().Properties, chk.NotNil)
 		count++
@@ -174,7 +174,7 @@ func (s *PagingGroupSuite) TestGetMultiplePagesFailureURI(c *chk.C) {
 	c.Assert(err, chk.ErrorMatches, ".*No scheme detected in URL.*")
 
 	count := 0
-	for iter, err := pagingClient.GetMultiplePagesFailureURIAll(context.Background()); err == nil; err = iter.Next() {
+	for iter, err := pagingClient.GetMultiplePagesFailureURIComplete(context.Background()); err == nil; err = iter.Next() {
 		c.Assert(err, chk.IsNil)
 		c.Assert(iter.Value(), chk.NotNil)
 		count++
@@ -194,7 +194,7 @@ func (s *PagingGroupSuite) TestGetMultiplePagesFragmentNextLink(c *chk.C) {
 	c.Assert(count, chk.Equals, 10)
 
 	count = 0
-	for iter, err := pagingClient.GetMultiplePagesFragmentNextLinkAll(context.Background(), "1.6", "test_user"); iter.NotDone(); err = iter.Next() {
+	for iter, err := pagingClient.GetMultiplePagesFragmentNextLinkComplete(context.Background(), "1.6", "test_user"); iter.NotDone(); err = iter.Next() {
 		c.Assert(err, chk.IsNil)
 		c.Assert(iter.Value(), chk.NotNil)
 		count++

--- a/test/src/tests/acceptancetests/paginggrouptest/paging_test.go
+++ b/test/src/tests/acceptancetests/paginggrouptest/paging_test.go
@@ -29,209 +29,175 @@ func getPagingClient() PagingClient {
 
 func (s *PagingGroupSuite) TestGetMultiplePages(c *chk.C) {
 	// Get pages one by one...
-	res, err := pagingClient.GetMultiplePages(context.Background(), clientID, nil, nil)
-	c.Assert(err, chk.IsNil)
-	c.Assert(res.NextLink, chk.NotNil)
-	count := 1
-	for res.NextLink != nil {
-		count++
-		resNext, err := pagingClient.GetMultiplePagesNextResults(res)
+	count := 0
+	for page, err := pagingClient.GetMultiplePages(context.Background(), clientID, nil, nil); page.NotDone(); err = page.Next() {
 		c.Assert(err, chk.IsNil)
-		res = resNext
+		c.Assert(page.Values(), chk.NotNil)
+		count++
 	}
 	c.Assert(count, chk.Equals, 10)
 
 	// Get all!
-	resChan, errChan := pagingClient.GetMultiplePagesComplete(context.Background(), clientID, nil, nil)
 	count = 0
-	for item := range resChan {
+	for iter, err := pagingClient.GetMultiplePagesAll(context.Background(), clientID, nil, nil); iter.NotDone(); err = iter.Next() {
+		c.Assert(err, chk.IsNil)
+		c.Assert(iter.Value().Properties, chk.NotNil)
 		count++
-		c.Assert(item, chk.NotNil)
 	}
 	c.Assert(count, chk.Equals, 10)
-	c.Assert(<-errChan, chk.IsNil)
-
-	// Get some and then cancel
-	ctx, cancel := context.WithCancel(context.Background())
-	resChan, errChan = pagingClient.GetMultiplePagesComplete(ctx, clientID, nil, nil)
-	for i := 0; i < 3; i++ {
-		_, ok := <-resChan
-		c.Assert(ok, chk.Equals, true)
-	}
-	cancel()
-	c.Assert(<-errChan, chk.ErrorMatches, "context canceled")
-	_, ok := <-resChan
-	c.Assert(ok, chk.Equals, false)
 }
 
 func (s *PagingGroupSuite) TestGetSinglePages(c *chk.C) {
-	res, err := pagingClient.GetSinglePages(context.Background())
+	page, err := pagingClient.GetSinglePages(context.Background())
 	c.Assert(err, chk.IsNil)
-	c.Assert(res.NextLink, chk.IsNil)
+	c.Assert(page.NotDone(), chk.Equals, true)
+	err = page.Next()
+	c.Assert(err, chk.IsNil)
+	c.Assert(page.NotDone(), chk.Equals, false)
+	err = page.Next()
+	c.Assert(err, chk.IsNil)
+	c.Assert(page.NotDone(), chk.Equals, false)
 }
 
 func (s *PagingGroupSuite) TestGetOdataMultiplePages(c *chk.C) {
-	res, err := pagingClient.GetOdataMultiplePages(context.Background(), clientID, nil, nil)
-	c.Assert(err, chk.IsNil)
-	c.Assert(res.OdataNextLink, chk.NotNil)
-	count := 1
-	for res.OdataNextLink != nil {
-		count++
-		resNext, err := pagingClient.GetOdataMultiplePagesNextResults(res)
+	count := 0
+	for page, err := pagingClient.GetOdataMultiplePages(context.Background(), clientID, nil, nil); page.NotDone(); err = page.Next() {
 		c.Assert(err, chk.IsNil)
-		res = resNext
+		c.Assert(page.Values(), chk.NotNil)
+		count++
 	}
 	c.Assert(count, chk.Equals, 10)
 
-	resChan, errChan := pagingClient.GetOdataMultiplePagesComplete(context.Background(), clientID, nil, nil)
 	count = 0
-	for item := range resChan {
+	for iter, err := pagingClient.GetOdataMultiplePagesAll(context.Background(), clientID, nil, nil); iter.NotDone(); err = iter.Next() {
+		c.Assert(err, chk.IsNil)
+		c.Assert(iter.Value().Properties, chk.NotNil)
 		count++
-		c.Assert(item, chk.NotNil)
 	}
 	c.Assert(count, chk.Equals, 10)
-	c.Assert(<-errChan, chk.IsNil)
 }
 
 func (s *PagingGroupSuite) TestGetMultiplePagesWithOffset(c *chk.C) {
-	res, err := pagingClient.GetMultiplePagesWithOffset(context.Background(), 100, clientID, nil, nil)
-	c.Assert(err, chk.IsNil)
-	c.Assert(res.NextLink, chk.NotNil)
-	count := 1
-	for res.NextLink != nil {
-		count++
-		resNext, err := pagingClient.GetMultiplePagesWithOffsetNextResults(res)
+	count := 0
+	var id int32
+	for page, err := pagingClient.GetMultiplePagesWithOffset(context.Background(), 100, clientID, nil, nil); page.NotDone(); err = page.Next() {
 		c.Assert(err, chk.IsNil)
-		res = resNext
-	}
-	c.Assert(count, chk.Equals, 10)
-	c.Assert(*(*res.Values)[0].Properties.ID, chk.Equals, int32(110))
-
-	resChan, errChan := pagingClient.GetMultiplePagesWithOffsetComplete(context.Background(), 100, clientID, nil, nil)
-	count = 0
-	for item := range resChan {
+		c.Assert(page.Values(), chk.NotNil)
 		count++
-		c.Assert(item, chk.NotNil)
+		id = *page.Values()[0].Properties.ID
 	}
 	c.Assert(count, chk.Equals, 10)
-	c.Assert(<-errChan, chk.IsNil)
+	c.Assert(id, chk.Equals, int32(110))
+
+	count = 0
+	for iter, err := pagingClient.GetMultiplePagesWithOffsetAll(context.Background(), 100, clientID, nil, nil); iter.NotDone(); err = iter.Next() {
+		c.Assert(err, chk.IsNil)
+		c.Assert(iter.Value().Properties, chk.NotNil)
+		count++
+	}
+	c.Assert(count, chk.Equals, 10)
 }
 
 func (s *PagingGroupSuite) TestGetMultiplePagesRetryFirst(c *chk.C) {
-	res, err := pagingClient.GetMultiplePagesRetryFirst(context.Background())
-	c.Assert(err, chk.IsNil)
-	count := 1
-	for res.NextLink != nil {
-		count++
-		resNext, err := pagingClient.GetMultiplePagesRetryFirstNextResults(res)
+	count := 0
+	for page, err := pagingClient.GetMultiplePagesRetryFirst(context.Background()); page.NotDone(); err = page.Next() {
 		c.Assert(err, chk.IsNil)
-		res = resNext
+		c.Assert(page.Values(), chk.NotNil)
+		count++
 	}
 	c.Assert(count, chk.Equals, 10)
 
-	resChan, errChan := pagingClient.GetMultiplePagesRetryFirstComplete(context.Background())
 	count = 0
-	for item := range resChan {
+	for iter, err := pagingClient.GetMultiplePagesRetryFirstAll(context.Background()); iter.NotDone(); err = iter.Next() {
+		c.Assert(err, chk.IsNil)
+		c.Assert(iter.Value().Properties, chk.NotNil)
 		count++
-		c.Assert(item, chk.NotNil)
 	}
 	c.Assert(count, chk.Equals, 10)
-	c.Assert(<-errChan, chk.IsNil)
 }
 
 func (s *PagingGroupSuite) TestGetMultiplePagesRetrySecond(c *chk.C) {
-	res, err := pagingClient.GetMultiplePagesRetrySecond(context.Background())
-	c.Assert(err, chk.IsNil)
-	count := 1
-	for res.NextLink != nil {
-		count++
-		resNext, err := pagingClient.GetMultiplePagesRetrySecondNextResults(res)
+	count := 0
+	for page, err := pagingClient.GetMultiplePagesRetrySecond(context.Background()); page.NotDone(); err = page.Next() {
 		c.Assert(err, chk.IsNil)
-		res = resNext
+		c.Assert(page.Values(), chk.NotNil)
+		count++
 	}
 	c.Assert(count, chk.Equals, 10)
 
-	resChan, errChan := pagingClient.GetMultiplePagesRetrySecondComplete(context.Background())
 	count = 0
-	for item := range resChan {
+	for iter, err := pagingClient.GetMultiplePagesRetrySecondAll(context.Background()); iter.NotDone(); err = iter.Next() {
+		c.Assert(err, chk.IsNil)
+		c.Assert(iter.Value().Properties, chk.NotNil)
 		count++
-		c.Assert(item, chk.NotNil)
 	}
 	c.Assert(count, chk.Equals, 10)
-	c.Assert(<-errChan, chk.IsNil)
 }
 
 func (s *PagingGroupSuite) TestGetSinglePagesFailure(c *chk.C) {
-	res, err := pagingClient.GetSinglePagesFailure(context.Background())
+	page, err := pagingClient.GetSinglePagesFailure(context.Background())
 	c.Assert(err, chk.NotNil)
-	c.Assert(res.StatusCode, chk.Equals, http.StatusBadRequest)
+	c.Assert(page.Response().StatusCode, chk.Equals, http.StatusBadRequest)
 
-	resChan, errChan := pagingClient.GetSinglePagesFailureComplete(context.Background())
 	count := 0
-	for item := range resChan {
+	for iter, err := pagingClient.GetSinglePagesFailureAll(context.Background()); iter.NotDone(); err = iter.Next() {
+		c.Assert(err, chk.IsNil)
+		c.Assert(iter.Value().Properties, chk.NotNil)
 		count++
-		c.Assert(item, chk.NotNil)
 	}
 	c.Assert(count, chk.Equals, 0)
-	c.Assert(<-errChan, chk.NotNil)
 }
 
 func (s *PagingGroupSuite) TestGetMultiplePagesFailure(c *chk.C) {
-	res, err := pagingClient.GetMultiplePagesFailure(context.Background())
+	page, err := pagingClient.GetMultiplePagesFailure(context.Background())
 	c.Assert(err, chk.IsNil)
-	c.Assert(res.NextLink, chk.NotNil)
-	res, err = pagingClient.GetMultiplePagesFailureNextResults(res)
+	c.Assert(page.NotDone(), chk.Equals, true)
+	err = page.Next()
 	c.Assert(err, chk.NotNil)
-	c.Assert(res.StatusCode, chk.Equals, http.StatusBadRequest)
+	//c.Assert(page.Response().StatusCode, chk.Equals, http.StatusBadRequest)
 
-	resChan, errChan := pagingClient.GetMultiplePagesFailureComplete(context.Background())
 	count := 0
-	for item := range resChan {
+	for iter, err := pagingClient.GetMultiplePagesFailureAll(context.Background()); err == nil; err = iter.Next() {
+		c.Assert(err, chk.IsNil)
+		c.Assert(iter.Value().Properties, chk.NotNil)
 		count++
-		c.Assert(item, chk.NotNil)
 	}
 	c.Assert(count, chk.Equals, 1)
-	c.Assert(<-errChan, chk.NotNil)
 }
 
 func (s *PagingGroupSuite) TestGetMultiplePagesFailureURI(c *chk.C) {
-	res, err := pagingClient.GetMultiplePagesFailureURI(context.Background())
+	page, err := pagingClient.GetMultiplePagesFailureURI(context.Background())
 	c.Assert(err, chk.IsNil)
-	c.Assert(*res.NextLink, chk.Equals, "*&*#&$")
-	_, err = pagingClient.GetMultiplePagesFailureURINextResults(res)
+	//c.Assert(*res.NextLink, chk.Equals, "*&*#&$")
+	err = page.Next()
 	c.Assert(err, chk.NotNil)
 	c.Assert(err, chk.ErrorMatches, ".*No scheme detected in URL.*")
 
-	resChan, errChan := pagingClient.GetMultiplePagesFailureURIComplete(context.Background())
 	count := 0
-	for item := range resChan {
+	for iter, err := pagingClient.GetMultiplePagesFailureURIAll(context.Background()); err == nil; err = iter.Next() {
+		c.Assert(err, chk.IsNil)
+		c.Assert(iter.Value(), chk.NotNil)
 		count++
-		c.Assert(item, chk.NotNil)
 	}
 	c.Assert(count, chk.Equals, 1)
-	err = <-errChan
 	c.Assert(err, chk.NotNil)
 	c.Assert(err, chk.ErrorMatches, ".*No scheme detected in URL.*")
 }
 
 func (s *PagingGroupSuite) TestGetMultiplePagesFragmentNextLink(c *chk.C) {
-	res, err := pagingClient.GetMultiplePagesFragmentNextLink(context.Background(), "1.6", "test_user")
-	c.Assert(err, chk.IsNil)
-	count := 1
-	for res.OdataNextLink != nil {
-		count++
-		resNext, err := pagingClient.NextFragment(context.Background(), "1.6", "test_user", *res.OdataNextLink)
+	count := 0
+	for page, err := pagingClient.GetMultiplePagesFragmentNextLink(context.Background(), "1.6", "test_user"); page.NotDone(); err = page.Next() {
 		c.Assert(err, chk.IsNil)
-		res = resNext
+		c.Assert(page.Values(), chk.NotNil)
+		count++
 	}
 	c.Assert(count, chk.Equals, 10)
 
-	resChan, errChan := pagingClient.GetMultiplePagesFragmentNextLinkComplete(context.Background(), "1.6", "test_user")
 	count = 0
-	for item := range resChan {
+	for iter, err := pagingClient.GetMultiplePagesFragmentNextLinkAll(context.Background(), "1.6", "test_user"); iter.NotDone(); err = iter.Next() {
+		c.Assert(err, chk.IsNil)
+		c.Assert(iter.Value(), chk.NotNil)
 		count++
-		c.Assert(item, chk.NotNil)
 	}
 	c.Assert(count, chk.Equals, 10)
-	c.Assert(<-errChan, chk.IsNil)
 }

--- a/test/src/tests/acceptancetests/paginggrouptest/paging_test.go
+++ b/test/src/tests/acceptancetests/paginggrouptest/paging_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest"
 	chk "gopkg.in/check.v1"
 
 	"tests/acceptancetests/utils"
@@ -154,7 +155,9 @@ func (s *PagingGroupSuite) TestGetMultiplePagesFailure(c *chk.C) {
 	c.Assert(page.NotDone(), chk.Equals, true)
 	err = page.Next()
 	c.Assert(err, chk.NotNil)
-	//c.Assert(page.Response().StatusCode, chk.Equals, http.StatusBadRequest)
+	detErr, ok := err.(autorest.DetailedError)
+	c.Assert(ok, chk.Equals, true)
+	c.Assert(detErr.StatusCode, chk.Equals, http.StatusBadRequest)
 
 	count := 0
 	for iter, err := pagingClient.GetMultiplePagesFailureComplete(context.Background()); err == nil; err = iter.Next() {
@@ -168,7 +171,7 @@ func (s *PagingGroupSuite) TestGetMultiplePagesFailure(c *chk.C) {
 func (s *PagingGroupSuite) TestGetMultiplePagesFailureURI(c *chk.C) {
 	page, err := pagingClient.GetMultiplePagesFailureURI(context.Background())
 	c.Assert(err, chk.IsNil)
-	//c.Assert(*res.NextLink, chk.Equals, "*&*#&$")
+	c.Assert(*page.Response().NextLink, chk.Equals, "*&*#&$")
 	err = page.Next()
 	c.Assert(err, chk.NotNil)
 	c.Assert(err, chk.ErrorMatches, ".*No scheme detected in URL.*")

--- a/test/src/tests/generated/azurereport/client.go
+++ b/test/src/tests/generated/azurereport/client.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Azurereport
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Azurereport.
@@ -41,8 +41,11 @@ func NewWithBaseURI(baseURI string) BaseClient {
 }
 
 // GetReport get test coverage report
-func (client BaseClient) GetReport(ctx context.Context) (result SetInt32, err error) {
-	req, err := client.GetReportPreparer(ctx)
+//
+// qualifier is if specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The only
+// effect is, that generators that run all tests several times, can distinguish the generated reports.
+func (client BaseClient) GetReport(ctx context.Context, qualifier string) (result SetInt32, err error) {
+	req, err := client.GetReportPreparer(ctx, qualifier)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "azurereport.BaseClient", "GetReport", nil, "Failure preparing request")
 		return
@@ -64,11 +67,17 @@ func (client BaseClient) GetReport(ctx context.Context) (result SetInt32, err er
 }
 
 // GetReportPreparer prepares the GetReport request.
-func (client BaseClient) GetReportPreparer(ctx context.Context) (*http.Request, error) {
+func (client BaseClient) GetReportPreparer(ctx context.Context, qualifier string) (*http.Request, error) {
+	queryParameters := map[string]interface{}{}
+	if len(qualifier) > 0 {
+		queryParameters["qualifier"] = autorest.Encode("query", qualifier)
+	}
+
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
 		autorest.WithBaseURL(client.BaseURI),
-		autorest.WithPath("/report/azure"))
+		autorest.WithPath("/report/azure"),
+		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 

--- a/test/src/tests/generated/body-array/client.go
+++ b/test/src/tests/generated/body-array/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Arraygroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Arraygroup.

--- a/test/src/tests/generated/body-boolean/client.go
+++ b/test/src/tests/generated/body-boolean/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Booleangroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Booleangroup.

--- a/test/src/tests/generated/body-byte/client.go
+++ b/test/src/tests/generated/body-byte/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Bytegroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Bytegroup.

--- a/test/src/tests/generated/body-complex/client.go
+++ b/test/src/tests/generated/body-complex/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Complexgroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Complexgroup.

--- a/test/src/tests/generated/body-complex/models.go
+++ b/test/src/tests/generated/body-complex/models.go
@@ -42,6 +42,8 @@ const (
 	FishtypeSawshark Fishtype = "sawshark"
 	// FishtypeShark specifies the fishtype shark state for fishtype.
 	FishtypeShark Fishtype = "shark"
+	// FishtypeSmartSalmon specifies the fishtype smart salmon state for fishtype.
+	FishtypeSmartSalmon Fishtype = "smart_salmon"
 )
 
 // ArrayWrapper
@@ -102,6 +104,16 @@ func (c Cookiecuttershark) MarshalJSON() ([]byte, error) {
 
 // AsSalmon is the BasicFish implementation for Cookiecuttershark.
 func (c Cookiecuttershark) AsSalmon() (*Salmon, bool) {
+	return nil, false
+}
+
+// AsBasicSalmon is the BasicFish implementation for Cookiecuttershark.
+func (c Cookiecuttershark) AsBasicSalmon() (BasicSalmon, bool) {
+	return nil, false
+}
+
+// AsSmartSalmon is the BasicFish implementation for Cookiecuttershark.
+func (c Cookiecuttershark) AsSmartSalmon() (*SmartSalmon, bool) {
 	return nil, false
 }
 
@@ -267,6 +279,8 @@ type Error struct {
 // BasicFish
 type BasicFish interface {
 	AsSalmon() (*Salmon, bool)
+	AsBasicSalmon() (BasicSalmon, bool)
+	AsSmartSalmon() (*SmartSalmon, bool)
 	AsShark() (*Shark, bool)
 	AsBasicShark() (BasicShark, bool)
 	AsSawshark() (*Sawshark, bool)
@@ -294,6 +308,10 @@ func unmarshalBasicFish(body []byte) (BasicFish, error) {
 	switch m["fishtype"] {
 	case string(FishtypeSalmon):
 		var s Salmon
+		err := json.Unmarshal(body, &s)
+		return s, err
+	case string(FishtypeSmartSalmon):
+		var s SmartSalmon
 		err := json.Unmarshal(body, &s)
 		return s, err
 	case string(FishtypeShark):
@@ -350,6 +368,16 @@ func (f Fish) MarshalJSON() ([]byte, error) {
 
 // AsSalmon is the BasicFish implementation for Fish.
 func (f Fish) AsSalmon() (*Salmon, bool) {
+	return nil, false
+}
+
+// AsBasicSalmon is the BasicFish implementation for Fish.
+func (f Fish) AsBasicSalmon() (BasicSalmon, bool) {
+	return nil, false
+}
+
+// AsSmartSalmon is the BasicFish implementation for Fish.
+func (f Fish) AsSmartSalmon() (*SmartSalmon, bool) {
 	return nil, false
 }
 
@@ -487,6 +515,16 @@ func (g Goblinshark) MarshalJSON() ([]byte, error) {
 
 // AsSalmon is the BasicFish implementation for Goblinshark.
 func (g Goblinshark) AsSalmon() (*Salmon, bool) {
+	return nil, false
+}
+
+// AsBasicSalmon is the BasicFish implementation for Goblinshark.
+func (g Goblinshark) AsBasicSalmon() (BasicSalmon, bool) {
+	return nil, false
+}
+
+// AsSmartSalmon is the BasicFish implementation for Goblinshark.
+func (g Goblinshark) AsSmartSalmon() (*SmartSalmon, bool) {
 	return nil, false
 }
 
@@ -633,14 +671,58 @@ type ReadonlyObj struct {
 	Size              *int32  `json:"size,omitempty"`
 }
 
+// BasicSalmon
+type BasicSalmon interface {
+	AsSmartSalmon() (*SmartSalmon, bool)
+	AsSalmon() (*Salmon, bool)
+}
+
 // Salmon
 type Salmon struct {
-	Species  *string      `json:"species,omitempty"`
-	Length   *float64     `json:"length,omitempty"`
-	Siblings *[]BasicFish `json:"siblings,omitempty"`
-	Fishtype Fishtype     `json:"fishtype,omitempty"`
-	Location *string      `json:"location,omitempty"`
-	Iswild   *bool        `json:"iswild,omitempty"`
+	autorest.Response `json:"-"`
+	Species           *string      `json:"species,omitempty"`
+	Length            *float64     `json:"length,omitempty"`
+	Siblings          *[]BasicFish `json:"siblings,omitempty"`
+	Fishtype          Fishtype     `json:"fishtype,omitempty"`
+	Location          *string      `json:"location,omitempty"`
+	Iswild            *bool        `json:"iswild,omitempty"`
+}
+
+func unmarshalBasicSalmon(body []byte) (BasicSalmon, error) {
+	var m map[string]interface{}
+	err := json.Unmarshal(body, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	switch m["fishtype"] {
+	case string(FishtypeSmartSalmon):
+		var s SmartSalmon
+		err := json.Unmarshal(body, &s)
+		return s, err
+	default:
+		var s Salmon
+		err := json.Unmarshal(body, &s)
+		return s, err
+	}
+}
+func unmarshalBasicSalmonArray(body []byte) ([]BasicSalmon, error) {
+	var rawMessages []*json.RawMessage
+	err := json.Unmarshal(body, &rawMessages)
+	if err != nil {
+		return nil, err
+	}
+
+	sArray := make([]BasicSalmon, len(rawMessages))
+
+	for index, rawMessage := range rawMessages {
+		s, err := unmarshalBasicSalmon(*rawMessage)
+		if err != nil {
+			return nil, err
+		}
+		sArray[index] = s
+	}
+	return sArray, nil
 }
 
 // MarshalJSON is the custom marshaler for Salmon.
@@ -657,6 +739,16 @@ func (s Salmon) MarshalJSON() ([]byte, error) {
 // AsSalmon is the BasicFish implementation for Salmon.
 func (s Salmon) AsSalmon() (*Salmon, bool) {
 	return &s, true
+}
+
+// AsBasicSalmon is the BasicFish implementation for Salmon.
+func (s Salmon) AsBasicSalmon() (BasicSalmon, bool) {
+	return &s, true
+}
+
+// AsSmartSalmon is the BasicFish implementation for Salmon.
+func (s Salmon) AsSmartSalmon() (*SmartSalmon, bool) {
+	return nil, false
 }
 
 // AsShark is the BasicFish implementation for Salmon.
@@ -765,6 +857,12 @@ func (s *Salmon) UnmarshalJSON(body []byte) error {
 	return nil
 }
 
+// SalmonModel
+type SalmonModel struct {
+	autorest.Response `json:"-"`
+	Value             *Salmon `json:"value,omitempty"`
+}
+
 // Sawshark
 type Sawshark struct {
 	Species  *string      `json:"species,omitempty"`
@@ -789,6 +887,16 @@ func (s Sawshark) MarshalJSON() ([]byte, error) {
 
 // AsSalmon is the BasicFish implementation for Sawshark.
 func (s Sawshark) AsSalmon() (*Salmon, bool) {
+	return nil, false
+}
+
+// AsBasicSalmon is the BasicFish implementation for Sawshark.
+func (s Sawshark) AsBasicSalmon() (BasicSalmon, bool) {
+	return nil, false
+}
+
+// AsSmartSalmon is the BasicFish implementation for Sawshark.
+func (s Sawshark) AsSmartSalmon() (*SmartSalmon, bool) {
 	return nil, false
 }
 
@@ -987,6 +1095,16 @@ func (s Shark) AsSalmon() (*Salmon, bool) {
 	return nil, false
 }
 
+// AsBasicSalmon is the BasicFish implementation for Shark.
+func (s Shark) AsBasicSalmon() (BasicSalmon, bool) {
+	return nil, false
+}
+
+// AsSmartSalmon is the BasicFish implementation for Shark.
+func (s Shark) AsSmartSalmon() (*SmartSalmon, bool) {
+	return nil, false
+}
+
 // AsShark is the BasicFish implementation for Shark.
 func (s Shark) AsShark() (*Shark, bool) {
 	return &s, true
@@ -1101,6 +1219,160 @@ type Siamese struct {
 	Color             *string `json:"color,omitempty"`
 	Hates             *[]Dog  `json:"hates,omitempty"`
 	Breed             *string `json:"breed,omitempty"`
+}
+
+// SmartSalmon
+type SmartSalmon struct {
+	Species              *string                             `json:"species,omitempty"`
+	Length               *float64                            `json:"length,omitempty"`
+	Siblings             *[]BasicFish                        `json:"siblings,omitempty"`
+	Fishtype             Fishtype                            `json:"fishtype,omitempty"`
+	Location             *string                             `json:"location,omitempty"`
+	Iswild               *bool                               `json:"iswild,omitempty"`
+	AdditionalProperties *map[string]*map[string]interface{} `json:",omitempty"`
+	CollegeDegree        *string                             `json:"college_degree,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for SmartSalmon.
+func (s SmartSalmon) MarshalJSON() ([]byte, error) {
+	s.Fishtype = FishtypeSmartSalmon
+	type Alias SmartSalmon
+	return json.Marshal(&struct {
+		Alias
+	}{
+		Alias: (Alias)(s),
+	})
+}
+
+// AsSalmon is the BasicFish implementation for SmartSalmon.
+func (s SmartSalmon) AsSalmon() (*Salmon, bool) {
+	return nil, false
+}
+
+// AsBasicSalmon is the BasicFish implementation for SmartSalmon.
+func (s SmartSalmon) AsBasicSalmon() (BasicSalmon, bool) {
+	return &s, true
+}
+
+// AsSmartSalmon is the BasicFish implementation for SmartSalmon.
+func (s SmartSalmon) AsSmartSalmon() (*SmartSalmon, bool) {
+	return &s, true
+}
+
+// AsShark is the BasicFish implementation for SmartSalmon.
+func (s SmartSalmon) AsShark() (*Shark, bool) {
+	return nil, false
+}
+
+// AsBasicShark is the BasicFish implementation for SmartSalmon.
+func (s SmartSalmon) AsBasicShark() (BasicShark, bool) {
+	return nil, false
+}
+
+// AsSawshark is the BasicFish implementation for SmartSalmon.
+func (s SmartSalmon) AsSawshark() (*Sawshark, bool) {
+	return nil, false
+}
+
+// AsGoblinshark is the BasicFish implementation for SmartSalmon.
+func (s SmartSalmon) AsGoblinshark() (*Goblinshark, bool) {
+	return nil, false
+}
+
+// AsCookiecuttershark is the BasicFish implementation for SmartSalmon.
+func (s SmartSalmon) AsCookiecuttershark() (*Cookiecuttershark, bool) {
+	return nil, false
+}
+
+// AsFish is the BasicFish implementation for SmartSalmon.
+func (s SmartSalmon) AsFish() (*Fish, bool) {
+	return nil, false
+}
+
+// AsBasicFish is the BasicFish implementation for SmartSalmon.
+func (s SmartSalmon) AsBasicFish() (BasicFish, bool) {
+	return &s, true
+}
+
+// UnmarshalJSON is the custom unmarshaler for SmartSalmon struct.
+func (s *SmartSalmon) UnmarshalJSON(body []byte) error {
+	var m map[string]*json.RawMessage
+	err := json.Unmarshal(body, &m)
+	if err != nil {
+		return err
+	}
+	var v *json.RawMessage
+
+	v = m["college_degree"]
+	if v != nil {
+		var collegeDegree string
+		err = json.Unmarshal(*m["college_degree"], &collegeDegree)
+		if err != nil {
+			return err
+		}
+		s.CollegeDegree = &collegeDegree
+	}
+
+	v = m["location"]
+	if v != nil {
+		var location string
+		err = json.Unmarshal(*m["location"], &location)
+		if err != nil {
+			return err
+		}
+		s.Location = &location
+	}
+
+	v = m["iswild"]
+	if v != nil {
+		var iswild bool
+		err = json.Unmarshal(*m["iswild"], &iswild)
+		if err != nil {
+			return err
+		}
+		s.Iswild = &iswild
+	}
+
+	v = m["species"]
+	if v != nil {
+		var species string
+		err = json.Unmarshal(*m["species"], &species)
+		if err != nil {
+			return err
+		}
+		s.Species = &species
+	}
+
+	v = m["length"]
+	if v != nil {
+		var length float64
+		err = json.Unmarshal(*m["length"], &length)
+		if err != nil {
+			return err
+		}
+		s.Length = &length
+	}
+
+	v = m["siblings"]
+	if v != nil {
+		siblings, err := unmarshalBasicFishArray(*m["siblings"])
+		if err != nil {
+			return err
+		}
+		s.Siblings = &siblings
+	}
+
+	v = m["fishtype"]
+	if v != nil {
+		var fishtype Fishtype
+		err = json.Unmarshal(*m["fishtype"], &fishtype)
+		if err != nil {
+			return err
+		}
+		s.Fishtype = fishtype
+	}
+
+	return nil
 }
 
 // StringWrapper

--- a/test/src/tests/generated/body-complex/polymorphism.go
+++ b/test/src/tests/generated/body-complex/polymorphism.go
@@ -29,6 +29,59 @@ func NewPolymorphismClientWithBaseURI(baseURI string) PolymorphismClient {
 	return PolymorphismClient{NewWithBaseURI(baseURI)}
 }
 
+// GetComplicated get complex types that are polymorphic, but not at the root of the hierarchy; also have additional
+// properties
+func (client PolymorphismClient) GetComplicated(ctx context.Context) (result SalmonModel, err error) {
+	req, err := client.GetComplicatedPreparer(ctx)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "complexgroup.PolymorphismClient", "GetComplicated", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.GetComplicatedSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "complexgroup.PolymorphismClient", "GetComplicated", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.GetComplicatedResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "complexgroup.PolymorphismClient", "GetComplicated", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// GetComplicatedPreparer prepares the GetComplicated request.
+func (client PolymorphismClient) GetComplicatedPreparer(ctx context.Context) (*http.Request, error) {
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPath("/complex/polymorphism/complicated"))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// GetComplicatedSender sends the GetComplicated request. The method will close the
+// http.Response Body if it receives an error.
+func (client PolymorphismClient) GetComplicatedSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+}
+
+// GetComplicatedResponder handles the response to the GetComplicated request. The method always
+// closes the http.Response Body.
+func (client PolymorphismClient) GetComplicatedResponder(resp *http.Response) (result SalmonModel, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Value),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
 // GetValid get complex types that are polymorphic
 func (client PolymorphismClient) GetValid(ctx context.Context) (result FishModel, err error) {
 	req, err := client.GetValidPreparer(ctx)
@@ -78,6 +131,61 @@ func (client PolymorphismClient) GetValidResponder(resp *http.Response) (result 
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
 	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// PutComplicated put complex types that are polymorphic, but not at the root of the hierarchy; also have additional
+// properties
+//
+func (client PolymorphismClient) PutComplicated(ctx context.Context, complexBody BasicSalmon) (result autorest.Response, err error) {
+	req, err := client.PutComplicatedPreparer(ctx, complexBody)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "complexgroup.PolymorphismClient", "PutComplicated", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.PutComplicatedSender(req)
+	if err != nil {
+		result.Response = resp
+		err = autorest.NewErrorWithError(err, "complexgroup.PolymorphismClient", "PutComplicated", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.PutComplicatedResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "complexgroup.PolymorphismClient", "PutComplicated", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// PutComplicatedPreparer prepares the PutComplicated request.
+func (client PolymorphismClient) PutComplicatedPreparer(ctx context.Context, complexBody BasicSalmon) (*http.Request, error) {
+	preparer := autorest.CreatePreparer(
+		autorest.AsJSON(),
+		autorest.AsPut(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPath("/complex/polymorphism/complicated"),
+		autorest.WithJSON(complexBody))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// PutComplicatedSender sends the PutComplicated request. The method will close the
+// http.Response Body if it receives an error.
+func (client PolymorphismClient) PutComplicatedSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+}
+
+// PutComplicatedResponder handles the response to the PutComplicated request. The method always
+// closes the http.Response Body.
+func (client PolymorphismClient) PutComplicatedResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result.Response = resp
 	return
 }
 

--- a/test/src/tests/generated/body-date/client.go
+++ b/test/src/tests/generated/body-date/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Dategroup
-	DefaultBaseURI = "https://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Dategroup.

--- a/test/src/tests/generated/body-datetime-rfc1123/client.go
+++ b/test/src/tests/generated/body-datetime-rfc1123/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Datetimerfc1123group
-	DefaultBaseURI = "https://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Datetimerfc1123group.

--- a/test/src/tests/generated/body-datetime/client.go
+++ b/test/src/tests/generated/body-datetime/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Datetimegroup
-	DefaultBaseURI = "https://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Datetimegroup.

--- a/test/src/tests/generated/body-dictionary/client.go
+++ b/test/src/tests/generated/body-dictionary/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Dictionarygroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Dictionarygroup.

--- a/test/src/tests/generated/body-duration/client.go
+++ b/test/src/tests/generated/body-duration/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Durationgroup
-	DefaultBaseURI = "https://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Durationgroup.

--- a/test/src/tests/generated/body-file/client.go
+++ b/test/src/tests/generated/body-file/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Filegroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Filegroup.

--- a/test/src/tests/generated/body-formdata/client.go
+++ b/test/src/tests/generated/body-formdata/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Formdatagroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Formdatagroup.

--- a/test/src/tests/generated/body-integer/client.go
+++ b/test/src/tests/generated/body-integer/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Integergroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Integergroup.

--- a/test/src/tests/generated/body-number/client.go
+++ b/test/src/tests/generated/body-number/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Numbergroup
-	DefaultBaseURI = "https://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Numbergroup.

--- a/test/src/tests/generated/body-string/client.go
+++ b/test/src/tests/generated/body-string/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Stringgroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Stringgroup.

--- a/test/src/tests/generated/body-string/string.go
+++ b/test/src/tests/generated/body-string/string.go
@@ -184,7 +184,7 @@ func (client StringClient) GetEmptyResponder(resp *http.Response) (result String
 	return
 }
 
-// GetMbcs get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '
+// GetMbcs get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
 func (client StringClient) GetMbcs(ctx context.Context) (result StringModel, err error) {
 	req, err := client.GetMbcsPreparer(ctx)
 	if err != nil {
@@ -554,7 +554,7 @@ func (client StringClient) PutEmptyResponder(resp *http.Response) (result autore
 	return
 }
 
-// PutMbcs set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ▇█〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€ '
+// PutMbcs set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
 //
 // stringBody is
 func (client StringClient) PutMbcs(ctx context.Context, stringBody string) (result autorest.Response, err error) {

--- a/test/src/tests/generated/header/client.go
+++ b/test/src/tests/generated/header/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Headergroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Headergroup.

--- a/test/src/tests/generated/httpinfrastructure/client.go
+++ b/test/src/tests/generated/httpinfrastructure/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Httpinfrastructuregroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Httpinfrastructuregroup.

--- a/test/src/tests/generated/lro/client.go
+++ b/test/src/tests/generated/lro/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Lrogroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Lrogroup.

--- a/test/src/tests/generated/lro/lroretrys.go
+++ b/test/src/tests/generated/lro/lroretrys.go
@@ -39,7 +39,7 @@ func (client LRORetrysClient) Delete202Retry200(ctx context.Context) (result LRO
 
 	result, err = client.Delete202Retry200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "Delete202Retry200", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "Delete202Retry200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -57,12 +57,17 @@ func (client LRORetrysClient) Delete202Retry200Preparer(ctx context.Context) (*h
 
 // Delete202Retry200Sender sends the Delete202Retry200 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LRORetrysClient) Delete202Retry200Sender(req *http.Request) (LRORetrysDelete202Retry200Future, error) {
+func (client LRORetrysClient) Delete202Retry200Sender(req *http.Request) (future LRORetrysDelete202Retry200Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LRORetrysDelete202Retry200Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // Delete202Retry200Responder handles the response to the Delete202Retry200 request. The method always
@@ -88,7 +93,7 @@ func (client LRORetrysClient) DeleteAsyncRelativeRetrySucceeded(ctx context.Cont
 
 	result, err = client.DeleteAsyncRelativeRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "DeleteAsyncRelativeRetrySucceeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "DeleteAsyncRelativeRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -106,12 +111,17 @@ func (client LRORetrysClient) DeleteAsyncRelativeRetrySucceededPreparer(ctx cont
 
 // DeleteAsyncRelativeRetrySucceededSender sends the DeleteAsyncRelativeRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LRORetrysClient) DeleteAsyncRelativeRetrySucceededSender(req *http.Request) (LRORetrysDeleteAsyncRelativeRetrySucceededFuture, error) {
+func (client LRORetrysClient) DeleteAsyncRelativeRetrySucceededSender(req *http.Request) (future LRORetrysDeleteAsyncRelativeRetrySucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LRORetrysDeleteAsyncRelativeRetrySucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // DeleteAsyncRelativeRetrySucceededResponder handles the response to the DeleteAsyncRelativeRetrySucceeded request. The method always
@@ -138,7 +148,7 @@ func (client LRORetrysClient) DeleteProvisioning202Accepted200Succeeded(ctx cont
 
 	result, err = client.DeleteProvisioning202Accepted200SucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "DeleteProvisioning202Accepted200Succeeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "DeleteProvisioning202Accepted200Succeeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -156,12 +166,17 @@ func (client LRORetrysClient) DeleteProvisioning202Accepted200SucceededPreparer(
 
 // DeleteProvisioning202Accepted200SucceededSender sends the DeleteProvisioning202Accepted200Succeeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LRORetrysClient) DeleteProvisioning202Accepted200SucceededSender(req *http.Request) (LRORetrysDeleteProvisioning202Accepted200SucceededFuture, error) {
+func (client LRORetrysClient) DeleteProvisioning202Accepted200SucceededSender(req *http.Request) (future LRORetrysDeleteProvisioning202Accepted200SucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LRORetrysDeleteProvisioning202Accepted200SucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // DeleteProvisioning202Accepted200SucceededResponder handles the response to the DeleteProvisioning202Accepted200Succeeded request. The method always
@@ -190,7 +205,7 @@ func (client LRORetrysClient) Post202Retry200(ctx context.Context, product *Prod
 
 	result, err = client.Post202Retry200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "Post202Retry200", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "Post202Retry200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -213,12 +228,17 @@ func (client LRORetrysClient) Post202Retry200Preparer(ctx context.Context, produ
 
 // Post202Retry200Sender sends the Post202Retry200 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LRORetrysClient) Post202Retry200Sender(req *http.Request) (LRORetrysPost202Retry200Future, error) {
+func (client LRORetrysClient) Post202Retry200Sender(req *http.Request) (future LRORetrysPost202Retry200Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LRORetrysPost202Retry200Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // Post202Retry200Responder handles the response to the Post202Retry200 request. The method always
@@ -247,7 +267,7 @@ func (client LRORetrysClient) PostAsyncRelativeRetrySucceeded(ctx context.Contex
 
 	result, err = client.PostAsyncRelativeRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "PostAsyncRelativeRetrySucceeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "PostAsyncRelativeRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -270,12 +290,17 @@ func (client LRORetrysClient) PostAsyncRelativeRetrySucceededPreparer(ctx contex
 
 // PostAsyncRelativeRetrySucceededSender sends the PostAsyncRelativeRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LRORetrysClient) PostAsyncRelativeRetrySucceededSender(req *http.Request) (LRORetrysPostAsyncRelativeRetrySucceededFuture, error) {
+func (client LRORetrysClient) PostAsyncRelativeRetrySucceededSender(req *http.Request) (future LRORetrysPostAsyncRelativeRetrySucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LRORetrysPostAsyncRelativeRetrySucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // PostAsyncRelativeRetrySucceededResponder handles the response to the PostAsyncRelativeRetrySucceeded request. The method always
@@ -304,7 +329,7 @@ func (client LRORetrysClient) Put201CreatingSucceeded200(ctx context.Context, pr
 
 	result, err = client.Put201CreatingSucceeded200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "Put201CreatingSucceeded200", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "Put201CreatingSucceeded200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -327,12 +352,17 @@ func (client LRORetrysClient) Put201CreatingSucceeded200Preparer(ctx context.Con
 
 // Put201CreatingSucceeded200Sender sends the Put201CreatingSucceeded200 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LRORetrysClient) Put201CreatingSucceeded200Sender(req *http.Request) (LRORetrysPut201CreatingSucceeded200Future, error) {
+func (client LRORetrysClient) Put201CreatingSucceeded200Sender(req *http.Request) (future LRORetrysPut201CreatingSucceeded200Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LRORetrysPut201CreatingSucceeded200Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	return
 }
 
 // Put201CreatingSucceeded200Responder handles the response to the Put201CreatingSucceeded200 request. The method always
@@ -362,7 +392,7 @@ func (client LRORetrysClient) PutAsyncRelativeRetrySucceeded(ctx context.Context
 
 	result, err = client.PutAsyncRelativeRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "PutAsyncRelativeRetrySucceeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "PutAsyncRelativeRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -385,12 +415,17 @@ func (client LRORetrysClient) PutAsyncRelativeRetrySucceededPreparer(ctx context
 
 // PutAsyncRelativeRetrySucceededSender sends the PutAsyncRelativeRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LRORetrysClient) PutAsyncRelativeRetrySucceededSender(req *http.Request) (LRORetrysPutAsyncRelativeRetrySucceededFuture, error) {
+func (client LRORetrysClient) PutAsyncRelativeRetrySucceededSender(req *http.Request) (future LRORetrysPutAsyncRelativeRetrySucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LRORetrysPutAsyncRelativeRetrySucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	return
 }
 
 // PutAsyncRelativeRetrySucceededResponder handles the response to the PutAsyncRelativeRetrySucceeded request. The method always

--- a/test/src/tests/generated/lro/lros.go
+++ b/test/src/tests/generated/lro/lros.go
@@ -39,7 +39,7 @@ func (client LROsClient) Delete202NoRetry204(ctx context.Context) (result LROsDe
 
 	result, err = client.Delete202NoRetry204Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Delete202NoRetry204", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Delete202NoRetry204", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -57,12 +57,17 @@ func (client LROsClient) Delete202NoRetry204Preparer(ctx context.Context) (*http
 
 // Delete202NoRetry204Sender sends the Delete202NoRetry204 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) Delete202NoRetry204Sender(req *http.Request) (LROsDelete202NoRetry204Future, error) {
+func (client LROsClient) Delete202NoRetry204Sender(req *http.Request) (future LROsDelete202NoRetry204Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsDelete202NoRetry204Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // Delete202NoRetry204Responder handles the response to the Delete202NoRetry204 request. The method always
@@ -89,7 +94,7 @@ func (client LROsClient) Delete202Retry200(ctx context.Context) (result LROsDele
 
 	result, err = client.Delete202Retry200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Delete202Retry200", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Delete202Retry200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -107,12 +112,17 @@ func (client LROsClient) Delete202Retry200Preparer(ctx context.Context) (*http.R
 
 // Delete202Retry200Sender sends the Delete202Retry200 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) Delete202Retry200Sender(req *http.Request) (LROsDelete202Retry200Future, error) {
+func (client LROsClient) Delete202Retry200Sender(req *http.Request) (future LROsDelete202Retry200Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsDelete202Retry200Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // Delete202Retry200Responder handles the response to the Delete202Retry200 request. The method always
@@ -138,7 +148,7 @@ func (client LROsClient) Delete204Succeeded(ctx context.Context) (result LROsDel
 
 	result, err = client.Delete204SucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Delete204Succeeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Delete204Succeeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -156,12 +166,17 @@ func (client LROsClient) Delete204SucceededPreparer(ctx context.Context) (*http.
 
 // Delete204SucceededSender sends the Delete204Succeeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) Delete204SucceededSender(req *http.Request) (LROsDelete204SucceededFuture, error) {
+func (client LROsClient) Delete204SucceededSender(req *http.Request) (future LROsDelete204SucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsDelete204SucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent))
+	return
 }
 
 // Delete204SucceededResponder handles the response to the Delete204Succeeded request. The method always
@@ -187,7 +202,7 @@ func (client LROsClient) DeleteAsyncNoHeaderInRetry(ctx context.Context) (result
 
 	result, err = client.DeleteAsyncNoHeaderInRetrySender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncNoHeaderInRetry", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncNoHeaderInRetry", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -205,12 +220,17 @@ func (client LROsClient) DeleteAsyncNoHeaderInRetryPreparer(ctx context.Context)
 
 // DeleteAsyncNoHeaderInRetrySender sends the DeleteAsyncNoHeaderInRetry request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) DeleteAsyncNoHeaderInRetrySender(req *http.Request) (LROsDeleteAsyncNoHeaderInRetryFuture, error) {
+func (client LROsClient) DeleteAsyncNoHeaderInRetrySender(req *http.Request) (future LROsDeleteAsyncNoHeaderInRetryFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsDeleteAsyncNoHeaderInRetryFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent, http.StatusAccepted))
+	return
 }
 
 // DeleteAsyncNoHeaderInRetryResponder handles the response to the DeleteAsyncNoHeaderInRetry request. The method always
@@ -236,7 +256,7 @@ func (client LROsClient) DeleteAsyncNoRetrySucceeded(ctx context.Context) (resul
 
 	result, err = client.DeleteAsyncNoRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncNoRetrySucceeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncNoRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -254,12 +274,17 @@ func (client LROsClient) DeleteAsyncNoRetrySucceededPreparer(ctx context.Context
 
 // DeleteAsyncNoRetrySucceededSender sends the DeleteAsyncNoRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) DeleteAsyncNoRetrySucceededSender(req *http.Request) (LROsDeleteAsyncNoRetrySucceededFuture, error) {
+func (client LROsClient) DeleteAsyncNoRetrySucceededSender(req *http.Request) (future LROsDeleteAsyncNoRetrySucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsDeleteAsyncNoRetrySucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // DeleteAsyncNoRetrySucceededResponder handles the response to the DeleteAsyncNoRetrySucceeded request. The method always
@@ -285,7 +310,7 @@ func (client LROsClient) DeleteAsyncRetrycanceled(ctx context.Context) (result L
 
 	result, err = client.DeleteAsyncRetrycanceledSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncRetrycanceled", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncRetrycanceled", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -303,12 +328,17 @@ func (client LROsClient) DeleteAsyncRetrycanceledPreparer(ctx context.Context) (
 
 // DeleteAsyncRetrycanceledSender sends the DeleteAsyncRetrycanceled request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) DeleteAsyncRetrycanceledSender(req *http.Request) (LROsDeleteAsyncRetrycanceledFuture, error) {
+func (client LROsClient) DeleteAsyncRetrycanceledSender(req *http.Request) (future LROsDeleteAsyncRetrycanceledFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsDeleteAsyncRetrycanceledFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // DeleteAsyncRetrycanceledResponder handles the response to the DeleteAsyncRetrycanceled request. The method always
@@ -334,7 +364,7 @@ func (client LROsClient) DeleteAsyncRetryFailed(ctx context.Context) (result LRO
 
 	result, err = client.DeleteAsyncRetryFailedSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncRetryFailed", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncRetryFailed", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -352,12 +382,17 @@ func (client LROsClient) DeleteAsyncRetryFailedPreparer(ctx context.Context) (*h
 
 // DeleteAsyncRetryFailedSender sends the DeleteAsyncRetryFailed request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) DeleteAsyncRetryFailedSender(req *http.Request) (LROsDeleteAsyncRetryFailedFuture, error) {
+func (client LROsClient) DeleteAsyncRetryFailedSender(req *http.Request) (future LROsDeleteAsyncRetryFailedFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsDeleteAsyncRetryFailedFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // DeleteAsyncRetryFailedResponder handles the response to the DeleteAsyncRetryFailed request. The method always
@@ -383,7 +418,7 @@ func (client LROsClient) DeleteAsyncRetrySucceeded(ctx context.Context) (result 
 
 	result, err = client.DeleteAsyncRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncRetrySucceeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -401,12 +436,17 @@ func (client LROsClient) DeleteAsyncRetrySucceededPreparer(ctx context.Context) 
 
 // DeleteAsyncRetrySucceededSender sends the DeleteAsyncRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) DeleteAsyncRetrySucceededSender(req *http.Request) (LROsDeleteAsyncRetrySucceededFuture, error) {
+func (client LROsClient) DeleteAsyncRetrySucceededSender(req *http.Request) (future LROsDeleteAsyncRetrySucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsDeleteAsyncRetrySucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // DeleteAsyncRetrySucceededResponder handles the response to the DeleteAsyncRetrySucceeded request. The method always
@@ -432,7 +472,7 @@ func (client LROsClient) DeleteNoHeaderInRetry(ctx context.Context) (result LROs
 
 	result, err = client.DeleteNoHeaderInRetrySender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteNoHeaderInRetry", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteNoHeaderInRetry", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -450,12 +490,17 @@ func (client LROsClient) DeleteNoHeaderInRetryPreparer(ctx context.Context) (*ht
 
 // DeleteNoHeaderInRetrySender sends the DeleteNoHeaderInRetry request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) DeleteNoHeaderInRetrySender(req *http.Request) (LROsDeleteNoHeaderInRetryFuture, error) {
+func (client LROsClient) DeleteNoHeaderInRetrySender(req *http.Request) (future LROsDeleteNoHeaderInRetryFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsDeleteNoHeaderInRetryFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent, http.StatusAccepted))
+	return
 }
 
 // DeleteNoHeaderInRetryResponder handles the response to the DeleteNoHeaderInRetry request. The method always
@@ -482,7 +527,7 @@ func (client LROsClient) DeleteProvisioning202Accepted200Succeeded(ctx context.C
 
 	result, err = client.DeleteProvisioning202Accepted200SucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteProvisioning202Accepted200Succeeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteProvisioning202Accepted200Succeeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -500,12 +545,17 @@ func (client LROsClient) DeleteProvisioning202Accepted200SucceededPreparer(ctx c
 
 // DeleteProvisioning202Accepted200SucceededSender sends the DeleteProvisioning202Accepted200Succeeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) DeleteProvisioning202Accepted200SucceededSender(req *http.Request) (LROsDeleteProvisioning202Accepted200SucceededFuture, error) {
+func (client LROsClient) DeleteProvisioning202Accepted200SucceededSender(req *http.Request) (future LROsDeleteProvisioning202Accepted200SucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsDeleteProvisioning202Accepted200SucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // DeleteProvisioning202Accepted200SucceededResponder handles the response to the DeleteProvisioning202Accepted200Succeeded request. The method always
@@ -533,7 +583,7 @@ func (client LROsClient) DeleteProvisioning202Deletingcanceled200(ctx context.Co
 
 	result, err = client.DeleteProvisioning202Deletingcanceled200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteProvisioning202Deletingcanceled200", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteProvisioning202Deletingcanceled200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -551,12 +601,17 @@ func (client LROsClient) DeleteProvisioning202Deletingcanceled200Preparer(ctx co
 
 // DeleteProvisioning202Deletingcanceled200Sender sends the DeleteProvisioning202Deletingcanceled200 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) DeleteProvisioning202Deletingcanceled200Sender(req *http.Request) (LROsDeleteProvisioning202Deletingcanceled200Future, error) {
+func (client LROsClient) DeleteProvisioning202Deletingcanceled200Sender(req *http.Request) (future LROsDeleteProvisioning202Deletingcanceled200Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsDeleteProvisioning202Deletingcanceled200Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // DeleteProvisioning202Deletingcanceled200Responder handles the response to the DeleteProvisioning202Deletingcanceled200 request. The method always
@@ -584,7 +639,7 @@ func (client LROsClient) DeleteProvisioning202DeletingFailed200(ctx context.Cont
 
 	result, err = client.DeleteProvisioning202DeletingFailed200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteProvisioning202DeletingFailed200", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteProvisioning202DeletingFailed200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -602,12 +657,17 @@ func (client LROsClient) DeleteProvisioning202DeletingFailed200Preparer(ctx cont
 
 // DeleteProvisioning202DeletingFailed200Sender sends the DeleteProvisioning202DeletingFailed200 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) DeleteProvisioning202DeletingFailed200Sender(req *http.Request) (LROsDeleteProvisioning202DeletingFailed200Future, error) {
+func (client LROsClient) DeleteProvisioning202DeletingFailed200Sender(req *http.Request) (future LROsDeleteProvisioning202DeletingFailed200Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsDeleteProvisioning202DeletingFailed200Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // DeleteProvisioning202DeletingFailed200Responder handles the response to the DeleteProvisioning202DeletingFailed200 request. The method always
@@ -634,7 +694,7 @@ func (client LROsClient) Post200WithPayload(ctx context.Context) (result LROsPos
 
 	result, err = client.Post200WithPayloadSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Post200WithPayload", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Post200WithPayload", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -652,12 +712,17 @@ func (client LROsClient) Post200WithPayloadPreparer(ctx context.Context) (*http.
 
 // Post200WithPayloadSender sends the Post200WithPayload request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) Post200WithPayloadSender(req *http.Request) (LROsPost200WithPayloadFuture, error) {
+func (client LROsClient) Post200WithPayloadSender(req *http.Request) (future LROsPost200WithPayloadFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPost200WithPayloadFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusAccepted, http.StatusOK))
+	return
 }
 
 // Post200WithPayloadResponder handles the response to the Post200WithPayload request. The method always
@@ -686,7 +751,7 @@ func (client LROsClient) Post202NoRetry204(ctx context.Context, product *Product
 
 	result, err = client.Post202NoRetry204Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Post202NoRetry204", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Post202NoRetry204", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -709,12 +774,17 @@ func (client LROsClient) Post202NoRetry204Preparer(ctx context.Context, product 
 
 // Post202NoRetry204Sender sends the Post202NoRetry204 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) Post202NoRetry204Sender(req *http.Request) (LROsPost202NoRetry204Future, error) {
+func (client LROsClient) Post202NoRetry204Sender(req *http.Request) (future LROsPost202NoRetry204Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPost202NoRetry204Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // Post202NoRetry204Responder handles the response to the Post202NoRetry204 request. The method always
@@ -743,7 +813,7 @@ func (client LROsClient) Post202Retry200(ctx context.Context, product *Product) 
 
 	result, err = client.Post202Retry200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Post202Retry200", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Post202Retry200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -766,12 +836,17 @@ func (client LROsClient) Post202Retry200Preparer(ctx context.Context, product *P
 
 // Post202Retry200Sender sends the Post202Retry200 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) Post202Retry200Sender(req *http.Request) (LROsPost202Retry200Future, error) {
+func (client LROsClient) Post202Retry200Sender(req *http.Request) (future LROsPost202Retry200Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPost202Retry200Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // Post202Retry200Responder handles the response to the Post202Retry200 request. The method always
@@ -800,7 +875,7 @@ func (client LROsClient) PostAsyncNoRetrySucceeded(ctx context.Context, product 
 
 	result, err = client.PostAsyncNoRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncNoRetrySucceeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncNoRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -823,12 +898,17 @@ func (client LROsClient) PostAsyncNoRetrySucceededPreparer(ctx context.Context, 
 
 // PostAsyncNoRetrySucceededSender sends the PostAsyncNoRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) PostAsyncNoRetrySucceededSender(req *http.Request) (LROsPostAsyncNoRetrySucceededFuture, error) {
+func (client LROsClient) PostAsyncNoRetrySucceededSender(req *http.Request) (future LROsPostAsyncNoRetrySucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPostAsyncNoRetrySucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusAccepted, http.StatusOK))
+	return
 }
 
 // PostAsyncNoRetrySucceededResponder handles the response to the PostAsyncNoRetrySucceeded request. The method always
@@ -858,7 +938,7 @@ func (client LROsClient) PostAsyncRetrycanceled(ctx context.Context, product *Pr
 
 	result, err = client.PostAsyncRetrycanceledSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncRetrycanceled", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncRetrycanceled", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -881,12 +961,17 @@ func (client LROsClient) PostAsyncRetrycanceledPreparer(ctx context.Context, pro
 
 // PostAsyncRetrycanceledSender sends the PostAsyncRetrycanceled request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) PostAsyncRetrycanceledSender(req *http.Request) (LROsPostAsyncRetrycanceledFuture, error) {
+func (client LROsClient) PostAsyncRetrycanceledSender(req *http.Request) (future LROsPostAsyncRetrycanceledFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPostAsyncRetrycanceledFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // PostAsyncRetrycanceledResponder handles the response to the PostAsyncRetrycanceled request. The method always
@@ -915,7 +1000,7 @@ func (client LROsClient) PostAsyncRetryFailed(ctx context.Context, product *Prod
 
 	result, err = client.PostAsyncRetryFailedSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncRetryFailed", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncRetryFailed", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -938,12 +1023,17 @@ func (client LROsClient) PostAsyncRetryFailedPreparer(ctx context.Context, produ
 
 // PostAsyncRetryFailedSender sends the PostAsyncRetryFailed request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) PostAsyncRetryFailedSender(req *http.Request) (LROsPostAsyncRetryFailedFuture, error) {
+func (client LROsClient) PostAsyncRetryFailedSender(req *http.Request) (future LROsPostAsyncRetryFailedFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPostAsyncRetryFailedFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // PostAsyncRetryFailedResponder handles the response to the PostAsyncRetryFailed request. The method always
@@ -972,7 +1062,7 @@ func (client LROsClient) PostAsyncRetrySucceeded(ctx context.Context, product *P
 
 	result, err = client.PostAsyncRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncRetrySucceeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -995,12 +1085,17 @@ func (client LROsClient) PostAsyncRetrySucceededPreparer(ctx context.Context, pr
 
 // PostAsyncRetrySucceededSender sends the PostAsyncRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) PostAsyncRetrySucceededSender(req *http.Request) (LROsPostAsyncRetrySucceededFuture, error) {
+func (client LROsClient) PostAsyncRetrySucceededSender(req *http.Request) (future LROsPostAsyncRetrySucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPostAsyncRetrySucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusAccepted, http.StatusOK))
+	return
 }
 
 // PostAsyncRetrySucceededResponder handles the response to the PostAsyncRetrySucceeded request. The method always
@@ -1030,7 +1125,7 @@ func (client LROsClient) Put200Acceptedcanceled200(ctx context.Context, product 
 
 	result, err = client.Put200Acceptedcanceled200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200Acceptedcanceled200", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200Acceptedcanceled200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1053,12 +1148,17 @@ func (client LROsClient) Put200Acceptedcanceled200Preparer(ctx context.Context, 
 
 // Put200Acceptedcanceled200Sender sends the Put200Acceptedcanceled200 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) Put200Acceptedcanceled200Sender(req *http.Request) (LROsPut200Acceptedcanceled200Future, error) {
+func (client LROsClient) Put200Acceptedcanceled200Sender(req *http.Request) (future LROsPut200Acceptedcanceled200Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPut200Acceptedcanceled200Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	return
 }
 
 // Put200Acceptedcanceled200Responder handles the response to the Put200Acceptedcanceled200 request. The method always
@@ -1087,7 +1187,7 @@ func (client LROsClient) Put200Succeeded(ctx context.Context, product *Product) 
 
 	result, err = client.Put200SucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200Succeeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200Succeeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1110,12 +1210,17 @@ func (client LROsClient) Put200SucceededPreparer(ctx context.Context, product *P
 
 // Put200SucceededSender sends the Put200Succeeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) Put200SucceededSender(req *http.Request) (LROsPut200SucceededFuture, error) {
+func (client LROsClient) Put200SucceededSender(req *http.Request) (future LROsPut200SucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPut200SucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent))
+	return
 }
 
 // Put200SucceededResponder handles the response to the Put200Succeeded request. The method always
@@ -1144,7 +1249,7 @@ func (client LROsClient) Put200SucceededNoState(ctx context.Context, product *Pr
 
 	result, err = client.Put200SucceededNoStateSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200SucceededNoState", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200SucceededNoState", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1167,12 +1272,17 @@ func (client LROsClient) Put200SucceededNoStatePreparer(ctx context.Context, pro
 
 // Put200SucceededNoStateSender sends the Put200SucceededNoState request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) Put200SucceededNoStateSender(req *http.Request) (LROsPut200SucceededNoStateFuture, error) {
+func (client LROsClient) Put200SucceededNoStateSender(req *http.Request) (future LROsPut200SucceededNoStateFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPut200SucceededNoStateFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	return
 }
 
 // Put200SucceededNoStateResponder handles the response to the Put200SucceededNoState request. The method always
@@ -1202,7 +1312,7 @@ func (client LROsClient) Put200UpdatingSucceeded204(ctx context.Context, product
 
 	result, err = client.Put200UpdatingSucceeded204Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200UpdatingSucceeded204", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200UpdatingSucceeded204", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1225,12 +1335,17 @@ func (client LROsClient) Put200UpdatingSucceeded204Preparer(ctx context.Context,
 
 // Put200UpdatingSucceeded204Sender sends the Put200UpdatingSucceeded204 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) Put200UpdatingSucceeded204Sender(req *http.Request) (LROsPut200UpdatingSucceeded204Future, error) {
+func (client LROsClient) Put200UpdatingSucceeded204Sender(req *http.Request) (future LROsPut200UpdatingSucceeded204Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPut200UpdatingSucceeded204Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	return
 }
 
 // Put200UpdatingSucceeded204Responder handles the response to the Put200UpdatingSucceeded204 request. The method always
@@ -1260,7 +1375,7 @@ func (client LROsClient) Put201CreatingFailed200(ctx context.Context, product *P
 
 	result, err = client.Put201CreatingFailed200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put201CreatingFailed200", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put201CreatingFailed200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1283,12 +1398,17 @@ func (client LROsClient) Put201CreatingFailed200Preparer(ctx context.Context, pr
 
 // Put201CreatingFailed200Sender sends the Put201CreatingFailed200 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) Put201CreatingFailed200Sender(req *http.Request) (LROsPut201CreatingFailed200Future, error) {
+func (client LROsClient) Put201CreatingFailed200Sender(req *http.Request) (future LROsPut201CreatingFailed200Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPut201CreatingFailed200Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	return
 }
 
 // Put201CreatingFailed200Responder handles the response to the Put201CreatingFailed200 request. The method always
@@ -1318,7 +1438,7 @@ func (client LROsClient) Put201CreatingSucceeded200(ctx context.Context, product
 
 	result, err = client.Put201CreatingSucceeded200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put201CreatingSucceeded200", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put201CreatingSucceeded200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1341,12 +1461,17 @@ func (client LROsClient) Put201CreatingSucceeded200Preparer(ctx context.Context,
 
 // Put201CreatingSucceeded200Sender sends the Put201CreatingSucceeded200 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) Put201CreatingSucceeded200Sender(req *http.Request) (LROsPut201CreatingSucceeded200Future, error) {
+func (client LROsClient) Put201CreatingSucceeded200Sender(req *http.Request) (future LROsPut201CreatingSucceeded200Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPut201CreatingSucceeded200Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	return
 }
 
 // Put201CreatingSucceeded200Responder handles the response to the Put201CreatingSucceeded200 request. The method always
@@ -1375,7 +1500,7 @@ func (client LROsClient) Put202Retry200(ctx context.Context, product *Product) (
 
 	result, err = client.Put202Retry200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put202Retry200", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put202Retry200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1398,12 +1523,17 @@ func (client LROsClient) Put202Retry200Preparer(ctx context.Context, product *Pr
 
 // Put202Retry200Sender sends the Put202Retry200 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) Put202Retry200Sender(req *http.Request) (LROsPut202Retry200Future, error) {
+func (client LROsClient) Put202Retry200Sender(req *http.Request) (future LROsPut202Retry200Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPut202Retry200Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // Put202Retry200Responder handles the response to the Put202Retry200 request. The method always
@@ -1432,7 +1562,7 @@ func (client LROsClient) PutAsyncNoHeaderInRetry(ctx context.Context, product *P
 
 	result, err = client.PutAsyncNoHeaderInRetrySender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNoHeaderInRetry", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNoHeaderInRetry", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1455,12 +1585,17 @@ func (client LROsClient) PutAsyncNoHeaderInRetryPreparer(ctx context.Context, pr
 
 // PutAsyncNoHeaderInRetrySender sends the PutAsyncNoHeaderInRetry request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) PutAsyncNoHeaderInRetrySender(req *http.Request) (LROsPutAsyncNoHeaderInRetryFuture, error) {
+func (client LROsClient) PutAsyncNoHeaderInRetrySender(req *http.Request) (future LROsPutAsyncNoHeaderInRetryFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPutAsyncNoHeaderInRetryFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	return
 }
 
 // PutAsyncNoHeaderInRetryResponder handles the response to the PutAsyncNoHeaderInRetry request. The method always
@@ -1488,7 +1623,7 @@ func (client LROsClient) PutAsyncNonResource(ctx context.Context, sku *Sku) (res
 
 	result, err = client.PutAsyncNonResourceSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNonResource", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNonResource", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1511,12 +1646,17 @@ func (client LROsClient) PutAsyncNonResourcePreparer(ctx context.Context, sku *S
 
 // PutAsyncNonResourceSender sends the PutAsyncNonResource request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) PutAsyncNonResourceSender(req *http.Request) (LROsPutAsyncNonResourceFuture, error) {
+func (client LROsClient) PutAsyncNonResourceSender(req *http.Request) (future LROsPutAsyncNonResourceFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPutAsyncNonResourceFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // PutAsyncNonResourceResponder handles the response to the PutAsyncNonResource request. The method always
@@ -1546,7 +1686,7 @@ func (client LROsClient) PutAsyncNoRetrycanceled(ctx context.Context, product *P
 
 	result, err = client.PutAsyncNoRetrycanceledSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNoRetrycanceled", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNoRetrycanceled", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1569,12 +1709,17 @@ func (client LROsClient) PutAsyncNoRetrycanceledPreparer(ctx context.Context, pr
 
 // PutAsyncNoRetrycanceledSender sends the PutAsyncNoRetrycanceled request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) PutAsyncNoRetrycanceledSender(req *http.Request) (LROsPutAsyncNoRetrycanceledFuture, error) {
+func (client LROsClient) PutAsyncNoRetrycanceledSender(req *http.Request) (future LROsPutAsyncNoRetrycanceledFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPutAsyncNoRetrycanceledFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	return
 }
 
 // PutAsyncNoRetrycanceledResponder handles the response to the PutAsyncNoRetrycanceled request. The method always
@@ -1604,7 +1749,7 @@ func (client LROsClient) PutAsyncNoRetrySucceeded(ctx context.Context, product *
 
 	result, err = client.PutAsyncNoRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNoRetrySucceeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNoRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1627,12 +1772,17 @@ func (client LROsClient) PutAsyncNoRetrySucceededPreparer(ctx context.Context, p
 
 // PutAsyncNoRetrySucceededSender sends the PutAsyncNoRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) PutAsyncNoRetrySucceededSender(req *http.Request) (LROsPutAsyncNoRetrySucceededFuture, error) {
+func (client LROsClient) PutAsyncNoRetrySucceededSender(req *http.Request) (future LROsPutAsyncNoRetrySucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPutAsyncNoRetrySucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	return
 }
 
 // PutAsyncNoRetrySucceededResponder handles the response to the PutAsyncNoRetrySucceeded request. The method always
@@ -1662,7 +1812,7 @@ func (client LROsClient) PutAsyncRetryFailed(ctx context.Context, product *Produ
 
 	result, err = client.PutAsyncRetryFailedSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncRetryFailed", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncRetryFailed", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1685,12 +1835,17 @@ func (client LROsClient) PutAsyncRetryFailedPreparer(ctx context.Context, produc
 
 // PutAsyncRetryFailedSender sends the PutAsyncRetryFailed request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) PutAsyncRetryFailedSender(req *http.Request) (LROsPutAsyncRetryFailedFuture, error) {
+func (client LROsClient) PutAsyncRetryFailedSender(req *http.Request) (future LROsPutAsyncRetryFailedFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPutAsyncRetryFailedFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	return
 }
 
 // PutAsyncRetryFailedResponder handles the response to the PutAsyncRetryFailed request. The method always
@@ -1720,7 +1875,7 @@ func (client LROsClient) PutAsyncRetrySucceeded(ctx context.Context, product *Pr
 
 	result, err = client.PutAsyncRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncRetrySucceeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1743,12 +1898,17 @@ func (client LROsClient) PutAsyncRetrySucceededPreparer(ctx context.Context, pro
 
 // PutAsyncRetrySucceededSender sends the PutAsyncRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) PutAsyncRetrySucceededSender(req *http.Request) (LROsPutAsyncRetrySucceededFuture, error) {
+func (client LROsClient) PutAsyncRetrySucceededSender(req *http.Request) (future LROsPutAsyncRetrySucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPutAsyncRetrySucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	return
 }
 
 // PutAsyncRetrySucceededResponder handles the response to the PutAsyncRetrySucceeded request. The method always
@@ -1776,7 +1936,7 @@ func (client LROsClient) PutAsyncSubResource(ctx context.Context, product *SubPr
 
 	result, err = client.PutAsyncSubResourceSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncSubResource", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncSubResource", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1799,12 +1959,17 @@ func (client LROsClient) PutAsyncSubResourcePreparer(ctx context.Context, produc
 
 // PutAsyncSubResourceSender sends the PutAsyncSubResource request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) PutAsyncSubResourceSender(req *http.Request) (LROsPutAsyncSubResourceFuture, error) {
+func (client LROsClient) PutAsyncSubResourceSender(req *http.Request) (future LROsPutAsyncSubResourceFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPutAsyncSubResourceFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // PutAsyncSubResourceResponder handles the response to the PutAsyncSubResource request. The method always
@@ -1833,7 +1998,7 @@ func (client LROsClient) PutNoHeaderInRetry(ctx context.Context, product *Produc
 
 	result, err = client.PutNoHeaderInRetrySender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutNoHeaderInRetry", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutNoHeaderInRetry", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1856,12 +2021,17 @@ func (client LROsClient) PutNoHeaderInRetryPreparer(ctx context.Context, product
 
 // PutNoHeaderInRetrySender sends the PutNoHeaderInRetry request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) PutNoHeaderInRetrySender(req *http.Request) (LROsPutNoHeaderInRetryFuture, error) {
+func (client LROsClient) PutNoHeaderInRetrySender(req *http.Request) (future LROsPutNoHeaderInRetryFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPutNoHeaderInRetryFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // PutNoHeaderInRetryResponder handles the response to the PutNoHeaderInRetry request. The method always
@@ -1889,7 +2059,7 @@ func (client LROsClient) PutNonResource(ctx context.Context, sku *Sku) (result L
 
 	result, err = client.PutNonResourceSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutNonResource", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutNonResource", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1912,12 +2082,17 @@ func (client LROsClient) PutNonResourcePreparer(ctx context.Context, sku *Sku) (
 
 // PutNonResourceSender sends the PutNonResource request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) PutNonResourceSender(req *http.Request) (LROsPutNonResourceFuture, error) {
+func (client LROsClient) PutNonResourceSender(req *http.Request) (future LROsPutNonResourceFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPutNonResourceFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // PutNonResourceResponder handles the response to the PutNonResource request. The method always
@@ -1945,7 +2120,7 @@ func (client LROsClient) PutSubResource(ctx context.Context, product *SubProduct
 
 	result, err = client.PutSubResourceSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutSubResource", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutSubResource", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1968,12 +2143,17 @@ func (client LROsClient) PutSubResourcePreparer(ctx context.Context, product *Su
 
 // PutSubResourceSender sends the PutSubResource request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsClient) PutSubResourceSender(req *http.Request) (LROsPutSubResourceFuture, error) {
+func (client LROsClient) PutSubResourceSender(req *http.Request) (future LROsPutSubResourceFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsPutSubResourceFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // PutSubResourceResponder handles the response to the PutSubResource request. The method always

--- a/test/src/tests/generated/lro/lrosads.go
+++ b/test/src/tests/generated/lro/lrosads.go
@@ -38,7 +38,7 @@ func (client LROSADsClient) Delete202NonRetry400(ctx context.Context) (result LR
 
 	result, err = client.Delete202NonRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Delete202NonRetry400", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Delete202NonRetry400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -56,12 +56,17 @@ func (client LROSADsClient) Delete202NonRetry400Preparer(ctx context.Context) (*
 
 // Delete202NonRetry400Sender sends the Delete202NonRetry400 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) Delete202NonRetry400Sender(req *http.Request) (LROSADsDelete202NonRetry400Future, error) {
+func (client LROSADsClient) Delete202NonRetry400Sender(req *http.Request) (future LROSADsDelete202NonRetry400Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsDelete202NonRetry400Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // Delete202NonRetry400Responder handles the response to the Delete202NonRetry400 request. The method always
@@ -87,7 +92,7 @@ func (client LROSADsClient) Delete202RetryInvalidHeader(ctx context.Context) (re
 
 	result, err = client.Delete202RetryInvalidHeaderSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Delete202RetryInvalidHeader", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Delete202RetryInvalidHeader", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -105,12 +110,17 @@ func (client LROSADsClient) Delete202RetryInvalidHeaderPreparer(ctx context.Cont
 
 // Delete202RetryInvalidHeaderSender sends the Delete202RetryInvalidHeader request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) Delete202RetryInvalidHeaderSender(req *http.Request) (LROSADsDelete202RetryInvalidHeaderFuture, error) {
+func (client LROSADsClient) Delete202RetryInvalidHeaderSender(req *http.Request) (future LROSADsDelete202RetryInvalidHeaderFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsDelete202RetryInvalidHeaderFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // Delete202RetryInvalidHeaderResponder handles the response to the Delete202RetryInvalidHeader request. The method always
@@ -135,7 +145,7 @@ func (client LROSADsClient) Delete204Succeeded(ctx context.Context) (result LROS
 
 	result, err = client.Delete204SucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Delete204Succeeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Delete204Succeeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -153,12 +163,17 @@ func (client LROSADsClient) Delete204SucceededPreparer(ctx context.Context) (*ht
 
 // Delete204SucceededSender sends the Delete204Succeeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) Delete204SucceededSender(req *http.Request) (LROSADsDelete204SucceededFuture, error) {
+func (client LROSADsClient) Delete204SucceededSender(req *http.Request) (future LROSADsDelete204SucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsDelete204SucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent))
+	return
 }
 
 // Delete204SucceededResponder handles the response to the Delete204Succeeded request. The method always
@@ -184,7 +199,7 @@ func (client LROSADsClient) DeleteAsyncRelativeRetry400(ctx context.Context) (re
 
 	result, err = client.DeleteAsyncRelativeRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetry400", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetry400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -202,12 +217,17 @@ func (client LROSADsClient) DeleteAsyncRelativeRetry400Preparer(ctx context.Cont
 
 // DeleteAsyncRelativeRetry400Sender sends the DeleteAsyncRelativeRetry400 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) DeleteAsyncRelativeRetry400Sender(req *http.Request) (LROSADsDeleteAsyncRelativeRetry400Future, error) {
+func (client LROSADsClient) DeleteAsyncRelativeRetry400Sender(req *http.Request) (future LROSADsDeleteAsyncRelativeRetry400Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsDeleteAsyncRelativeRetry400Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // DeleteAsyncRelativeRetry400Responder handles the response to the DeleteAsyncRelativeRetry400 request. The method always
@@ -233,7 +253,7 @@ func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidHeader(ctx context.Co
 
 	result, err = client.DeleteAsyncRelativeRetryInvalidHeaderSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetryInvalidHeader", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetryInvalidHeader", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -251,12 +271,17 @@ func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidHeaderPreparer(ctx co
 
 // DeleteAsyncRelativeRetryInvalidHeaderSender sends the DeleteAsyncRelativeRetryInvalidHeader request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidHeaderSender(req *http.Request) (LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture, error) {
+func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidHeaderSender(req *http.Request) (future LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // DeleteAsyncRelativeRetryInvalidHeaderResponder handles the response to the DeleteAsyncRelativeRetryInvalidHeader request. The method always
@@ -282,7 +307,7 @@ func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidJSONPolling(ctx conte
 
 	result, err = client.DeleteAsyncRelativeRetryInvalidJSONPollingSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetryInvalidJSONPolling", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetryInvalidJSONPolling", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -300,12 +325,17 @@ func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidJSONPollingPreparer(c
 
 // DeleteAsyncRelativeRetryInvalidJSONPollingSender sends the DeleteAsyncRelativeRetryInvalidJSONPolling request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidJSONPollingSender(req *http.Request) (LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture, error) {
+func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidJSONPollingSender(req *http.Request) (future LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // DeleteAsyncRelativeRetryInvalidJSONPollingResponder handles the response to the DeleteAsyncRelativeRetryInvalidJSONPolling request. The method always
@@ -331,7 +361,7 @@ func (client LROSADsClient) DeleteAsyncRelativeRetryNoStatus(ctx context.Context
 
 	result, err = client.DeleteAsyncRelativeRetryNoStatusSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetryNoStatus", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetryNoStatus", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -349,12 +379,17 @@ func (client LROSADsClient) DeleteAsyncRelativeRetryNoStatusPreparer(ctx context
 
 // DeleteAsyncRelativeRetryNoStatusSender sends the DeleteAsyncRelativeRetryNoStatus request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) DeleteAsyncRelativeRetryNoStatusSender(req *http.Request) (LROSADsDeleteAsyncRelativeRetryNoStatusFuture, error) {
+func (client LROSADsClient) DeleteAsyncRelativeRetryNoStatusSender(req *http.Request) (future LROSADsDeleteAsyncRelativeRetryNoStatusFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsDeleteAsyncRelativeRetryNoStatusFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // DeleteAsyncRelativeRetryNoStatusResponder handles the response to the DeleteAsyncRelativeRetryNoStatus request. The method always
@@ -379,7 +414,7 @@ func (client LROSADsClient) DeleteNonRetry400(ctx context.Context) (result LROSA
 
 	result, err = client.DeleteNonRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteNonRetry400", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteNonRetry400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -397,12 +432,17 @@ func (client LROSADsClient) DeleteNonRetry400Preparer(ctx context.Context) (*htt
 
 // DeleteNonRetry400Sender sends the DeleteNonRetry400 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) DeleteNonRetry400Sender(req *http.Request) (LROSADsDeleteNonRetry400Future, error) {
+func (client LROSADsClient) DeleteNonRetry400Sender(req *http.Request) (future LROSADsDeleteNonRetry400Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsDeleteNonRetry400Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // DeleteNonRetry400Responder handles the response to the DeleteNonRetry400 request. The method always
@@ -430,7 +470,7 @@ func (client LROSADsClient) Post202NoLocation(ctx context.Context, product *Prod
 
 	result, err = client.Post202NoLocationSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Post202NoLocation", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Post202NoLocation", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -453,12 +493,17 @@ func (client LROSADsClient) Post202NoLocationPreparer(ctx context.Context, produ
 
 // Post202NoLocationSender sends the Post202NoLocation request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) Post202NoLocationSender(req *http.Request) (LROSADsPost202NoLocationFuture, error) {
+func (client LROSADsClient) Post202NoLocationSender(req *http.Request) (future LROSADsPost202NoLocationFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPost202NoLocationFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // Post202NoLocationResponder handles the response to the Post202NoLocation request. The method always
@@ -485,7 +530,7 @@ func (client LROSADsClient) Post202NonRetry400(ctx context.Context, product *Pro
 
 	result, err = client.Post202NonRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Post202NonRetry400", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Post202NonRetry400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -508,12 +553,17 @@ func (client LROSADsClient) Post202NonRetry400Preparer(ctx context.Context, prod
 
 // Post202NonRetry400Sender sends the Post202NonRetry400 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) Post202NonRetry400Sender(req *http.Request) (LROSADsPost202NonRetry400Future, error) {
+func (client LROSADsClient) Post202NonRetry400Sender(req *http.Request) (future LROSADsPost202NonRetry400Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPost202NonRetry400Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // Post202NonRetry400Responder handles the response to the Post202NonRetry400 request. The method always
@@ -541,7 +591,7 @@ func (client LROSADsClient) Post202RetryInvalidHeader(ctx context.Context, produ
 
 	result, err = client.Post202RetryInvalidHeaderSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Post202RetryInvalidHeader", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Post202RetryInvalidHeader", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -564,12 +614,17 @@ func (client LROSADsClient) Post202RetryInvalidHeaderPreparer(ctx context.Contex
 
 // Post202RetryInvalidHeaderSender sends the Post202RetryInvalidHeader request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) Post202RetryInvalidHeaderSender(req *http.Request) (LROSADsPost202RetryInvalidHeaderFuture, error) {
+func (client LROSADsClient) Post202RetryInvalidHeaderSender(req *http.Request) (future LROSADsPost202RetryInvalidHeaderFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPost202RetryInvalidHeaderFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // Post202RetryInvalidHeaderResponder handles the response to the Post202RetryInvalidHeader request. The method always
@@ -597,7 +652,7 @@ func (client LROSADsClient) PostAsyncRelativeRetry400(ctx context.Context, produ
 
 	result, err = client.PostAsyncRelativeRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetry400", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetry400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -620,12 +675,17 @@ func (client LROSADsClient) PostAsyncRelativeRetry400Preparer(ctx context.Contex
 
 // PostAsyncRelativeRetry400Sender sends the PostAsyncRelativeRetry400 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) PostAsyncRelativeRetry400Sender(req *http.Request) (LROSADsPostAsyncRelativeRetry400Future, error) {
+func (client LROSADsClient) PostAsyncRelativeRetry400Sender(req *http.Request) (future LROSADsPostAsyncRelativeRetry400Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPostAsyncRelativeRetry400Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // PostAsyncRelativeRetry400Responder handles the response to the PostAsyncRelativeRetry400 request. The method always
@@ -654,7 +714,7 @@ func (client LROSADsClient) PostAsyncRelativeRetryInvalidHeader(ctx context.Cont
 
 	result, err = client.PostAsyncRelativeRetryInvalidHeaderSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetryInvalidHeader", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetryInvalidHeader", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -677,12 +737,17 @@ func (client LROSADsClient) PostAsyncRelativeRetryInvalidHeaderPreparer(ctx cont
 
 // PostAsyncRelativeRetryInvalidHeaderSender sends the PostAsyncRelativeRetryInvalidHeader request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) PostAsyncRelativeRetryInvalidHeaderSender(req *http.Request) (LROSADsPostAsyncRelativeRetryInvalidHeaderFuture, error) {
+func (client LROSADsClient) PostAsyncRelativeRetryInvalidHeaderSender(req *http.Request) (future LROSADsPostAsyncRelativeRetryInvalidHeaderFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPostAsyncRelativeRetryInvalidHeaderFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // PostAsyncRelativeRetryInvalidHeaderResponder handles the response to the PostAsyncRelativeRetryInvalidHeader request. The method always
@@ -711,7 +776,7 @@ func (client LROSADsClient) PostAsyncRelativeRetryInvalidJSONPolling(ctx context
 
 	result, err = client.PostAsyncRelativeRetryInvalidJSONPollingSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetryInvalidJSONPolling", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetryInvalidJSONPolling", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -734,12 +799,17 @@ func (client LROSADsClient) PostAsyncRelativeRetryInvalidJSONPollingPreparer(ctx
 
 // PostAsyncRelativeRetryInvalidJSONPollingSender sends the PostAsyncRelativeRetryInvalidJSONPolling request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) PostAsyncRelativeRetryInvalidJSONPollingSender(req *http.Request) (LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture, error) {
+func (client LROSADsClient) PostAsyncRelativeRetryInvalidJSONPollingSender(req *http.Request) (future LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // PostAsyncRelativeRetryInvalidJSONPollingResponder handles the response to the PostAsyncRelativeRetryInvalidJSONPolling request. The method always
@@ -768,7 +838,7 @@ func (client LROSADsClient) PostAsyncRelativeRetryNoPayload(ctx context.Context,
 
 	result, err = client.PostAsyncRelativeRetryNoPayloadSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetryNoPayload", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetryNoPayload", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -791,12 +861,17 @@ func (client LROSADsClient) PostAsyncRelativeRetryNoPayloadPreparer(ctx context.
 
 // PostAsyncRelativeRetryNoPayloadSender sends the PostAsyncRelativeRetryNoPayload request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) PostAsyncRelativeRetryNoPayloadSender(req *http.Request) (LROSADsPostAsyncRelativeRetryNoPayloadFuture, error) {
+func (client LROSADsClient) PostAsyncRelativeRetryNoPayloadSender(req *http.Request) (future LROSADsPostAsyncRelativeRetryNoPayloadFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPostAsyncRelativeRetryNoPayloadFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // PostAsyncRelativeRetryNoPayloadResponder handles the response to the PostAsyncRelativeRetryNoPayload request. The method always
@@ -823,7 +898,7 @@ func (client LROSADsClient) PostNonRetry400(ctx context.Context, product *Produc
 
 	result, err = client.PostNonRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostNonRetry400", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostNonRetry400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -846,12 +921,17 @@ func (client LROSADsClient) PostNonRetry400Preparer(ctx context.Context, product
 
 // PostNonRetry400Sender sends the PostNonRetry400 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) PostNonRetry400Sender(req *http.Request) (LROSADsPostNonRetry400Future, error) {
+func (client LROSADsClient) PostNonRetry400Sender(req *http.Request) (future LROSADsPostNonRetry400Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPostNonRetry400Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // PostNonRetry400Responder handles the response to the PostNonRetry400 request. The method always
@@ -879,7 +959,7 @@ func (client LROSADsClient) Put200InvalidJSON(ctx context.Context, product *Prod
 
 	result, err = client.Put200InvalidJSONSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Put200InvalidJSON", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Put200InvalidJSON", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -902,12 +982,17 @@ func (client LROSADsClient) Put200InvalidJSONPreparer(ctx context.Context, produ
 
 // Put200InvalidJSONSender sends the Put200InvalidJSON request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) Put200InvalidJSONSender(req *http.Request) (LROSADsPut200InvalidJSONFuture, error) {
+func (client LROSADsClient) Put200InvalidJSONSender(req *http.Request) (future LROSADsPut200InvalidJSONFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPut200InvalidJSONFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent))
+	return
 }
 
 // Put200InvalidJSONResponder handles the response to the Put200InvalidJSON request. The method always
@@ -936,7 +1021,7 @@ func (client LROSADsClient) PutAsyncRelativeRetry400(ctx context.Context, produc
 
 	result, err = client.PutAsyncRelativeRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetry400", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetry400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -959,12 +1044,17 @@ func (client LROSADsClient) PutAsyncRelativeRetry400Preparer(ctx context.Context
 
 // PutAsyncRelativeRetry400Sender sends the PutAsyncRelativeRetry400 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) PutAsyncRelativeRetry400Sender(req *http.Request) (LROSADsPutAsyncRelativeRetry400Future, error) {
+func (client LROSADsClient) PutAsyncRelativeRetry400Sender(req *http.Request) (future LROSADsPutAsyncRelativeRetry400Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPutAsyncRelativeRetry400Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	return
 }
 
 // PutAsyncRelativeRetry400Responder handles the response to the PutAsyncRelativeRetry400 request. The method always
@@ -994,7 +1084,7 @@ func (client LROSADsClient) PutAsyncRelativeRetryInvalidHeader(ctx context.Conte
 
 	result, err = client.PutAsyncRelativeRetryInvalidHeaderSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryInvalidHeader", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryInvalidHeader", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1017,12 +1107,17 @@ func (client LROSADsClient) PutAsyncRelativeRetryInvalidHeaderPreparer(ctx conte
 
 // PutAsyncRelativeRetryInvalidHeaderSender sends the PutAsyncRelativeRetryInvalidHeader request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) PutAsyncRelativeRetryInvalidHeaderSender(req *http.Request) (LROSADsPutAsyncRelativeRetryInvalidHeaderFuture, error) {
+func (client LROSADsClient) PutAsyncRelativeRetryInvalidHeaderSender(req *http.Request) (future LROSADsPutAsyncRelativeRetryInvalidHeaderFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPutAsyncRelativeRetryInvalidHeaderFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	return
 }
 
 // PutAsyncRelativeRetryInvalidHeaderResponder handles the response to the PutAsyncRelativeRetryInvalidHeader request. The method always
@@ -1052,7 +1147,7 @@ func (client LROSADsClient) PutAsyncRelativeRetryInvalidJSONPolling(ctx context.
 
 	result, err = client.PutAsyncRelativeRetryInvalidJSONPollingSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryInvalidJSONPolling", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryInvalidJSONPolling", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1075,12 +1170,17 @@ func (client LROSADsClient) PutAsyncRelativeRetryInvalidJSONPollingPreparer(ctx 
 
 // PutAsyncRelativeRetryInvalidJSONPollingSender sends the PutAsyncRelativeRetryInvalidJSONPolling request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) PutAsyncRelativeRetryInvalidJSONPollingSender(req *http.Request) (LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture, error) {
+func (client LROSADsClient) PutAsyncRelativeRetryInvalidJSONPollingSender(req *http.Request) (future LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	return
 }
 
 // PutAsyncRelativeRetryInvalidJSONPollingResponder handles the response to the PutAsyncRelativeRetryInvalidJSONPolling request. The method always
@@ -1110,7 +1210,7 @@ func (client LROSADsClient) PutAsyncRelativeRetryNoStatus(ctx context.Context, p
 
 	result, err = client.PutAsyncRelativeRetryNoStatusSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryNoStatus", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryNoStatus", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1133,12 +1233,17 @@ func (client LROSADsClient) PutAsyncRelativeRetryNoStatusPreparer(ctx context.Co
 
 // PutAsyncRelativeRetryNoStatusSender sends the PutAsyncRelativeRetryNoStatus request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) PutAsyncRelativeRetryNoStatusSender(req *http.Request) (LROSADsPutAsyncRelativeRetryNoStatusFuture, error) {
+func (client LROSADsClient) PutAsyncRelativeRetryNoStatusSender(req *http.Request) (future LROSADsPutAsyncRelativeRetryNoStatusFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPutAsyncRelativeRetryNoStatusFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	return
 }
 
 // PutAsyncRelativeRetryNoStatusResponder handles the response to the PutAsyncRelativeRetryNoStatus request. The method always
@@ -1168,7 +1273,7 @@ func (client LROSADsClient) PutAsyncRelativeRetryNoStatusPayload(ctx context.Con
 
 	result, err = client.PutAsyncRelativeRetryNoStatusPayloadSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryNoStatusPayload", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryNoStatusPayload", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1191,12 +1296,17 @@ func (client LROSADsClient) PutAsyncRelativeRetryNoStatusPayloadPreparer(ctx con
 
 // PutAsyncRelativeRetryNoStatusPayloadSender sends the PutAsyncRelativeRetryNoStatusPayload request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) PutAsyncRelativeRetryNoStatusPayloadSender(req *http.Request) (LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture, error) {
+func (client LROSADsClient) PutAsyncRelativeRetryNoStatusPayloadSender(req *http.Request) (future LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	return
 }
 
 // PutAsyncRelativeRetryNoStatusPayloadResponder handles the response to the PutAsyncRelativeRetryNoStatusPayload request. The method always
@@ -1225,7 +1335,7 @@ func (client LROSADsClient) PutError201NoProvisioningStatePayload(ctx context.Co
 
 	result, err = client.PutError201NoProvisioningStatePayloadSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutError201NoProvisioningStatePayload", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutError201NoProvisioningStatePayload", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1248,12 +1358,17 @@ func (client LROSADsClient) PutError201NoProvisioningStatePayloadPreparer(ctx co
 
 // PutError201NoProvisioningStatePayloadSender sends the PutError201NoProvisioningStatePayload request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) PutError201NoProvisioningStatePayloadSender(req *http.Request) (LROSADsPutError201NoProvisioningStatePayloadFuture, error) {
+func (client LROSADsClient) PutError201NoProvisioningStatePayloadSender(req *http.Request) (future LROSADsPutError201NoProvisioningStatePayloadFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPutError201NoProvisioningStatePayloadFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	return
 }
 
 // PutError201NoProvisioningStatePayloadResponder handles the response to the PutError201NoProvisioningStatePayload request. The method always
@@ -1282,7 +1397,7 @@ func (client LROSADsClient) PutNonRetry201Creating400(ctx context.Context, produ
 
 	result, err = client.PutNonRetry201Creating400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutNonRetry201Creating400", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutNonRetry201Creating400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1305,12 +1420,17 @@ func (client LROSADsClient) PutNonRetry201Creating400Preparer(ctx context.Contex
 
 // PutNonRetry201Creating400Sender sends the PutNonRetry201Creating400 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) PutNonRetry201Creating400Sender(req *http.Request) (LROSADsPutNonRetry201Creating400Future, error) {
+func (client LROSADsClient) PutNonRetry201Creating400Sender(req *http.Request) (future LROSADsPutNonRetry201Creating400Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPutNonRetry201Creating400Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	return
 }
 
 // PutNonRetry201Creating400Responder handles the response to the PutNonRetry201Creating400 request. The method always
@@ -1339,7 +1459,7 @@ func (client LROSADsClient) PutNonRetry201Creating400InvalidJSON(ctx context.Con
 
 	result, err = client.PutNonRetry201Creating400InvalidJSONSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutNonRetry201Creating400InvalidJSON", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutNonRetry201Creating400InvalidJSON", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1362,12 +1482,17 @@ func (client LROSADsClient) PutNonRetry201Creating400InvalidJSONPreparer(ctx con
 
 // PutNonRetry201Creating400InvalidJSONSender sends the PutNonRetry201Creating400InvalidJSON request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) PutNonRetry201Creating400InvalidJSONSender(req *http.Request) (LROSADsPutNonRetry201Creating400InvalidJSONFuture, error) {
+func (client LROSADsClient) PutNonRetry201Creating400InvalidJSONSender(req *http.Request) (future LROSADsPutNonRetry201Creating400InvalidJSONFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPutNonRetry201Creating400InvalidJSONFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	return
 }
 
 // PutNonRetry201Creating400InvalidJSONResponder handles the response to the PutNonRetry201Creating400InvalidJSON request. The method always
@@ -1395,7 +1520,7 @@ func (client LROSADsClient) PutNonRetry400(ctx context.Context, product *Product
 
 	result, err = client.PutNonRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutNonRetry400", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutNonRetry400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1418,12 +1543,17 @@ func (client LROSADsClient) PutNonRetry400Preparer(ctx context.Context, product 
 
 // PutNonRetry400Sender sends the PutNonRetry400 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROSADsClient) PutNonRetry400Sender(req *http.Request) (LROSADsPutNonRetry400Future, error) {
+func (client LROSADsClient) PutNonRetry400Sender(req *http.Request) (future LROSADsPutNonRetry400Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROSADsPutNonRetry400Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	return
 }
 
 // PutNonRetry400Responder handles the response to the PutNonRetry400 request. The method always

--- a/test/src/tests/generated/lro/lroscustomheader.go
+++ b/test/src/tests/generated/lro/lroscustomheader.go
@@ -42,7 +42,7 @@ func (client LROsCustomHeaderClient) Post202Retry200(ctx context.Context, produc
 
 	result, err = client.Post202Retry200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "Post202Retry200", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "Post202Retry200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -65,12 +65,17 @@ func (client LROsCustomHeaderClient) Post202Retry200Preparer(ctx context.Context
 
 // Post202Retry200Sender sends the Post202Retry200 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsCustomHeaderClient) Post202Retry200Sender(req *http.Request) (LROsCustomHeaderPost202Retry200Future, error) {
+func (client LROsCustomHeaderClient) Post202Retry200Sender(req *http.Request) (future LROsCustomHeaderPost202Retry200Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsCustomHeaderPost202Retry200Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // Post202Retry200Responder handles the response to the Post202Retry200 request. The method always
@@ -99,7 +104,7 @@ func (client LROsCustomHeaderClient) PostAsyncRetrySucceeded(ctx context.Context
 
 	result, err = client.PostAsyncRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "PostAsyncRetrySucceeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "PostAsyncRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -122,12 +127,17 @@ func (client LROsCustomHeaderClient) PostAsyncRetrySucceededPreparer(ctx context
 
 // PostAsyncRetrySucceededSender sends the PostAsyncRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsCustomHeaderClient) PostAsyncRetrySucceededSender(req *http.Request) (LROsCustomHeaderPostAsyncRetrySucceededFuture, error) {
+func (client LROsCustomHeaderClient) PostAsyncRetrySucceededSender(req *http.Request) (future LROsCustomHeaderPostAsyncRetrySucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsCustomHeaderPostAsyncRetrySucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	return
 }
 
 // PostAsyncRetrySucceededResponder handles the response to the PostAsyncRetrySucceeded request. The method always
@@ -157,7 +167,7 @@ func (client LROsCustomHeaderClient) Put201CreatingSucceeded200(ctx context.Cont
 
 	result, err = client.Put201CreatingSucceeded200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "Put201CreatingSucceeded200", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "Put201CreatingSucceeded200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -180,12 +190,17 @@ func (client LROsCustomHeaderClient) Put201CreatingSucceeded200Preparer(ctx cont
 
 // Put201CreatingSucceeded200Sender sends the Put201CreatingSucceeded200 request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsCustomHeaderClient) Put201CreatingSucceeded200Sender(req *http.Request) (LROsCustomHeaderPut201CreatingSucceeded200Future, error) {
+func (client LROsCustomHeaderClient) Put201CreatingSucceeded200Sender(req *http.Request) (future LROsCustomHeaderPut201CreatingSucceeded200Future, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsCustomHeaderPut201CreatingSucceeded200Future{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	return
 }
 
 // Put201CreatingSucceeded200Responder handles the response to the Put201CreatingSucceeded200 request. The method always
@@ -215,7 +230,7 @@ func (client LROsCustomHeaderClient) PutAsyncRetrySucceeded(ctx context.Context,
 
 	result, err = client.PutAsyncRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "PutAsyncRetrySucceeded", nil, "Failure sending request'result.Response()'")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "PutAsyncRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -238,12 +253,17 @@ func (client LROsCustomHeaderClient) PutAsyncRetrySucceededPreparer(ctx context.
 
 // PutAsyncRetrySucceededSender sends the PutAsyncRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
-func (client LROsCustomHeaderClient) PutAsyncRetrySucceededSender(req *http.Request) (LROsCustomHeaderPutAsyncRetrySucceededFuture, error) {
+func (client LROsCustomHeaderClient) PutAsyncRetrySucceededSender(req *http.Request) (future LROsCustomHeaderPutAsyncRetrySucceededFuture, err error) {
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future := azure.NewFuture(req)
-	_, err := future.Done(sender)
-	f := LROsCustomHeaderPutAsyncRetrySucceededFuture{Future: future, req: req}
-	return f, err
+	future.Future = azure.NewFuture(req)
+	future.req = req
+	_, err = future.Done(sender)
+	if err != nil {
+		return
+	}
+	err = autorest.Respond(future.Response(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	return
 }
 
 // PutAsyncRetrySucceededResponder handles the response to the PutAsyncRetrySucceeded request. The method always

--- a/test/src/tests/generated/lro/models.go
+++ b/test/src/tests/generated/lro/models.go
@@ -121,23 +121,27 @@ type LRORetrysDelete202Retry200Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LRORetrysDelete202Retry200Future) Result(client LRORetrysClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LRORetrysDelete202Retry200Future) Result(client LRORetrysClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LRORetrysDelete202Retry200Future", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LRORetrysDelete202Retry200Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Delete202Retry200Responder(future.Response())
+		ar, err = client.Delete202Retry200Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.Delete202Retry200Responder(resp)
+	ar, err = client.Delete202Retry200Responder(resp)
+	return
 }
 
 // LRORetrysDeleteAsyncRelativeRetrySucceededFuture an abstraction for monitoring and retrieving the results of a
@@ -149,23 +153,27 @@ type LRORetrysDeleteAsyncRelativeRetrySucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LRORetrysDeleteAsyncRelativeRetrySucceededFuture) Result(client LRORetrysClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LRORetrysDeleteAsyncRelativeRetrySucceededFuture) Result(client LRORetrysClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LRORetrysDeleteAsyncRelativeRetrySucceededFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LRORetrysDeleteAsyncRelativeRetrySucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteAsyncRelativeRetrySucceededResponder(future.Response())
+		ar, err = client.DeleteAsyncRelativeRetrySucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.DeleteAsyncRelativeRetrySucceededResponder(resp)
+	ar, err = client.DeleteAsyncRelativeRetrySucceededResponder(resp)
+	return
 }
 
 // LRORetrysDeleteProvisioning202Accepted200SucceededFuture an abstraction for monitoring and retrieving the results of
@@ -177,23 +185,27 @@ type LRORetrysDeleteProvisioning202Accepted200SucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LRORetrysDeleteProvisioning202Accepted200SucceededFuture) Result(client LRORetrysClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LRORetrysDeleteProvisioning202Accepted200SucceededFuture) Result(client LRORetrysClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LRORetrysDeleteProvisioning202Accepted200SucceededFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LRORetrysDeleteProvisioning202Accepted200SucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteProvisioning202Accepted200SucceededResponder(future.Response())
+		p, err = client.DeleteProvisioning202Accepted200SucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.DeleteProvisioning202Accepted200SucceededResponder(resp)
+	p, err = client.DeleteProvisioning202Accepted200SucceededResponder(resp)
+	return
 }
 
 // LRORetrysPost202Retry200Future an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -204,23 +216,27 @@ type LRORetrysPost202Retry200Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LRORetrysPost202Retry200Future) Result(client LRORetrysClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LRORetrysPost202Retry200Future) Result(client LRORetrysClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LRORetrysPost202Retry200Future", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LRORetrysPost202Retry200Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Post202Retry200Responder(future.Response())
+		ar, err = client.Post202Retry200Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.Post202Retry200Responder(resp)
+	ar, err = client.Post202Retry200Responder(resp)
+	return
 }
 
 // LRORetrysPostAsyncRelativeRetrySucceededFuture an abstraction for monitoring and retrieving the results of a
@@ -232,23 +248,27 @@ type LRORetrysPostAsyncRelativeRetrySucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LRORetrysPostAsyncRelativeRetrySucceededFuture) Result(client LRORetrysClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LRORetrysPostAsyncRelativeRetrySucceededFuture) Result(client LRORetrysClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LRORetrysPostAsyncRelativeRetrySucceededFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LRORetrysPostAsyncRelativeRetrySucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PostAsyncRelativeRetrySucceededResponder(future.Response())
+		ar, err = client.PostAsyncRelativeRetrySucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.PostAsyncRelativeRetrySucceededResponder(resp)
+	ar, err = client.PostAsyncRelativeRetrySucceededResponder(resp)
+	return
 }
 
 // LRORetrysPut201CreatingSucceeded200Future an abstraction for monitoring and retrieving the results of a long-running
@@ -260,23 +280,27 @@ type LRORetrysPut201CreatingSucceeded200Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LRORetrysPut201CreatingSucceeded200Future) Result(client LRORetrysClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LRORetrysPut201CreatingSucceeded200Future) Result(client LRORetrysClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LRORetrysPut201CreatingSucceeded200Future", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LRORetrysPut201CreatingSucceeded200Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Put201CreatingSucceeded200Responder(future.Response())
+		p, err = client.Put201CreatingSucceeded200Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.Put201CreatingSucceeded200Responder(resp)
+	p, err = client.Put201CreatingSucceeded200Responder(resp)
+	return
 }
 
 // LRORetrysPutAsyncRelativeRetrySucceededFuture an abstraction for monitoring and retrieving the results of a
@@ -288,23 +312,27 @@ type LRORetrysPutAsyncRelativeRetrySucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LRORetrysPutAsyncRelativeRetrySucceededFuture) Result(client LRORetrysClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LRORetrysPutAsyncRelativeRetrySucceededFuture) Result(client LRORetrysClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LRORetrysPutAsyncRelativeRetrySucceededFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LRORetrysPutAsyncRelativeRetrySucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutAsyncRelativeRetrySucceededResponder(future.Response())
+		p, err = client.PutAsyncRelativeRetrySucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutAsyncRelativeRetrySucceededResponder(resp)
+	p, err = client.PutAsyncRelativeRetrySucceededResponder(resp)
+	return
 }
 
 // LROSADsDelete202NonRetry400Future an abstraction for monitoring and retrieving the results of a long-running
@@ -316,23 +344,27 @@ type LROSADsDelete202NonRetry400Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDelete202NonRetry400Future) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsDelete202NonRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsDelete202NonRetry400Future", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsDelete202NonRetry400Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Delete202NonRetry400Responder(future.Response())
+		ar, err = client.Delete202NonRetry400Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.Delete202NonRetry400Responder(resp)
+	ar, err = client.Delete202NonRetry400Responder(resp)
+	return
 }
 
 // LROSADsDelete202RetryInvalidHeaderFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -344,23 +376,27 @@ type LROSADsDelete202RetryInvalidHeaderFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDelete202RetryInvalidHeaderFuture) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsDelete202RetryInvalidHeaderFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsDelete202RetryInvalidHeaderFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsDelete202RetryInvalidHeaderFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Delete202RetryInvalidHeaderResponder(future.Response())
+		ar, err = client.Delete202RetryInvalidHeaderResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.Delete202RetryInvalidHeaderResponder(resp)
+	ar, err = client.Delete202RetryInvalidHeaderResponder(resp)
+	return
 }
 
 // LROSADsDelete204SucceededFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -372,23 +408,27 @@ type LROSADsDelete204SucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDelete204SucceededFuture) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsDelete204SucceededFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsDelete204SucceededFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsDelete204SucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Delete204SucceededResponder(future.Response())
+		ar, err = client.Delete204SucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.Delete204SucceededResponder(resp)
+	ar, err = client.Delete204SucceededResponder(resp)
+	return
 }
 
 // LROSADsDeleteAsyncRelativeRetry400Future an abstraction for monitoring and retrieving the results of a long-running
@@ -400,23 +440,27 @@ type LROSADsDeleteAsyncRelativeRetry400Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDeleteAsyncRelativeRetry400Future) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsDeleteAsyncRelativeRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsDeleteAsyncRelativeRetry400Future", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsDeleteAsyncRelativeRetry400Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteAsyncRelativeRetry400Responder(future.Response())
+		ar, err = client.DeleteAsyncRelativeRetry400Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.DeleteAsyncRelativeRetry400Responder(resp)
+	ar, err = client.DeleteAsyncRelativeRetry400Responder(resp)
+	return
 }
 
 // LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture an abstraction for monitoring and retrieving the results of a
@@ -428,23 +472,27 @@ type LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteAsyncRelativeRetryInvalidHeaderResponder(future.Response())
+		ar, err = client.DeleteAsyncRelativeRetryInvalidHeaderResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.DeleteAsyncRelativeRetryInvalidHeaderResponder(resp)
+	ar, err = client.DeleteAsyncRelativeRetryInvalidHeaderResponder(resp)
+	return
 }
 
 // LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture an abstraction for monitoring and retrieving the results of
@@ -456,23 +504,27 @@ type LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteAsyncRelativeRetryInvalidJSONPollingResponder(future.Response())
+		ar, err = client.DeleteAsyncRelativeRetryInvalidJSONPollingResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.DeleteAsyncRelativeRetryInvalidJSONPollingResponder(resp)
+	ar, err = client.DeleteAsyncRelativeRetryInvalidJSONPollingResponder(resp)
+	return
 }
 
 // LROSADsDeleteAsyncRelativeRetryNoStatusFuture an abstraction for monitoring and retrieving the results of a
@@ -484,23 +536,27 @@ type LROSADsDeleteAsyncRelativeRetryNoStatusFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDeleteAsyncRelativeRetryNoStatusFuture) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsDeleteAsyncRelativeRetryNoStatusFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsDeleteAsyncRelativeRetryNoStatusFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsDeleteAsyncRelativeRetryNoStatusFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteAsyncRelativeRetryNoStatusResponder(future.Response())
+		ar, err = client.DeleteAsyncRelativeRetryNoStatusResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.DeleteAsyncRelativeRetryNoStatusResponder(resp)
+	ar, err = client.DeleteAsyncRelativeRetryNoStatusResponder(resp)
+	return
 }
 
 // LROSADsDeleteNonRetry400Future an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -511,23 +567,27 @@ type LROSADsDeleteNonRetry400Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDeleteNonRetry400Future) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsDeleteNonRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsDeleteNonRetry400Future", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsDeleteNonRetry400Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteNonRetry400Responder(future.Response())
+		ar, err = client.DeleteNonRetry400Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.DeleteNonRetry400Responder(resp)
+	ar, err = client.DeleteNonRetry400Responder(resp)
+	return
 }
 
 // LROSADsPost202NoLocationFuture an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -538,23 +598,27 @@ type LROSADsPost202NoLocationFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPost202NoLocationFuture) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsPost202NoLocationFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsPost202NoLocationFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsPost202NoLocationFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Post202NoLocationResponder(future.Response())
+		ar, err = client.Post202NoLocationResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.Post202NoLocationResponder(resp)
+	ar, err = client.Post202NoLocationResponder(resp)
+	return
 }
 
 // LROSADsPost202NonRetry400Future an abstraction for monitoring and retrieving the results of a long-running
@@ -566,23 +630,27 @@ type LROSADsPost202NonRetry400Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPost202NonRetry400Future) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsPost202NonRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsPost202NonRetry400Future", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsPost202NonRetry400Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Post202NonRetry400Responder(future.Response())
+		ar, err = client.Post202NonRetry400Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.Post202NonRetry400Responder(resp)
+	ar, err = client.Post202NonRetry400Responder(resp)
+	return
 }
 
 // LROSADsPost202RetryInvalidHeaderFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -594,23 +662,27 @@ type LROSADsPost202RetryInvalidHeaderFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPost202RetryInvalidHeaderFuture) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsPost202RetryInvalidHeaderFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsPost202RetryInvalidHeaderFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsPost202RetryInvalidHeaderFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Post202RetryInvalidHeaderResponder(future.Response())
+		ar, err = client.Post202RetryInvalidHeaderResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.Post202RetryInvalidHeaderResponder(resp)
+	ar, err = client.Post202RetryInvalidHeaderResponder(resp)
+	return
 }
 
 // LROSADsPostAsyncRelativeRetry400Future an abstraction for monitoring and retrieving the results of a long-running
@@ -622,23 +694,27 @@ type LROSADsPostAsyncRelativeRetry400Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPostAsyncRelativeRetry400Future) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsPostAsyncRelativeRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsPostAsyncRelativeRetry400Future", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsPostAsyncRelativeRetry400Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PostAsyncRelativeRetry400Responder(future.Response())
+		ar, err = client.PostAsyncRelativeRetry400Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.PostAsyncRelativeRetry400Responder(resp)
+	ar, err = client.PostAsyncRelativeRetry400Responder(resp)
+	return
 }
 
 // LROSADsPostAsyncRelativeRetryInvalidHeaderFuture an abstraction for monitoring and retrieving the results of a
@@ -650,23 +726,27 @@ type LROSADsPostAsyncRelativeRetryInvalidHeaderFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPostAsyncRelativeRetryInvalidHeaderFuture) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsPostAsyncRelativeRetryInvalidHeaderFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsPostAsyncRelativeRetryInvalidHeaderFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsPostAsyncRelativeRetryInvalidHeaderFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PostAsyncRelativeRetryInvalidHeaderResponder(future.Response())
+		ar, err = client.PostAsyncRelativeRetryInvalidHeaderResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.PostAsyncRelativeRetryInvalidHeaderResponder(resp)
+	ar, err = client.PostAsyncRelativeRetryInvalidHeaderResponder(resp)
+	return
 }
 
 // LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture an abstraction for monitoring and retrieving the results of a
@@ -678,23 +758,27 @@ type LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PostAsyncRelativeRetryInvalidJSONPollingResponder(future.Response())
+		ar, err = client.PostAsyncRelativeRetryInvalidJSONPollingResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.PostAsyncRelativeRetryInvalidJSONPollingResponder(resp)
+	ar, err = client.PostAsyncRelativeRetryInvalidJSONPollingResponder(resp)
+	return
 }
 
 // LROSADsPostAsyncRelativeRetryNoPayloadFuture an abstraction for monitoring and retrieving the results of a
@@ -706,23 +790,27 @@ type LROSADsPostAsyncRelativeRetryNoPayloadFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPostAsyncRelativeRetryNoPayloadFuture) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsPostAsyncRelativeRetryNoPayloadFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsPostAsyncRelativeRetryNoPayloadFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsPostAsyncRelativeRetryNoPayloadFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PostAsyncRelativeRetryNoPayloadResponder(future.Response())
+		ar, err = client.PostAsyncRelativeRetryNoPayloadResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.PostAsyncRelativeRetryNoPayloadResponder(resp)
+	ar, err = client.PostAsyncRelativeRetryNoPayloadResponder(resp)
+	return
 }
 
 // LROSADsPostNonRetry400Future an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -733,23 +821,27 @@ type LROSADsPostNonRetry400Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPostNonRetry400Future) Result(client LROSADsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROSADsPostNonRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROSADsPostNonRetry400Future", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROSADsPostNonRetry400Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PostNonRetry400Responder(future.Response())
+		ar, err = client.PostNonRetry400Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.PostNonRetry400Responder(resp)
+	ar, err = client.PostNonRetry400Responder(resp)
+	return
 }
 
 // LROSADsPut200InvalidJSONFuture an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -760,23 +852,27 @@ type LROSADsPut200InvalidJSONFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPut200InvalidJSONFuture) Result(client LROSADsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROSADsPut200InvalidJSONFuture) Result(client LROSADsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROSADsPut200InvalidJSONFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROSADsPut200InvalidJSONFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Put200InvalidJSONResponder(future.Response())
+		p, err = client.Put200InvalidJSONResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.Put200InvalidJSONResponder(resp)
+	p, err = client.Put200InvalidJSONResponder(resp)
+	return
 }
 
 // LROSADsPutAsyncRelativeRetry400Future an abstraction for monitoring and retrieving the results of a long-running
@@ -788,23 +884,27 @@ type LROSADsPutAsyncRelativeRetry400Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutAsyncRelativeRetry400Future) Result(client LROSADsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROSADsPutAsyncRelativeRetry400Future) Result(client LROSADsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROSADsPutAsyncRelativeRetry400Future", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROSADsPutAsyncRelativeRetry400Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutAsyncRelativeRetry400Responder(future.Response())
+		p, err = client.PutAsyncRelativeRetry400Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutAsyncRelativeRetry400Responder(resp)
+	p, err = client.PutAsyncRelativeRetry400Responder(resp)
+	return
 }
 
 // LROSADsPutAsyncRelativeRetryInvalidHeaderFuture an abstraction for monitoring and retrieving the results of a
@@ -816,23 +916,27 @@ type LROSADsPutAsyncRelativeRetryInvalidHeaderFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutAsyncRelativeRetryInvalidHeaderFuture) Result(client LROSADsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROSADsPutAsyncRelativeRetryInvalidHeaderFuture) Result(client LROSADsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROSADsPutAsyncRelativeRetryInvalidHeaderFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROSADsPutAsyncRelativeRetryInvalidHeaderFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutAsyncRelativeRetryInvalidHeaderResponder(future.Response())
+		p, err = client.PutAsyncRelativeRetryInvalidHeaderResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutAsyncRelativeRetryInvalidHeaderResponder(resp)
+	p, err = client.PutAsyncRelativeRetryInvalidHeaderResponder(resp)
+	return
 }
 
 // LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture an abstraction for monitoring and retrieving the results of a
@@ -844,23 +948,27 @@ type LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture) Result(client LROSADsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture) Result(client LROSADsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutAsyncRelativeRetryInvalidJSONPollingResponder(future.Response())
+		p, err = client.PutAsyncRelativeRetryInvalidJSONPollingResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutAsyncRelativeRetryInvalidJSONPollingResponder(resp)
+	p, err = client.PutAsyncRelativeRetryInvalidJSONPollingResponder(resp)
+	return
 }
 
 // LROSADsPutAsyncRelativeRetryNoStatusFuture an abstraction for monitoring and retrieving the results of a
@@ -872,23 +980,27 @@ type LROSADsPutAsyncRelativeRetryNoStatusFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutAsyncRelativeRetryNoStatusFuture) Result(client LROSADsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROSADsPutAsyncRelativeRetryNoStatusFuture) Result(client LROSADsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROSADsPutAsyncRelativeRetryNoStatusFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROSADsPutAsyncRelativeRetryNoStatusFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutAsyncRelativeRetryNoStatusResponder(future.Response())
+		p, err = client.PutAsyncRelativeRetryNoStatusResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutAsyncRelativeRetryNoStatusResponder(resp)
+	p, err = client.PutAsyncRelativeRetryNoStatusResponder(resp)
+	return
 }
 
 // LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture an abstraction for monitoring and retrieving the results of a
@@ -900,23 +1012,27 @@ type LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture) Result(client LROSADsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture) Result(client LROSADsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutAsyncRelativeRetryNoStatusPayloadResponder(future.Response())
+		p, err = client.PutAsyncRelativeRetryNoStatusPayloadResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutAsyncRelativeRetryNoStatusPayloadResponder(resp)
+	p, err = client.PutAsyncRelativeRetryNoStatusPayloadResponder(resp)
+	return
 }
 
 // LROSADsPutError201NoProvisioningStatePayloadFuture an abstraction for monitoring and retrieving the results of a
@@ -928,23 +1044,27 @@ type LROSADsPutError201NoProvisioningStatePayloadFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutError201NoProvisioningStatePayloadFuture) Result(client LROSADsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROSADsPutError201NoProvisioningStatePayloadFuture) Result(client LROSADsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROSADsPutError201NoProvisioningStatePayloadFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROSADsPutError201NoProvisioningStatePayloadFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutError201NoProvisioningStatePayloadResponder(future.Response())
+		p, err = client.PutError201NoProvisioningStatePayloadResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutError201NoProvisioningStatePayloadResponder(resp)
+	p, err = client.PutError201NoProvisioningStatePayloadResponder(resp)
+	return
 }
 
 // LROSADsPutNonRetry201Creating400Future an abstraction for monitoring and retrieving the results of a long-running
@@ -956,23 +1076,27 @@ type LROSADsPutNonRetry201Creating400Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutNonRetry201Creating400Future) Result(client LROSADsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROSADsPutNonRetry201Creating400Future) Result(client LROSADsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROSADsPutNonRetry201Creating400Future", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROSADsPutNonRetry201Creating400Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutNonRetry201Creating400Responder(future.Response())
+		p, err = client.PutNonRetry201Creating400Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutNonRetry201Creating400Responder(resp)
+	p, err = client.PutNonRetry201Creating400Responder(resp)
+	return
 }
 
 // LROSADsPutNonRetry201Creating400InvalidJSONFuture an abstraction for monitoring and retrieving the results of a
@@ -984,23 +1108,27 @@ type LROSADsPutNonRetry201Creating400InvalidJSONFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutNonRetry201Creating400InvalidJSONFuture) Result(client LROSADsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROSADsPutNonRetry201Creating400InvalidJSONFuture) Result(client LROSADsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROSADsPutNonRetry201Creating400InvalidJSONFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROSADsPutNonRetry201Creating400InvalidJSONFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutNonRetry201Creating400InvalidJSONResponder(future.Response())
+		p, err = client.PutNonRetry201Creating400InvalidJSONResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutNonRetry201Creating400InvalidJSONResponder(resp)
+	p, err = client.PutNonRetry201Creating400InvalidJSONResponder(resp)
+	return
 }
 
 // LROSADsPutNonRetry400Future an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -1011,23 +1139,27 @@ type LROSADsPutNonRetry400Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutNonRetry400Future) Result(client LROSADsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROSADsPutNonRetry400Future) Result(client LROSADsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROSADsPutNonRetry400Future", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROSADsPutNonRetry400Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutNonRetry400Responder(future.Response())
+		p, err = client.PutNonRetry400Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutNonRetry400Responder(resp)
+	p, err = client.PutNonRetry400Responder(resp)
+	return
 }
 
 // LROsCustomHeaderPost202Retry200Future an abstraction for monitoring and retrieving the results of a long-running
@@ -1039,23 +1171,27 @@ type LROsCustomHeaderPost202Retry200Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsCustomHeaderPost202Retry200Future) Result(client LROsCustomHeaderClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROsCustomHeaderPost202Retry200Future) Result(client LROsCustomHeaderClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROsCustomHeaderPost202Retry200Future", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROsCustomHeaderPost202Retry200Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Post202Retry200Responder(future.Response())
+		ar, err = client.Post202Retry200Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.Post202Retry200Responder(resp)
+	ar, err = client.Post202Retry200Responder(resp)
+	return
 }
 
 // LROsCustomHeaderPostAsyncRetrySucceededFuture an abstraction for monitoring and retrieving the results of a
@@ -1067,23 +1203,27 @@ type LROsCustomHeaderPostAsyncRetrySucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsCustomHeaderPostAsyncRetrySucceededFuture) Result(client LROsCustomHeaderClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROsCustomHeaderPostAsyncRetrySucceededFuture) Result(client LROsCustomHeaderClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROsCustomHeaderPostAsyncRetrySucceededFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROsCustomHeaderPostAsyncRetrySucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PostAsyncRetrySucceededResponder(future.Response())
+		ar, err = client.PostAsyncRetrySucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.PostAsyncRetrySucceededResponder(resp)
+	ar, err = client.PostAsyncRetrySucceededResponder(resp)
+	return
 }
 
 // LROsCustomHeaderPut201CreatingSucceeded200Future an abstraction for monitoring and retrieving the results of a
@@ -1095,23 +1235,27 @@ type LROsCustomHeaderPut201CreatingSucceeded200Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsCustomHeaderPut201CreatingSucceeded200Future) Result(client LROsCustomHeaderClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsCustomHeaderPut201CreatingSucceeded200Future) Result(client LROsCustomHeaderClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsCustomHeaderPut201CreatingSucceeded200Future", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsCustomHeaderPut201CreatingSucceeded200Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Put201CreatingSucceeded200Responder(future.Response())
+		p, err = client.Put201CreatingSucceeded200Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.Put201CreatingSucceeded200Responder(resp)
+	p, err = client.Put201CreatingSucceeded200Responder(resp)
+	return
 }
 
 // LROsCustomHeaderPutAsyncRetrySucceededFuture an abstraction for monitoring and retrieving the results of a
@@ -1123,23 +1267,27 @@ type LROsCustomHeaderPutAsyncRetrySucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsCustomHeaderPutAsyncRetrySucceededFuture) Result(client LROsCustomHeaderClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsCustomHeaderPutAsyncRetrySucceededFuture) Result(client LROsCustomHeaderClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsCustomHeaderPutAsyncRetrySucceededFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsCustomHeaderPutAsyncRetrySucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutAsyncRetrySucceededResponder(future.Response())
+		p, err = client.PutAsyncRetrySucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutAsyncRetrySucceededResponder(resp)
+	p, err = client.PutAsyncRetrySucceededResponder(resp)
+	return
 }
 
 // LROsDelete202NoRetry204Future an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -1150,23 +1298,27 @@ type LROsDelete202NoRetry204Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDelete202NoRetry204Future) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsDelete202NoRetry204Future) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsDelete202NoRetry204Future", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsDelete202NoRetry204Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Delete202NoRetry204Responder(future.Response())
+		p, err = client.Delete202NoRetry204Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.Delete202NoRetry204Responder(resp)
+	p, err = client.Delete202NoRetry204Responder(resp)
+	return
 }
 
 // LROsDelete202Retry200Future an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -1177,23 +1329,27 @@ type LROsDelete202Retry200Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDelete202Retry200Future) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsDelete202Retry200Future) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsDelete202Retry200Future", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsDelete202Retry200Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Delete202Retry200Responder(future.Response())
+		p, err = client.Delete202Retry200Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.Delete202Retry200Responder(resp)
+	p, err = client.Delete202Retry200Responder(resp)
+	return
 }
 
 // LROsDelete204SucceededFuture an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -1204,23 +1360,27 @@ type LROsDelete204SucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDelete204SucceededFuture) Result(client LROsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROsDelete204SucceededFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROsDelete204SucceededFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROsDelete204SucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Delete204SucceededResponder(future.Response())
+		ar, err = client.Delete204SucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.Delete204SucceededResponder(resp)
+	ar, err = client.Delete204SucceededResponder(resp)
+	return
 }
 
 // LROsDeleteAsyncNoHeaderInRetryFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -1232,23 +1392,27 @@ type LROsDeleteAsyncNoHeaderInRetryFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteAsyncNoHeaderInRetryFuture) Result(client LROsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROsDeleteAsyncNoHeaderInRetryFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROsDeleteAsyncNoHeaderInRetryFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROsDeleteAsyncNoHeaderInRetryFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteAsyncNoHeaderInRetryResponder(future.Response())
+		ar, err = client.DeleteAsyncNoHeaderInRetryResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.DeleteAsyncNoHeaderInRetryResponder(resp)
+	ar, err = client.DeleteAsyncNoHeaderInRetryResponder(resp)
+	return
 }
 
 // LROsDeleteAsyncNoRetrySucceededFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -1260,23 +1424,27 @@ type LROsDeleteAsyncNoRetrySucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteAsyncNoRetrySucceededFuture) Result(client LROsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROsDeleteAsyncNoRetrySucceededFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROsDeleteAsyncNoRetrySucceededFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROsDeleteAsyncNoRetrySucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteAsyncNoRetrySucceededResponder(future.Response())
+		ar, err = client.DeleteAsyncNoRetrySucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.DeleteAsyncNoRetrySucceededResponder(resp)
+	ar, err = client.DeleteAsyncNoRetrySucceededResponder(resp)
+	return
 }
 
 // LROsDeleteAsyncRetrycanceledFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -1288,23 +1456,27 @@ type LROsDeleteAsyncRetrycanceledFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteAsyncRetrycanceledFuture) Result(client LROsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROsDeleteAsyncRetrycanceledFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROsDeleteAsyncRetrycanceledFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROsDeleteAsyncRetrycanceledFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteAsyncRetrycanceledResponder(future.Response())
+		ar, err = client.DeleteAsyncRetrycanceledResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.DeleteAsyncRetrycanceledResponder(resp)
+	ar, err = client.DeleteAsyncRetrycanceledResponder(resp)
+	return
 }
 
 // LROsDeleteAsyncRetryFailedFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -1316,23 +1488,27 @@ type LROsDeleteAsyncRetryFailedFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteAsyncRetryFailedFuture) Result(client LROsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROsDeleteAsyncRetryFailedFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROsDeleteAsyncRetryFailedFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROsDeleteAsyncRetryFailedFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteAsyncRetryFailedResponder(future.Response())
+		ar, err = client.DeleteAsyncRetryFailedResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.DeleteAsyncRetryFailedResponder(resp)
+	ar, err = client.DeleteAsyncRetryFailedResponder(resp)
+	return
 }
 
 // LROsDeleteAsyncRetrySucceededFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -1344,23 +1520,27 @@ type LROsDeleteAsyncRetrySucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteAsyncRetrySucceededFuture) Result(client LROsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROsDeleteAsyncRetrySucceededFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROsDeleteAsyncRetrySucceededFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROsDeleteAsyncRetrySucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteAsyncRetrySucceededResponder(future.Response())
+		ar, err = client.DeleteAsyncRetrySucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.DeleteAsyncRetrySucceededResponder(resp)
+	ar, err = client.DeleteAsyncRetrySucceededResponder(resp)
+	return
 }
 
 // LROsDeleteNoHeaderInRetryFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -1372,23 +1552,27 @@ type LROsDeleteNoHeaderInRetryFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteNoHeaderInRetryFuture) Result(client LROsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROsDeleteNoHeaderInRetryFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROsDeleteNoHeaderInRetryFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROsDeleteNoHeaderInRetryFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteNoHeaderInRetryResponder(future.Response())
+		ar, err = client.DeleteNoHeaderInRetryResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.DeleteNoHeaderInRetryResponder(resp)
+	ar, err = client.DeleteNoHeaderInRetryResponder(resp)
+	return
 }
 
 // LROsDeleteProvisioning202Accepted200SucceededFuture an abstraction for monitoring and retrieving the results of a
@@ -1400,23 +1584,27 @@ type LROsDeleteProvisioning202Accepted200SucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteProvisioning202Accepted200SucceededFuture) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsDeleteProvisioning202Accepted200SucceededFuture) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsDeleteProvisioning202Accepted200SucceededFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsDeleteProvisioning202Accepted200SucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteProvisioning202Accepted200SucceededResponder(future.Response())
+		p, err = client.DeleteProvisioning202Accepted200SucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.DeleteProvisioning202Accepted200SucceededResponder(resp)
+	p, err = client.DeleteProvisioning202Accepted200SucceededResponder(resp)
+	return
 }
 
 // LROsDeleteProvisioning202Deletingcanceled200Future an abstraction for monitoring and retrieving the results of a
@@ -1428,23 +1616,27 @@ type LROsDeleteProvisioning202Deletingcanceled200Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteProvisioning202Deletingcanceled200Future) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsDeleteProvisioning202Deletingcanceled200Future) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsDeleteProvisioning202Deletingcanceled200Future", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsDeleteProvisioning202Deletingcanceled200Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteProvisioning202Deletingcanceled200Responder(future.Response())
+		p, err = client.DeleteProvisioning202Deletingcanceled200Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.DeleteProvisioning202Deletingcanceled200Responder(resp)
+	p, err = client.DeleteProvisioning202Deletingcanceled200Responder(resp)
+	return
 }
 
 // LROsDeleteProvisioning202DeletingFailed200Future an abstraction for monitoring and retrieving the results of a
@@ -1456,23 +1648,27 @@ type LROsDeleteProvisioning202DeletingFailed200Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteProvisioning202DeletingFailed200Future) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsDeleteProvisioning202DeletingFailed200Future) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsDeleteProvisioning202DeletingFailed200Future", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsDeleteProvisioning202DeletingFailed200Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.DeleteProvisioning202DeletingFailed200Responder(future.Response())
+		p, err = client.DeleteProvisioning202DeletingFailed200Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.DeleteProvisioning202DeletingFailed200Responder(resp)
+	p, err = client.DeleteProvisioning202DeletingFailed200Responder(resp)
+	return
 }
 
 // LROsPost200WithPayloadFuture an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -1483,23 +1679,27 @@ type LROsPost200WithPayloadFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPost200WithPayloadFuture) Result(client LROsClient) (Sku, error) {
-	done, err := future.Done(client)
+func (future LROsPost200WithPayloadFuture) Result(client LROsClient) (s Sku, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Sku{}, err
+		return
 	}
 	if !done {
-		return Sku{}, autorest.NewError("lrogroup.LROsPost200WithPayloadFuture", "Result", "asynchronous operation has not completed")
+		return s, autorest.NewError("lrogroup.LROsPost200WithPayloadFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Post200WithPayloadResponder(future.Response())
+		s, err = client.Post200WithPayloadResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Sku{}, err
+		return
 	}
-	return client.Post200WithPayloadResponder(resp)
+	s, err = client.Post200WithPayloadResponder(resp)
+	return
 }
 
 // LROsPost202NoRetry204Future an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -1510,23 +1710,27 @@ type LROsPost202NoRetry204Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPost202NoRetry204Future) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPost202NoRetry204Future) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPost202NoRetry204Future", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPost202NoRetry204Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Post202NoRetry204Responder(future.Response())
+		p, err = client.Post202NoRetry204Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.Post202NoRetry204Responder(resp)
+	p, err = client.Post202NoRetry204Responder(resp)
+	return
 }
 
 // LROsPost202Retry200Future an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -1537,23 +1741,27 @@ type LROsPost202Retry200Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPost202Retry200Future) Result(client LROsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROsPost202Retry200Future) Result(client LROsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROsPost202Retry200Future", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROsPost202Retry200Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Post202Retry200Responder(future.Response())
+		ar, err = client.Post202Retry200Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.Post202Retry200Responder(resp)
+	ar, err = client.Post202Retry200Responder(resp)
+	return
 }
 
 // LROsPostAsyncNoRetrySucceededFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -1565,23 +1773,27 @@ type LROsPostAsyncNoRetrySucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPostAsyncNoRetrySucceededFuture) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPostAsyncNoRetrySucceededFuture) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPostAsyncNoRetrySucceededFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPostAsyncNoRetrySucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PostAsyncNoRetrySucceededResponder(future.Response())
+		p, err = client.PostAsyncNoRetrySucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PostAsyncNoRetrySucceededResponder(resp)
+	p, err = client.PostAsyncNoRetrySucceededResponder(resp)
+	return
 }
 
 // LROsPostAsyncRetrycanceledFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -1593,23 +1805,27 @@ type LROsPostAsyncRetrycanceledFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPostAsyncRetrycanceledFuture) Result(client LROsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROsPostAsyncRetrycanceledFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROsPostAsyncRetrycanceledFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROsPostAsyncRetrycanceledFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PostAsyncRetrycanceledResponder(future.Response())
+		ar, err = client.PostAsyncRetrycanceledResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.PostAsyncRetrycanceledResponder(resp)
+	ar, err = client.PostAsyncRetrycanceledResponder(resp)
+	return
 }
 
 // LROsPostAsyncRetryFailedFuture an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -1620,23 +1836,27 @@ type LROsPostAsyncRetryFailedFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPostAsyncRetryFailedFuture) Result(client LROsClient) (autorest.Response, error) {
-	done, err := future.Done(client)
+func (future LROsPostAsyncRetryFailedFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
 	if !done {
-		return autorest.Response{}, autorest.NewError("lrogroup.LROsPostAsyncRetryFailedFuture", "Result", "asynchronous operation has not completed")
+		return ar, autorest.NewError("lrogroup.LROsPostAsyncRetryFailedFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PostAsyncRetryFailedResponder(future.Response())
+		ar, err = client.PostAsyncRetryFailedResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return autorest.Response{}, err
+		return
 	}
-	return client.PostAsyncRetryFailedResponder(resp)
+	ar, err = client.PostAsyncRetryFailedResponder(resp)
+	return
 }
 
 // LROsPostAsyncRetrySucceededFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -1648,23 +1868,27 @@ type LROsPostAsyncRetrySucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPostAsyncRetrySucceededFuture) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPostAsyncRetrySucceededFuture) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPostAsyncRetrySucceededFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPostAsyncRetrySucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PostAsyncRetrySucceededResponder(future.Response())
+		p, err = client.PostAsyncRetrySucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PostAsyncRetrySucceededResponder(resp)
+	p, err = client.PostAsyncRetrySucceededResponder(resp)
+	return
 }
 
 // LROsPut200Acceptedcanceled200Future an abstraction for monitoring and retrieving the results of a long-running
@@ -1676,23 +1900,27 @@ type LROsPut200Acceptedcanceled200Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPut200Acceptedcanceled200Future) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPut200Acceptedcanceled200Future) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPut200Acceptedcanceled200Future", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPut200Acceptedcanceled200Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Put200Acceptedcanceled200Responder(future.Response())
+		p, err = client.Put200Acceptedcanceled200Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.Put200Acceptedcanceled200Responder(resp)
+	p, err = client.Put200Acceptedcanceled200Responder(resp)
+	return
 }
 
 // LROsPut200SucceededFuture an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -1703,23 +1931,27 @@ type LROsPut200SucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPut200SucceededFuture) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPut200SucceededFuture) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPut200SucceededFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPut200SucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Put200SucceededResponder(future.Response())
+		p, err = client.Put200SucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.Put200SucceededResponder(resp)
+	p, err = client.Put200SucceededResponder(resp)
+	return
 }
 
 // LROsPut200SucceededNoStateFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -1731,23 +1963,27 @@ type LROsPut200SucceededNoStateFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPut200SucceededNoStateFuture) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPut200SucceededNoStateFuture) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPut200SucceededNoStateFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPut200SucceededNoStateFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Put200SucceededNoStateResponder(future.Response())
+		p, err = client.Put200SucceededNoStateResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.Put200SucceededNoStateResponder(resp)
+	p, err = client.Put200SucceededNoStateResponder(resp)
+	return
 }
 
 // LROsPut200UpdatingSucceeded204Future an abstraction for monitoring and retrieving the results of a long-running
@@ -1759,23 +1995,27 @@ type LROsPut200UpdatingSucceeded204Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPut200UpdatingSucceeded204Future) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPut200UpdatingSucceeded204Future) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPut200UpdatingSucceeded204Future", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPut200UpdatingSucceeded204Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Put200UpdatingSucceeded204Responder(future.Response())
+		p, err = client.Put200UpdatingSucceeded204Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.Put200UpdatingSucceeded204Responder(resp)
+	p, err = client.Put200UpdatingSucceeded204Responder(resp)
+	return
 }
 
 // LROsPut201CreatingFailed200Future an abstraction for monitoring and retrieving the results of a long-running
@@ -1787,23 +2027,27 @@ type LROsPut201CreatingFailed200Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPut201CreatingFailed200Future) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPut201CreatingFailed200Future) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPut201CreatingFailed200Future", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPut201CreatingFailed200Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Put201CreatingFailed200Responder(future.Response())
+		p, err = client.Put201CreatingFailed200Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.Put201CreatingFailed200Responder(resp)
+	p, err = client.Put201CreatingFailed200Responder(resp)
+	return
 }
 
 // LROsPut201CreatingSucceeded200Future an abstraction for monitoring and retrieving the results of a long-running
@@ -1815,23 +2059,27 @@ type LROsPut201CreatingSucceeded200Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPut201CreatingSucceeded200Future) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPut201CreatingSucceeded200Future) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPut201CreatingSucceeded200Future", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPut201CreatingSucceeded200Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Put201CreatingSucceeded200Responder(future.Response())
+		p, err = client.Put201CreatingSucceeded200Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.Put201CreatingSucceeded200Responder(resp)
+	p, err = client.Put201CreatingSucceeded200Responder(resp)
+	return
 }
 
 // LROsPut202Retry200Future an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -1842,23 +2090,27 @@ type LROsPut202Retry200Future struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPut202Retry200Future) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPut202Retry200Future) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPut202Retry200Future", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPut202Retry200Future", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.Put202Retry200Responder(future.Response())
+		p, err = client.Put202Retry200Responder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.Put202Retry200Responder(resp)
+	p, err = client.Put202Retry200Responder(resp)
+	return
 }
 
 // LROsPutAsyncNoHeaderInRetryFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -1870,23 +2122,27 @@ type LROsPutAsyncNoHeaderInRetryFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutAsyncNoHeaderInRetryFuture) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPutAsyncNoHeaderInRetryFuture) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPutAsyncNoHeaderInRetryFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPutAsyncNoHeaderInRetryFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutAsyncNoHeaderInRetryResponder(future.Response())
+		p, err = client.PutAsyncNoHeaderInRetryResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutAsyncNoHeaderInRetryResponder(resp)
+	p, err = client.PutAsyncNoHeaderInRetryResponder(resp)
+	return
 }
 
 // LROsPutAsyncNonResourceFuture an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -1897,23 +2153,27 @@ type LROsPutAsyncNonResourceFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutAsyncNonResourceFuture) Result(client LROsClient) (Sku, error) {
-	done, err := future.Done(client)
+func (future LROsPutAsyncNonResourceFuture) Result(client LROsClient) (s Sku, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Sku{}, err
+		return
 	}
 	if !done {
-		return Sku{}, autorest.NewError("lrogroup.LROsPutAsyncNonResourceFuture", "Result", "asynchronous operation has not completed")
+		return s, autorest.NewError("lrogroup.LROsPutAsyncNonResourceFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutAsyncNonResourceResponder(future.Response())
+		s, err = client.PutAsyncNonResourceResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Sku{}, err
+		return
 	}
-	return client.PutAsyncNonResourceResponder(resp)
+	s, err = client.PutAsyncNonResourceResponder(resp)
+	return
 }
 
 // LROsPutAsyncNoRetrycanceledFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -1925,23 +2185,27 @@ type LROsPutAsyncNoRetrycanceledFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutAsyncNoRetrycanceledFuture) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPutAsyncNoRetrycanceledFuture) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPutAsyncNoRetrycanceledFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPutAsyncNoRetrycanceledFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutAsyncNoRetrycanceledResponder(future.Response())
+		p, err = client.PutAsyncNoRetrycanceledResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutAsyncNoRetrycanceledResponder(resp)
+	p, err = client.PutAsyncNoRetrycanceledResponder(resp)
+	return
 }
 
 // LROsPutAsyncNoRetrySucceededFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -1953,23 +2217,27 @@ type LROsPutAsyncNoRetrySucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutAsyncNoRetrySucceededFuture) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPutAsyncNoRetrySucceededFuture) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPutAsyncNoRetrySucceededFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPutAsyncNoRetrySucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutAsyncNoRetrySucceededResponder(future.Response())
+		p, err = client.PutAsyncNoRetrySucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutAsyncNoRetrySucceededResponder(resp)
+	p, err = client.PutAsyncNoRetrySucceededResponder(resp)
+	return
 }
 
 // LROsPutAsyncRetryFailedFuture an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -1980,23 +2248,27 @@ type LROsPutAsyncRetryFailedFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutAsyncRetryFailedFuture) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPutAsyncRetryFailedFuture) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPutAsyncRetryFailedFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPutAsyncRetryFailedFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutAsyncRetryFailedResponder(future.Response())
+		p, err = client.PutAsyncRetryFailedResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutAsyncRetryFailedResponder(resp)
+	p, err = client.PutAsyncRetryFailedResponder(resp)
+	return
 }
 
 // LROsPutAsyncRetrySucceededFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -2008,23 +2280,27 @@ type LROsPutAsyncRetrySucceededFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutAsyncRetrySucceededFuture) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPutAsyncRetrySucceededFuture) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPutAsyncRetrySucceededFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPutAsyncRetrySucceededFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutAsyncRetrySucceededResponder(future.Response())
+		p, err = client.PutAsyncRetrySucceededResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutAsyncRetrySucceededResponder(resp)
+	p, err = client.PutAsyncRetrySucceededResponder(resp)
+	return
 }
 
 // LROsPutAsyncSubResourceFuture an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -2035,23 +2311,27 @@ type LROsPutAsyncSubResourceFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutAsyncSubResourceFuture) Result(client LROsClient) (SubProduct, error) {
-	done, err := future.Done(client)
+func (future LROsPutAsyncSubResourceFuture) Result(client LROsClient) (sp SubProduct, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return SubProduct{}, err
+		return
 	}
 	if !done {
-		return SubProduct{}, autorest.NewError("lrogroup.LROsPutAsyncSubResourceFuture", "Result", "asynchronous operation has not completed")
+		return sp, autorest.NewError("lrogroup.LROsPutAsyncSubResourceFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutAsyncSubResourceResponder(future.Response())
+		sp, err = client.PutAsyncSubResourceResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return SubProduct{}, err
+		return
 	}
-	return client.PutAsyncSubResourceResponder(resp)
+	sp, err = client.PutAsyncSubResourceResponder(resp)
+	return
 }
 
 // LROsPutNoHeaderInRetryFuture an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -2062,23 +2342,27 @@ type LROsPutNoHeaderInRetryFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutNoHeaderInRetryFuture) Result(client LROsClient) (Product, error) {
-	done, err := future.Done(client)
+func (future LROsPutNoHeaderInRetryFuture) Result(client LROsClient) (p Product, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Product{}, err
+		return
 	}
 	if !done {
-		return Product{}, autorest.NewError("lrogroup.LROsPutNoHeaderInRetryFuture", "Result", "asynchronous operation has not completed")
+		return p, autorest.NewError("lrogroup.LROsPutNoHeaderInRetryFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutNoHeaderInRetryResponder(future.Response())
+		p, err = client.PutNoHeaderInRetryResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Product{}, err
+		return
 	}
-	return client.PutNoHeaderInRetryResponder(resp)
+	p, err = client.PutNoHeaderInRetryResponder(resp)
+	return
 }
 
 // LROsPutNonResourceFuture an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -2089,23 +2373,27 @@ type LROsPutNonResourceFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutNonResourceFuture) Result(client LROsClient) (Sku, error) {
-	done, err := future.Done(client)
+func (future LROsPutNonResourceFuture) Result(client LROsClient) (s Sku, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return Sku{}, err
+		return
 	}
 	if !done {
-		return Sku{}, autorest.NewError("lrogroup.LROsPutNonResourceFuture", "Result", "asynchronous operation has not completed")
+		return s, autorest.NewError("lrogroup.LROsPutNonResourceFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutNonResourceResponder(future.Response())
+		s, err = client.PutNonResourceResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return Sku{}, err
+		return
 	}
-	return client.PutNonResourceResponder(resp)
+	s, err = client.PutNonResourceResponder(resp)
+	return
 }
 
 // LROsPutSubResourceFuture an abstraction for monitoring and retrieving the results of a long-running operation.
@@ -2116,23 +2404,27 @@ type LROsPutSubResourceFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutSubResourceFuture) Result(client LROsClient) (SubProduct, error) {
-	done, err := future.Done(client)
+func (future LROsPutSubResourceFuture) Result(client LROsClient) (sp SubProduct, err error) {
+	var done bool
+	done, err = future.Done(client)
 	if err != nil {
-		return SubProduct{}, err
+		return
 	}
 	if !done {
-		return SubProduct{}, autorest.NewError("lrogroup.LROsPutSubResourceFuture", "Result", "asynchronous operation has not completed")
+		return sp, autorest.NewError("lrogroup.LROsPutSubResourceFuture", "Result", "asynchronous operation has not completed")
 	}
 	if future.PollingMethod() == azure.PollingLocation {
-		return client.PutSubResourceResponder(future.Response())
+		sp, err = client.PutSubResourceResponder(future.Response())
+		return
 	}
-	resp, err := autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, autorest.ChangeToGet(future.req),
 		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
-		return SubProduct{}, err
+		return
 	}
-	return client.PutSubResourceResponder(resp)
+	sp, err = client.PutSubResourceResponder(resp)
+	return
 }
 
 // OperationResult

--- a/test/src/tests/generated/model-flattening/client.go
+++ b/test/src/tests/generated/model-flattening/client.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Modelflatteninggroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Modelflatteninggroup.

--- a/test/src/tests/generated/paging/client.go
+++ b/test/src/tests/generated/paging/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Paginggroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Paginggroup.

--- a/test/src/tests/generated/paging/models.go
+++ b/test/src/tests/generated/paging/models.go
@@ -47,16 +47,97 @@ type OdataProductResult struct {
 	OdataNextLink     *string    `json:"odata.nextLink,omitempty"`
 }
 
-// OdataProductResultPreparer prepares a request to retrieve the next set of results. It returns
-// nil if no more results exist.
-func (client OdataProductResult) OdataProductResultPreparer() (*http.Request, error) {
-	if client.OdataNextLink == nil || len(to.String(client.OdataNextLink)) <= 0 {
+// OdataProductResultIterator provides access to a complete listing of Product values.
+type OdataProductResultIterator struct {
+	i    int
+	page OdataProductResultPage
+}
+
+// Next advances to the next value.  If there was an error making
+// the request the iterator does not advance and the error is returned.
+func (iter *OdataProductResultIterator) Next() error {
+	iter.i++
+	if iter.i < len(iter.page.Values()) {
+		return nil
+	}
+	err := iter.page.Next()
+	if err != nil {
+		iter.i--
+		return err
+	}
+	iter.i = 0
+	return nil
+}
+
+// NotDone returns true if the enumeration should be started or is not yet complete.
+func (iter OdataProductResultIterator) NotDone() bool {
+	return iter.page.NotDone() && iter.i < len(iter.page.Values())
+}
+
+// Response returns the raw server response.
+func (iter OdataProductResultIterator) Response() autorest.Response {
+	return iter.page.Response()
+}
+
+// Value returns the current value or a zero-initialized value if the
+// iterator has advanced beyond the end of the collection.
+func (iter OdataProductResultIterator) Value() Product {
+	if !iter.page.NotDone() {
+		return Product{}
+	}
+	return iter.page.Values()[iter.i]
+}
+
+// IsEmpty returns true if the ListResult contains no values.
+func (opr OdataProductResult) IsEmpty() bool {
+	return opr.Values == nil || len(*opr.Values) == 0
+}
+
+// odataProductResultPreparer prepares a request to retrieve the next set of results.
+// It returns nil if no more results exist.
+func (opr OdataProductResult) odataProductResultPreparer() (*http.Request, error) {
+	if opr.OdataNextLink == nil || len(to.String(opr.OdataNextLink)) < 1 {
 		return nil, nil
 	}
 	return autorest.Prepare(&http.Request{},
 		autorest.AsJSON(),
 		autorest.AsGet(),
-		autorest.WithBaseURL(to.String(client.OdataNextLink)))
+		autorest.WithBaseURL(to.String(opr.OdataNextLink)))
+}
+
+// OdataProductResultPage contains a page of Product values.
+type OdataProductResultPage struct {
+	fn  func(OdataProductResult) (OdataProductResult, error)
+	opr OdataProductResult
+}
+
+// Next advances to the next page of values.  If there was an error making
+// the request the page does not advance and the error is returned.
+func (page *OdataProductResultPage) Next() error {
+	next, err := page.fn(page.opr)
+	if err != nil {
+		return err
+	}
+	page.opr = next
+	return nil
+}
+
+// NotDone returns true if the page enumeration should be started or is not yet complete.
+func (page OdataProductResultPage) NotDone() bool {
+	return !page.opr.IsEmpty()
+}
+
+// Response returns the raw server response from the last page request.
+func (page OdataProductResultPage) Response() autorest.Response {
+	return page.opr.Response
+}
+
+// Values returns the slice of values for the current page or nil if there are no values.
+func (page OdataProductResultPage) Values() []Product {
+	if page.opr.IsEmpty() {
+		return nil
+	}
+	return *page.opr.Values
 }
 
 // OperationResult
@@ -82,14 +163,95 @@ type ProductResult struct {
 	NextLink          *string    `json:"nextLink,omitempty"`
 }
 
-// ProductResultPreparer prepares a request to retrieve the next set of results. It returns
-// nil if no more results exist.
-func (client ProductResult) ProductResultPreparer() (*http.Request, error) {
-	if client.NextLink == nil || len(to.String(client.NextLink)) <= 0 {
+// ProductResultIterator provides access to a complete listing of Product values.
+type ProductResultIterator struct {
+	i    int
+	page ProductResultPage
+}
+
+// Next advances to the next value.  If there was an error making
+// the request the iterator does not advance and the error is returned.
+func (iter *ProductResultIterator) Next() error {
+	iter.i++
+	if iter.i < len(iter.page.Values()) {
+		return nil
+	}
+	err := iter.page.Next()
+	if err != nil {
+		iter.i--
+		return err
+	}
+	iter.i = 0
+	return nil
+}
+
+// NotDone returns true if the enumeration should be started or is not yet complete.
+func (iter ProductResultIterator) NotDone() bool {
+	return iter.page.NotDone() && iter.i < len(iter.page.Values())
+}
+
+// Response returns the raw server response.
+func (iter ProductResultIterator) Response() autorest.Response {
+	return iter.page.Response()
+}
+
+// Value returns the current value or a zero-initialized value if the
+// iterator has advanced beyond the end of the collection.
+func (iter ProductResultIterator) Value() Product {
+	if !iter.page.NotDone() {
+		return Product{}
+	}
+	return iter.page.Values()[iter.i]
+}
+
+// IsEmpty returns true if the ListResult contains no values.
+func (pr ProductResult) IsEmpty() bool {
+	return pr.Values == nil || len(*pr.Values) == 0
+}
+
+// productResultPreparer prepares a request to retrieve the next set of results.
+// It returns nil if no more results exist.
+func (pr ProductResult) productResultPreparer() (*http.Request, error) {
+	if pr.NextLink == nil || len(to.String(pr.NextLink)) < 1 {
 		return nil, nil
 	}
 	return autorest.Prepare(&http.Request{},
 		autorest.AsJSON(),
 		autorest.AsGet(),
-		autorest.WithBaseURL(to.String(client.NextLink)))
+		autorest.WithBaseURL(to.String(pr.NextLink)))
+}
+
+// ProductResultPage contains a page of Product values.
+type ProductResultPage struct {
+	fn func(ProductResult) (ProductResult, error)
+	pr ProductResult
+}
+
+// Next advances to the next page of values.  If there was an error making
+// the request the page does not advance and the error is returned.
+func (page *ProductResultPage) Next() error {
+	next, err := page.fn(page.pr)
+	if err != nil {
+		return err
+	}
+	page.pr = next
+	return nil
+}
+
+// NotDone returns true if the page enumeration should be started or is not yet complete.
+func (page ProductResultPage) NotDone() bool {
+	return !page.pr.IsEmpty()
+}
+
+// Response returns the raw server response from the last page request.
+func (page ProductResultPage) Response() autorest.Response {
+	return page.pr.Response
+}
+
+// Values returns the slice of values for the current page or nil if there are no values.
+func (page ProductResultPage) Values() []Product {
+	if page.pr.IsEmpty() {
+		return nil
+	}
+	return *page.pr.Values
 }

--- a/test/src/tests/generated/paging/models.go
+++ b/test/src/tests/generated/paging/models.go
@@ -74,8 +74,8 @@ func (iter OdataProductResultIterator) NotDone() bool {
 	return iter.page.NotDone() && iter.i < len(iter.page.Values())
 }
 
-// Response returns the raw server response.
-func (iter OdataProductResultIterator) Response() autorest.Response {
+// Response returns the raw server response from the last page request.
+func (iter OdataProductResultIterator) Response() OdataProductResult {
 	return iter.page.Response()
 }
 
@@ -128,8 +128,8 @@ func (page OdataProductResultPage) NotDone() bool {
 }
 
 // Response returns the raw server response from the last page request.
-func (page OdataProductResultPage) Response() autorest.Response {
-	return page.opr.Response
+func (page OdataProductResultPage) Response() OdataProductResult {
+	return page.opr
 }
 
 // Values returns the slice of values for the current page or nil if there are no values.
@@ -190,8 +190,8 @@ func (iter ProductResultIterator) NotDone() bool {
 	return iter.page.NotDone() && iter.i < len(iter.page.Values())
 }
 
-// Response returns the raw server response.
-func (iter ProductResultIterator) Response() autorest.Response {
+// Response returns the raw server response from the last page request.
+func (iter ProductResultIterator) Response() ProductResult {
 	return iter.page.Response()
 }
 
@@ -244,8 +244,8 @@ func (page ProductResultPage) NotDone() bool {
 }
 
 // Response returns the raw server response from the last page request.
-func (page ProductResultPage) Response() autorest.Response {
-	return page.pr.Response
+func (page ProductResultPage) Response() ProductResult {
+	return page.pr
 }
 
 // Values returns the slice of values for the current page or nil if there are no values.

--- a/test/src/tests/generated/paging/paging.go
+++ b/test/src/tests/generated/paging/paging.go
@@ -118,8 +118,8 @@ func (client PagingClient) getMultiplePagesNextResults(lastResults ProductResult
 	return
 }
 
-// GetMultiplePagesAll enumerates all values, automatically crossing page boundaries as required.
-func (client PagingClient) GetMultiplePagesAll(ctx context.Context, clientRequestID string, maxresults *int32, timeout *int32) (result ProductResultIterator, err error) {
+// GetMultiplePagesComplete enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesComplete(ctx context.Context, clientRequestID string, maxresults *int32, timeout *int32) (result ProductResultIterator, err error) {
 	result.page, err = client.GetMultiplePages(ctx, clientRequestID, maxresults, timeout)
 	return
 }
@@ -198,8 +198,8 @@ func (client PagingClient) getMultiplePagesFailureNextResults(lastResults Produc
 	return
 }
 
-// GetMultiplePagesFailureAll enumerates all values, automatically crossing page boundaries as required.
-func (client PagingClient) GetMultiplePagesFailureAll(ctx context.Context) (result ProductResultIterator, err error) {
+// GetMultiplePagesFailureComplete enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesFailureComplete(ctx context.Context) (result ProductResultIterator, err error) {
 	result.page, err = client.GetMultiplePagesFailure(ctx)
 	return
 }
@@ -278,8 +278,8 @@ func (client PagingClient) getMultiplePagesFailureURINextResults(lastResults Pro
 	return
 }
 
-// GetMultiplePagesFailureURIAll enumerates all values, automatically crossing page boundaries as required.
-func (client PagingClient) GetMultiplePagesFailureURIAll(ctx context.Context) (result ProductResultIterator, err error) {
+// GetMultiplePagesFailureURIComplete enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesFailureURIComplete(ctx context.Context) (result ProductResultIterator, err error) {
 	result.page, err = client.GetMultiplePagesFailureURI(ctx)
 	return
 }
@@ -353,8 +353,8 @@ func (client PagingClient) GetMultiplePagesFragmentNextLinkResponder(resp *http.
 	return
 }
 
-// GetMultiplePagesFragmentNextLinkAll enumerates all values, automatically crossing page boundaries as required.
-func (client PagingClient) GetMultiplePagesFragmentNextLinkAll(ctx context.Context, APIVersion string, tenant string) (result OdataProductResultIterator, err error) {
+// GetMultiplePagesFragmentNextLinkComplete enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesFragmentNextLinkComplete(ctx context.Context, APIVersion string, tenant string) (result OdataProductResultIterator, err error) {
 	result.page, err = client.GetMultiplePagesFragmentNextLink(ctx, APIVersion, tenant)
 	return
 }
@@ -429,8 +429,8 @@ func (client PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkResponder
 	return
 }
 
-// GetMultiplePagesFragmentWithGroupingNextLinkAll enumerates all values, automatically crossing page boundaries as required.
-func (client PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkAll(ctx context.Context, APIVersion string, tenant string) (result OdataProductResultIterator, err error) {
+// GetMultiplePagesFragmentWithGroupingNextLinkComplete enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkComplete(ctx context.Context, APIVersion string, tenant string) (result OdataProductResultIterator, err error) {
 	result.page, err = client.GetMultiplePagesFragmentWithGroupingNextLink(ctx, APIVersion, tenant)
 	return
 }
@@ -510,8 +510,8 @@ func (client PagingClient) getMultiplePagesRetryFirstNextResults(lastResults Pro
 	return
 }
 
-// GetMultiplePagesRetryFirstAll enumerates all values, automatically crossing page boundaries as required.
-func (client PagingClient) GetMultiplePagesRetryFirstAll(ctx context.Context) (result ProductResultIterator, err error) {
+// GetMultiplePagesRetryFirstComplete enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesRetryFirstComplete(ctx context.Context) (result ProductResultIterator, err error) {
 	result.page, err = client.GetMultiplePagesRetryFirst(ctx)
 	return
 }
@@ -591,8 +591,8 @@ func (client PagingClient) getMultiplePagesRetrySecondNextResults(lastResults Pr
 	return
 }
 
-// GetMultiplePagesRetrySecondAll enumerates all values, automatically crossing page boundaries as required.
-func (client PagingClient) GetMultiplePagesRetrySecondAll(ctx context.Context) (result ProductResultIterator, err error) {
+// GetMultiplePagesRetrySecondComplete enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesRetrySecondComplete(ctx context.Context) (result ProductResultIterator, err error) {
 	result.page, err = client.GetMultiplePagesRetrySecond(ctx)
 	return
 }
@@ -690,8 +690,8 @@ func (client PagingClient) getMultiplePagesWithOffsetNextResults(lastResults Pro
 	return
 }
 
-// GetMultiplePagesWithOffsetAll enumerates all values, automatically crossing page boundaries as required.
-func (client PagingClient) GetMultiplePagesWithOffsetAll(ctx context.Context, offset int32, clientRequestID string, maxresults *int32, timeout *int32) (result ProductResultIterator, err error) {
+// GetMultiplePagesWithOffsetComplete enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesWithOffsetComplete(ctx context.Context, offset int32, clientRequestID string, maxresults *int32, timeout *int32) (result ProductResultIterator, err error) {
 	result.page, err = client.GetMultiplePagesWithOffset(ctx, offset, clientRequestID, maxresults, timeout)
 	return
 }
@@ -785,8 +785,8 @@ func (client PagingClient) getOdataMultiplePagesNextResults(lastResults OdataPro
 	return
 }
 
-// GetOdataMultiplePagesAll enumerates all values, automatically crossing page boundaries as required.
-func (client PagingClient) GetOdataMultiplePagesAll(ctx context.Context, clientRequestID string, maxresults *int32, timeout *int32) (result OdataProductResultIterator, err error) {
+// GetOdataMultiplePagesComplete enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetOdataMultiplePagesComplete(ctx context.Context, clientRequestID string, maxresults *int32, timeout *int32) (result OdataProductResultIterator, err error) {
 	result.page, err = client.GetOdataMultiplePages(ctx, clientRequestID, maxresults, timeout)
 	return
 }
@@ -865,8 +865,8 @@ func (client PagingClient) getSinglePagesNextResults(lastResults ProductResult) 
 	return
 }
 
-// GetSinglePagesAll enumerates all values, automatically crossing page boundaries as required.
-func (client PagingClient) GetSinglePagesAll(ctx context.Context) (result ProductResultIterator, err error) {
+// GetSinglePagesComplete enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetSinglePagesComplete(ctx context.Context) (result ProductResultIterator, err error) {
 	result.page, err = client.GetSinglePages(ctx)
 	return
 }
@@ -945,8 +945,8 @@ func (client PagingClient) getSinglePagesFailureNextResults(lastResults ProductR
 	return
 }
 
-// GetSinglePagesFailureAll enumerates all values, automatically crossing page boundaries as required.
-func (client PagingClient) GetSinglePagesFailureAll(ctx context.Context) (result ProductResultIterator, err error) {
+// GetSinglePagesFailureComplete enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetSinglePagesFailureComplete(ctx context.Context) (result ProductResultIterator, err error) {
 	result.page, err = client.GetSinglePagesFailure(ctx)
 	return
 }

--- a/test/src/tests/generated/paging/paging.go
+++ b/test/src/tests/generated/paging/paging.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/to"
 	"net/http"
 )
 
@@ -32,7 +33,8 @@ func NewPagingClientWithBaseURI(baseURI string) PagingClient {
 //
 // maxresults is sets the maximum number of items to return in the response. timeout is sets the maximum time that the
 // server can spend processing the request, in seconds. The default is 30 seconds.
-func (client PagingClient) GetMultiplePages(ctx context.Context, clientRequestID string, maxresults *int32, timeout *int32) (result ProductResult, err error) {
+func (client PagingClient) GetMultiplePages(ctx context.Context, clientRequestID string, maxresults *int32, timeout *int32) (result ProductResultPage, err error) {
+	result.fn = client.getMultiplePagesNextResults
 	req, err := client.GetMultiplePagesPreparer(ctx, clientRequestID, maxresults, timeout)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePages", nil, "Failure preparing request")
@@ -41,12 +43,12 @@ func (client PagingClient) GetMultiplePages(ctx context.Context, clientRequestID
 
 	resp, err := client.GetMultiplePagesSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.pr.Response = autorest.Response{Response: resp}
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePages", resp, "Failure sending request")
 		return
 	}
 
-	result, err = client.GetMultiplePagesResponder(resp)
+	result.pr, err = client.GetMultiplePagesResponder(resp)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePages", resp, "Failure responding to request")
 	}
@@ -95,11 +97,11 @@ func (client PagingClient) GetMultiplePagesResponder(resp *http.Response) (resul
 	return
 }
 
-// GetMultiplePagesNextResults retrieves the next set of results, if any.
-func (client PagingClient) GetMultiplePagesNextResults(lastResults ProductResult) (result ProductResult, err error) {
-	req, err := lastResults.ProductResultPreparer()
+// getMultiplePagesNextResults retrieves the next set of results, if any.
+func (client PagingClient) getMultiplePagesNextResults(lastResults ProductResult) (result ProductResult, err error) {
+	req, err := lastResults.productResultPreparer()
 	if err != nil {
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePages", nil, "Failure preparing next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesNextResults", nil, "Failure preparing next results request")
 	}
 	if req == nil {
 		return
@@ -107,64 +109,24 @@ func (client PagingClient) GetMultiplePagesNextResults(lastResults ProductResult
 	resp, err := client.GetMultiplePagesSender(req)
 	if err != nil {
 		result.Response = autorest.Response{Response: resp}
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePages", resp, "Failure sending next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesNextResults", resp, "Failure sending next results request")
 	}
 	result, err = client.GetMultiplePagesResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePages", resp, "Failure responding to next results request")
+		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesNextResults", resp, "Failure responding to next results request")
 	}
 	return
 }
 
-// GetMultiplePagesComplete gets all elements from the list without paging.
-func (client PagingClient) GetMultiplePagesComplete(ctx context.Context, clientRequestID string, maxresults *int32, timeout *int32) (<-chan Product, <-chan error) {
-	resultChan := make(chan Product)
-	errChan := make(chan error, 1)
-	go func() {
-		defer func() {
-			close(resultChan)
-			close(errChan)
-		}()
-		list, err := client.GetMultiplePages(ctx, clientRequestID, maxresults, timeout)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		if list.Values != nil {
-			for _, item := range *list.Values {
-				select {
-				case <-ctx.Done():
-					errChan <- ctx.Err()
-					return
-				case resultChan <- item:
-					// Intentionally left blank
-				}
-			}
-		}
-		for list.NextLink != nil {
-			list, err = client.GetMultiplePagesNextResults(list)
-			if err != nil {
-				errChan <- err
-				return
-			}
-			if list.Values != nil {
-				for _, item := range *list.Values {
-					select {
-					case <-ctx.Done():
-						errChan <- ctx.Err()
-						return
-					case resultChan <- item:
-						// Intentionally left blank
-					}
-				}
-			}
-		}
-	}()
-	return resultChan, errChan
+// GetMultiplePagesAll enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesAll(ctx context.Context, clientRequestID string, maxresults *int32, timeout *int32) (result ProductResultIterator, err error) {
+	result.page, err = client.GetMultiplePages(ctx, clientRequestID, maxresults, timeout)
+	return
 }
 
 // GetMultiplePagesFailure a paging operation that receives a 400 on the second call
-func (client PagingClient) GetMultiplePagesFailure(ctx context.Context) (result ProductResult, err error) {
+func (client PagingClient) GetMultiplePagesFailure(ctx context.Context) (result ProductResultPage, err error) {
+	result.fn = client.getMultiplePagesFailureNextResults
 	req, err := client.GetMultiplePagesFailurePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFailure", nil, "Failure preparing request")
@@ -173,12 +135,12 @@ func (client PagingClient) GetMultiplePagesFailure(ctx context.Context) (result 
 
 	resp, err := client.GetMultiplePagesFailureSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.pr.Response = autorest.Response{Response: resp}
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFailure", resp, "Failure sending request")
 		return
 	}
 
-	result, err = client.GetMultiplePagesFailureResponder(resp)
+	result.pr, err = client.GetMultiplePagesFailureResponder(resp)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFailure", resp, "Failure responding to request")
 	}
@@ -215,11 +177,11 @@ func (client PagingClient) GetMultiplePagesFailureResponder(resp *http.Response)
 	return
 }
 
-// GetMultiplePagesFailureNextResults retrieves the next set of results, if any.
-func (client PagingClient) GetMultiplePagesFailureNextResults(lastResults ProductResult) (result ProductResult, err error) {
-	req, err := lastResults.ProductResultPreparer()
+// getMultiplePagesFailureNextResults retrieves the next set of results, if any.
+func (client PagingClient) getMultiplePagesFailureNextResults(lastResults ProductResult) (result ProductResult, err error) {
+	req, err := lastResults.productResultPreparer()
 	if err != nil {
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFailure", nil, "Failure preparing next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesFailureNextResults", nil, "Failure preparing next results request")
 	}
 	if req == nil {
 		return
@@ -227,64 +189,24 @@ func (client PagingClient) GetMultiplePagesFailureNextResults(lastResults Produc
 	resp, err := client.GetMultiplePagesFailureSender(req)
 	if err != nil {
 		result.Response = autorest.Response{Response: resp}
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFailure", resp, "Failure sending next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesFailureNextResults", resp, "Failure sending next results request")
 	}
 	result, err = client.GetMultiplePagesFailureResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFailure", resp, "Failure responding to next results request")
+		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesFailureNextResults", resp, "Failure responding to next results request")
 	}
 	return
 }
 
-// GetMultiplePagesFailureComplete gets all elements from the list without paging.
-func (client PagingClient) GetMultiplePagesFailureComplete(ctx context.Context) (<-chan Product, <-chan error) {
-	resultChan := make(chan Product)
-	errChan := make(chan error, 1)
-	go func() {
-		defer func() {
-			close(resultChan)
-			close(errChan)
-		}()
-		list, err := client.GetMultiplePagesFailure(ctx)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		if list.Values != nil {
-			for _, item := range *list.Values {
-				select {
-				case <-ctx.Done():
-					errChan <- ctx.Err()
-					return
-				case resultChan <- item:
-					// Intentionally left blank
-				}
-			}
-		}
-		for list.NextLink != nil {
-			list, err = client.GetMultiplePagesFailureNextResults(list)
-			if err != nil {
-				errChan <- err
-				return
-			}
-			if list.Values != nil {
-				for _, item := range *list.Values {
-					select {
-					case <-ctx.Done():
-						errChan <- ctx.Err()
-						return
-					case resultChan <- item:
-						// Intentionally left blank
-					}
-				}
-			}
-		}
-	}()
-	return resultChan, errChan
+// GetMultiplePagesFailureAll enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesFailureAll(ctx context.Context) (result ProductResultIterator, err error) {
+	result.page, err = client.GetMultiplePagesFailure(ctx)
+	return
 }
 
 // GetMultiplePagesFailureURI a paging operation that receives an invalid nextLink
-func (client PagingClient) GetMultiplePagesFailureURI(ctx context.Context) (result ProductResult, err error) {
+func (client PagingClient) GetMultiplePagesFailureURI(ctx context.Context) (result ProductResultPage, err error) {
+	result.fn = client.getMultiplePagesFailureURINextResults
 	req, err := client.GetMultiplePagesFailureURIPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFailureURI", nil, "Failure preparing request")
@@ -293,12 +215,12 @@ func (client PagingClient) GetMultiplePagesFailureURI(ctx context.Context) (resu
 
 	resp, err := client.GetMultiplePagesFailureURISender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.pr.Response = autorest.Response{Response: resp}
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFailureURI", resp, "Failure sending request")
 		return
 	}
 
-	result, err = client.GetMultiplePagesFailureURIResponder(resp)
+	result.pr, err = client.GetMultiplePagesFailureURIResponder(resp)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFailureURI", resp, "Failure responding to request")
 	}
@@ -335,11 +257,11 @@ func (client PagingClient) GetMultiplePagesFailureURIResponder(resp *http.Respon
 	return
 }
 
-// GetMultiplePagesFailureURINextResults retrieves the next set of results, if any.
-func (client PagingClient) GetMultiplePagesFailureURINextResults(lastResults ProductResult) (result ProductResult, err error) {
-	req, err := lastResults.ProductResultPreparer()
+// getMultiplePagesFailureURINextResults retrieves the next set of results, if any.
+func (client PagingClient) getMultiplePagesFailureURINextResults(lastResults ProductResult) (result ProductResult, err error) {
+	req, err := lastResults.productResultPreparer()
 	if err != nil {
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFailureURI", nil, "Failure preparing next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesFailureURINextResults", nil, "Failure preparing next results request")
 	}
 	if req == nil {
 		return
@@ -347,66 +269,31 @@ func (client PagingClient) GetMultiplePagesFailureURINextResults(lastResults Pro
 	resp, err := client.GetMultiplePagesFailureURISender(req)
 	if err != nil {
 		result.Response = autorest.Response{Response: resp}
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFailureURI", resp, "Failure sending next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesFailureURINextResults", resp, "Failure sending next results request")
 	}
 	result, err = client.GetMultiplePagesFailureURIResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFailureURI", resp, "Failure responding to next results request")
+		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesFailureURINextResults", resp, "Failure responding to next results request")
 	}
 	return
 }
 
-// GetMultiplePagesFailureURIComplete gets all elements from the list without paging.
-func (client PagingClient) GetMultiplePagesFailureURIComplete(ctx context.Context) (<-chan Product, <-chan error) {
-	resultChan := make(chan Product)
-	errChan := make(chan error, 1)
-	go func() {
-		defer func() {
-			close(resultChan)
-			close(errChan)
-		}()
-		list, err := client.GetMultiplePagesFailureURI(ctx)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		if list.Values != nil {
-			for _, item := range *list.Values {
-				select {
-				case <-ctx.Done():
-					errChan <- ctx.Err()
-					return
-				case resultChan <- item:
-					// Intentionally left blank
-				}
-			}
-		}
-		for list.NextLink != nil {
-			list, err = client.GetMultiplePagesFailureURINextResults(list)
-			if err != nil {
-				errChan <- err
-				return
-			}
-			if list.Values != nil {
-				for _, item := range *list.Values {
-					select {
-					case <-ctx.Done():
-						errChan <- ctx.Err()
-						return
-					case resultChan <- item:
-						// Intentionally left blank
-					}
-				}
-			}
-		}
-	}()
-	return resultChan, errChan
+// GetMultiplePagesFailureURIAll enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesFailureURIAll(ctx context.Context) (result ProductResultIterator, err error) {
+	result.page, err = client.GetMultiplePagesFailureURI(ctx)
+	return
 }
 
 // GetMultiplePagesFragmentNextLink a paging operation that doesn't return a full URL, just a fragment
 //
 // APIVersion is sets the api version to use. tenant is sets the tenant to use.
-func (client PagingClient) GetMultiplePagesFragmentNextLink(ctx context.Context, APIVersion string, tenant string) (result OdataProductResult, err error) {
+func (client PagingClient) GetMultiplePagesFragmentNextLink(ctx context.Context, APIVersion string, tenant string) (result OdataProductResultPage, err error) {
+	result.fn = func(lastResult OdataProductResult) (OdataProductResult, error) {
+		if lastResult.OdataNextLink == nil || len(to.String(lastResult.OdataNextLink)) < 1 {
+			return OdataProductResult{}, nil
+		}
+		return client.NextFragment(ctx, APIVersion, tenant, *lastResult.OdataNextLink)
+	}
 	req, err := client.GetMultiplePagesFragmentNextLinkPreparer(ctx, APIVersion, tenant)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFragmentNextLink", nil, "Failure preparing request")
@@ -415,12 +302,12 @@ func (client PagingClient) GetMultiplePagesFragmentNextLink(ctx context.Context,
 
 	resp, err := client.GetMultiplePagesFragmentNextLinkSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.opr.Response = autorest.Response{Response: resp}
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFragmentNextLink", resp, "Failure sending request")
 		return
 	}
 
-	result, err = client.GetMultiplePagesFragmentNextLinkResponder(resp)
+	result.opr, err = client.GetMultiplePagesFragmentNextLinkResponder(resp)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFragmentNextLink", resp, "Failure responding to request")
 	}
@@ -466,58 +353,23 @@ func (client PagingClient) GetMultiplePagesFragmentNextLinkResponder(resp *http.
 	return
 }
 
-// GetMultiplePagesFragmentNextLinkComplete gets all elements from the list without paging.
-func (client PagingClient) GetMultiplePagesFragmentNextLinkComplete(ctx context.Context, APIVersion string, tenant string) (<-chan Product, <-chan error) {
-	resultChan := make(chan Product)
-	errChan := make(chan error, 1)
-	go func() {
-		defer func() {
-			close(resultChan)
-			close(errChan)
-		}()
-		list, err := client.GetMultiplePagesFragmentNextLink(ctx, APIVersion, tenant)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		if list.Values != nil {
-			for _, item := range *list.Values {
-				select {
-				case <-ctx.Done():
-					errChan <- ctx.Err()
-					return
-				case resultChan <- item:
-					// Intentionally left blank
-				}
-			}
-		}
-		for list.OdataNextLink != nil {
-			list, err = client.NextFragment(ctx, APIVersion, tenant, *list.OdataNextLink)
-			if err != nil {
-				errChan <- err
-				return
-			}
-			if list.Values != nil {
-				for _, item := range *list.Values {
-					select {
-					case <-ctx.Done():
-						errChan <- ctx.Err()
-						return
-					case resultChan <- item:
-						// Intentionally left blank
-					}
-				}
-			}
-		}
-	}()
-	return resultChan, errChan
+// GetMultiplePagesFragmentNextLinkAll enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesFragmentNextLinkAll(ctx context.Context, APIVersion string, tenant string) (result OdataProductResultIterator, err error) {
+	result.page, err = client.GetMultiplePagesFragmentNextLink(ctx, APIVersion, tenant)
+	return
 }
 
 // GetMultiplePagesFragmentWithGroupingNextLink a paging operation that doesn't return a full URL, just a fragment with
 // parameters grouped
 //
 // APIVersion is sets the api version to use. tenant is sets the tenant to use.
-func (client PagingClient) GetMultiplePagesFragmentWithGroupingNextLink(ctx context.Context, APIVersion string, tenant string) (result OdataProductResult, err error) {
+func (client PagingClient) GetMultiplePagesFragmentWithGroupingNextLink(ctx context.Context, APIVersion string, tenant string) (result OdataProductResultPage, err error) {
+	result.fn = func(lastResult OdataProductResult) (OdataProductResult, error) {
+		if lastResult.OdataNextLink == nil || len(to.String(lastResult.OdataNextLink)) < 1 {
+			return OdataProductResult{}, nil
+		}
+		return client.NextFragmentWithGrouping(ctx, APIVersion, tenant, *lastResult.OdataNextLink)
+	}
 	req, err := client.GetMultiplePagesFragmentWithGroupingNextLinkPreparer(ctx, APIVersion, tenant)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFragmentWithGroupingNextLink", nil, "Failure preparing request")
@@ -526,12 +378,12 @@ func (client PagingClient) GetMultiplePagesFragmentWithGroupingNextLink(ctx cont
 
 	resp, err := client.GetMultiplePagesFragmentWithGroupingNextLinkSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.opr.Response = autorest.Response{Response: resp}
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFragmentWithGroupingNextLink", resp, "Failure sending request")
 		return
 	}
 
-	result, err = client.GetMultiplePagesFragmentWithGroupingNextLinkResponder(resp)
+	result.opr, err = client.GetMultiplePagesFragmentWithGroupingNextLinkResponder(resp)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesFragmentWithGroupingNextLink", resp, "Failure responding to request")
 	}
@@ -577,56 +429,16 @@ func (client PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkResponder
 	return
 }
 
-// GetMultiplePagesFragmentWithGroupingNextLinkComplete gets all elements from the list without paging.
-func (client PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkComplete(ctx context.Context, APIVersion string, tenant string) (<-chan Product, <-chan error) {
-	resultChan := make(chan Product)
-	errChan := make(chan error, 1)
-	go func() {
-		defer func() {
-			close(resultChan)
-			close(errChan)
-		}()
-		list, err := client.GetMultiplePagesFragmentWithGroupingNextLink(ctx, APIVersion, tenant)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		if list.Values != nil {
-			for _, item := range *list.Values {
-				select {
-				case <-ctx.Done():
-					errChan <- ctx.Err()
-					return
-				case resultChan <- item:
-					// Intentionally left blank
-				}
-			}
-		}
-		for list.OdataNextLink != nil {
-			list, err = client.NextFragmentWithGrouping(ctx, APIVersion, tenant, *list.OdataNextLink)
-			if err != nil {
-				errChan <- err
-				return
-			}
-			if list.Values != nil {
-				for _, item := range *list.Values {
-					select {
-					case <-ctx.Done():
-						errChan <- ctx.Err()
-						return
-					case resultChan <- item:
-						// Intentionally left blank
-					}
-				}
-			}
-		}
-	}()
-	return resultChan, errChan
+// GetMultiplePagesFragmentWithGroupingNextLinkAll enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkAll(ctx context.Context, APIVersion string, tenant string) (result OdataProductResultIterator, err error) {
+	result.page, err = client.GetMultiplePagesFragmentWithGroupingNextLink(ctx, APIVersion, tenant)
+	return
 }
 
 // GetMultiplePagesRetryFirst a paging operation that fails on the first call with 500 and then retries and then get a
 // response including a nextLink that has 10 pages
-func (client PagingClient) GetMultiplePagesRetryFirst(ctx context.Context) (result ProductResult, err error) {
+func (client PagingClient) GetMultiplePagesRetryFirst(ctx context.Context) (result ProductResultPage, err error) {
+	result.fn = client.getMultiplePagesRetryFirstNextResults
 	req, err := client.GetMultiplePagesRetryFirstPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesRetryFirst", nil, "Failure preparing request")
@@ -635,12 +447,12 @@ func (client PagingClient) GetMultiplePagesRetryFirst(ctx context.Context) (resu
 
 	resp, err := client.GetMultiplePagesRetryFirstSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.pr.Response = autorest.Response{Response: resp}
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesRetryFirst", resp, "Failure sending request")
 		return
 	}
 
-	result, err = client.GetMultiplePagesRetryFirstResponder(resp)
+	result.pr, err = client.GetMultiplePagesRetryFirstResponder(resp)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesRetryFirst", resp, "Failure responding to request")
 	}
@@ -677,11 +489,11 @@ func (client PagingClient) GetMultiplePagesRetryFirstResponder(resp *http.Respon
 	return
 }
 
-// GetMultiplePagesRetryFirstNextResults retrieves the next set of results, if any.
-func (client PagingClient) GetMultiplePagesRetryFirstNextResults(lastResults ProductResult) (result ProductResult, err error) {
-	req, err := lastResults.ProductResultPreparer()
+// getMultiplePagesRetryFirstNextResults retrieves the next set of results, if any.
+func (client PagingClient) getMultiplePagesRetryFirstNextResults(lastResults ProductResult) (result ProductResult, err error) {
+	req, err := lastResults.productResultPreparer()
 	if err != nil {
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesRetryFirst", nil, "Failure preparing next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesRetryFirstNextResults", nil, "Failure preparing next results request")
 	}
 	if req == nil {
 		return
@@ -689,65 +501,25 @@ func (client PagingClient) GetMultiplePagesRetryFirstNextResults(lastResults Pro
 	resp, err := client.GetMultiplePagesRetryFirstSender(req)
 	if err != nil {
 		result.Response = autorest.Response{Response: resp}
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesRetryFirst", resp, "Failure sending next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesRetryFirstNextResults", resp, "Failure sending next results request")
 	}
 	result, err = client.GetMultiplePagesRetryFirstResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesRetryFirst", resp, "Failure responding to next results request")
+		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesRetryFirstNextResults", resp, "Failure responding to next results request")
 	}
 	return
 }
 
-// GetMultiplePagesRetryFirstComplete gets all elements from the list without paging.
-func (client PagingClient) GetMultiplePagesRetryFirstComplete(ctx context.Context) (<-chan Product, <-chan error) {
-	resultChan := make(chan Product)
-	errChan := make(chan error, 1)
-	go func() {
-		defer func() {
-			close(resultChan)
-			close(errChan)
-		}()
-		list, err := client.GetMultiplePagesRetryFirst(ctx)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		if list.Values != nil {
-			for _, item := range *list.Values {
-				select {
-				case <-ctx.Done():
-					errChan <- ctx.Err()
-					return
-				case resultChan <- item:
-					// Intentionally left blank
-				}
-			}
-		}
-		for list.NextLink != nil {
-			list, err = client.GetMultiplePagesRetryFirstNextResults(list)
-			if err != nil {
-				errChan <- err
-				return
-			}
-			if list.Values != nil {
-				for _, item := range *list.Values {
-					select {
-					case <-ctx.Done():
-						errChan <- ctx.Err()
-						return
-					case resultChan <- item:
-						// Intentionally left blank
-					}
-				}
-			}
-		}
-	}()
-	return resultChan, errChan
+// GetMultiplePagesRetryFirstAll enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesRetryFirstAll(ctx context.Context) (result ProductResultIterator, err error) {
+	result.page, err = client.GetMultiplePagesRetryFirst(ctx)
+	return
 }
 
 // GetMultiplePagesRetrySecond a paging operation that includes a nextLink that has 10 pages, of which the 2nd call
 // fails first with 500. The client should retry and finish all 10 pages eventually.
-func (client PagingClient) GetMultiplePagesRetrySecond(ctx context.Context) (result ProductResult, err error) {
+func (client PagingClient) GetMultiplePagesRetrySecond(ctx context.Context) (result ProductResultPage, err error) {
+	result.fn = client.getMultiplePagesRetrySecondNextResults
 	req, err := client.GetMultiplePagesRetrySecondPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesRetrySecond", nil, "Failure preparing request")
@@ -756,12 +528,12 @@ func (client PagingClient) GetMultiplePagesRetrySecond(ctx context.Context) (res
 
 	resp, err := client.GetMultiplePagesRetrySecondSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.pr.Response = autorest.Response{Response: resp}
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesRetrySecond", resp, "Failure sending request")
 		return
 	}
 
-	result, err = client.GetMultiplePagesRetrySecondResponder(resp)
+	result.pr, err = client.GetMultiplePagesRetrySecondResponder(resp)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesRetrySecond", resp, "Failure responding to request")
 	}
@@ -798,11 +570,11 @@ func (client PagingClient) GetMultiplePagesRetrySecondResponder(resp *http.Respo
 	return
 }
 
-// GetMultiplePagesRetrySecondNextResults retrieves the next set of results, if any.
-func (client PagingClient) GetMultiplePagesRetrySecondNextResults(lastResults ProductResult) (result ProductResult, err error) {
-	req, err := lastResults.ProductResultPreparer()
+// getMultiplePagesRetrySecondNextResults retrieves the next set of results, if any.
+func (client PagingClient) getMultiplePagesRetrySecondNextResults(lastResults ProductResult) (result ProductResult, err error) {
+	req, err := lastResults.productResultPreparer()
 	if err != nil {
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesRetrySecond", nil, "Failure preparing next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesRetrySecondNextResults", nil, "Failure preparing next results request")
 	}
 	if req == nil {
 		return
@@ -810,67 +582,27 @@ func (client PagingClient) GetMultiplePagesRetrySecondNextResults(lastResults Pr
 	resp, err := client.GetMultiplePagesRetrySecondSender(req)
 	if err != nil {
 		result.Response = autorest.Response{Response: resp}
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesRetrySecond", resp, "Failure sending next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesRetrySecondNextResults", resp, "Failure sending next results request")
 	}
 	result, err = client.GetMultiplePagesRetrySecondResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesRetrySecond", resp, "Failure responding to next results request")
+		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesRetrySecondNextResults", resp, "Failure responding to next results request")
 	}
 	return
 }
 
-// GetMultiplePagesRetrySecondComplete gets all elements from the list without paging.
-func (client PagingClient) GetMultiplePagesRetrySecondComplete(ctx context.Context) (<-chan Product, <-chan error) {
-	resultChan := make(chan Product)
-	errChan := make(chan error, 1)
-	go func() {
-		defer func() {
-			close(resultChan)
-			close(errChan)
-		}()
-		list, err := client.GetMultiplePagesRetrySecond(ctx)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		if list.Values != nil {
-			for _, item := range *list.Values {
-				select {
-				case <-ctx.Done():
-					errChan <- ctx.Err()
-					return
-				case resultChan <- item:
-					// Intentionally left blank
-				}
-			}
-		}
-		for list.NextLink != nil {
-			list, err = client.GetMultiplePagesRetrySecondNextResults(list)
-			if err != nil {
-				errChan <- err
-				return
-			}
-			if list.Values != nil {
-				for _, item := range *list.Values {
-					select {
-					case <-ctx.Done():
-						errChan <- ctx.Err()
-						return
-					case resultChan <- item:
-						// Intentionally left blank
-					}
-				}
-			}
-		}
-	}()
-	return resultChan, errChan
+// GetMultiplePagesRetrySecondAll enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesRetrySecondAll(ctx context.Context) (result ProductResultIterator, err error) {
+	result.page, err = client.GetMultiplePagesRetrySecond(ctx)
+	return
 }
 
 // GetMultiplePagesWithOffset a paging operation that includes a nextLink that has 10 pages
 //
 // offset is offset of return value maxresults is sets the maximum number of items to return in the response. timeout
 // is sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.
-func (client PagingClient) GetMultiplePagesWithOffset(ctx context.Context, offset int32, clientRequestID string, maxresults *int32, timeout *int32) (result ProductResult, err error) {
+func (client PagingClient) GetMultiplePagesWithOffset(ctx context.Context, offset int32, clientRequestID string, maxresults *int32, timeout *int32) (result ProductResultPage, err error) {
+	result.fn = client.getMultiplePagesWithOffsetNextResults
 	req, err := client.GetMultiplePagesWithOffsetPreparer(ctx, offset, clientRequestID, maxresults, timeout)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesWithOffset", nil, "Failure preparing request")
@@ -879,12 +611,12 @@ func (client PagingClient) GetMultiplePagesWithOffset(ctx context.Context, offse
 
 	resp, err := client.GetMultiplePagesWithOffsetSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.pr.Response = autorest.Response{Response: resp}
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesWithOffset", resp, "Failure sending request")
 		return
 	}
 
-	result, err = client.GetMultiplePagesWithOffsetResponder(resp)
+	result.pr, err = client.GetMultiplePagesWithOffsetResponder(resp)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesWithOffset", resp, "Failure responding to request")
 	}
@@ -937,11 +669,11 @@ func (client PagingClient) GetMultiplePagesWithOffsetResponder(resp *http.Respon
 	return
 }
 
-// GetMultiplePagesWithOffsetNextResults retrieves the next set of results, if any.
-func (client PagingClient) GetMultiplePagesWithOffsetNextResults(lastResults ProductResult) (result ProductResult, err error) {
-	req, err := lastResults.ProductResultPreparer()
+// getMultiplePagesWithOffsetNextResults retrieves the next set of results, if any.
+func (client PagingClient) getMultiplePagesWithOffsetNextResults(lastResults ProductResult) (result ProductResult, err error) {
+	req, err := lastResults.productResultPreparer()
 	if err != nil {
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesWithOffset", nil, "Failure preparing next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesWithOffsetNextResults", nil, "Failure preparing next results request")
 	}
 	if req == nil {
 		return
@@ -949,67 +681,27 @@ func (client PagingClient) GetMultiplePagesWithOffsetNextResults(lastResults Pro
 	resp, err := client.GetMultiplePagesWithOffsetSender(req)
 	if err != nil {
 		result.Response = autorest.Response{Response: resp}
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesWithOffset", resp, "Failure sending next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesWithOffsetNextResults", resp, "Failure sending next results request")
 	}
 	result, err = client.GetMultiplePagesWithOffsetResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesWithOffset", resp, "Failure responding to next results request")
+		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getMultiplePagesWithOffsetNextResults", resp, "Failure responding to next results request")
 	}
 	return
 }
 
-// GetMultiplePagesWithOffsetComplete gets all elements from the list without paging.
-func (client PagingClient) GetMultiplePagesWithOffsetComplete(ctx context.Context, offset int32, clientRequestID string, maxresults *int32, timeout *int32) (<-chan Product, <-chan error) {
-	resultChan := make(chan Product)
-	errChan := make(chan error, 1)
-	go func() {
-		defer func() {
-			close(resultChan)
-			close(errChan)
-		}()
-		list, err := client.GetMultiplePagesWithOffset(ctx, offset, clientRequestID, maxresults, timeout)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		if list.Values != nil {
-			for _, item := range *list.Values {
-				select {
-				case <-ctx.Done():
-					errChan <- ctx.Err()
-					return
-				case resultChan <- item:
-					// Intentionally left blank
-				}
-			}
-		}
-		for list.NextLink != nil {
-			list, err = client.GetMultiplePagesWithOffsetNextResults(list)
-			if err != nil {
-				errChan <- err
-				return
-			}
-			if list.Values != nil {
-				for _, item := range *list.Values {
-					select {
-					case <-ctx.Done():
-						errChan <- ctx.Err()
-						return
-					case resultChan <- item:
-						// Intentionally left blank
-					}
-				}
-			}
-		}
-	}()
-	return resultChan, errChan
+// GetMultiplePagesWithOffsetAll enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetMultiplePagesWithOffsetAll(ctx context.Context, offset int32, clientRequestID string, maxresults *int32, timeout *int32) (result ProductResultIterator, err error) {
+	result.page, err = client.GetMultiplePagesWithOffset(ctx, offset, clientRequestID, maxresults, timeout)
+	return
 }
 
 // GetOdataMultiplePages a paging operation that includes a nextLink in odata format that has 10 pages
 //
 // maxresults is sets the maximum number of items to return in the response. timeout is sets the maximum time that the
 // server can spend processing the request, in seconds. The default is 30 seconds.
-func (client PagingClient) GetOdataMultiplePages(ctx context.Context, clientRequestID string, maxresults *int32, timeout *int32) (result OdataProductResult, err error) {
+func (client PagingClient) GetOdataMultiplePages(ctx context.Context, clientRequestID string, maxresults *int32, timeout *int32) (result OdataProductResultPage, err error) {
+	result.fn = client.getOdataMultiplePagesNextResults
 	req, err := client.GetOdataMultiplePagesPreparer(ctx, clientRequestID, maxresults, timeout)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetOdataMultiplePages", nil, "Failure preparing request")
@@ -1018,12 +710,12 @@ func (client PagingClient) GetOdataMultiplePages(ctx context.Context, clientRequ
 
 	resp, err := client.GetOdataMultiplePagesSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.opr.Response = autorest.Response{Response: resp}
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetOdataMultiplePages", resp, "Failure sending request")
 		return
 	}
 
-	result, err = client.GetOdataMultiplePagesResponder(resp)
+	result.opr, err = client.GetOdataMultiplePagesResponder(resp)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetOdataMultiplePages", resp, "Failure responding to request")
 	}
@@ -1072,11 +764,11 @@ func (client PagingClient) GetOdataMultiplePagesResponder(resp *http.Response) (
 	return
 }
 
-// GetOdataMultiplePagesNextResults retrieves the next set of results, if any.
-func (client PagingClient) GetOdataMultiplePagesNextResults(lastResults OdataProductResult) (result OdataProductResult, err error) {
-	req, err := lastResults.OdataProductResultPreparer()
+// getOdataMultiplePagesNextResults retrieves the next set of results, if any.
+func (client PagingClient) getOdataMultiplePagesNextResults(lastResults OdataProductResult) (result OdataProductResult, err error) {
+	req, err := lastResults.odataProductResultPreparer()
 	if err != nil {
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetOdataMultiplePages", nil, "Failure preparing next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getOdataMultiplePagesNextResults", nil, "Failure preparing next results request")
 	}
 	if req == nil {
 		return
@@ -1084,64 +776,24 @@ func (client PagingClient) GetOdataMultiplePagesNextResults(lastResults OdataPro
 	resp, err := client.GetOdataMultiplePagesSender(req)
 	if err != nil {
 		result.Response = autorest.Response{Response: resp}
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetOdataMultiplePages", resp, "Failure sending next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getOdataMultiplePagesNextResults", resp, "Failure sending next results request")
 	}
 	result, err = client.GetOdataMultiplePagesResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetOdataMultiplePages", resp, "Failure responding to next results request")
+		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getOdataMultiplePagesNextResults", resp, "Failure responding to next results request")
 	}
 	return
 }
 
-// GetOdataMultiplePagesComplete gets all elements from the list without paging.
-func (client PagingClient) GetOdataMultiplePagesComplete(ctx context.Context, clientRequestID string, maxresults *int32, timeout *int32) (<-chan Product, <-chan error) {
-	resultChan := make(chan Product)
-	errChan := make(chan error, 1)
-	go func() {
-		defer func() {
-			close(resultChan)
-			close(errChan)
-		}()
-		list, err := client.GetOdataMultiplePages(ctx, clientRequestID, maxresults, timeout)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		if list.Values != nil {
-			for _, item := range *list.Values {
-				select {
-				case <-ctx.Done():
-					errChan <- ctx.Err()
-					return
-				case resultChan <- item:
-					// Intentionally left blank
-				}
-			}
-		}
-		for list.OdataNextLink != nil {
-			list, err = client.GetOdataMultiplePagesNextResults(list)
-			if err != nil {
-				errChan <- err
-				return
-			}
-			if list.Values != nil {
-				for _, item := range *list.Values {
-					select {
-					case <-ctx.Done():
-						errChan <- ctx.Err()
-						return
-					case resultChan <- item:
-						// Intentionally left blank
-					}
-				}
-			}
-		}
-	}()
-	return resultChan, errChan
+// GetOdataMultiplePagesAll enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetOdataMultiplePagesAll(ctx context.Context, clientRequestID string, maxresults *int32, timeout *int32) (result OdataProductResultIterator, err error) {
+	result.page, err = client.GetOdataMultiplePages(ctx, clientRequestID, maxresults, timeout)
+	return
 }
 
 // GetSinglePages a paging operation that finishes on the first call without a nextlink
-func (client PagingClient) GetSinglePages(ctx context.Context) (result ProductResult, err error) {
+func (client PagingClient) GetSinglePages(ctx context.Context) (result ProductResultPage, err error) {
+	result.fn = client.getSinglePagesNextResults
 	req, err := client.GetSinglePagesPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetSinglePages", nil, "Failure preparing request")
@@ -1150,12 +802,12 @@ func (client PagingClient) GetSinglePages(ctx context.Context) (result ProductRe
 
 	resp, err := client.GetSinglePagesSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.pr.Response = autorest.Response{Response: resp}
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetSinglePages", resp, "Failure sending request")
 		return
 	}
 
-	result, err = client.GetSinglePagesResponder(resp)
+	result.pr, err = client.GetSinglePagesResponder(resp)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetSinglePages", resp, "Failure responding to request")
 	}
@@ -1192,11 +844,11 @@ func (client PagingClient) GetSinglePagesResponder(resp *http.Response) (result 
 	return
 }
 
-// GetSinglePagesNextResults retrieves the next set of results, if any.
-func (client PagingClient) GetSinglePagesNextResults(lastResults ProductResult) (result ProductResult, err error) {
-	req, err := lastResults.ProductResultPreparer()
+// getSinglePagesNextResults retrieves the next set of results, if any.
+func (client PagingClient) getSinglePagesNextResults(lastResults ProductResult) (result ProductResult, err error) {
+	req, err := lastResults.productResultPreparer()
 	if err != nil {
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetSinglePages", nil, "Failure preparing next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getSinglePagesNextResults", nil, "Failure preparing next results request")
 	}
 	if req == nil {
 		return
@@ -1204,64 +856,24 @@ func (client PagingClient) GetSinglePagesNextResults(lastResults ProductResult) 
 	resp, err := client.GetSinglePagesSender(req)
 	if err != nil {
 		result.Response = autorest.Response{Response: resp}
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetSinglePages", resp, "Failure sending next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getSinglePagesNextResults", resp, "Failure sending next results request")
 	}
 	result, err = client.GetSinglePagesResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetSinglePages", resp, "Failure responding to next results request")
+		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getSinglePagesNextResults", resp, "Failure responding to next results request")
 	}
 	return
 }
 
-// GetSinglePagesComplete gets all elements from the list without paging.
-func (client PagingClient) GetSinglePagesComplete(ctx context.Context) (<-chan Product, <-chan error) {
-	resultChan := make(chan Product)
-	errChan := make(chan error, 1)
-	go func() {
-		defer func() {
-			close(resultChan)
-			close(errChan)
-		}()
-		list, err := client.GetSinglePages(ctx)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		if list.Values != nil {
-			for _, item := range *list.Values {
-				select {
-				case <-ctx.Done():
-					errChan <- ctx.Err()
-					return
-				case resultChan <- item:
-					// Intentionally left blank
-				}
-			}
-		}
-		for list.NextLink != nil {
-			list, err = client.GetSinglePagesNextResults(list)
-			if err != nil {
-				errChan <- err
-				return
-			}
-			if list.Values != nil {
-				for _, item := range *list.Values {
-					select {
-					case <-ctx.Done():
-						errChan <- ctx.Err()
-						return
-					case resultChan <- item:
-						// Intentionally left blank
-					}
-				}
-			}
-		}
-	}()
-	return resultChan, errChan
+// GetSinglePagesAll enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetSinglePagesAll(ctx context.Context) (result ProductResultIterator, err error) {
+	result.page, err = client.GetSinglePages(ctx)
+	return
 }
 
 // GetSinglePagesFailure a paging operation that receives a 400 on the first call
-func (client PagingClient) GetSinglePagesFailure(ctx context.Context) (result ProductResult, err error) {
+func (client PagingClient) GetSinglePagesFailure(ctx context.Context) (result ProductResultPage, err error) {
+	result.fn = client.getSinglePagesFailureNextResults
 	req, err := client.GetSinglePagesFailurePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetSinglePagesFailure", nil, "Failure preparing request")
@@ -1270,12 +882,12 @@ func (client PagingClient) GetSinglePagesFailure(ctx context.Context) (result Pr
 
 	resp, err := client.GetSinglePagesFailureSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
+		result.pr.Response = autorest.Response{Response: resp}
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetSinglePagesFailure", resp, "Failure sending request")
 		return
 	}
 
-	result, err = client.GetSinglePagesFailureResponder(resp)
+	result.pr, err = client.GetSinglePagesFailureResponder(resp)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetSinglePagesFailure", resp, "Failure responding to request")
 	}
@@ -1312,11 +924,11 @@ func (client PagingClient) GetSinglePagesFailureResponder(resp *http.Response) (
 	return
 }
 
-// GetSinglePagesFailureNextResults retrieves the next set of results, if any.
-func (client PagingClient) GetSinglePagesFailureNextResults(lastResults ProductResult) (result ProductResult, err error) {
-	req, err := lastResults.ProductResultPreparer()
+// getSinglePagesFailureNextResults retrieves the next set of results, if any.
+func (client PagingClient) getSinglePagesFailureNextResults(lastResults ProductResult) (result ProductResult, err error) {
+	req, err := lastResults.productResultPreparer()
 	if err != nil {
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetSinglePagesFailure", nil, "Failure preparing next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getSinglePagesFailureNextResults", nil, "Failure preparing next results request")
 	}
 	if req == nil {
 		return
@@ -1324,60 +936,19 @@ func (client PagingClient) GetSinglePagesFailureNextResults(lastResults ProductR
 	resp, err := client.GetSinglePagesFailureSender(req)
 	if err != nil {
 		result.Response = autorest.Response{Response: resp}
-		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetSinglePagesFailure", resp, "Failure sending next results request")
+		return result, autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getSinglePagesFailureNextResults", resp, "Failure sending next results request")
 	}
 	result, err = client.GetSinglePagesFailureResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetSinglePagesFailure", resp, "Failure responding to next results request")
+		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "getSinglePagesFailureNextResults", resp, "Failure responding to next results request")
 	}
 	return
 }
 
-// GetSinglePagesFailureComplete gets all elements from the list without paging.
-func (client PagingClient) GetSinglePagesFailureComplete(ctx context.Context) (<-chan Product, <-chan error) {
-	resultChan := make(chan Product)
-	errChan := make(chan error, 1)
-	go func() {
-		defer func() {
-			close(resultChan)
-			close(errChan)
-		}()
-		list, err := client.GetSinglePagesFailure(ctx)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		if list.Values != nil {
-			for _, item := range *list.Values {
-				select {
-				case <-ctx.Done():
-					errChan <- ctx.Err()
-					return
-				case resultChan <- item:
-					// Intentionally left blank
-				}
-			}
-		}
-		for list.NextLink != nil {
-			list, err = client.GetSinglePagesFailureNextResults(list)
-			if err != nil {
-				errChan <- err
-				return
-			}
-			if list.Values != nil {
-				for _, item := range *list.Values {
-					select {
-					case <-ctx.Done():
-						errChan <- ctx.Err()
-						return
-					case resultChan <- item:
-						// Intentionally left blank
-					}
-				}
-			}
-		}
-	}()
-	return resultChan, errChan
+// GetSinglePagesFailureAll enumerates all values, automatically crossing page boundaries as required.
+func (client PagingClient) GetSinglePagesFailureAll(ctx context.Context) (result ProductResultIterator, err error) {
+	result.page, err = client.GetSinglePagesFailure(ctx)
+	return
 }
 
 // NextFragment a paging operation that doesn't return a full URL, just a fragment

--- a/test/src/tests/generated/report/client.go
+++ b/test/src/tests/generated/report/client.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Report
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Report.
@@ -41,8 +41,11 @@ func NewWithBaseURI(baseURI string) BaseClient {
 }
 
 // GetReport get test coverage report
-func (client BaseClient) GetReport(ctx context.Context) (result SetInt32, err error) {
-	req, err := client.GetReportPreparer(ctx)
+//
+// qualifier is if specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The only
+// effect is, that generators that run all tests several times, can distinguish the generated reports.
+func (client BaseClient) GetReport(ctx context.Context, qualifier string) (result SetInt32, err error) {
+	req, err := client.GetReportPreparer(ctx, qualifier)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "report.BaseClient", "GetReport", nil, "Failure preparing request")
 		return
@@ -64,11 +67,17 @@ func (client BaseClient) GetReport(ctx context.Context) (result SetInt32, err er
 }
 
 // GetReportPreparer prepares the GetReport request.
-func (client BaseClient) GetReportPreparer(ctx context.Context) (*http.Request, error) {
+func (client BaseClient) GetReportPreparer(ctx context.Context, qualifier string) (*http.Request, error) {
+	queryParameters := map[string]interface{}{}
+	if len(qualifier) > 0 {
+		queryParameters["qualifier"] = autorest.Encode("query", qualifier)
+	}
+
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
 		autorest.WithBaseURL(client.BaseURI),
-		autorest.WithPath("/report"))
+		autorest.WithPath("/report"),
+		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 

--- a/test/src/tests/generated/required-optional/client.go
+++ b/test/src/tests/generated/required-optional/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Optionalgroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Optionalgroup.

--- a/test/src/tests/generated/url/client.go
+++ b/test/src/tests/generated/url/client.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Urlgroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Urlgroup.

--- a/test/src/tests/generated/validation/client.go
+++ b/test/src/tests/generated/validation/client.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// DefaultBaseURI is the default URI used for the service Validationgroup
-	DefaultBaseURI = "http://localhost"
+	DefaultBaseURI = "http://localhost:3000"
 )
 
 // BaseClient is the base client for Validationgroup.

--- a/test/src/tests/runner.go
+++ b/test/src/tests/runner.go
@@ -93,7 +93,7 @@ func runTests(allPass *bool) {
 
 func getReport(ctx context.Context) {
 	var reportClient = report.NewWithBaseURI(utils.GetBaseURI())
-	res, err := reportClient.GetReport(ctx)
+	res, err := reportClient.GetReport(ctx, "")
 	if err != nil {
 		fmt.Println("Error:", err)
 	}
@@ -102,7 +102,7 @@ func getReport(ctx context.Context) {
 
 func getAzureReport(ctx context.Context) {
 	var reportClient = azurereport.NewWithBaseURI(utils.GetBaseURI())
-	res, err := reportClient.GetReport(ctx)
+	res, err := reportClient.GetReport(ctx, "")
 	if err != nil {
 		fmt.Println("Error:", err)
 	}


### PR DESCRIPTION
Methods that are pageable will now return a custom page type that is
used to iterate over the pages of data; this "pageable type" utilizes
the same methods as the current implementation but the methods are no
longer exported.
The "*Complete" method has been renamed to "*All" to align with the
Python SDK; it returns an iterator type that builds on top of the
pageable type to seamlessly iterate over the result set, crossing page
boundaries as required.
For long-running operations that return pageable results, the LRO will
return a future that will return a pageable type as its result once the
LRO has completed.