### PR TITLE
Support non-root discriminators

### DIFF
--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -125,11 +125,11 @@ namespace AutoRest.Go.Model
         {
             get
             {
-                var siblingTypes = RootType.DerivedTypes;
+                var siblingTypes = ((CompositeTypeGo)BaseModelType).DerivedTypes;
 
-                if (RootType.IsPolymorphic)
+                if (BaseIsPolymorphic)
                 {
-                    siblingTypes = siblingTypes.ConcatSingleItem(RootType);
+                    siblingTypes = siblingTypes.ConcatSingleItem(BaseModelType);
                 }
 
                 return siblingTypes;
@@ -248,10 +248,10 @@ namespace AutoRest.Go.Model
             var indented = new IndentedStringBuilder("    ");
             var properties = AllProperties.ToHashSet();
 
-            if (!IsPolymorphic && RootType.IsPolymorphic)
+            if (!IsPolymorphic && BaseIsPolymorphic)
             {
-                RootType.AddPolymorphicPropertyIfNecessary();
-                properties.Add((PropertyGo)RootType.PolymorphicDiscriminatorProperty);
+                ((CompositeTypeGo)BaseModelType).AddPolymorphicPropertyIfNecessary();
+                properties.Add((PropertyGo)BaseModelType.PolymorphicDiscriminatorProperty);
             }
 
             // Emit each property, except for named Enumerated types, as a pointer to the type


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-go/issues/1077 

 - Discriminators might start being present from non-root nodes on the composition chain.