### PR TITLE
Update responder policy with new type name.

### DIFF
--- a/.gulp/gulpfile.iced
+++ b/.gulp/gulpfile.iced
@@ -19,7 +19,13 @@ Import
 task 'init', "" ,(done)->
   Fail "YOU MUST HAVE NODEJS VERSION GREATER THAN 7.10.0" if semver.lt( process.versions.node , "7.10.0" )
   done()
-  
+
+# Update test dependencies
+task 'updatetestdep', "", [], (done) ->
+  process.env.GOPATH = path.normalize("#{basefolder}/test")
+  await execute "dep ensure -update",          { cwd: './test/src/tests' }, defer code, stderr, stdout
+  done()
+
 # Run language-specific tests:
 task 'test', "", ['regenerate'], (done) ->
   process.env.GOPATH = path.normalize("#{basefolder}/test")

--- a/src/CodeNamerGo.cs
+++ b/src/CodeNamerGo.cs
@@ -527,7 +527,8 @@ namespace AutoRest.Go
                 var path = Settings.Instance.Host?.GetValue<string>("go-pipeline-import").Result;
                 if (string.IsNullOrWhiteSpace(path))
                 {
-                    return string.Empty;
+                    // default location
+                    return "github.com/Azure/azure-pipeline-go/pipeline";
                 }
                 return path;
             }

--- a/src/Templates/ResponderPolicy.cshtml
+++ b/src/Templates/ResponderPolicy.cshtml
@@ -29,7 +29,7 @@ type responderPolicyFactory struct {
 }
 
 // New creates a responder policy factory.
