### PR TITLE
Fix validation code for required properties.

### DIFF
--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -414,7 +414,7 @@ namespace AutoRest.Go
             }
             else
             {
-                if (p.IsRequired && (p.CheckNull() || isCompositeProperties))
+                if (p.IsRequired && p.CheckNull())
                     y.AddNullValidation(name, p.IsRequired);
             }
             return y;
@@ -478,7 +478,7 @@ namespace AutoRest.Go
             }
             else
             {
-                if (p.IsRequired && (p.CheckNull() || isCompositeProperties))
+                if (p.IsRequired && p.CheckNull())
                     y.AddNullValidation(name, p.IsRequired);
             }
             return y;

--- a/test/src/tests/generated/body-string/enum.go
+++ b/test/src/tests/generated/body-string/enum.go
@@ -272,11 +272,6 @@ func (client EnumClient) putReferencedResponder(resp pipeline.Response) (pipelin
 // PutReferencedConstant sends value 'green-color' from a constant
 //
 func (client EnumClient) PutReferencedConstant(ctx context.Context, enumStringBody RefColorConstant) (*http.Response, error) {
-	if err := validate([]validation{
-		{targetValue: enumStringBody,
-			constraints: []constraint{{target: "enumStringBody.ColorConstant", name: null, rule: true, chain: nil}}}}); err != nil {
-		return nil, err
-	}
 	req, err := client.putReferencedConstantPreparer(enumStringBody)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The v3 generator does not emit required properties as pointer types
however the validation codegen wasn't taking that into account (it
assumed that all struct fields were byrefs).  Removed the OR clause that
was causing the validation codegen to always assume fields are byref.