### PR TITLE
Treat multi status code as an error

### DIFF
--- a/src/CodeNamerGo.cs
+++ b/src/CodeNamerGo.cs
@@ -20,17 +20,17 @@ namespace AutoRest.Go
 
         public virtual IEnumerable<string> AutorestImports => new string[] { PrimaryTypeGo.GetImportLine(package: "github.com/Azure/go-autorest/autorest") };
 
-        public virtual IEnumerable<string> StandardImports => new string[] 
-        { 
-            PrimaryTypeGo.GetImportLine(package: "github.com/Azure/go-autorest/autorest/azure"), 
+        public virtual IEnumerable<string> StandardImports => new string[]
+        {
+            PrimaryTypeGo.GetImportLine(package: "github.com/Azure/go-autorest/autorest/azure"),
             PrimaryTypeGo.GetImportLine(package: "net/http"),
             PrimaryTypeGo.GetImportLine(package: "context")
         };
 
-        public virtual IEnumerable<string> PageableImports => new string[] 
-        { 
-            PrimaryTypeGo.GetImportLine(package: "net/http"), 
-            PrimaryTypeGo.GetImportLine(package: "github.com/Azure/go-autorest/autorest/to") 
+        public virtual IEnumerable<string> PageableImports => new string[]
+        {
+            PrimaryTypeGo.GetImportLine(package: "net/http"),
+            PrimaryTypeGo.GetImportLine(package: "github.com/Azure/go-autorest/autorest/to")
         };
 
         public virtual IEnumerable<string> ValidationImport => new string[] { PrimaryTypeGo.GetImportLine(package: "github.com/Azure/go-autorest/autorest/validation") };
@@ -157,6 +157,9 @@ namespace AutoRest.Go
             statusCodeMap[tooManyRequests] = "http.StatusTooManyRequests";
             statusCodeMap[HttpStatusCode.HttpVersionNotSupported] = "http.StatusHTTPVersionNotSupported";
 
+            // Add the status which are not in the System.Net.HttpStatusCode enumeration
+            statusCodeMap[(HttpStatusCode)207] = "http.StatusMultiStatus";
+
             StatusCodeToGoString = statusCodeMap;
 
             ReservedWords.AddRange(
@@ -167,8 +170,8 @@ namespace AutoRest.Go
                     "case",         "defer",        "go",           "map",          "struct",
                     "chan",         "else",         "goto",         "package",      "switch",
                     "const",        "fallthrough",  "if",           "range",        "type",
-                    "continue",     "for",          "import",       "return",       "var",        
-                
+                    "continue",     "for",          "import",       "return",       "var",
+
                     // Reserved predeclared identifiers -- list retrieved from http://golang.org/ref/spec#Predeclared_identifiers
                     "bool", "byte",
                     "complex64", "complex128",
@@ -266,7 +269,7 @@ namespace AutoRest.Go
             }
 
             return
-                name.Split(new Char[]{'.', '_', '@', '-', ' ', '$'})
+                name.Split(new Char[] { '.', '_', '@', '-', ' ', '$' })
                     .Where(s => !string.IsNullOrEmpty(s))
                     .Select(s => char.ToUpperInvariant(s[0]) + s.Substring(1, s.Length - 1))
                     .DefaultIfEmpty("")
@@ -335,7 +338,7 @@ namespace AutoRest.Go
         /// </summary>
         /// <param name="name"></param>
         /// <returns>The formatted string.</returns>
-        public override string GetTypeName(string name) => 
+        public override string GetTypeName(string name) =>
             string.IsNullOrWhiteSpace(name) ?
             name :
             EnsureNameCase(GetEscapedReservedName(RemoveInvalidCharacters(PascalCase(name)), "Type"));

--- a/src/Model/MethodGo.cs
+++ b/src/Model/MethodGo.cs
@@ -332,6 +332,12 @@ namespace AutoRest.Go.Model
                 // Refactor -> generator
                 foreach (var sc in Responses.Keys)
                 {
+                    // Multi status represents partial success for multi resource operations.Given that there are some failures, treating
+                    // this as an error.
+                    if (sc == (HttpStatusCode)207)
+                    {
+                        continue;
+                    }
                     codes.Add(CodeNamerGo.Instance.StatusCodeToGoString[sc]);
                 }
                 return codes;

--- a/src/Model/MethodGo.cs
+++ b/src/Model/MethodGo.cs
@@ -332,12 +332,6 @@ namespace AutoRest.Go.Model
                 // Refactor -> generator
                 foreach (var sc in Responses.Keys)
                 {
-                    // Multi status represents partial success for multi resource operations.Given that there are some failures, treating
-                    // this as an error.
-                    if (sc == (HttpStatusCode)207)
-                    {
-                        continue;
-                    }
                     codes.Add(CodeNamerGo.Instance.StatusCodeToGoString[sc]);
                 }
                 return codes;


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-go/issues/988

- Multi Status Code 207 is not in the `System.Net.HttpStatusCode` enum which was causing generation failure on the latest updates to CS LUIS Programmatic 

- There are 2 options in treating this since the format of the body will be dependent on who returns it
   - Either return it as an error ( since in the only case we have it it signals Partial Success ) 
   - Return it without an error and let the clients inspect the response and see what to do with it.

I went with option one here.