### PR TITLE
Remove unnecessary if check in unmarshalling code.

### DIFF
--- a/src/Templates/Marshalling.cshtml
+++ b/src/Templates/Marshalling.cshtml
@@ -85,11 +85,7 @@ func (@rec *@ct.Name) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 		panic("size mismatch between @ct.Name and @internalName")
 	}
 	@local := (*@internalName)(unsafe.Pointer(@rec))
-	err := d.DecodeElement(@local, &start)
-	if err != nil {
-		@rec = (*@ct.Name)(unsafe.Pointer(@local))
-	}
-	return err
+	return d.DecodeElement(@local, &start)
 }
 </text>
 }


### PR DESCRIPTION
Since both variables point to the same address there is no need to cast
and assign (plus the if check is just wrong).