### PR TITLE
Don't treat constants as parameters.

### DIFF
--- a/src/CodeNamerGo.cs
+++ b/src/CodeNamerGo.cs
@@ -380,7 +380,7 @@ namespace AutoRest.Go
                 case KnownPrimaryType.Boolean:
                     return defaultValue.ToLowerInvariant();
                 case KnownPrimaryType.ByteArray:
-                    return "[]bytearray(\"" + defaultValue + "\")";
+                    return "[]byte(\"" + defaultValue + "\")";
                 default:
                     //TODO: handle imports for package types.
                     break;

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -442,6 +442,18 @@ namespace AutoRest.Go
             throw new NotImplementedException($"GetZeroInitExpression for type {type} NYI");
         }
 
+        /// <summary>
+        /// Returns true if the format is a date/time.
+        /// </summary>
+        /// <param name="format">The format type to check.</param>
+        /// <returns>True if the format is a date/time.</returns>
+        public static bool IsDateTime(this KnownFormat format)
+        {
+            return format == KnownFormat.date ||
+                format == KnownFormat.date_time ||
+                format == KnownFormat.date_time_rfc1123;
+        }
+
         /////////////////////////////////////////////////////////////////////////////////////////
         // Validate code
         //

--- a/src/Model/ParameterGo.cs
+++ b/src/Model/ParameterGo.cs
@@ -63,7 +63,49 @@ namespace AutoRest.Go.Model
 
         public virtual bool IsAPIVersion => SerializedName.IsApiVersion();
 
-        public virtual bool IsMethodArgument => !IsClientProperty && !IsAPIVersion;
+        public virtual bool IsMethodArgument => !IsClientProperty && !IsAPIVersion && !IsConstant;
+
+        /// <summary>
+        /// Returns a properly formatted DefaultValue string.
+        /// </summary>
+        public string DefaultValueString
+        {
+            // unfortunately the modeler doesn't uniformly wrap default values in double quotes, so
+            // depending on the type's format it might or might not be quoted.  e.g. plain ol' strings
+            // will be double-quoted but a string in date/time format will not.  note that there can
+            // be other "interesting" default values, e.g. []byte(""), so you can't simply check for
+            // the absense of double-quotes and then add them.  right now the only affected type is
+            // date/times, if we find more cases this will need to be updated.
+            get
+            {
+                // another irritant is that the javascript front-end to autorest will
+                // munge certain decimals/doubles, e.g. it will change 1.034E+20 to
+                // 103400000000000000000 which we don't want, so we have to round-trip
+                // these types to get the desired output.
+                if (string.IsNullOrWhiteSpace(DefaultValue))
+                {
+                    return DefaultValue;
+                }
+                else if (ModelType.Cast<PrimaryTypeGo>().KnownFormat.IsDateTime())
+                {
+                    return $"\"{DefaultValue}\"";
+                }
+                else if (ModelType.Cast<PrimaryTypeGo>().KnownPrimaryType == KnownPrimaryType.Decimal)
+                {
+                    var asDecimal = decimal.Parse(DefaultValue);
+                    return asDecimal.ToString();
+                }
+                else if (ModelType.Cast<PrimaryTypeGo>().KnownPrimaryType == KnownPrimaryType.Double)
+                {
+                    var asDouble = double.Parse(DefaultValue);
+                    return asDouble.ToString();
+                }
+                else
+                {
+                    return DefaultValue;
+                }
+            }
+        }
 
         /// <summary>
         /// Get Name for parameter for Go map.
@@ -91,6 +133,15 @@ namespace AutoRest.Go.Model
             if (IsAPIVersion)
             {
                 return APIVersionName;
+            }
+
+            if (IsConstant)
+            {
+                if (RequiresUrlEncoding())
+                {
+                    return $"autorest.Encode(\"{Location.ToString().ToLower()}\", {DefaultValueString})";
+                }
+                return DefaultValueString;
             }
 
             var value = IsClientProperty
