### PR TITLE
Add support for deprecation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/Azure/autorest.go/blob/master/README.md",
   "devDependencies": {
     "@microsoft.azure/autorest.testserver": "^2.3.20",
+    "@microsoft.azure/autorest.modeler": "2.3.47",
     "autorest": "^2.0.4222",
     "coffee-script": "^1.11.1",
     "dotnet-sdk-2.0.0": "^1.4.4",

--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -268,7 +268,7 @@ namespace AutoRest.Go.Model
                     {
                         message = property.DeprecationMessage;
                     }
-                    indented.Append($"// Deprecated: {message}");
+                    indented.Append($"// Deprecated: {message}\n");
                 }
 
                 indented.AppendLine(property.Field);

--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -268,7 +268,7 @@ namespace AutoRest.Go.Model
                     {
                         message = property.DeprecationMessage;
                     }
-                    indented.Append($"// Deprecated: {message}\n");
+                    indented.Append($"//\n// Deprecated: {message}\n");
                 }
 
                 indented.AppendLine(property.Field);

--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -261,6 +261,15 @@ namespace AutoRest.Go.Model
                 {
                     indented.Append($"{property.Name} - {property.Documentation}".ToCommentBlock());
                 }
+                if (property.Deprecated)
+                {
+                    var message = "This property has been deprecated.";
+                    if (!string.IsNullOrWhiteSpace(property.DeprecationMessage))
+                    {
+                        message = property.DeprecationMessage;
+                    }
+                    indented.Append($"// Deprecated: {message}");
+                }
 
                 indented.AppendLine(property.Field);
             }

--- a/src/Model/FutureTypeGo.cs
+++ b/src/Model/FutureTypeGo.cs
@@ -27,6 +27,10 @@ namespace AutoRest.Go.Model
             ClientTypeName = method.Owner;
             ResultType = method.ReturnValue().Body;
             ResponderMethodName = method.ResponderMethodName;
+            if (method.Deprecated)
+            {
+                DeprecationMessage = "The method for this type has been deprecated.";
+            }
         }
 
         /// <summary>

--- a/src/Model/PageTypeGo.cs
+++ b/src/Model/PageTypeGo.cs
@@ -41,6 +41,10 @@ namespace AutoRest.Go.Model
             ItemName = CodeNamerGo.Instance.GetPropertyName((string)pageableExtension["itemName"] ?? "value");
 
             IteratorType = new IteratorTypeGo(this);
+            if (method.Deprecated)
+            {
+                DeprecationMessage = "The method for this type has been deprecated.";
+            }
         }
 
         /// <summary>

--- a/src/Templates/EnumTemplate.cshtml
+++ b/src/Templates/EnumTemplate.cshtml
@@ -23,6 +23,7 @@ else
     {
         message = Model.DeprecationMessage;
     }
+@://
 @:@WrapComment("// Deprecated: ", message)
 }
 type @Model.Name string

--- a/src/Templates/EnumTemplate.cshtml
+++ b/src/Templates/EnumTemplate.cshtml
@@ -16,6 +16,15 @@ else
         @WrapComment("// ", Model.Documentation)
     </text>
 }
+@if (Model.Deprecated)
+{
+    var message = "This type has been deprecated.";
+    if (!string.IsNullOrWhiteSpace(Model.DeprecationMessage))
+    {
+        message = Model.DeprecationMessage;
+    }
+@:@WrapComment("// Deprecated: ", message)
+}
 type @Model.Name string
 
 @EmptyLine

