### PR TITLE
Fix method group name collisions in batch generation.

### DIFF
--- a/src/Model/MethodGroupGo.cs
+++ b/src/Model/MethodGroupGo.cs
@@ -43,11 +43,15 @@ namespace AutoRest.Go.Model
             // can introduce collisions.  if there's a collision append "Group" to
             // the name.  unfortunately we can't do this in the namer as we don't
             // have access to the package name.
-            if (s_AllNames.Contains(Name.Value))
+            // NOTE: we must include the API version in the set to support batch
+            //       generation which invokes the generator over multiple API versions.
+            //       if we don't do this we end up with erroneous collisions across
+            //       API versions because the generator isn't recycled per batch.
+            if (s_AllNames.Contains($"{cmg.ApiVersion}_{Name.Value}"))
             {
                 Name += "Group";
             }
-            s_AllNames.Add(Name.Value);
+            s_AllNames.Add($"{cmg.ApiVersion}_{Name.Value}");
 
             if (Name != originalName)
             {


### PR DESCRIPTION
When AutoRest is run in batch mode the generators aren't recycled per
batch, so as a result any static data persists between batches; this
causes erroneous method group name collisions because the names are
indexed in an object-static hash set.  To fix this include the API
version in the set to ensure they're unique.