### PR TITLE
add tagging to publishing

### DIFF
--- a/.gulp/common.iced
+++ b/.gulp/common.iced
@@ -475,6 +475,23 @@ task 'fix-line-endings', 'Fixes line endings to file-type appropriate values.', 
     .pipe eol {eolc: 'LF', encoding:'utf8'}
     .pipe destination '.'
 
+task 'get-tag', '!', (done)->
+  if argv.tag 
+    # take the argument if they specified it.
+    global.tag = argv.tag  
+    done()
+  else 
+    # pick up the tag from the pkg.json version entry 
+    global.tag = semver.parse((package_json.version).trim()).prerelease.join(".")
+    if( global.tag ) 
+      return done()
+
+    # grab the git branch name.
+    execute "git rev-parse --abbrev-ref HEAD" , {silent:true}, (c,o,e)->
+      o = "preview" if( o == undefined || o == null || o == "" || o.trim() == 'master')
+      global.tag = o.trim()
+      done();
+
 task 'version-number', '!', (done)->
   if argv.version
     global.version =  argv.version if argv.version

--- a/.gulp/publishing.iced
+++ b/.gulp/publishing.iced
@@ -1,9 +1,9 @@
-task 'publish-preview', '', ['version-number','build'] , (done) ->
+task 'publish-preview', '', ['version-number','get-tag','build'] , (done) ->
   package_json = require "#{basefolder}/package.json"
 
   # move .gitignore out  of the way - yarn bug
   rm "-f", "#{basefolder}/.gitignore"
-  execute "#{basefolder}/node_modules/.bin/yarn publish --tag preview --new-version #{version} --access public --no-git-tag-version",{cwd:basefolder, silent:false }, (c,o,e) -> 
-    echo  "\n\nPublished:  #{package_json.name}@#{info version} (tagged as @preview)\n\n"
+  execute "#{basefolder}/node_modules/.bin/yarn publish --tag #{tag} --new-version #{version} --access public --no-git-tag-version",{cwd:basefolder, silent:false }, (c,o,e) -> 
+    echo  "\n\nPublished:  #{package_json.name}@#{info version} (tagged as @#{tag})\n\n"
     # bring back .gitignore!
     execute "git checkout #{basefolder}/.gitignore",{cwd:basefolder, silent:true }, done


### PR DESCRIPTION
This will use the branch name (or suffix in `version` in pkg.json) for the tag name in npm