### PR TITLE
Fix missing marshaller

### DIFF
--- a/src/Templates/ModelTemplate.cshtml
+++ b/src/Templates/ModelTemplate.cshtml
@@ -141,7 +141,7 @@ else
     </text>
 }
 
-@if (Model.BaseIsPolymorphic || Model.IsPolymorphic || Model.AllProperties.Any(p => p.ModelType is DictionaryTypeGo))
+@if (Model.BaseIsPolymorphic || Model.IsPolymorphic || Model.HasFlattenedFields ||  Model.AllProperties.Any(p => p.ModelType is DictionaryTypeGo))
 {
     <text>
         @EmptyLine
@@ -319,7 +319,7 @@ else
             {
                     @:@(Model.Name.FixedValue.ToShortName()).@(p.Name) = @(CodeNamerGo.Instance.GetVariableName(p.Name))
             }
-            else 
+            else
             {
                 @:@(Model.Name.FixedValue.ToShortName()).@(p.Name) = &@(CodeNamerGo.Instance.GetVariableName(p.Name))
             }

--- a/test/src/tests/generated/lro/models.go
+++ b/test/src/tests/generated/lro/models.go
@@ -3854,6 +3854,18 @@ type SubProduct struct {
 	ID *string `json:"id,omitempty"`
 }
 
+// MarshalJSON is the custom marshaler for SubProduct.
+func (sp SubProduct) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if sp.SubProductProperties != nil {
+		objectMap["properties"] = sp.SubProductProperties
+	}
+	if sp.ID != nil {
+		objectMap["id"] = sp.ID
+	}
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON is the custom unmarshaler for SubProduct struct.
 func (sp *SubProduct) UnmarshalJSON(body []byte) error {
 	var m map[string]*json.RawMessage

--- a/test/src/tests/generated/model-flattening/models.go
+++ b/test/src/tests/generated/model-flattening/models.go
@@ -54,6 +54,21 @@ type Error struct {
 	*Error  `json:"parentError,omitempty"`
 }
 
+// MarshalJSON is the custom marshaler for Error.
+func (e Error) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if e.Status != nil {
+		objectMap["status"] = e.Status
+	}
+	if e.Message != nil {
+		objectMap["message"] = e.Message
+	}
+	if e.Error != nil {
+		objectMap["parentError"] = e.Error
+	}
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON is the custom unmarshaler for Error struct.
 func (e *Error) UnmarshalJSON(body []byte) error {
 	var m map[string]*json.RawMessage
@@ -243,6 +258,15 @@ type ProductWrapper struct {
 	*WrappedProduct `json:"property,omitempty"`
 }
 
+// MarshalJSON is the custom marshaler for ProductWrapper.
+func (pw ProductWrapper) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if pw.WrappedProduct != nil {
+		objectMap["property"] = pw.WrappedProduct
+	}
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON is the custom unmarshaler for ProductWrapper struct.
 func (pw *ProductWrapper) UnmarshalJSON(body []byte) error {
 	var m map[string]*json.RawMessage
@@ -349,6 +373,21 @@ type SimpleProduct struct {
 	Description *string `json:"base_product_description,omitempty"`
 }
 
+// MarshalJSON is the custom marshaler for SimpleProduct.
+func (sp SimpleProduct) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if sp.SimpleProductProperties != nil {
+		objectMap["details"] = sp.SimpleProductProperties
+	}
+	if sp.ProductID != nil {
+		objectMap["base_product_id"] = sp.ProductID
+	}
+	if sp.Description != nil {
+		objectMap["base_product_description"] = sp.Description
+	}
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON is the custom unmarshaler for SimpleProduct struct.
 func (sp *SimpleProduct) UnmarshalJSON(body []byte) error {
 	var m map[string]*json.RawMessage
@@ -398,6 +437,21 @@ type SimpleProductProperties struct {
 	// Capacity - Capacity of product. For example, 4 people.
 	Capacity    *string `json:"max_product_capacity,omitempty"`
 	*ProductURL `json:"max_product_image,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for SimpleProductProperties.
+func (spp SimpleProductProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if spp.MaxProductDisplayName != nil {
+		objectMap["max_product_display_name"] = spp.MaxProductDisplayName
+	}
+	if spp.Capacity != nil {
+		objectMap["max_product_capacity"] = spp.Capacity
+	}
+	if spp.ProductURL != nil {
+		objectMap["max_product_image"] = spp.ProductURL
+	}
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON is the custom unmarshaler for SimpleProductProperties struct.


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-go/issues/1161

The same logic applied to the unmarshaller applies here also. If there are embedded types
they might have custom marhsallers which will get called in the embedding type  ( which will be incorrect ). So we need to generate on all chain a custom marshaller so the embedded type's one is not used.