### PR TITLE
Add support for central version number.

### DIFF
--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -15,6 +15,7 @@ namespace AutoRest.Go.Model
 {
     public class CodeModelGo : CodeModel
     {
+        public static readonly string OneVerString = "version.Number";
         private static readonly Regex semVerPattern = new Regex(@"^v?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<tag>\S+))?$", RegexOptions.Compiled);
 
         public CodeModelGo()
@@ -31,11 +32,17 @@ namespace AutoRest.Go.Model
             set => SpecifiedUserAgent = value;
         }
 
+        /// <summary>
+        /// Returns true if the --use-onever flag was specified (off by default).
+        /// </summary>
+        public bool UseOneVer => Settings.Instance.Host?.GetValue<bool>("use-onever").Result ?? false;
+
         private string DefaultUserAgent
         {
             get
             {
-                return $"Azure-SDK-For-Go/{Version} arm-{Namespace}/{ApiVersion}";
+                var verStr = UseOneVer ? $"\" + {OneVerString} + \"" : Version;
+                return $"Azure-SDK-For-Go/{verStr} arm-{Namespace}/{ApiVersion}";
             }
         }
 

--- a/src/Templates/VersionTemplate.cshtml
+++ b/src/Templates/VersionTemplate.cshtml
@@ -7,7 +7,16 @@
 @using System.Collections.Generic
 
 @inherits AutoRest.Core.Template<AutoRest.Go.Model.CodeModelGo>
+@{ 
+    var verStr = $"\"{Model.Version}\"";
+}
 package @Model.Namespace
+@EmptyLine
+@if (Model.UseOneVer)
+{
+    verStr = CodeModelGo.OneVerString;
+@:import "github.com/Azure/azure-sdk-for-go/version"
+}
 @EmptyLine
 @Header("// ")
 
@@ -22,5 +31,5 @@ func UserAgent() string {
 @EmptyLine
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-  return "@(Model.Version)"
+  return @verStr
 }


### PR DESCRIPTION
Use the --use-onever switch (off by default) to enable.  Instead of
embedding a version number in user agents and Version() functions it
will use whatever value in version.Number.