@@ -326,7 +377,7 @@ namespace AutoRest.Go.Model
 
             foreach (var p in parameters)
             {
-                if (p.IsAPIVersion)
+                if (p.IsAPIVersion || p.IsConstant)
                 {
                     continue;
                 }

--- a/test/src/tests/acceptancetests/booleangrouptest/body-boolean_test.go
+++ b/test/src/tests/acceptancetests/booleangrouptest/body-boolean_test.go
@@ -32,7 +32,7 @@ func (s *BoolGroupSuite) TestGetTrue(c *chk.C) {
 }
 
 func (s *BoolGroupSuite) TestPutTrue(c *chk.C) {
-	_, err := boolClient.PutTrue(context.Background(), true)
+	_, err := boolClient.PutTrue(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
@@ -43,7 +43,7 @@ func (s *BoolGroupSuite) TestGetFalse(c *chk.C) {
 }
 
 func (s *BoolGroupSuite) TestPutFalse(c *chk.C) {
-	_, err := boolClient.PutFalse(context.Background(), false)
+	_, err := boolClient.PutFalse(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 

--- a/test/src/tests/acceptancetests/numbergrouptest/body-number_test.go
+++ b/test/src/tests/acceptancetests/numbergrouptest/body-number_test.go
@@ -86,12 +86,12 @@ func (s *NumberSuite) TestPutBigDouble(c *chk.C) {
 }
 
 func (s *NumberSuite) TestPutBigDoubleNegativeDecimal(c *chk.C) {
-	_, err := numberClient.PutBigDoubleNegativeDecimal(context.Background(), -99999999.99)
+	_, err := numberClient.PutBigDoubleNegativeDecimal(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *NumberSuite) TestPutBigDoublePositiveDecimal(c *chk.C) {
-	_, err := numberClient.PutBigDoublePositiveDecimal(context.Background(), 99999999.99)
+	_, err := numberClient.PutBigDoublePositiveDecimal(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 

--- a/test/src/tests/acceptancetests/stringgrouptest/body-string_test.go
+++ b/test/src/tests/acceptancetests/stringgrouptest/body-string_test.go
@@ -78,17 +78,17 @@ func (s *StringSuite) TestGetWhitespace(c *chk.C) {
 }
 
 func (s *StringSuite) TestPutEmptyString(c *chk.C) {
-	_, err := stringClient.PutEmpty(context.Background(), emptyString)
+	_, err := stringClient.PutEmpty(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *StringSuite) TestPutMbcs(c *chk.C) {
-	_, err := stringClient.PutMbcs(context.Background(), multibyteBufferBody)
+	_, err := stringClient.PutMbcs(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *StringSuite) TestPutWhitespace(c *chk.C) {
-	_, err := stringClient.PutWhitespace(context.Background(), whitespaceText)
+	_, err := stringClient.PutWhitespace(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 

--- a/test/src/tests/acceptancetests/urlgrouptest/url_test.go
+++ b/test/src/tests/acceptancetests/urlgrouptest/url_test.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"testing"
-	"time"
 
-	"github.com/Azure/go-autorest/autorest/date"
 	chk "gopkg.in/check.v1"
 
 	"tests/acceptancetests/utils"
@@ -53,18 +51,18 @@ func getPathClient() PathsClient {
 //path tests
 
 func (s *URLSuite) TestPathGetBooleanFalse(c *chk.C) {
-	_, err := pathClient.GetBooleanFalse(context.Background(), false)
+	_, err := pathClient.GetBooleanFalse(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestPathGetBooleanTrue(c *chk.C) {
-	_, err := pathClient.GetBooleanTrue(context.Background(), true)
+	_, err := pathClient.GetBooleanTrue(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 // Path parameter can't be empty or null.
 func (s *URLSuite) TestPathByteEmpty(c *chk.C) {
-	_, err := pathClient.ByteEmpty(context.Background(), []byte{})
+	_, err := pathClient.ByteEmpty(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
@@ -80,22 +78,22 @@ func (s *URLSuite) TestPathByteMultiByte(c *chk.C) {
 // }
 
 func (s *URLSuite) TestPathDateTimeValid(c *chk.C) {
-	_, err := pathClient.DateTimeValid(context.Background(), utils.ToDateTime("2012-01-01T01:01:01Z"))
+	_, err := pathClient.DateTimeValid(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestPathDateValid(c *chk.C) {
-	_, err := pathClient.DateValid(context.Background(), date.Date{Time: time.Date(2012, time.January, 1, 0, 0, 0, 0, time.UTC)})
+	_, err := pathClient.DateValid(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestPathDoubleDecimalNegative(c *chk.C) {
-	_, err := pathClient.DoubleDecimalNegative(context.Background(), -9999999.999)
+	_, err := pathClient.DoubleDecimalNegative(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestPathDoubleDecimalPositive(c *chk.C) {
-	_, err := pathClient.DoubleDecimalPositive(context.Background(), 9999999.999)
+	_, err := pathClient.DoubleDecimalPositive(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
@@ -110,38 +108,38 @@ func (s *URLSuite) TestPathEnumValid(c *chk.C) {
 }
 
 func (s *URLSuite) TestPathFloatScientificNegative(c *chk.C) {
-	_, err := pathClient.FloatScientificNegative(context.Background(), -1.034E-20)
+	_, err := pathClient.FloatScientificNegative(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestPathFloatScientificPositive(c *chk.C) {
-	_, err := pathClient.FloatScientificPositive(context.Background(), 1.034E+20)
+	_, err := pathClient.FloatScientificPositive(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestPathGetIntNegativeOneMillion(c *chk.C) {
-	_, err := pathClient.GetIntNegativeOneMillion(context.Background(), -1000000)
+	_, err := pathClient.GetIntNegativeOneMillion(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestPathGetIntOneMillion(c *chk.C) {
-	_, err := pathClient.GetIntOneMillion(context.Background(), 1000000)
+	_, err := pathClient.GetIntOneMillion(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestPathGetNegativeTenBillion(c *chk.C) {
-	_, err := pathClient.GetNegativeTenBillion(context.Background(), -10000000000)
+	_, err := pathClient.GetNegativeTenBillion(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestPathGetTenBillion(c *chk.C) {
-	_, err := pathClient.GetTenBillion(context.Background(), 10000000000)
+	_, err := pathClient.GetTenBillion(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 // Path parameter can't be empty or null.
 func (s *URLSuite) TestPathStringEmpty(c *chk.C) {
-	_, err := pathClient.StringEmpty(context.Background(), "")
+	_, err := pathClient.StringEmpty(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
@@ -151,7 +149,7 @@ func (s *URLSuite) TestPathStringNull(c *chk.C) {
 }
 
 func (s *URLSuite) TestPathStringURLEncoded(c *chk.C) {
-	_, err := pathClient.StringURLEncoded(context.Background(), "begin!*'();:@ &=+$,/?#[]end")
+	_, err := pathClient.StringURLEncoded(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
@@ -201,7 +199,7 @@ func (s *URLSuite) TestQueryArrayStringTsvValid(c *chk.C) {
 
 // Query parameter is required so can't be empty or null.
 func (s *URLSuite) TestQueryByteEmpty(c *chk.C) {
-	_, err := queryClient.ByteEmpty(context.Background(), []byte(""))
+	_, err := queryClient.ByteEmpty(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
@@ -228,25 +226,22 @@ func (s *URLSuite) TestQueryDateTimeNull(c *chk.C) {
 
 // dont why not working
 func (s *URLSuite) TestQueryDateTimeValid(c *chk.C) {
-	dt := utils.ToDateTime("2012-01-01T01:01:01Z")
-	_, err := queryClient.DateTimeValid(context.Background(), dt)
+	_, err := queryClient.DateTimeValid(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestQueryDateValid(c *chk.C) {
-	_, err := queryClient.DateValid(context.Background(), date.Date{Time: time.Date(2012, time.January, 1, 0, 0, 0, 0, time.UTC)})
+	_, err := queryClient.DateValid(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestQueryDoubleDecimalNegative(c *chk.C) {
-	i := -9999999.999
-	_, err := queryClient.DoubleDecimalNegative(context.Background(), i)
+	_, err := queryClient.DoubleDecimalNegative(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestQueryDoubleDecimalPositive(c *chk.C) {
-	i := 9999999.999
-	_, err := queryClient.DoubleDecimalPositive(context.Background(), i)
+	_, err := queryClient.DoubleDecimalPositive(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
@@ -271,26 +266,22 @@ func (s *URLSuite) TestQueryFloatNull(c *chk.C) {
 }
 
 func (s *URLSuite) TestQueryFloatScientificNegative(c *chk.C) {
-	i := -1.034E-20
-	_, err := queryClient.FloatScientificNegative(context.Background(), i)
+	_, err := queryClient.FloatScientificNegative(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestQueryFloatScientificPositive(c *chk.C) {
-	i := 1.034E+20
-	_, err := queryClient.FloatScientificPositive(context.Background(), i)
+	_, err := queryClient.FloatScientificPositive(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestQueryGetBooleanFalse(c *chk.C) {
-	b := false
-	_, err := queryClient.GetBooleanFalse(context.Background(), b)
+	_, err := queryClient.GetBooleanFalse(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestQueryGetBooleanTrue(c *chk.C) {
-	b := true
-	_, err := queryClient.GetBooleanTrue(context.Background(), b)
+	_, err := queryClient.GetBooleanTrue(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
@@ -300,14 +291,12 @@ func (s *URLSuite) TestQueryGetBooleanNull(c *chk.C) {
 }
 
 func (s *URLSuite) TestQueryGetIntNegativeOneMillion(c *chk.C) {
-	i := int32(-1000000)
-	_, err := queryClient.GetIntNegativeOneMillion(context.Background(), i)
+	_, err := queryClient.GetIntNegativeOneMillion(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestQueryGetIntOneMillion(c *chk.C) {
-	i := int32(1000000)
-	_, err := queryClient.GetIntOneMillion(context.Background(), i)
+	_, err := queryClient.GetIntOneMillion(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
@@ -322,20 +311,18 @@ func (s *URLSuite) TestQueryGetLongNull(c *chk.C) {
 }
 
 func (s *URLSuite) TestQueryGetNegativeTenBillion(c *chk.C) {
-	i := int64(-10000000000)
-	_, err := queryClient.GetNegativeTenBillion(context.Background(), i)
+	_, err := queryClient.GetNegativeTenBillion(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 func (s *URLSuite) TestQueryGetTenBillion(c *chk.C) {
-	i := int64(10000000000)
-	_, err := queryClient.GetTenBillion(context.Background(), i)
+	_, err := queryClient.GetTenBillion(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
 // Query parameter is required so can't be empty or null.
 func (s *URLSuite) TestQueryStringEmpty(c *chk.C) {
-	_, err := queryClient.StringEmpty(context.Background(), "")
+	_, err := queryClient.StringEmpty(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
@@ -346,7 +333,7 @@ func (s *URLSuite) TestQueryStringNull(c *chk.C) {
 }
 
 func (s *URLSuite) TestQueryStringURLEncoded(c *chk.C) {
-	_, err := queryClient.StringURLEncoded(context.Background(), "begin!*'();:@ &=+$,/?#[]end")
+	_, err := queryClient.StringURLEncoded(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 

--- a/test/src/tests/acceptancetests/validationgrouptest/validation_test.go
+++ b/test/src/tests/acceptancetests/validationgrouptest/validation_test.go
@@ -26,7 +26,7 @@ func getValidationClient() BaseClient {
 }
 
 func (s *ValidationSuite) TestGetWithConstantInPath(c *chk.C) {
-	_, err := validationClient.GetWithConstantInPath(context.Background(), "constant")
+	_, err := validationClient.GetWithConstantInPath(context.Background())
 	c.Assert(err, chk.IsNil)
 }
 
@@ -43,7 +43,7 @@ func (s *ValidationSuite) TestPostWithConstantInBody(c *chk.C) {
 			ConstProperty2: &constProperty2,
 		},
 	}
-	res, err := validationClient.PostWithConstantInBody(context.Background(), "constant", &p)
+	res, err := validationClient.PostWithConstantInBody(context.Background(), &p)
 	p.Response = res.Response
 	c.Assert(err, chk.IsNil)
 	c.Assert(res, chk.DeepEquals, p)

--- a/test/src/tests/generated/body-boolean/bool.go
+++ b/test/src/tests/generated/body-boolean/bool.go
@@ -237,9 +237,8 @@ func (client BoolClient) GetTrueResponder(resp *http.Response) (result BoolModel
 }
 
 // PutFalse set Boolean value false
-//
-func (client BoolClient) PutFalse(ctx context.Context, boolBody bool) (result autorest.Response, err error) {
-	req, err := client.PutFalsePreparer(ctx, boolBody)
+func (client BoolClient) PutFalse(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.PutFalsePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "booleangroup.BoolClient", "PutFalse", nil, "Failure preparing request")
 		return
@@ -261,13 +260,13 @@ func (client BoolClient) PutFalse(ctx context.Context, boolBody bool) (result au
 }
 
 // PutFalsePreparer prepares the PutFalse request.
-func (client BoolClient) PutFalsePreparer(ctx context.Context, boolBody bool) (*http.Request, error) {
+func (client BoolClient) PutFalsePreparer(ctx context.Context) (*http.Request, error) {
 	preparer := autorest.CreatePreparer(
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
 		autorest.WithPath("/bool/false"),
-		autorest.WithJSON(boolBody))
+		autorest.WithJSON(false))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 
@@ -291,9 +290,8 @@ func (client BoolClient) PutFalseResponder(resp *http.Response) (result autorest
 }
 
 // PutTrue set Boolean value true
-//
-func (client BoolClient) PutTrue(ctx context.Context, boolBody bool) (result autorest.Response, err error) {
-	req, err := client.PutTruePreparer(ctx, boolBody)
+func (client BoolClient) PutTrue(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.PutTruePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "booleangroup.BoolClient", "PutTrue", nil, "Failure preparing request")
 		return
@@ -315,13 +313,13 @@ func (client BoolClient) PutTrue(ctx context.Context, boolBody bool) (result aut
 }
 
 // PutTruePreparer prepares the PutTrue request.
-func (client BoolClient) PutTruePreparer(ctx context.Context, boolBody bool) (*http.Request, error) {
+func (client BoolClient) PutTruePreparer(ctx context.Context) (*http.Request, error) {
 	preparer := autorest.CreatePreparer(
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
 		autorest.WithPath("/bool/true"),
-		autorest.WithJSON(boolBody))
+		autorest.WithJSON(true))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 

--- a/test/src/tests/generated/body-number/number.go
+++ b/test/src/tests/generated/body-number/number.go
@@ -812,9 +812,8 @@ func (client NumberClient) PutBigDecimalResponder(resp *http.Response) (result a
 }
 
 // PutBigDecimalNegativeDecimal put big decimal value -99999999.99
-//
-func (client NumberClient) PutBigDecimalNegativeDecimal(ctx context.Context, numberBody decimal.Decimal) (result autorest.Response, err error) {
-	req, err := client.PutBigDecimalNegativeDecimalPreparer(ctx, numberBody)
+func (client NumberClient) PutBigDecimalNegativeDecimal(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.PutBigDecimalNegativeDecimalPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "numbergroup.NumberClient", "PutBigDecimalNegativeDecimal", nil, "Failure preparing request")
 		return
@@ -836,13 +835,13 @@ func (client NumberClient) PutBigDecimalNegativeDecimal(ctx context.Context, num
 }
 
 // PutBigDecimalNegativeDecimalPreparer prepares the PutBigDecimalNegativeDecimal request.
-func (client NumberClient) PutBigDecimalNegativeDecimalPreparer(ctx context.Context, numberBody decimal.Decimal) (*http.Request, error) {
+func (client NumberClient) PutBigDecimalNegativeDecimalPreparer(ctx context.Context) (*http.Request, error) {
 	preparer := autorest.CreatePreparer(
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
 		autorest.WithPath("/number/big/decimal/-99999999.99"),
-		autorest.WithJSON(numberBody))
+		autorest.WithJSON(-99999999.99))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 
@@ -866,9 +865,8 @@ func (client NumberClient) PutBigDecimalNegativeDecimalResponder(resp *http.Resp
 }
 
 // PutBigDecimalPositiveDecimal put big decimal value 99999999.99
-//
-func (client NumberClient) PutBigDecimalPositiveDecimal(ctx context.Context, numberBody decimal.Decimal) (result autorest.Response, err error) {
-	req, err := client.PutBigDecimalPositiveDecimalPreparer(ctx, numberBody)
+func (client NumberClient) PutBigDecimalPositiveDecimal(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.PutBigDecimalPositiveDecimalPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "numbergroup.NumberClient", "PutBigDecimalPositiveDecimal", nil, "Failure preparing request")
 		return
@@ -890,13 +888,13 @@ func (client NumberClient) PutBigDecimalPositiveDecimal(ctx context.Context, num
 }
 
 // PutBigDecimalPositiveDecimalPreparer prepares the PutBigDecimalPositiveDecimal request.
-func (client NumberClient) PutBigDecimalPositiveDecimalPreparer(ctx context.Context, numberBody decimal.Decimal) (*http.Request, error) {
+func (client NumberClient) PutBigDecimalPositiveDecimalPreparer(ctx context.Context) (*http.Request, error) {
 	preparer := autorest.CreatePreparer(
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
 		autorest.WithPath("/number/big/decimal/99999999.99"),
-		autorest.WithJSON(numberBody))
+		autorest.WithJSON(99999999.99))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 
@@ -974,9 +972,8 @@ func (client NumberClient) PutBigDoubleResponder(resp *http.Response) (result au
 }
 
 // PutBigDoubleNegativeDecimal put big double value -99999999.99
-//
-func (client NumberClient) PutBigDoubleNegativeDecimal(ctx context.Context, numberBody float64) (result autorest.Response, err error) {
-	req, err := client.PutBigDoubleNegativeDecimalPreparer(ctx, numberBody)
+func (client NumberClient) PutBigDoubleNegativeDecimal(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.PutBigDoubleNegativeDecimalPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "numbergroup.NumberClient", "PutBigDoubleNegativeDecimal", nil, "Failure preparing request")
 		return
@@ -998,13 +995,13 @@ func (client NumberClient) PutBigDoubleNegativeDecimal(ctx context.Context, numb
 }
 
 // PutBigDoubleNegativeDecimalPreparer prepares the PutBigDoubleNegativeDecimal request.
-func (client NumberClient) PutBigDoubleNegativeDecimalPreparer(ctx context.Context, numberBody float64) (*http.Request, error) {
+func (client NumberClient) PutBigDoubleNegativeDecimalPreparer(ctx context.Context) (*http.Request, error) {
 	preparer := autorest.CreatePreparer(
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
 		autorest.WithPath("/number/big/double/-99999999.99"),
-		autorest.WithJSON(numberBody))
+		autorest.WithJSON(-99999999.99))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 
@@ -1028,9 +1025,8 @@ func (client NumberClient) PutBigDoubleNegativeDecimalResponder(resp *http.Respo
 }
 
 // PutBigDoublePositiveDecimal put big double value 99999999.99
-//
-func (client NumberClient) PutBigDoublePositiveDecimal(ctx context.Context, numberBody float64) (result autorest.Response, err error) {
-	req, err := client.PutBigDoublePositiveDecimalPreparer(ctx, numberBody)
+func (client NumberClient) PutBigDoublePositiveDecimal(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.PutBigDoublePositiveDecimalPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "numbergroup.NumberClient", "PutBigDoublePositiveDecimal", nil, "Failure preparing request")
 		return
@@ -1052,13 +1048,13 @@ func (client NumberClient) PutBigDoublePositiveDecimal(ctx context.Context, numb
 }
 
 // PutBigDoublePositiveDecimalPreparer prepares the PutBigDoublePositiveDecimal request.
-func (client NumberClient) PutBigDoublePositiveDecimalPreparer(ctx context.Context, numberBody float64) (*http.Request, error) {
+func (client NumberClient) PutBigDoublePositiveDecimalPreparer(ctx context.Context) (*http.Request, error) {
 	preparer := autorest.CreatePreparer(
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
 		autorest.WithPath("/number/big/double/99999999.99"),
-		autorest.WithJSON(numberBody))
+		autorest.WithJSON(99999999.99))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 

--- a/test/src/tests/generated/body-string/string.go
+++ b/test/src/tests/generated/body-string/string.go
@@ -500,9 +500,8 @@ func (client StringClient) PutBase64URLEncodedResponder(resp *http.Response) (re
 }
 
 // PutEmpty set string value empty ''
-//
-func (client StringClient) PutEmpty(ctx context.Context, stringBody string) (result autorest.Response, err error) {
-	req, err := client.PutEmptyPreparer(ctx, stringBody)
+func (client StringClient) PutEmpty(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.PutEmptyPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "stringgroup.StringClient", "PutEmpty", nil, "Failure preparing request")
 		return
@@ -524,13 +523,13 @@ func (client StringClient) PutEmpty(ctx context.Context, stringBody string) (res
 }
 
 // PutEmptyPreparer prepares the PutEmpty request.
-func (client StringClient) PutEmptyPreparer(ctx context.Context, stringBody string) (*http.Request, error) {
+func (client StringClient) PutEmptyPreparer(ctx context.Context) (*http.Request, error) {
 	preparer := autorest.CreatePreparer(
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
 		autorest.WithPath("/string/empty"),
-		autorest.WithJSON(stringBody))
+		autorest.WithJSON(""))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 
@@ -554,9 +553,8 @@ func (client StringClient) PutEmptyResponder(resp *http.Response) (result autore
 }
 
 // PutMbcs set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
-//
-func (client StringClient) PutMbcs(ctx context.Context, stringBody string) (result autorest.Response, err error) {
-	req, err := client.PutMbcsPreparer(ctx, stringBody)
+func (client StringClient) PutMbcs(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.PutMbcsPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "stringgroup.StringClient", "PutMbcs", nil, "Failure preparing request")
 		return
@@ -578,13 +576,13 @@ func (client StringClient) PutMbcs(ctx context.Context, stringBody string) (resu
 }
 
 // PutMbcsPreparer prepares the PutMbcs request.
-func (client StringClient) PutMbcsPreparer(ctx context.Context, stringBody string) (*http.Request, error) {
+func (client StringClient) PutMbcsPreparer(ctx context.Context) (*http.Request, error) {
 	preparer := autorest.CreatePreparer(
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
 		autorest.WithPath("/string/mbcs"),
-		autorest.WithJSON(stringBody))
+		autorest.WithJSON("啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€"))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 
@@ -667,9 +665,8 @@ func (client StringClient) PutNullResponder(resp *http.Response) (result autores
 
 // PutWhitespace set String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good
 // men to come to the aid of their country<tab><space><space>'
-//
-func (client StringClient) PutWhitespace(ctx context.Context, stringBody string) (result autorest.Response, err error) {
-	req, err := client.PutWhitespacePreparer(ctx, stringBody)
+func (client StringClient) PutWhitespace(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.PutWhitespacePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "stringgroup.StringClient", "PutWhitespace", nil, "Failure preparing request")
 		return
@@ -691,13 +688,13 @@ func (client StringClient) PutWhitespace(ctx context.Context, stringBody string)
 }
 
 // PutWhitespacePreparer prepares the PutWhitespace request.
-func (client StringClient) PutWhitespacePreparer(ctx context.Context, stringBody string) (*http.Request, error) {
+func (client StringClient) PutWhitespacePreparer(ctx context.Context) (*http.Request, error) {
 	preparer := autorest.CreatePreparer(
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
 		autorest.WithPath("/string/whitespace"),
-		autorest.WithJSON(stringBody))
+		autorest.WithJSON("    Now is the time for all good men to come to the aid of their country    "))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 

--- a/test/src/tests/generated/url/paths.go
+++ b/test/src/tests/generated/url/paths.go
@@ -152,16 +152,8 @@ func (client PathsClient) Base64URLResponder(resp *http.Response) (result autore
 }
 
 // ByteEmpty get '' as byte array
-//
-// bytePath is '' as byte array
-func (client PathsClient) ByteEmpty(ctx context.Context, bytePath []byte) (result autorest.Response, err error) {
-	if err := validation.Validate([]validation.Validation{
-		{TargetValue: bytePath,
-			Constraints: []validation.Constraint{{Target: "bytePath", Name: validation.Null, Rule: true, Chain: nil}}}}); err != nil {
-		return result, validation.NewErrorWithValidationError(err, "urlgroup.PathsClient", "ByteEmpty")
-	}
-
-	req, err := client.ByteEmptyPreparer(ctx, bytePath)
+func (client PathsClient) ByteEmpty(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.ByteEmptyPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "ByteEmpty", nil, "Failure preparing request")
 		return
@@ -183,9 +175,9 @@ func (client PathsClient) ByteEmpty(ctx context.Context, bytePath []byte) (resul
 }
 
 // ByteEmptyPreparer prepares the ByteEmpty request.
-func (client PathsClient) ByteEmptyPreparer(ctx context.Context, bytePath []byte) (*http.Request, error) {
+func (client PathsClient) ByteEmptyPreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"bytePath": autorest.Encode("path", bytePath),
+		"bytePath": autorest.Encode("path", []byte("")),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -455,10 +447,8 @@ func (client PathsClient) DateTimeNullResponder(resp *http.Response) (result aut
 }
 
 // DateTimeValid get '2012-01-01T01:01:01Z' as date-time
-//
-// dateTimePath is '2012-01-01T01:01:01Z' as date-time
-func (client PathsClient) DateTimeValid(ctx context.Context, dateTimePath date.Time) (result autorest.Response, err error) {
-	req, err := client.DateTimeValidPreparer(ctx, dateTimePath)
+func (client PathsClient) DateTimeValid(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.DateTimeValidPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "DateTimeValid", nil, "Failure preparing request")
 		return
@@ -480,9 +470,9 @@ func (client PathsClient) DateTimeValid(ctx context.Context, dateTimePath date.T
 }
 
 // DateTimeValidPreparer prepares the DateTimeValid request.
-func (client PathsClient) DateTimeValidPreparer(ctx context.Context, dateTimePath date.Time) (*http.Request, error) {
+func (client PathsClient) DateTimeValidPreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"dateTimePath": autorest.Encode("path", dateTimePath),
+		"dateTimePath": autorest.Encode("path", "2012-01-01T01:01:01Z"),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -512,10 +502,8 @@ func (client PathsClient) DateTimeValidResponder(resp *http.Response) (result au
 }
 
 // DateValid get '2012-01-01' as date
-//
-// datePath is '2012-01-01' as date
-func (client PathsClient) DateValid(ctx context.Context, datePath date.Date) (result autorest.Response, err error) {
-	req, err := client.DateValidPreparer(ctx, datePath)
+func (client PathsClient) DateValid(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.DateValidPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "DateValid", nil, "Failure preparing request")
 		return
@@ -537,9 +525,9 @@ func (client PathsClient) DateValid(ctx context.Context, datePath date.Date) (re
 }
 
 // DateValidPreparer prepares the DateValid request.
-func (client PathsClient) DateValidPreparer(ctx context.Context, datePath date.Date) (*http.Request, error) {
+func (client PathsClient) DateValidPreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"datePath": autorest.Encode("path", datePath),
+		"datePath": autorest.Encode("path", "2012-01-01"),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -569,10 +557,8 @@ func (client PathsClient) DateValidResponder(resp *http.Response) (result autore
 }
 
 // DoubleDecimalNegative get '-9999999.999' numeric value
-//
-// doublePath is '-9999999.999'numeric value
-func (client PathsClient) DoubleDecimalNegative(ctx context.Context, doublePath float64) (result autorest.Response, err error) {
-	req, err := client.DoubleDecimalNegativePreparer(ctx, doublePath)
+func (client PathsClient) DoubleDecimalNegative(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.DoubleDecimalNegativePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "DoubleDecimalNegative", nil, "Failure preparing request")
 		return
@@ -594,9 +580,9 @@ func (client PathsClient) DoubleDecimalNegative(ctx context.Context, doublePath 
 }
 
 // DoubleDecimalNegativePreparer prepares the DoubleDecimalNegative request.
-func (client PathsClient) DoubleDecimalNegativePreparer(ctx context.Context, doublePath float64) (*http.Request, error) {
+func (client PathsClient) DoubleDecimalNegativePreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"doublePath": autorest.Encode("path", doublePath),
+		"doublePath": autorest.Encode("path", -9999999.999),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -626,10 +612,8 @@ func (client PathsClient) DoubleDecimalNegativeResponder(resp *http.Response) (r
 }
 
 // DoubleDecimalPositive get '9999999.999' numeric value
-//
-// doublePath is '9999999.999'numeric value
-func (client PathsClient) DoubleDecimalPositive(ctx context.Context, doublePath float64) (result autorest.Response, err error) {
-	req, err := client.DoubleDecimalPositivePreparer(ctx, doublePath)
+func (client PathsClient) DoubleDecimalPositive(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.DoubleDecimalPositivePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "DoubleDecimalPositive", nil, "Failure preparing request")
 		return
@@ -651,9 +635,9 @@ func (client PathsClient) DoubleDecimalPositive(ctx context.Context, doublePath 
 }
 
 // DoubleDecimalPositivePreparer prepares the DoubleDecimalPositive request.
-func (client PathsClient) DoubleDecimalPositivePreparer(ctx context.Context, doublePath float64) (*http.Request, error) {
+func (client PathsClient) DoubleDecimalPositivePreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"doublePath": autorest.Encode("path", doublePath),
+		"doublePath": autorest.Encode("path", 9999999.999),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -797,10 +781,8 @@ func (client PathsClient) EnumValidResponder(resp *http.Response) (result autore
 }
 
 // FloatScientificNegative get '-1.034E-20' numeric value
-//
-// floatPath is '-1.034E-20'numeric value
-func (client PathsClient) FloatScientificNegative(ctx context.Context, floatPath float64) (result autorest.Response, err error) {
-	req, err := client.FloatScientificNegativePreparer(ctx, floatPath)
+func (client PathsClient) FloatScientificNegative(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.FloatScientificNegativePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "FloatScientificNegative", nil, "Failure preparing request")
 		return
@@ -822,9 +804,9 @@ func (client PathsClient) FloatScientificNegative(ctx context.Context, floatPath
 }
 
 // FloatScientificNegativePreparer prepares the FloatScientificNegative request.
-func (client PathsClient) FloatScientificNegativePreparer(ctx context.Context, floatPath float64) (*http.Request, error) {
+func (client PathsClient) FloatScientificNegativePreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"floatPath": autorest.Encode("path", floatPath),
+		"floatPath": autorest.Encode("path", -1.034E-20),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -854,10 +836,8 @@ func (client PathsClient) FloatScientificNegativeResponder(resp *http.Response) 
 }
 
 // FloatScientificPositive get '1.034E+20' numeric value
-//
-// floatPath is '1.034E+20'numeric value
-func (client PathsClient) FloatScientificPositive(ctx context.Context, floatPath float64) (result autorest.Response, err error) {
-	req, err := client.FloatScientificPositivePreparer(ctx, floatPath)
+func (client PathsClient) FloatScientificPositive(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.FloatScientificPositivePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "FloatScientificPositive", nil, "Failure preparing request")
 		return
@@ -879,9 +859,9 @@ func (client PathsClient) FloatScientificPositive(ctx context.Context, floatPath
 }
 
 // FloatScientificPositivePreparer prepares the FloatScientificPositive request.
-func (client PathsClient) FloatScientificPositivePreparer(ctx context.Context, floatPath float64) (*http.Request, error) {
+func (client PathsClient) FloatScientificPositivePreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"floatPath": autorest.Encode("path", floatPath),
+		"floatPath": autorest.Encode("path", 1.034E+20),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -911,10 +891,8 @@ func (client PathsClient) FloatScientificPositiveResponder(resp *http.Response) 
 }
 
 // GetBooleanFalse get false Boolean value on path
-//
-// boolPath is false boolean value
-func (client PathsClient) GetBooleanFalse(ctx context.Context, boolPath bool) (result autorest.Response, err error) {
-	req, err := client.GetBooleanFalsePreparer(ctx, boolPath)
+func (client PathsClient) GetBooleanFalse(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.GetBooleanFalsePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "GetBooleanFalse", nil, "Failure preparing request")
 		return
@@ -936,9 +914,9 @@ func (client PathsClient) GetBooleanFalse(ctx context.Context, boolPath bool) (r
 }
 
 // GetBooleanFalsePreparer prepares the GetBooleanFalse request.
-func (client PathsClient) GetBooleanFalsePreparer(ctx context.Context, boolPath bool) (*http.Request, error) {
+func (client PathsClient) GetBooleanFalsePreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"boolPath": autorest.Encode("path", boolPath),
+		"boolPath": autorest.Encode("path", false),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -968,10 +946,8 @@ func (client PathsClient) GetBooleanFalseResponder(resp *http.Response) (result 
 }
 
 // GetBooleanTrue get true Boolean value on path
-//
-// boolPath is true boolean value
-func (client PathsClient) GetBooleanTrue(ctx context.Context, boolPath bool) (result autorest.Response, err error) {
-	req, err := client.GetBooleanTruePreparer(ctx, boolPath)
+func (client PathsClient) GetBooleanTrue(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.GetBooleanTruePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "GetBooleanTrue", nil, "Failure preparing request")
 		return
@@ -993,9 +969,9 @@ func (client PathsClient) GetBooleanTrue(ctx context.Context, boolPath bool) (re
 }
 
 // GetBooleanTruePreparer prepares the GetBooleanTrue request.
-func (client PathsClient) GetBooleanTruePreparer(ctx context.Context, boolPath bool) (*http.Request, error) {
+func (client PathsClient) GetBooleanTruePreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"boolPath": autorest.Encode("path", boolPath),
+		"boolPath": autorest.Encode("path", true),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1025,10 +1001,8 @@ func (client PathsClient) GetBooleanTrueResponder(resp *http.Response) (result a
 }
 
 // GetIntNegativeOneMillion get '-1000000' integer value
-//
-// intPath is '-1000000' integer value
-func (client PathsClient) GetIntNegativeOneMillion(ctx context.Context, intPath int32) (result autorest.Response, err error) {
-	req, err := client.GetIntNegativeOneMillionPreparer(ctx, intPath)
+func (client PathsClient) GetIntNegativeOneMillion(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.GetIntNegativeOneMillionPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "GetIntNegativeOneMillion", nil, "Failure preparing request")
 		return
@@ -1050,9 +1024,9 @@ func (client PathsClient) GetIntNegativeOneMillion(ctx context.Context, intPath 
 }
 
 // GetIntNegativeOneMillionPreparer prepares the GetIntNegativeOneMillion request.
-func (client PathsClient) GetIntNegativeOneMillionPreparer(ctx context.Context, intPath int32) (*http.Request, error) {
+func (client PathsClient) GetIntNegativeOneMillionPreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"intPath": autorest.Encode("path", intPath),
+		"intPath": autorest.Encode("path", -1000000),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1082,10 +1056,8 @@ func (client PathsClient) GetIntNegativeOneMillionResponder(resp *http.Response)
 }
 
 // GetIntOneMillion get '1000000' integer value
-//
-// intPath is '1000000' integer value
-func (client PathsClient) GetIntOneMillion(ctx context.Context, intPath int32) (result autorest.Response, err error) {
-	req, err := client.GetIntOneMillionPreparer(ctx, intPath)
+func (client PathsClient) GetIntOneMillion(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.GetIntOneMillionPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "GetIntOneMillion", nil, "Failure preparing request")
 		return
@@ -1107,9 +1079,9 @@ func (client PathsClient) GetIntOneMillion(ctx context.Context, intPath int32) (
 }
 
 // GetIntOneMillionPreparer prepares the GetIntOneMillion request.
-func (client PathsClient) GetIntOneMillionPreparer(ctx context.Context, intPath int32) (*http.Request, error) {
+func (client PathsClient) GetIntOneMillionPreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"intPath": autorest.Encode("path", intPath),
+		"intPath": autorest.Encode("path", 1000000),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1139,10 +1111,8 @@ func (client PathsClient) GetIntOneMillionResponder(resp *http.Response) (result
 }
 
 // GetNegativeTenBillion get '-10000000000' 64 bit integer value
-//
-// longPath is '-10000000000' 64 bit integer value
-func (client PathsClient) GetNegativeTenBillion(ctx context.Context, longPath int64) (result autorest.Response, err error) {
-	req, err := client.GetNegativeTenBillionPreparer(ctx, longPath)
+func (client PathsClient) GetNegativeTenBillion(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.GetNegativeTenBillionPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "GetNegativeTenBillion", nil, "Failure preparing request")
 		return
@@ -1164,9 +1134,9 @@ func (client PathsClient) GetNegativeTenBillion(ctx context.Context, longPath in
 }
 
 // GetNegativeTenBillionPreparer prepares the GetNegativeTenBillion request.
-func (client PathsClient) GetNegativeTenBillionPreparer(ctx context.Context, longPath int64) (*http.Request, error) {
+func (client PathsClient) GetNegativeTenBillionPreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"longPath": autorest.Encode("path", longPath),
+		"longPath": autorest.Encode("path", -10000000000),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1196,10 +1166,8 @@ func (client PathsClient) GetNegativeTenBillionResponder(resp *http.Response) (r
 }
 
 // GetTenBillion get '10000000000' 64 bit integer value
-//
-// longPath is '10000000000' 64 bit integer value
-func (client PathsClient) GetTenBillion(ctx context.Context, longPath int64) (result autorest.Response, err error) {
-	req, err := client.GetTenBillionPreparer(ctx, longPath)
+func (client PathsClient) GetTenBillion(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.GetTenBillionPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "GetTenBillion", nil, "Failure preparing request")
 		return
@@ -1221,9 +1189,9 @@ func (client PathsClient) GetTenBillion(ctx context.Context, longPath int64) (re
 }
 
 // GetTenBillionPreparer prepares the GetTenBillion request.
-func (client PathsClient) GetTenBillionPreparer(ctx context.Context, longPath int64) (*http.Request, error) {
+func (client PathsClient) GetTenBillionPreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"longPath": autorest.Encode("path", longPath),
+		"longPath": autorest.Encode("path", 10000000000),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1253,10 +1221,8 @@ func (client PathsClient) GetTenBillionResponder(resp *http.Response) (result au
 }
 
 // StringEmpty get ''
-//
-// stringPath is '' string value
-func (client PathsClient) StringEmpty(ctx context.Context, stringPath string) (result autorest.Response, err error) {
-	req, err := client.StringEmptyPreparer(ctx, stringPath)
+func (client PathsClient) StringEmpty(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.StringEmptyPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "StringEmpty", nil, "Failure preparing request")
 		return
@@ -1278,9 +1244,9 @@ func (client PathsClient) StringEmpty(ctx context.Context, stringPath string) (r
 }
 
 // StringEmptyPreparer prepares the StringEmpty request.
-func (client PathsClient) StringEmptyPreparer(ctx context.Context, stringPath string) (*http.Request, error) {
+func (client PathsClient) StringEmptyPreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"stringPath": autorest.Encode("path", stringPath),
+		"stringPath": autorest.Encode("path", ""),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1367,10 +1333,8 @@ func (client PathsClient) StringNullResponder(resp *http.Response) (result autor
 }
 
 // StringUnicode get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
-//
-// stringPath is '啊齄丂狛狜隣郎隣兀﨩'multi-byte string value
-func (client PathsClient) StringUnicode(ctx context.Context, stringPath string) (result autorest.Response, err error) {
-	req, err := client.StringUnicodePreparer(ctx, stringPath)
+func (client PathsClient) StringUnicode(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.StringUnicodePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "StringUnicode", nil, "Failure preparing request")
 		return
@@ -1392,9 +1356,9 @@ func (client PathsClient) StringUnicode(ctx context.Context, stringPath string) 
 }
 
 // StringUnicodePreparer prepares the StringUnicode request.
-func (client PathsClient) StringUnicodePreparer(ctx context.Context, stringPath string) (*http.Request, error) {
+func (client PathsClient) StringUnicodePreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"stringPath": autorest.Encode("path", stringPath),
+		"stringPath": autorest.Encode("path", "啊齄丂狛狜隣郎隣兀﨩"),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1424,10 +1388,8 @@ func (client PathsClient) StringUnicodeResponder(resp *http.Response) (result au
 }
 
 // StringURLEncoded get 'begin!*'();:@ &=+$,/?#[]end
-//
-// stringPath is 'begin!*'();:@ &=+$,/?#[]end' url encoded string value
-func (client PathsClient) StringURLEncoded(ctx context.Context, stringPath string) (result autorest.Response, err error) {
-	req, err := client.StringURLEncodedPreparer(ctx, stringPath)
+func (client PathsClient) StringURLEncoded(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.StringURLEncodedPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.PathsClient", "StringURLEncoded", nil, "Failure preparing request")
 		return
@@ -1449,9 +1411,9 @@ func (client PathsClient) StringURLEncoded(ctx context.Context, stringPath strin
 }
 
 // StringURLEncodedPreparer prepares the StringURLEncoded request.
-func (client PathsClient) StringURLEncodedPreparer(ctx context.Context, stringPath string) (*http.Request, error) {
+func (client PathsClient) StringURLEncodedPreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"stringPath": autorest.Encode("path", stringPath),
+		"stringPath": autorest.Encode("path", "begin!*'();:@ &=+$,/?#[]end"),
 	}
 
 	preparer := autorest.CreatePreparer(

--- a/test/src/tests/generated/url/queries.go
+++ b/test/src/tests/generated/url/queries.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/date"
-	"github.com/Azure/go-autorest/autorest/validation"
 	"net/http"
 )
 
@@ -393,16 +392,8 @@ func (client QueriesClient) ArrayStringTsvValidResponder(resp *http.Response) (r
 }
 
 // ByteEmpty get '' as byte array
-//
-// byteQuery is '' as byte array
-func (client QueriesClient) ByteEmpty(ctx context.Context, byteQuery []byte) (result autorest.Response, err error) {
-	if err := validation.Validate([]validation.Validation{
-		{TargetValue: byteQuery,
-			Constraints: []validation.Constraint{{Target: "byteQuery", Name: validation.Null, Rule: true, Chain: nil}}}}); err != nil {
-		return result, validation.NewErrorWithValidationError(err, "urlgroup.QueriesClient", "ByteEmpty")
-	}
-
-	req, err := client.ByteEmptyPreparer(ctx, byteQuery)
+func (client QueriesClient) ByteEmpty(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.ByteEmptyPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "ByteEmpty", nil, "Failure preparing request")
 		return
@@ -424,9 +415,9 @@ func (client QueriesClient) ByteEmpty(ctx context.Context, byteQuery []byte) (re
 }
 
 // ByteEmptyPreparer prepares the ByteEmpty request.
-func (client QueriesClient) ByteEmptyPreparer(ctx context.Context, byteQuery []byte) (*http.Request, error) {
+func (client QueriesClient) ByteEmptyPreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"byteQuery": autorest.Encode("query", byteQuery),
+		"byteQuery": autorest.Encode("query", []byte("")),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -693,10 +684,8 @@ func (client QueriesClient) DateTimeNullResponder(resp *http.Response) (result a
 }
 
 // DateTimeValid get '2012-01-01T01:01:01Z' as date-time
-//
-// dateTimeQuery is '2012-01-01T01:01:01Z' as date-time
-func (client QueriesClient) DateTimeValid(ctx context.Context, dateTimeQuery date.Time) (result autorest.Response, err error) {
-	req, err := client.DateTimeValidPreparer(ctx, dateTimeQuery)
+func (client QueriesClient) DateTimeValid(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.DateTimeValidPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "DateTimeValid", nil, "Failure preparing request")
 		return
@@ -718,9 +707,9 @@ func (client QueriesClient) DateTimeValid(ctx context.Context, dateTimeQuery dat
 }
 
 // DateTimeValidPreparer prepares the DateTimeValid request.
-func (client QueriesClient) DateTimeValidPreparer(ctx context.Context, dateTimeQuery date.Time) (*http.Request, error) {
+func (client QueriesClient) DateTimeValidPreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"dateTimeQuery": autorest.Encode("query", dateTimeQuery),
+		"dateTimeQuery": autorest.Encode("query", "2012-01-01T01:01:01Z"),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -751,10 +740,8 @@ func (client QueriesClient) DateTimeValidResponder(resp *http.Response) (result 
 }
 
 // DateValid get '2012-01-01' as date
-//
-// dateQuery is '2012-01-01' as date
-func (client QueriesClient) DateValid(ctx context.Context, dateQuery date.Date) (result autorest.Response, err error) {
-	req, err := client.DateValidPreparer(ctx, dateQuery)
+func (client QueriesClient) DateValid(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.DateValidPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "DateValid", nil, "Failure preparing request")
 		return
@@ -776,9 +763,9 @@ func (client QueriesClient) DateValid(ctx context.Context, dateQuery date.Date) 
 }
 
 // DateValidPreparer prepares the DateValid request.
-func (client QueriesClient) DateValidPreparer(ctx context.Context, dateQuery date.Date) (*http.Request, error) {
+func (client QueriesClient) DateValidPreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"dateQuery": autorest.Encode("query", dateQuery),
+		"dateQuery": autorest.Encode("query", "2012-01-01"),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -809,10 +796,8 @@ func (client QueriesClient) DateValidResponder(resp *http.Response) (result auto
 }
 
 // DoubleDecimalNegative get '-9999999.999' numeric value
-//
-// doubleQuery is '-9999999.999'numeric value
-func (client QueriesClient) DoubleDecimalNegative(ctx context.Context, doubleQuery float64) (result autorest.Response, err error) {
-	req, err := client.DoubleDecimalNegativePreparer(ctx, doubleQuery)
+func (client QueriesClient) DoubleDecimalNegative(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.DoubleDecimalNegativePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "DoubleDecimalNegative", nil, "Failure preparing request")
 		return
@@ -834,9 +819,9 @@ func (client QueriesClient) DoubleDecimalNegative(ctx context.Context, doubleQue
 }
 
 // DoubleDecimalNegativePreparer prepares the DoubleDecimalNegative request.
-func (client QueriesClient) DoubleDecimalNegativePreparer(ctx context.Context, doubleQuery float64) (*http.Request, error) {
+func (client QueriesClient) DoubleDecimalNegativePreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"doubleQuery": autorest.Encode("query", doubleQuery),
+		"doubleQuery": autorest.Encode("query", -9999999.999),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -867,10 +852,8 @@ func (client QueriesClient) DoubleDecimalNegativeResponder(resp *http.Response) 
 }
 
 // DoubleDecimalPositive get '9999999.999' numeric value
-//
-// doubleQuery is '9999999.999'numeric value
-func (client QueriesClient) DoubleDecimalPositive(ctx context.Context, doubleQuery float64) (result autorest.Response, err error) {
-	req, err := client.DoubleDecimalPositivePreparer(ctx, doubleQuery)
+func (client QueriesClient) DoubleDecimalPositive(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.DoubleDecimalPositivePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "DoubleDecimalPositive", nil, "Failure preparing request")
 		return
@@ -892,9 +875,9 @@ func (client QueriesClient) DoubleDecimalPositive(ctx context.Context, doubleQue
 }
 
 // DoubleDecimalPositivePreparer prepares the DoubleDecimalPositive request.
-func (client QueriesClient) DoubleDecimalPositivePreparer(ctx context.Context, doubleQuery float64) (*http.Request, error) {
+func (client QueriesClient) DoubleDecimalPositivePreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"doubleQuery": autorest.Encode("query", doubleQuery),
+		"doubleQuery": autorest.Encode("query", 9999999.999),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1161,10 +1144,8 @@ func (client QueriesClient) FloatNullResponder(resp *http.Response) (result auto
 }
 
 // FloatScientificNegative get '-1.034E-20' numeric value
-//
-// floatQuery is '-1.034E-20'numeric value
-func (client QueriesClient) FloatScientificNegative(ctx context.Context, floatQuery float64) (result autorest.Response, err error) {
-	req, err := client.FloatScientificNegativePreparer(ctx, floatQuery)
+func (client QueriesClient) FloatScientificNegative(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.FloatScientificNegativePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "FloatScientificNegative", nil, "Failure preparing request")
 		return
@@ -1186,9 +1167,9 @@ func (client QueriesClient) FloatScientificNegative(ctx context.Context, floatQu
 }
 
 // FloatScientificNegativePreparer prepares the FloatScientificNegative request.
-func (client QueriesClient) FloatScientificNegativePreparer(ctx context.Context, floatQuery float64) (*http.Request, error) {
+func (client QueriesClient) FloatScientificNegativePreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"floatQuery": autorest.Encode("query", floatQuery),
+		"floatQuery": autorest.Encode("query", -1.034E-20),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1219,10 +1200,8 @@ func (client QueriesClient) FloatScientificNegativeResponder(resp *http.Response
 }
 
 // FloatScientificPositive get '1.034E+20' numeric value
-//
-// floatQuery is '1.034E+20'numeric value
-func (client QueriesClient) FloatScientificPositive(ctx context.Context, floatQuery float64) (result autorest.Response, err error) {
-	req, err := client.FloatScientificPositivePreparer(ctx, floatQuery)
+func (client QueriesClient) FloatScientificPositive(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.FloatScientificPositivePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "FloatScientificPositive", nil, "Failure preparing request")
 		return
@@ -1244,9 +1223,9 @@ func (client QueriesClient) FloatScientificPositive(ctx context.Context, floatQu
 }
 
 // FloatScientificPositivePreparer prepares the FloatScientificPositive request.
-func (client QueriesClient) FloatScientificPositivePreparer(ctx context.Context, floatQuery float64) (*http.Request, error) {
+func (client QueriesClient) FloatScientificPositivePreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"floatQuery": autorest.Encode("query", floatQuery),
+		"floatQuery": autorest.Encode("query", 1.034E+20),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1277,10 +1256,8 @@ func (client QueriesClient) FloatScientificPositiveResponder(resp *http.Response
 }
 
 // GetBooleanFalse get false Boolean value on path
-//
-// boolQuery is false boolean value
-func (client QueriesClient) GetBooleanFalse(ctx context.Context, boolQuery bool) (result autorest.Response, err error) {
-	req, err := client.GetBooleanFalsePreparer(ctx, boolQuery)
+func (client QueriesClient) GetBooleanFalse(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.GetBooleanFalsePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "GetBooleanFalse", nil, "Failure preparing request")
 		return
@@ -1302,9 +1279,9 @@ func (client QueriesClient) GetBooleanFalse(ctx context.Context, boolQuery bool)
 }
 
 // GetBooleanFalsePreparer prepares the GetBooleanFalse request.
-func (client QueriesClient) GetBooleanFalsePreparer(ctx context.Context, boolQuery bool) (*http.Request, error) {
+func (client QueriesClient) GetBooleanFalsePreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"boolQuery": autorest.Encode("query", boolQuery),
+		"boolQuery": autorest.Encode("query", false),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1394,10 +1371,8 @@ func (client QueriesClient) GetBooleanNullResponder(resp *http.Response) (result
 }
 
 // GetBooleanTrue get true Boolean value on path
-//
-// boolQuery is true boolean value
-func (client QueriesClient) GetBooleanTrue(ctx context.Context, boolQuery bool) (result autorest.Response, err error) {
-	req, err := client.GetBooleanTruePreparer(ctx, boolQuery)
+func (client QueriesClient) GetBooleanTrue(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.GetBooleanTruePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "GetBooleanTrue", nil, "Failure preparing request")
 		return
@@ -1419,9 +1394,9 @@ func (client QueriesClient) GetBooleanTrue(ctx context.Context, boolQuery bool) 
 }
 
 // GetBooleanTruePreparer prepares the GetBooleanTrue request.
-func (client QueriesClient) GetBooleanTruePreparer(ctx context.Context, boolQuery bool) (*http.Request, error) {
+func (client QueriesClient) GetBooleanTruePreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"boolQuery": autorest.Encode("query", boolQuery),
+		"boolQuery": autorest.Encode("query", true),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1452,10 +1427,8 @@ func (client QueriesClient) GetBooleanTrueResponder(resp *http.Response) (result
 }
 
 // GetIntNegativeOneMillion get '-1000000' integer value
-//
-// intQuery is '-1000000' integer value
-func (client QueriesClient) GetIntNegativeOneMillion(ctx context.Context, intQuery int32) (result autorest.Response, err error) {
-	req, err := client.GetIntNegativeOneMillionPreparer(ctx, intQuery)
+func (client QueriesClient) GetIntNegativeOneMillion(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.GetIntNegativeOneMillionPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "GetIntNegativeOneMillion", nil, "Failure preparing request")
 		return
@@ -1477,9 +1450,9 @@ func (client QueriesClient) GetIntNegativeOneMillion(ctx context.Context, intQue
 }
 
 // GetIntNegativeOneMillionPreparer prepares the GetIntNegativeOneMillion request.
-func (client QueriesClient) GetIntNegativeOneMillionPreparer(ctx context.Context, intQuery int32) (*http.Request, error) {
+func (client QueriesClient) GetIntNegativeOneMillionPreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"intQuery": autorest.Encode("query", intQuery),
+		"intQuery": autorest.Encode("query", -1000000),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1569,10 +1542,8 @@ func (client QueriesClient) GetIntNullResponder(resp *http.Response) (result aut
 }
 
 // GetIntOneMillion get '1000000' integer value
-//
-// intQuery is '1000000' integer value
-func (client QueriesClient) GetIntOneMillion(ctx context.Context, intQuery int32) (result autorest.Response, err error) {
-	req, err := client.GetIntOneMillionPreparer(ctx, intQuery)
+func (client QueriesClient) GetIntOneMillion(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.GetIntOneMillionPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "GetIntOneMillion", nil, "Failure preparing request")
 		return
@@ -1594,9 +1565,9 @@ func (client QueriesClient) GetIntOneMillion(ctx context.Context, intQuery int32
 }
 
 // GetIntOneMillionPreparer prepares the GetIntOneMillion request.
-func (client QueriesClient) GetIntOneMillionPreparer(ctx context.Context, intQuery int32) (*http.Request, error) {
+func (client QueriesClient) GetIntOneMillionPreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"intQuery": autorest.Encode("query", intQuery),
+		"intQuery": autorest.Encode("query", 1000000),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1686,10 +1657,8 @@ func (client QueriesClient) GetLongNullResponder(resp *http.Response) (result au
 }
 
 // GetNegativeTenBillion get '-10000000000' 64 bit integer value
-//
-// longQuery is '-10000000000' 64 bit integer value
-func (client QueriesClient) GetNegativeTenBillion(ctx context.Context, longQuery int64) (result autorest.Response, err error) {
-	req, err := client.GetNegativeTenBillionPreparer(ctx, longQuery)
+func (client QueriesClient) GetNegativeTenBillion(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.GetNegativeTenBillionPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "GetNegativeTenBillion", nil, "Failure preparing request")
 		return
@@ -1711,9 +1680,9 @@ func (client QueriesClient) GetNegativeTenBillion(ctx context.Context, longQuery
 }
 
 // GetNegativeTenBillionPreparer prepares the GetNegativeTenBillion request.
-func (client QueriesClient) GetNegativeTenBillionPreparer(ctx context.Context, longQuery int64) (*http.Request, error) {
+func (client QueriesClient) GetNegativeTenBillionPreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"longQuery": autorest.Encode("query", longQuery),
+		"longQuery": autorest.Encode("query", -10000000000),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1744,10 +1713,8 @@ func (client QueriesClient) GetNegativeTenBillionResponder(resp *http.Response) 
 }
 
 // GetTenBillion get '10000000000' 64 bit integer value
-//
-// longQuery is '10000000000' 64 bit integer value
-func (client QueriesClient) GetTenBillion(ctx context.Context, longQuery int64) (result autorest.Response, err error) {
-	req, err := client.GetTenBillionPreparer(ctx, longQuery)
+func (client QueriesClient) GetTenBillion(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.GetTenBillionPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "GetTenBillion", nil, "Failure preparing request")
 		return
@@ -1769,9 +1736,9 @@ func (client QueriesClient) GetTenBillion(ctx context.Context, longQuery int64) 
 }
 
 // GetTenBillionPreparer prepares the GetTenBillion request.
-func (client QueriesClient) GetTenBillionPreparer(ctx context.Context, longQuery int64) (*http.Request, error) {
+func (client QueriesClient) GetTenBillionPreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"longQuery": autorest.Encode("query", longQuery),
+		"longQuery": autorest.Encode("query", 10000000000),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1802,10 +1769,8 @@ func (client QueriesClient) GetTenBillionResponder(resp *http.Response) (result 
 }
 
 // StringEmpty get ''
-//
-// stringQuery is '' string value
-func (client QueriesClient) StringEmpty(ctx context.Context, stringQuery string) (result autorest.Response, err error) {
-	req, err := client.StringEmptyPreparer(ctx, stringQuery)
+func (client QueriesClient) StringEmpty(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.StringEmptyPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "StringEmpty", nil, "Failure preparing request")
 		return
@@ -1827,9 +1792,9 @@ func (client QueriesClient) StringEmpty(ctx context.Context, stringQuery string)
 }
 
 // StringEmptyPreparer prepares the StringEmpty request.
-func (client QueriesClient) StringEmptyPreparer(ctx context.Context, stringQuery string) (*http.Request, error) {
+func (client QueriesClient) StringEmptyPreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"stringQuery": autorest.Encode("query", stringQuery),
+		"stringQuery": autorest.Encode("query", ""),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1919,10 +1884,8 @@ func (client QueriesClient) StringNullResponder(resp *http.Response) (result aut
 }
 
 // StringUnicode get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
-//
-// stringQuery is '啊齄丂狛狜隣郎隣兀﨩'multi-byte string value
-func (client QueriesClient) StringUnicode(ctx context.Context, stringQuery string) (result autorest.Response, err error) {
-	req, err := client.StringUnicodePreparer(ctx, stringQuery)
+func (client QueriesClient) StringUnicode(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.StringUnicodePreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "StringUnicode", nil, "Failure preparing request")
 		return
@@ -1944,9 +1907,9 @@ func (client QueriesClient) StringUnicode(ctx context.Context, stringQuery strin
 }
 
 // StringUnicodePreparer prepares the StringUnicode request.
-func (client QueriesClient) StringUnicodePreparer(ctx context.Context, stringQuery string) (*http.Request, error) {
+func (client QueriesClient) StringUnicodePreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"stringQuery": autorest.Encode("query", stringQuery),
+		"stringQuery": autorest.Encode("query", "啊齄丂狛狜隣郎隣兀﨩"),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1977,10 +1940,8 @@ func (client QueriesClient) StringUnicodeResponder(resp *http.Response) (result 
 }
 
 // StringURLEncoded get 'begin!*'();:@ &=+$,/?#[]end
-//
-// stringQuery is 'begin!*'();:@ &=+$,/?#[]end' url encoded string value
-func (client QueriesClient) StringURLEncoded(ctx context.Context, stringQuery string) (result autorest.Response, err error) {
-	req, err := client.StringURLEncodedPreparer(ctx, stringQuery)
+func (client QueriesClient) StringURLEncoded(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.StringURLEncodedPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "urlgroup.QueriesClient", "StringURLEncoded", nil, "Failure preparing request")
 		return
@@ -2002,9 +1963,9 @@ func (client QueriesClient) StringURLEncoded(ctx context.Context, stringQuery st
 }
 
 // StringURLEncodedPreparer prepares the StringURLEncoded request.
-func (client QueriesClient) StringURLEncodedPreparer(ctx context.Context, stringQuery string) (*http.Request, error) {
+func (client QueriesClient) StringURLEncodedPreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"stringQuery": autorest.Encode("query", stringQuery),
+		"stringQuery": autorest.Encode("query", "begin!*'();:@ &=+$,/?#[]end"),
 	}
 
 	preparer := autorest.CreatePreparer(

--- a/test/src/tests/generated/validation/client.go
+++ b/test/src/tests/generated/validation/client.go
@@ -44,9 +44,8 @@ func NewWithBaseURI(baseURI string, subscriptionID string) BaseClient {
 }
 
 // GetWithConstantInPath sends the get with constant in path request.
-//
-func (client BaseClient) GetWithConstantInPath(ctx context.Context, constantParam string) (result autorest.Response, err error) {
-	req, err := client.GetWithConstantInPathPreparer(ctx, constantParam)
+func (client BaseClient) GetWithConstantInPath(ctx context.Context) (result autorest.Response, err error) {
+	req, err := client.GetWithConstantInPathPreparer(ctx)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "validationgroup.BaseClient", "GetWithConstantInPath", nil, "Failure preparing request")
 		return
@@ -68,9 +67,9 @@ func (client BaseClient) GetWithConstantInPath(ctx context.Context, constantPara
 }
 
 // GetWithConstantInPathPreparer prepares the GetWithConstantInPath request.
-func (client BaseClient) GetWithConstantInPathPreparer(ctx context.Context, constantParam string) (*http.Request, error) {
+func (client BaseClient) GetWithConstantInPathPreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"constantParam": autorest.Encode("path", constantParam),
+		"constantParam": autorest.Encode("path", "constant"),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -101,7 +100,7 @@ func (client BaseClient) GetWithConstantInPathResponder(resp *http.Response) (re
 
 // PostWithConstantInBody sends the post with constant in body request.
 //
-func (client BaseClient) PostWithConstantInBody(ctx context.Context, constantParam string, body *Product) (result Product, err error) {
+func (client BaseClient) PostWithConstantInBody(ctx context.Context, body *Product) (result Product, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: body,
 			Constraints: []validation.Constraint{{Target: "body", Name: validation.Null, Rule: false,
@@ -128,7 +127,7 @@ func (client BaseClient) PostWithConstantInBody(ctx context.Context, constantPar
 		return result, validation.NewErrorWithValidationError(err, "validationgroup.BaseClient", "PostWithConstantInBody")
 	}
 
-	req, err := client.PostWithConstantInBodyPreparer(ctx, constantParam, body)
+	req, err := client.PostWithConstantInBodyPreparer(ctx, body)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "validationgroup.BaseClient", "PostWithConstantInBody", nil, "Failure preparing request")
 		return
@@ -150,9 +149,9 @@ func (client BaseClient) PostWithConstantInBody(ctx context.Context, constantPar
 }
 
 // PostWithConstantInBodyPreparer prepares the PostWithConstantInBody request.
-func (client BaseClient) PostWithConstantInBodyPreparer(ctx context.Context, constantParam string, body *Product) (*http.Request, error) {
+func (client BaseClient) PostWithConstantInBodyPreparer(ctx context.Context, body *Product) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"constantParam": autorest.Encode("path", constantParam),
+		"constantParam": autorest.Encode("path", "constant"),
 	}
 
 	preparer := autorest.CreatePreparer(


### PR DESCRIPTION
Per swagger spec, required enums with one value are constants thus they
shouldn't be paramaters, so just emit the value directly in the code.