### PR TITLE
Emit correct code for optional body param stream.

### DIFF
--- a/src/Templates/MethodTemplate.cshtml
+++ b/src/Templates/MethodTemplate.cshtml
@@ -139,10 +139,14 @@ func (client @(Model.Owner)) @(Model.PreparerMethodName)(@(Model.MethodParameter
 
 @if (Model.BodyParameter != null && !Model.BodyParameter.IsRequired)
 {
+    var bodyParam = string.Format(Model.BodyParameter.ModelType.PrimaryType(KnownPrimaryType.Stream)
+                                        ? "autorest.WithFile({0})"
+                                        : "autorest.WithJSON({0})",
+                                Model.BodyParameter.Name);
 <text>
     if @(Model.BodyParameter.GetEmptyCheck(Model.BodyParameter.Name, false)) {
         preparer = autorest.DecoratePreparer(preparer,
-                            @(string.Format("autorest.WithJSON({0})", Model.BodyParameter.Name)))
+                            @(bodyParam))
     }
 </text>
 }


### PR DESCRIPTION
Don't assume that an optional body param is a JSON object as it could be
a binary stream.