-func (arpf responderPolicyFactory) New(next pipeline.Policy, config *pipeline.Configuration) pipeline.Policy {
+func (arpf responderPolicyFactory) New(next pipeline.Policy, po *pipeline.PolicyOptions) pipeline.Policy {
 	return responderPolicy{next: next, responder: arpf.responder}
 }
 

--- a/test/src/tests/Gopkg.lock
+++ b/test/src/tests/Gopkg.lock
@@ -4,14 +4,14 @@
 [[projects]]
   name = "github.com/Azure/azure-pipeline-go"
   packages = ["pipeline"]
-  revision = "9ba84729a0153bc8c89541ae19d98e05029638b3"
-  version = "0.1.2"
+  revision = "f4da77e3846319876aebb41f2e6dccc6b1d7f1e0"
+  version = "1.1.3"
 
 [[projects]]
   name = "github.com/Azure/go-autorest"
   packages = ["autorest","autorest/adal","autorest/azure","autorest/date","autorest/to","autorest/validation"]
-  revision = "cab8279ba5cd5e165c58201f798712f2ec0f49d6"
-  version = "v9.4.2"
+  revision = "3b13154dcaec43ea581ea56cbf6645e5bcbe8be0"
+  version = "v9.5.3"
 
 [[projects]]
   name = "github.com/dgrijalva/jwt-go"
@@ -40,6 +40,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "da77136271915bd0aec149931a3f0a63105117682475cc9e140e3fba3ec27116"
+  inputs-digest = "3fa660cbc8c6f5fd35b7ead3890e6ca423f0f05c9281b9715e35cd392879809a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/test/src/tests/Gopkg.toml
+++ b/test/src/tests/Gopkg.toml
@@ -22,11 +22,11 @@
 
 [[constraint]]
   name = "github.com/Azure/azure-pipeline-go"
-  version = "0.1.2"
+  version = "1.1.3"
 
 [[constraint]]
   name = "github.com/Azure/go-autorest"
-  version = "9.4.2"
+  version = "9.5.3"
 
 [[constraint]]
   name = "github.com/satori/go.uuid"

--- a/test/src/tests/acceptancetests/utils/utils.go
+++ b/test/src/tests/acceptancetests/utils/utils.go
@@ -39,7 +39,7 @@ func NewPipelineWithRetry() pipeline.Pipeline {
 
 type HTTPSenderWithCookiesFactory struct{}
 
-func (swc HTTPSenderWithCookiesFactory) New(node pipeline.Policy, config *pipeline.Configuration) pipeline.Policy {
+func (swc HTTPSenderWithCookiesFactory) New(node pipeline.Policy, po *pipeline.PolicyOptions) pipeline.Policy {
 	j, _ := cookiejar.New(nil)
 	return &HTTPSenderWithCookiesPolicy{
 		sender: &http.Client{
@@ -59,7 +59,7 @@ func (swc HTTPSenderWithCookiesPolicy) Do(ctx context.Context, request pipeline.
 
 type SimpleRetryPolicyFactory struct{}
 
-func (srpf SimpleRetryPolicyFactory) New(node pipeline.Policy, config *pipeline.Configuration) pipeline.Policy {
+func (srpf SimpleRetryPolicyFactory) New(node pipeline.Policy, po *pipeline.PolicyOptions) pipeline.Policy {
 	return &SimpleRetryPolicy{
 		node: node,
 		statusCodesForRetry: []int{

--- a/test/src/tests/generated/azurereport/responder_policy.go
+++ b/test/src/tests/generated/azurereport/responder_policy.go
@@ -21,7 +21,7 @@ type responderPolicyFactory struct {
 }
 
 // New creates a responder policy factory.
-func (arpf responderPolicyFactory) New(next pipeline.Policy, config *pipeline.Configuration) pipeline.Policy {
+func (arpf responderPolicyFactory) New(next pipeline.Policy, po *pipeline.PolicyOptions) pipeline.Policy {
 	return responderPolicy{next: next, responder: arpf.responder}
 }
 

--- a/test/src/tests/generated/body-boolean/responder_policy.go
+++ b/test/src/tests/generated/body-boolean/responder_policy.go
@@ -21,7 +21,7 @@ type responderPolicyFactory struct {
 }
 
 // New creates a responder policy factory.
-func (arpf responderPolicyFactory) New(next pipeline.Policy, config *pipeline.Configuration) pipeline.Policy {
+func (arpf responderPolicyFactory) New(next pipeline.Policy, po *pipeline.PolicyOptions) pipeline.Policy {
 	return responderPolicy{next: next, responder: arpf.responder}
 }
 

--- a/test/src/tests/generated/body-byte/responder_policy.go
+++ b/test/src/tests/generated/body-byte/responder_policy.go
@@ -21,7 +21,7 @@ type responderPolicyFactory struct {
 }
 
 // New creates a responder policy factory.
-func (arpf responderPolicyFactory) New(next pipeline.Policy, config *pipeline.Configuration) pipeline.Policy {
+func (arpf responderPolicyFactory) New(next pipeline.Policy, po *pipeline.PolicyOptions) pipeline.Policy {
 	return responderPolicy{next: next, responder: arpf.responder}
 }
 

--- a/test/src/tests/generated/body-integer/responder_policy.go
+++ b/test/src/tests/generated/body-integer/responder_policy.go
@@ -21,7 +21,7 @@ type responderPolicyFactory struct {
 }
 
 // New creates a responder policy factory.
-func (arpf responderPolicyFactory) New(next pipeline.Policy, config *pipeline.Configuration) pipeline.Policy {
+func (arpf responderPolicyFactory) New(next pipeline.Policy, po *pipeline.PolicyOptions) pipeline.Policy {
 	return responderPolicy{next: next, responder: arpf.responder}
 }
 

--- a/test/src/tests/generated/body-string/responder_policy.go
+++ b/test/src/tests/generated/body-string/responder_policy.go
@@ -21,7 +21,7 @@ type responderPolicyFactory struct {
 }
 
 // New creates a responder policy factory.
-func (arpf responderPolicyFactory) New(next pipeline.Policy, config *pipeline.Configuration) pipeline.Policy {
+func (arpf responderPolicyFactory) New(next pipeline.Policy, po *pipeline.PolicyOptions) pipeline.Policy {
 	return responderPolicy{next: next, responder: arpf.responder}
 }
 

--- a/test/src/tests/generated/httpinfrastructure/responder_policy.go
+++ b/test/src/tests/generated/httpinfrastructure/responder_policy.go
@@ -21,7 +21,7 @@ type responderPolicyFactory struct {
 }
 
 // New creates a responder policy factory.
-func (arpf responderPolicyFactory) New(next pipeline.Policy, config *pipeline.Configuration) pipeline.Policy {
+func (arpf responderPolicyFactory) New(next pipeline.Policy, po *pipeline.PolicyOptions) pipeline.Policy {
 	return responderPolicy{next: next, responder: arpf.responder}
 }
 

--- a/test/src/tests/generated/report/responder_policy.go
+++ b/test/src/tests/generated/report/responder_policy.go
@@ -21,7 +21,7 @@ type responderPolicyFactory struct {
 }
 
 // New creates a responder policy factory.
-func (arpf responderPolicyFactory) New(next pipeline.Policy, config *pipeline.Configuration) pipeline.Policy {
+func (arpf responderPolicyFactory) New(next pipeline.Policy, po *pipeline.PolicyOptions) pipeline.Policy {
 	return responderPolicy{next: next, responder: arpf.responder}
 }
 


### PR DESCRIPTION
The pipeline.Configuration type was renamed to PolicyOptions.
If go-pipeline-import isn't specified use the default location.