### PR TITLE
Better codegen when converting types to strings.

### DIFF
--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -393,6 +393,21 @@ namespace AutoRest.Go
                 format == KnownFormat.date_time_rfc1123;
         }
 
+        /// <summary>
+        /// Returns true if the specified type is of the specified format.
+        /// </summary>
+        /// <param name="type">Type to test.</param>
+        /// <param name="format">The format type to check.</param>
+        /// <returns>True if type.KnownFormat == format.</returns>
+        public static bool IsFormat(this IModelType type, KnownFormat format)
+        {
+            if (type is PrimaryTypeGo ptg)
+            {
+                return ptg.KnownFormat == format;
+            }
+            return false;
+        }
+
         /////////////////////////////////////////////////////////////////////////////////////////
         // Validate code
         //

--- a/src/Model/ParameterGo.cs
+++ b/src/Model/ParameterGo.cs
@@ -33,17 +33,13 @@ namespace AutoRest.Go.Model
             if ((Location == Core.Model.ParameterLocation.Header || Location == Core.Model.ParameterLocation.Query))
             {
                 if (ModelType.IsPrimaryType(KnownPrimaryType.Int) || ModelType.IsPrimaryType(KnownPrimaryType.Long) ||
-                    ModelType.IsPrimaryType(KnownPrimaryType.Double))
+                    ModelType.IsPrimaryType(KnownPrimaryType.Double) || ModelType.IsPrimaryType(KnownPrimaryType.Boolean))
                 {
                     imports.Add(PrimaryTypeGo.GetImportLine(package: "strconv"));
                 }
                 else if (ModelType.IsFormat(KnownFormat.@byte))
                 {
                     imports.Add(PrimaryTypeGo.GetImportLine(package: "encoding/base64"));
-                }
-                else if (ModelType.IsPrimaryType(KnownPrimaryType.Boolean) || ModelType is EnumTypeGo)
-                {
-                    imports.Add(PrimaryTypeGo.GetImportLine(package: "fmt"));
                 }
             }
         }
@@ -346,6 +342,10 @@ namespace AutoRest.Go.Model
                 }
                 return defaultFormat;
             }
+            else if (parameter.ModelType is EnumTypeGo)
+            {
+                return $"string({defaultFormat})";
+            }
             else if (parameter.ModelType.IsPrimaryType(KnownPrimaryType.Int))
             {
                 return $"strconv.FormatInt(int64({defaultFormat}), 10)";
@@ -361,6 +361,10 @@ namespace AutoRest.Go.Model
             else if (parameter.ModelType.IsPrimaryType(KnownPrimaryType.Double))
             {
                 return $"strconv.FormatFloat({defaultFormat}, 'f', -1, 64)";
+            }
+            else if (parameter.ModelType.IsPrimaryType(KnownPrimaryType.Boolean))
+            {
+                return $"strconv.FormatBool({defaultFormat})";
             }
             else if (parameter.ModelType.IsDateTimeType())
             {
@@ -384,7 +388,7 @@ namespace AutoRest.Go.Model
             }
             else
             {
-                return $"fmt.Sprintf(\"%v\", {defaultFormat})";
+                return defaultFormat;
             }
         }
 


### PR DESCRIPTION
Use specific conversion methods instead of fmt.Sprintf().
For byte arrays convert them to base-64 encoded strings.