### PR TITLE
[DO NOT MERGE] Fix object type codegen to return canonical representation.

### DIFF
--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -314,6 +314,7 @@ namespace AutoRest.Go
             return 
                 type is DictionaryType
                 || type is SequenceType
+                || type is InterfaceTypeGo
                 || (type is PrimaryType primaryType
                     && (primaryType.KnownPrimaryType == KnownPrimaryType.ByteArray
                         || primaryType.KnownPrimaryType == KnownPrimaryType.Stream

--- a/src/Model/DictionaryTypeGo.cs
+++ b/src/Model/DictionaryTypeGo.cs
@@ -33,6 +33,13 @@ namespace AutoRest.Go.Model
             ValueType.AddImports(imports);
         }
 
+        public override IModelType ValueType
+        {
+            // for dictionaries of objects the value type is always the empty interface
+            get => base.ValueType.PrimaryType(KnownPrimaryType.Object) ? InterfaceTypeGo.Instance : base.ValueType;
+            set => base.ValueType = value;
+        }
+
         /// <summary>
         /// Determines whether the specified object is equal to this object based on the ValueType.
         /// </summary>

--- a/src/Model/InterfaceTypeGo.cs
+++ b/src/Model/InterfaceTypeGo.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using AutoRest.Core.Model;
+using AutoRest.Core.Utilities;
+
+namespace AutoRest.Go.Model
+{
+    /// <summary>
+    /// Represents the empty interface type.  It uses the singleton
+    /// pattern as there's no need to create more than one of these.
+    /// Most of the IModelType methods aren't required which is why
+    /// they throw, so in the event that any of them do become
+    /// required it should be obvious which one(s).
+    /// </summary>
+    internal class InterfaceTypeGo : IModelType
+    {
+        private static InterfaceTypeGo s_Instance = new InterfaceTypeGo();
+
+        public static InterfaceTypeGo Instance  => s_Instance;
+
+        private InterfaceTypeGo() { }
+
+        public Fixable<string> Name => "interface{}";
+
+        public string ExtendedDocumentation => throw new NotImplementedException();
+
+        public string DefaultValue => null;
+
+        public bool IsConstant => false;
+
+        public string DeclarationName => Name.Value;
+
+        public string ClassName => Name.Value;
+
+        public XmlProperties XmlProperties { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public string XmlName => throw new NotImplementedException();
+
+        public string XmlNamespace => throw new NotImplementedException();
+
+        public string XmlPrefix => throw new NotImplementedException();
+
+        public bool XmlIsWrapped => throw new NotImplementedException();
+
+        public bool XmlIsAttribute => throw new NotImplementedException();
+
+        public IEnumerable<IChild> Children => null;
+
+        public CodeModel CodeModel => null;
+
+        public IEnumerable<IIdentifier> IdentifiersInScope => null;
+
+        public IParent Parent => null;
+
+        public HashSet<string> LocallyUsedNames => null;
+
+        public IEnumerable<string> MyReservedNames => null;
+
+        public string Qualifier => "Interface";
+
+        public void Disambiguate()
+        {
+            // empty
+        }
+
+        public bool StructurallyEquals(IModelType other)
+        {
+            return other is InterfaceTypeGo;
+        }
+    }
+}

--- a/src/Model/PrimaryTypeGo.cs
+++ b/src/Model/PrimaryTypeGo.cs
@@ -104,8 +104,7 @@ namespace AutoRest.Go.Model
                         return "string";
 
                     case KnownPrimaryType.Object:
-                        // TODO: is this the correct way to support object types?
-                        return "interface{}";
+                        return "map[string]interface{}";
 
                     case KnownPrimaryType.UnixTime:
                         return "date.UnixTime";

--- a/test/src/tests/acceptancetests/httpInfrastructuregrouptest/httpInfrastructure_test.go
+++ b/test/src/tests/acceptancetests/httpInfrastructuregrouptest/httpInfrastructure_test.go
@@ -716,25 +716,19 @@ func (s *HTTPSuite) TestGet200ModelA201ModelC404ModelDDefaultError200Valid(c *ch
 	res, err := httpMultipleResponsesClient.Get200ModelA201ModelC404ModelDDefaultError200Valid(context.Background())
 	c.Assert(err, chk.IsNil)
 	c.Assert(res, chk.NotNil)
-	v, ok := res.Value.(map[string]interface{})
-	c.Assert(ok, chk.Equals, true)
-	c.Assert(v["statusCode"], chk.Equals, strconv.Itoa(http.StatusOK))
+	c.Assert(res.Value["statusCode"], chk.Equals, strconv.Itoa(http.StatusOK))
 }
 
 func (s *HTTPSuite) TestGet200ModelA201ModelC404ModelDDefaultError201Valid(c *chk.C) {
 	res, err := httpMultipleResponsesClient.Get200ModelA201ModelC404ModelDDefaultError201Valid(context.Background())
 	c.Assert(err, chk.IsNil)
-	v, ok := res.Value.(map[string]interface{})
-	c.Assert(ok, chk.Equals, true)
-	c.Assert(v["httpCode"], chk.Equals, strconv.Itoa(http.StatusCreated))
+	c.Assert(res.Value["httpCode"], chk.Equals, strconv.Itoa(http.StatusCreated))
 }
 
 func (s *HTTPSuite) TestGet200ModelA201ModelC404ModelDDefaultError404Valid(c *chk.C) {
 	res, err := httpMultipleResponsesClient.Get200ModelA201ModelC404ModelDDefaultError404Valid(context.Background())
 	c.Assert(err, chk.IsNil)
-	v, ok := res.Value.(map[string]interface{})
-	c.Assert(ok, chk.Equals, true)
-	c.Assert(v["httpStatusCode"], chk.Equals, strconv.Itoa(http.StatusNotFound))
+	c.Assert(res.Value["httpStatusCode"], chk.Equals, strconv.Itoa(http.StatusNotFound))
 }
 
 func (s *HTTPSuite) TestGet200ModelA201ModelC404ModelDDefaultError400Valid(c *chk.C) {

--- a/test/src/tests/generated/httpinfrastructure/models.go
+++ b/test/src/tests/generated/httpinfrastructure/models.go
@@ -54,5 +54,5 @@ type ListString struct {
 // SetObject ...
 type SetObject struct {
 	autorest.Response `json:"-"`
-	Value             interface{} `json:"value,omitempty"`
+	Value             map[string]interface{} `json:"value,omitempty"`
 }


### PR DESCRIPTION
In Go a JSON object should be modeled as map[string]interface{}.
Unfortunately this uncovers a broken edge-case in the modeler as it
models objects as a dictionary of objects so you end up with the
following incorrect codegen.
map[string]map[string]interface{}
To work around this I've added a new type InterfaceTypeGo which
represents the empty interface.  For dictionaries where the value type
is object return an InterfaceTypeGo object.