### PR TITLE
Close the response body.

### DIFF
--- a/src/Templates/MethodTemplate.cshtml
+++ b/src/Templates/MethodTemplate.cshtml
@@ -149,6 +149,10 @@ func (client @(Model.MethodGroup.ClientName)) @(opIdCamelCase)Responder(resp pip
 	if resp == nil {
 		return nil, err
 	}
+@if (!Model.ReturnType.Body.IsStreamType() && !Model.ReturnValueRequiresUnmarshalling())
+{
+    @:resp.Response().Body.Close()
+}
 @if (Model.ReturnValueRequiresUnmarshalling())
 {
     var unmarshalInto = "result";

--- a/test/src/tests/generated/body-boolean/bool.go
+++ b/test/src/tests/generated/body-boolean/bool.go
@@ -267,6 +267,7 @@ func (client BoolClient) putFalseResponder(resp pipeline.Response) (pipeline.Res
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -312,5 +313,6 @@ func (client BoolClient) putTrueResponder(resp pipeline.Response) (pipeline.Resp
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }

--- a/test/src/tests/generated/body-byte/byte.go
+++ b/test/src/tests/generated/body-byte/byte.go
@@ -273,5 +273,6 @@ func (client ByteClient) putNonASCIIResponder(resp pipeline.Response) (pipeline.
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }

--- a/test/src/tests/generated/body-integer/int.go
+++ b/test/src/tests/generated/body-integer/int.go
@@ -518,6 +518,7 @@ func (client IntClient) putMax32Responder(resp pipeline.Response) (pipeline.Resp
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -563,6 +564,7 @@ func (client IntClient) putMax64Responder(resp pipeline.Response) (pipeline.Resp
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -608,6 +610,7 @@ func (client IntClient) putMin32Responder(resp pipeline.Response) (pipeline.Resp
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -653,6 +656,7 @@ func (client IntClient) putMin64Responder(resp pipeline.Response) (pipeline.Resp
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -698,5 +702,6 @@ func (client IntClient) putUnixTimeDateResponder(resp pipeline.Response) (pipeli
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }

--- a/test/src/tests/generated/body-string/enum.go
+++ b/test/src/tests/generated/body-string/enum.go
@@ -218,6 +218,7 @@ func (client EnumClient) putNotExpandableResponder(resp pipeline.Response) (pipe
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -264,6 +265,7 @@ func (client EnumClient) putReferencedResponder(resp pipeline.Response) (pipelin
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -314,5 +316,6 @@ func (client EnumClient) putReferencedConstantResponder(resp pipeline.Response) 
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }

--- a/test/src/tests/generated/body-string/string.go
+++ b/test/src/tests/generated/body-string/string.go
@@ -468,6 +468,7 @@ func (client StringClient) putBase64URLEncodedResponder(resp pipeline.Response) 
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -514,6 +515,7 @@ func (client StringClient) putEmptyResponder(resp pipeline.Response) (pipeline.R
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -560,6 +562,7 @@ func (client StringClient) putMbcsResponder(resp pipeline.Response) (pipeline.Re
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -606,6 +609,7 @@ func (client StringClient) putNullResponder(resp pipeline.Response) (pipeline.Re
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -653,5 +657,6 @@ func (client StringClient) putWhitespaceResponder(resp pipeline.Response) (pipel
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }

--- a/test/src/tests/generated/httpinfrastructure/http_redirects.go
+++ b/test/src/tests/generated/httpinfrastructure/http_redirects.go
@@ -68,6 +68,7 @@ func (client HTTPRedirectsClient) delete307Responder(resp pipeline.Response) (pi
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return &HTTPRedirectsDelete307Response{rawResponse: resp.Response()}, err
 }
 
@@ -153,6 +154,7 @@ func (client HTTPRedirectsClient) get301Responder(resp pipeline.Response) (pipel
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return &HTTPRedirectsGet301Response{rawResponse: resp.Response()}, err
 }
 
@@ -188,6 +190,7 @@ func (client HTTPRedirectsClient) get302Responder(resp pipeline.Response) (pipel
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return &HTTPRedirectsGet302Response{rawResponse: resp.Response()}, err
 }
 
@@ -223,6 +226,7 @@ func (client HTTPRedirectsClient) get307Responder(resp pipeline.Response) (pipel
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return &HTTPRedirectsGet307Response{rawResponse: resp.Response()}, err
 }
 
@@ -258,6 +262,7 @@ func (client HTTPRedirectsClient) head300Responder(resp pipeline.Response) (pipe
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return &HTTPRedirectsHead300Response{rawResponse: resp.Response()}, err
 }
 
@@ -293,6 +298,7 @@ func (client HTTPRedirectsClient) head301Responder(resp pipeline.Response) (pipe
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return &HTTPRedirectsHead301Response{rawResponse: resp.Response()}, err
 }
 
@@ -328,6 +334,7 @@ func (client HTTPRedirectsClient) head302Responder(resp pipeline.Response) (pipe
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return &HTTPRedirectsHead302Response{rawResponse: resp.Response()}, err
 }
 
@@ -363,6 +370,7 @@ func (client HTTPRedirectsClient) head307Responder(resp pipeline.Response) (pipe
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return &HTTPRedirectsHead307Response{rawResponse: resp.Response()}, err
 }
 
@@ -410,6 +418,7 @@ func (client HTTPRedirectsClient) patch302Responder(resp pipeline.Response) (pip
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return &HTTPRedirectsPatch302Response{rawResponse: resp.Response()}, err
 }
 
@@ -456,6 +465,7 @@ func (client HTTPRedirectsClient) patch307Responder(resp pipeline.Response) (pip
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return &HTTPRedirectsPatch307Response{rawResponse: resp.Response()}, err
 }
 
@@ -503,6 +513,7 @@ func (client HTTPRedirectsClient) post303Responder(resp pipeline.Response) (pipe
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return &HTTPRedirectsPost303Response{rawResponse: resp.Response()}, err
 }
 
@@ -549,6 +560,7 @@ func (client HTTPRedirectsClient) post307Responder(resp pipeline.Response) (pipe
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return &HTTPRedirectsPost307Response{rawResponse: resp.Response()}, err
 }
 
@@ -596,6 +608,7 @@ func (client HTTPRedirectsClient) put301Responder(resp pipeline.Response) (pipel
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return &HTTPRedirectsPut301Response{rawResponse: resp.Response()}, err
 }
 
@@ -642,5 +655,6 @@ func (client HTTPRedirectsClient) put307Responder(resp pipeline.Response) (pipel
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return &HTTPRedirectsPut307Response{rawResponse: resp.Response()}, err
 }

--- a/test/src/tests/generated/httpinfrastructure/http_retry.go
+++ b/test/src/tests/generated/httpinfrastructure/http_retry.go
@@ -67,6 +67,7 @@ func (client HTTPRetryClient) delete503Responder(resp pipeline.Response) (pipeli
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -102,6 +103,7 @@ func (client HTTPRetryClient) get502Responder(resp pipeline.Response) (pipeline.
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -137,6 +139,7 @@ func (client HTTPRetryClient) head408Responder(resp pipeline.Response) (pipeline
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -183,6 +186,7 @@ func (client HTTPRetryClient) patch500Responder(resp pipeline.Response) (pipelin
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -229,6 +233,7 @@ func (client HTTPRetryClient) patch504Responder(resp pipeline.Response) (pipelin
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -275,6 +280,7 @@ func (client HTTPRetryClient) post503Responder(resp pipeline.Response) (pipeline
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -321,6 +327,7 @@ func (client HTTPRetryClient) put500Responder(resp pipeline.Response) (pipeline.
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -367,5 +374,6 @@ func (client HTTPRetryClient) put504Responder(resp pipeline.Response) (pipeline.
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }

--- a/test/src/tests/generated/httpinfrastructure/http_success.go
+++ b/test/src/tests/generated/httpinfrastructure/http_success.go
@@ -68,6 +68,7 @@ func (client HTTPSuccessClient) delete200Responder(resp pipeline.Response) (pipe
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -114,6 +115,7 @@ func (client HTTPSuccessClient) delete202Responder(resp pipeline.Response) (pipe
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -160,6 +162,7 @@ func (client HTTPSuccessClient) delete204Responder(resp pipeline.Response) (pipe
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -245,6 +248,7 @@ func (client HTTPSuccessClient) head200Responder(resp pipeline.Response) (pipeli
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -280,6 +284,7 @@ func (client HTTPSuccessClient) head204Responder(resp pipeline.Response) (pipeli
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -315,6 +320,7 @@ func (client HTTPSuccessClient) head404Responder(resp pipeline.Response) (pipeli
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -361,6 +367,7 @@ func (client HTTPSuccessClient) patch200Responder(resp pipeline.Response) (pipel
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -407,6 +414,7 @@ func (client HTTPSuccessClient) patch202Responder(resp pipeline.Response) (pipel
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -453,6 +461,7 @@ func (client HTTPSuccessClient) patch204Responder(resp pipeline.Response) (pipel
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -499,6 +508,7 @@ func (client HTTPSuccessClient) post200Responder(resp pipeline.Response) (pipeli
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -545,6 +555,7 @@ func (client HTTPSuccessClient) post201Responder(resp pipeline.Response) (pipeli
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -591,6 +602,7 @@ func (client HTTPSuccessClient) post202Responder(resp pipeline.Response) (pipeli
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -637,6 +649,7 @@ func (client HTTPSuccessClient) post204Responder(resp pipeline.Response) (pipeli
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -683,6 +696,7 @@ func (client HTTPSuccessClient) put200Responder(resp pipeline.Response) (pipelin
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -729,6 +743,7 @@ func (client HTTPSuccessClient) put201Responder(resp pipeline.Response) (pipelin
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -775,6 +790,7 @@ func (client HTTPSuccessClient) put202Responder(resp pipeline.Response) (pipelin
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -821,5 +837,6 @@ func (client HTTPSuccessClient) put204Responder(resp pipeline.Response) (pipelin
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }

--- a/test/src/tests/generated/httpinfrastructure/multiple_responses.go
+++ b/test/src/tests/generated/httpinfrastructure/multiple_responses.go
@@ -1011,6 +1011,7 @@ func (client MultipleResponsesClient) get202None204NoneDefaultError202NoneRespon
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -1046,6 +1047,7 @@ func (client MultipleResponsesClient) get202None204NoneDefaultError204NoneRespon
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -1082,6 +1084,7 @@ func (client MultipleResponsesClient) get202None204NoneDefaultError400ValidRespo
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -1117,6 +1120,7 @@ func (client MultipleResponsesClient) get202None204NoneDefaultNone202InvalidResp
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -1152,6 +1156,7 @@ func (client MultipleResponsesClient) get202None204NoneDefaultNone204NoneRespond
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -1187,6 +1192,7 @@ func (client MultipleResponsesClient) get202None204NoneDefaultNone400InvalidResp
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -1222,6 +1228,7 @@ func (client MultipleResponsesClient) get202None204NoneDefaultNone400NoneRespond
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -1457,6 +1464,7 @@ func (client MultipleResponsesClient) getDefaultNone200InvalidResponder(resp pip
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -1492,6 +1500,7 @@ func (client MultipleResponsesClient) getDefaultNone200NoneResponder(resp pipeli
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -1527,6 +1536,7 @@ func (client MultipleResponsesClient) getDefaultNone400InvalidResponder(resp pip
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }
 
@@ -1562,5 +1572,6 @@ func (client MultipleResponsesClient) getDefaultNone400NoneResponder(resp pipeli
 	if resp == nil {
 		return nil, err
 	}
+	resp.Response().Body.Close()
 	return resp, err
 }


### PR DESCRIPTION
Previously the response body was closed only if the method returned
content via the response body; this is incorrect and leads to leaked
connections.  Now the responders will close the response body except
when the method explicitly returns a stream.