### PR TITLE
Make possible enum values funcs return slices.

### DIFF
--- a/src/Templates/EnumTemplate.cshtml
+++ b/src/Templates/EnumTemplate.cshtml
@@ -62,8 +62,8 @@ type @Model.Name string
     }
     )
     // @possibleFuncName returns an array of possible values for the @Model.Name const type.
-    func @(possibleFuncName)() [@(Model.Values.Count)]@Model.Name {
-        return [@(Model.Values.Count)]@(Model.Name){@(string.Join(',', orderedValues))}
+    func @(possibleFuncName)() []@Model.Name {
+        return []@(Model.Name){@(string.Join(',', orderedValues))}
     }
     </text>
 }

--- a/test/src/tests/generated/body-complex/models.go
+++ b/test/src/tests/generated/body-complex/models.go
@@ -27,8 +27,8 @@ const (
 )
 
 // PossibleCMYKColorsValues returns an array of possible values for the CMYKColors const type.
-func PossibleCMYKColorsValues() [4]CMYKColors {
-	return [4]CMYKColors{BlacK, Cyan, Magenta, YELLOW}
+func PossibleCMYKColorsValues() []CMYKColors {
+	return []CMYKColors{BlacK, Cyan, Magenta, YELLOW}
 }
 
 // Fishtype enumerates the values for fishtype.
@@ -52,8 +52,8 @@ const (
 )
 
 // PossibleFishtypeValues returns an array of possible values for the Fishtype const type.
-func PossibleFishtypeValues() [7]Fishtype {
-	return [7]Fishtype{FishtypeCookiecuttershark, FishtypeFish, FishtypeGoblin, FishtypeSalmon, FishtypeSawshark, FishtypeShark, FishtypeSmartSalmon}
+func PossibleFishtypeValues() []Fishtype {
+	return []Fishtype{FishtypeCookiecuttershark, FishtypeFish, FishtypeGoblin, FishtypeSalmon, FishtypeSawshark, FishtypeShark, FishtypeSmartSalmon}
 }
 
 // GoblinSharkColor enumerates the values for goblin shark color.
@@ -69,8 +69,8 @@ const (
 )
 
 // PossibleGoblinSharkColorValues returns an array of possible values for the GoblinSharkColor const type.
-func PossibleGoblinSharkColorValues() [3]GoblinSharkColor {
-	return [3]GoblinSharkColor{Brown, Gray, Pink}
+func PossibleGoblinSharkColorValues() []GoblinSharkColor {
+	return []GoblinSharkColor{Brown, Gray, Pink}
 }
 
 // ArrayWrapper ...

--- a/test/src/tests/generated/body-string/models.go
+++ b/test/src/tests/generated/body-string/models.go
@@ -23,8 +23,8 @@ const (
 )
 
 // PossibleColorsValues returns an array of possible values for the Colors const type.
-func PossibleColorsValues() [3]Colors {
-	return [3]Colors{BlueColor, GreenColor, Redcolor}
+func PossibleColorsValues() []Colors {
+	return []Colors{BlueColor, GreenColor, Redcolor}
 }
 
 // Base64URL ...

--- a/test/src/tests/generated/header/models.go
+++ b/test/src/tests/generated/header/models.go
@@ -19,8 +19,8 @@ const (
 )
 
 // PossibleGreyscaleColorsValues returns an array of possible values for the GreyscaleColors const type.
-func PossibleGreyscaleColorsValues() [3]GreyscaleColors {
-	return [3]GreyscaleColors{Black, GREY, White}
+func PossibleGreyscaleColorsValues() []GreyscaleColors {
+	return []GreyscaleColors{Black, GREY, White}
 }
 
 // Error ...

--- a/test/src/tests/generated/lro/models.go
+++ b/test/src/tests/generated/lro/models.go
@@ -42,8 +42,8 @@ const (
 )
 
 // PossibleProvisioningStateValuesValues returns an array of possible values for the ProvisioningStateValues const type.
-func PossibleProvisioningStateValuesValues() [11]ProvisioningStateValues {
-	return [11]ProvisioningStateValues{Accepted, Canceled, Created, Creating, Deleted, Deleting, Failed, OK, Succeeded, Updated, Updating}
+func PossibleProvisioningStateValuesValues() []ProvisioningStateValues {
+	return []ProvisioningStateValues{Accepted, Canceled, Created, Creating, Deleted, Deleting, Failed, OK, Succeeded, Updated, Updating}
 }
 
 // ProvisioningStateValues1 enumerates the values for provisioning state values 1.
@@ -75,8 +75,8 @@ const (
 )
 
 // PossibleProvisioningStateValues1Values returns an array of possible values for the ProvisioningStateValues1 const type.
-func PossibleProvisioningStateValues1Values() [11]ProvisioningStateValues1 {
-	return [11]ProvisioningStateValues1{ProvisioningStateValues1Accepted, ProvisioningStateValues1Canceled, ProvisioningStateValues1Created, ProvisioningStateValues1Creating, ProvisioningStateValues1Deleted, ProvisioningStateValues1Deleting, ProvisioningStateValues1Failed, ProvisioningStateValues1OK, ProvisioningStateValues1Succeeded, ProvisioningStateValues1Updated, ProvisioningStateValues1Updating}
+func PossibleProvisioningStateValues1Values() []ProvisioningStateValues1 {
+	return []ProvisioningStateValues1{ProvisioningStateValues1Accepted, ProvisioningStateValues1Canceled, ProvisioningStateValues1Created, ProvisioningStateValues1Creating, ProvisioningStateValues1Deleted, ProvisioningStateValues1Deleting, ProvisioningStateValues1Failed, ProvisioningStateValues1OK, ProvisioningStateValues1Succeeded, ProvisioningStateValues1Updated, ProvisioningStateValues1Updating}
 }
 
 // Status enumerates the values for status.
@@ -108,8 +108,8 @@ const (
 )
 
 // PossibleStatusValues returns an array of possible values for the Status const type.
-func PossibleStatusValues() [11]Status {
-	return [11]Status{StatusAccepted, StatusCanceled, StatusCreated, StatusCreating, StatusDeleted, StatusDeleting, StatusFailed, StatusOK, StatusSucceeded, StatusUpdated, StatusUpdating}
+func PossibleStatusValues() []Status {
+	return []Status{StatusAccepted, StatusCanceled, StatusCreated, StatusCreating, StatusDeleted, StatusDeleting, StatusFailed, StatusOK, StatusSucceeded, StatusUpdated, StatusUpdating}
 }
 
 // CloudError ...

--- a/test/src/tests/generated/model-flattening/models.go
+++ b/test/src/tests/generated/model-flattening/models.go
@@ -40,8 +40,8 @@ const (
 )
 
 // PossibleProvisioningStateValuesValues returns an array of possible values for the ProvisioningStateValues const type.
-func PossibleProvisioningStateValuesValues() [11]ProvisioningStateValues {
-	return [11]ProvisioningStateValues{Accepted, Canceled, Created, Creating, Deleted, Deleting, Failed, OK, Succeeded, Updated, Updating}
+func PossibleProvisioningStateValuesValues() []ProvisioningStateValues {
+	return []ProvisioningStateValues{Accepted, Canceled, Created, Creating, Deleted, Deleting, Failed, OK, Succeeded, Updated, Updating}
 }
 
 // BaseProduct the product documentation.

--- a/test/src/tests/generated/paging/models.go
+++ b/test/src/tests/generated/paging/models.go
@@ -41,8 +41,8 @@ const (
 )
 
 // PossibleStatusValues returns an array of possible values for the Status const type.
-func PossibleStatusValues() [11]Status {
-	return [11]Status{Accepted, Canceled, Created, Creating, Deleted, Deleting, Failed, OK, Succeeded, Updated, Updating}
+func PossibleStatusValues() []Status {
+	return []Status{Accepted, Canceled, Created, Creating, Deleted, Deleting, Failed, OK, Succeeded, Updated, Updating}
 }
 
 // OdataProductResult ...

--- a/test/src/tests/generated/url/models.go
+++ b/test/src/tests/generated/url/models.go
@@ -19,8 +19,8 @@ const (
 )
 
 // PossibleURIColorValues returns an array of possible values for the URIColor const type.
-func PossibleURIColorValues() [3]URIColor {
-	return [3]URIColor{Bluecolor, Greencolor, Redcolor}
+func PossibleURIColorValues() []URIColor {
+	return []URIColor{Bluecolor, Greencolor, Redcolor}
 }
 
 // Error ...

--- a/test/src/tests/generated/validation/models.go
+++ b/test/src/tests/generated/validation/models.go
@@ -19,8 +19,8 @@ const (
 )
 
 // PossibleEnumConstValues returns an array of possible values for the EnumConst const type.
-func PossibleEnumConstValues() [1]EnumConst {
-	return [1]EnumConst{ConstantStringAsEnum}
+func PossibleEnumConstValues() []EnumConst {
+	return []EnumConst{ConstantStringAsEnum}
 }
 
 // ChildProduct the product documentation.


### PR DESCRIPTION
In order to avoid breaking changes when enums are added make the funcs
return a slice instead of an array.