### PR TITLE
Avoid duplicate header response methods

### DIFF
--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -87,18 +87,17 @@ namespace AutoRest.Go.Model
                     .ForEach(mt =>
                     {
                         mt.AddImports(imports);
-                        // include the strconv package if this response type has
-                        // response headers that need to be converted to integers
+                        // add any imports for packages needed to parse/convert response header values
                         if (mt.IsResponseType && mt.ResponseHeaders().Any())
                         {
-                            foreach (var p in mt.Properties)
+                            foreach (var rh in mt.ResponseHeaders())
                             {
-                                if (p.ModelType.IsPrimaryType(KnownPrimaryType.Int) || p.ModelType.IsPrimaryType(KnownPrimaryType.Long))
+                                if (rh.Type.ModelType.IsPrimaryType(KnownPrimaryType.Int) || rh.Type.ModelType.IsPrimaryType(KnownPrimaryType.Long))
                                 {
                                     addStrConvImport = true;
                                     break;
                                 }
-                                else if (p.ModelType.IsPrimaryType(KnownPrimaryType.ByteArray))
+                                else if (rh.Type.ModelType.IsPrimaryType(KnownPrimaryType.ByteArray))
                                 {
                                     addBase64Import = true;
                                     break;

--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -342,7 +342,7 @@ namespace AutoRest.Go.Model
         /// <summary>
         /// Represents a response value that comes from an HTTP header.
         /// </summary>
-        public class HeaderResponse
+        public class HeaderResponse : IEquatable<HeaderResponse>
         {
             /// <summary>
             /// Gets the name of the response method.
@@ -358,6 +358,11 @@ namespace AutoRest.Go.Model
             {
                 Name = CodeNamerGo.Instance.GetMethodName(pg.GetClientName());
                 Type = pg;
+            }
+
+            public bool Equals(HeaderResponse other)
+            {
+                return string.CompareOrdinal(Name, other.Name) == 0 && string.CompareOrdinal(Type.Name, other.Type.Name) == 0;
             }
         }
 
@@ -383,7 +388,11 @@ namespace AutoRest.Go.Model
                                 // skip the metadata header as it's handled separately
                                 continue;
                             }
-                            respHeaders.Add(new HeaderResponse(property));
+                            var hr = new HeaderResponse(property);
+                            if (!respHeaders.Contains(hr))
+                            {
+                                respHeaders.Add(hr);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Avoid adding duplicate entries to the list of header response methods.
Fixed a bug adding imports needed by header response methods.