--- a/src/Templates/MethodTemplate.cshtml
+++ b/src/Templates/MethodTemplate.cshtml
@@ -27,6 +27,7 @@
 
 @if (Model.Deprecated)
 {
+    @://
     @:@WrapComment("// Deprecated: ", depMessage)
 }
 func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@Model.MethodReturnSignature()) {
@@ -102,6 +103,7 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
     // @(Model.PreparerMethodName) prepares the @(Model.Name) request.
 @if (Model.Deprecated)
 {
+    @://
     @:@WrapComment("// Deprecated: ", depMessage)
 }
     func (client @(Model.Owner)) @(Model.PreparerMethodName)(@(Model.MethodParametersSignature)) (*http.Request, error) {
@@ -206,6 +208,7 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
     // http.Response Body if it receives an error.
 @if (Model.Deprecated)
 {
+    @://
     @:@WrapComment("// Deprecated: ", depMessage)
 }
     func (client @(Model.Owner)) @(Model.SenderMethodName)(req *http.Request) (@senderRetSig) {
@@ -238,6 +241,7 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
     // closes the http.Response Body.
 @if (Model.Deprecated)
 {
+    @://
     @:@WrapComment("// Deprecated: ", depMessage)
 }
     func (client @(Model.Owner)) @(Model.ResponderMethodName)(resp *http.Response) (@Model.ResponderReturnSignature()) {

--- a/src/Templates/MethodTemplate.cshtml
+++ b/src/Templates/MethodTemplate.cshtml
@@ -8,6 +8,13 @@
 @using AutoRest.Go.Model
 
 @inherits AutoRest.Core.Template<AutoRest.Go.Model.MethodGo>
+@{
+    var depMessage = "This method has been deprecated.";
+    if (!string.IsNullOrWhiteSpace(Model.DeprecationMessage))
+    {
+        depMessage = Model.DeprecationMessage;
+    }
+}
 
 @WrapComment("// ", Model.Name + " " + Model.Description.ToSentence())
 @if (Model.LocalParameters.Any())
@@ -18,6 +25,10 @@
     </text>
 }
 
+@if (Model.Deprecated)
+{
+    @:@WrapComment("// Deprecated: ", depMessage)
+}
 func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@Model.MethodReturnSignature()) {
 @if ((Model.CodeModel as CodeModelGo).ShouldValidate && !Model.ParameterValidations.IsNullOrEmpty())
 {
@@ -89,6 +100,10 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
 
     @EmptyLine
     // @(Model.PreparerMethodName) prepares the @(Model.Name) request.
+@if (Model.Deprecated)
+{
+    @:@WrapComment("// Deprecated: ", depMessage)
+}
     func (client @(Model.Owner)) @(Model.PreparerMethodName)(@(Model.MethodParametersSignature)) (*http.Request, error) {
     @if (Model.IsCustomBaseUri && Model.URLParameters.Any())
     {
@@ -189,6 +204,10 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
     @EmptyLine
     // @(Model.SenderMethodName) sends the @(Model.Name) request. The method will close the
     // http.Response Body if it receives an error.
+@if (Model.Deprecated)
+{
+    @:@WrapComment("// Deprecated: ", depMessage)
+}
     func (client @(Model.Owner)) @(Model.SenderMethodName)(req *http.Request) (@senderRetSig) {
     @if (Model.IsLongRunningOperation())
     {
@@ -217,6 +236,10 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
     @EmptyLine
     // @(Model.ResponderMethodName) handles the response to the @(Model.Name) request. The method always
     // closes the http.Response Body.
+@if (Model.Deprecated)
+{
+    @:@WrapComment("// Deprecated: ", depMessage)
+}
     func (client @(Model.Owner)) @(Model.ResponderMethodName)(resp *http.Response) (@Model.ResponderReturnSignature()) {
     @if (Model.IsLongRunningOperation() && Model.IsPageable)
     {

--- a/src/Templates/ModelTemplate.cshtml
+++ b/src/Templates/ModelTemplate.cshtml
@@ -7,9 +7,21 @@
 
 @inherits AutoRest.Core.Template<AutoRest.Go.Model.CompositeTypeGo>
 
+@{
+    var depMessage = "This type has been deprecated.";
+    if (!string.IsNullOrWhiteSpace(Model.DeprecationMessage))
+    {
+        depMessage = Model.DeprecationMessage;
+    }
+}
+
 @if (Model.HasInterface())
 {
     @WrapComment("// ", $"{Model.GetInterfaceName()} {Model.Documentation.ToSentence()}")
+    @if (Model.Deprecated)
+    {
+    @:@WrapComment("// Deprecated: ", depMessage)
+    }
     <text>
     type @(Model.GetInterfaceName()) interface {
     @foreach (var dt in Model.DerivedTypes)
@@ -25,6 +37,10 @@
 
     @EmptyLine
     @WrapComment("// ", $"{Model.Name} {Model.Documentation.ToSentence()}")
+    @if (Model.Deprecated)
+    {
+    @:@WrapComment("// Deprecated: ", depMessage)
+    }
     type @(Model.Name) struct {
     @(Model.AddHTTPResponse())
     @(Model.Fields())
@@ -112,6 +128,10 @@ else
     }
     <text>
     @WrapComment("// ", $"{Model.Name} {Model.Documentation.ToSentence()}")
+    @if (Model.Deprecated)
+    {
+    @:@WrapComment("// Deprecated: ", depMessage)
+    }
     type @(Model.Name) struct {
     @(Model.AddHTTPResponse())
     @(Model.Fields())

--- a/src/Templates/ModelTemplate.cshtml
+++ b/src/Templates/ModelTemplate.cshtml
@@ -20,6 +20,7 @@
     @WrapComment("// ", $"{Model.GetInterfaceName()} {Model.Documentation.ToSentence()}")
     @if (Model.Deprecated)
     {
+    @://
     @:@WrapComment("// Deprecated: ", depMessage)
     }
     <text>
@@ -39,6 +40,7 @@
     @WrapComment("// ", $"{Model.Name} {Model.Documentation.ToSentence()}")
     @if (Model.Deprecated)
     {
+    @://
     @:@WrapComment("// Deprecated: ", depMessage)
     }
     type @(Model.Name) struct {

--- a/src/autorest.go.csproj
+++ b/src/autorest.go.csproj
@@ -61,8 +61,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.2.1" />
-    <PackageReference Include="autorest.common" Version="2.3.31" />
-    <!-- <ProjectReference Include="../../autorest.common/src/autorest.common.csproj" /> -->
+    <PackageReference Include="Microsoft.AutoRest.Common" Version="2.4.39" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The modeler has exposed deprecation settings and messages for types,
methods, and properties.  When true, emit the deprecation message if
available else a default message.