### PR TITLE
Fix non-root discriminator generation behavior

### DIFF
--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -176,7 +176,7 @@ namespace AutoRest.Go.Model
                 {
 
                     CompositeType rootModelType = this;
-                    while (rootModelType.BaseModelType != null && rootModelType.BaseIsPolymorphic)
+                    while (rootModelType.BaseModelType?.BaseIsPolymorphic == true)
                     {
                         rootModelType = rootModelType.BaseModelType;
                     }


### PR DESCRIPTION
Fixes #97 

Autorest.common is unlikely to change since it might break other generators which rely on the behavior. Meanwhile note that:
 - `type.BaseIsPolymorphic` is true when the base is polymorphic OR the type itself is polymorphic.
 - To check if ONLY the base is polymporhic use `type.BaseModelType.BaseIsPolymorphic`