### PR TITLE
Improve method comment blocks.

### DIFF
--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -257,10 +257,6 @@ namespace AutoRest.Go.Model
             // Emit each property, except for named Enumerated types, as a pointer to the type
             foreach (var property in properties)
             {
-                if (!string.IsNullOrWhiteSpace(property.Documentation))
-                {
-                    indented.Append($"{property.Name} - {property.Documentation}".ToCommentBlock());
-                }
                 if (property.Deprecated)
                 {
                     var message = "This property has been deprecated.";
@@ -268,7 +264,11 @@ namespace AutoRest.Go.Model
                     {
                         message = property.DeprecationMessage;
                     }
-                    indented.Append($"//\n// Deprecated: {message}\n");
+                    indented.Append($"// Deprecated: {message}\n");
+                }
+                if (!string.IsNullOrWhiteSpace(property.Documentation))
+                {
+                    indented.Append($"{property.Name} - {property.Documentation}".ToCommentBlock());
                 }
 
                 indented.AppendLine(property.Field);

--- a/src/Model/MethodGo.cs
+++ b/src/Model/MethodGo.cs
@@ -84,27 +84,21 @@ namespace AutoRest.Go.Model
             RegisterRP = cmg.APIType.EqualsIgnoreCase("arm") && Url.Split("/").Any(p => p.EqualsIgnoreCase("subscriptions"));
         }
 
-        public string ParametersDocumentation
+        /// <summary>
+        /// Returns true if the local parameters contain documentation.
+        /// </summary>
+        public bool AddParamsDoc
         {
             get
             {
-                StringBuilder sb = new StringBuilder();
                 foreach (var parameter in LocalParameters)
                 {
-                    if (!string.IsNullOrEmpty(parameter.Documentation))
+                    if (!string.IsNullOrWhiteSpace(parameter.Documentation.FixedValue))
                     {
-                        sb.Append(parameter.Name);
-                        sb.Append(" is ");
-                        sb.Append(parameter.Documentation.FixedValue.ToSentence());
-                        sb.Append(" ");
-                    }
-                    if (parameter.ModelType.PrimaryType(KnownPrimaryType.Stream))
-                    {
-                        sb.Append(parameter.Name);
-                        sb.Append(" will be closed upon successful return. Callers should ensure closure when receiving an error.");
+                        return true;
                     }
                 }
-                return sb.ToString();
+                return false;
             }
         }
 

--- a/src/Templates/EnumTemplate.cshtml
+++ b/src/Templates/EnumTemplate.cshtml
@@ -4,6 +4,15 @@
 
 @inherits AutoRest.Core.Template<AutoRest.Go.Model.EnumTypeGo>
 
+@if (Model.Deprecated)
+{
+    var message = "This type has been deprecated.";
+    if (!string.IsNullOrWhiteSpace(Model.DeprecationMessage))
+    {
+        message = Model.DeprecationMessage;
+    }
+@:@WrapComment("// Deprecated: ", message)
+}
 @if (Model.Name.Value.Length >= Settings.MaximumCommentColumns)
 {
     <text>
@@ -15,16 +24,6 @@ else
     <text>
         @WrapComment("// ", Model.Documentation)
     </text>
-}
-@if (Model.Deprecated)
-{
-    var message = "This type has been deprecated.";
-    if (!string.IsNullOrWhiteSpace(Model.DeprecationMessage))
-    {
-        message = Model.DeprecationMessage;
-    }
-@://
-@:@WrapComment("// Deprecated: ", message)
 }
 type @Model.Name string
 

--- a/src/Templates/MethodTemplate.cshtml
+++ b/src/Templates/MethodTemplate.cshtml
@@ -16,20 +16,24 @@
     }
 }
 
-@WrapComment("// ", Model.Name + " " + Model.Description.ToSentence())
-@if (Model.LocalParameters.Any())
-{
-    <text>
-    //
-    @WrapComment("// ", Model.ParametersDocumentation)
-    </text>
-}
-
 @if (Model.Deprecated)
 {
-    @://
     @:@WrapComment("// Deprecated: ", depMessage)
 }
+@WrapComment("// ", Model.Name + " " + Model.Description.ToSentence())
+@if (Model.AddParamsDoc)
+{
+    @:// Parameters:
+    foreach (var param in Model.LocalParameters)
+    {
+        if (param.Documentation.IsNullOrEmpty())
+        {
+            continue;
+        }
+        @:@WrapComment("// ", $"{param.Name} - {param.Documentation.FixedValue.ToSentence()}")
+    }
+}
+
 func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@Model.MethodReturnSignature()) {
 @if ((Model.CodeModel as CodeModelGo).ShouldValidate && !Model.ParameterValidations.IsNullOrEmpty())
 {
@@ -100,12 +104,11 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
     }
 
     @EmptyLine
-    // @(Model.PreparerMethodName) prepares the @(Model.Name) request.
 @if (Model.Deprecated)
 {
-    @://
     @:@WrapComment("// Deprecated: ", depMessage)
 }
+    // @(Model.PreparerMethodName) prepares the @(Model.Name) request.
     func (client @(Model.Owner)) @(Model.PreparerMethodName)(@(Model.MethodParametersSignature)) (*http.Request, error) {
     @if (Model.IsCustomBaseUri && Model.URLParameters.Any())
     {
@@ -208,13 +211,12 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
     }
 
     @EmptyLine
-    // @(Model.SenderMethodName) sends the @(Model.Name) request. The method will close the
-    // http.Response Body if it receives an error.
 @if (Model.Deprecated)
 {
-    @://
     @:@WrapComment("// Deprecated: ", depMessage)
 }
+    // @(Model.SenderMethodName) sends the @(Model.Name) request. The method will close the
+    // http.Response Body if it receives an error.
     func (client @(Model.Owner)) @(Model.SenderMethodName)(req *http.Request) (@senderRetSig) {
     @if (Model.IsLongRunningOperation())
     {
@@ -241,13 +243,12 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
     }
 
     @EmptyLine
-    // @(Model.ResponderMethodName) handles the response to the @(Model.Name) request. The method always
-    // closes the http.Response Body.
 @if (Model.Deprecated)
 {
-    @://
     @:@WrapComment("// Deprecated: ", depMessage)
 }
+    // @(Model.ResponderMethodName) handles the response to the @(Model.Name) request. The method always
+    // closes the http.Response Body.
     func (client @(Model.Owner)) @(Model.ResponderMethodName)(resp *http.Response) (@Model.ResponderReturnSignature()) {
     @if (Model.IsLongRunningOperation() && Model.IsPageable)
     {

--- a/src/Templates/ModelTemplate.cshtml
+++ b/src/Templates/ModelTemplate.cshtml
@@ -17,12 +17,11 @@
 
 @if (Model.HasInterface())
 {
-    @WrapComment("// ", $"{Model.GetInterfaceName()} {Model.Documentation.ToSentence()}")
     @if (Model.Deprecated)
     {
-    @://
     @:@WrapComment("// Deprecated: ", depMessage)
     }
+    @WrapComment("// ", $"{Model.GetInterfaceName()} {Model.Documentation.ToSentence()}")
     <text>
     type @(Model.GetInterfaceName()) interface {
     @foreach (var dt in Model.DerivedTypes)
@@ -37,12 +36,11 @@
     }
 
     @EmptyLine
-    @WrapComment("// ", $"{Model.Name} {Model.Documentation.ToSentence()}")
     @if (Model.Deprecated)
     {
-    @://
     @:@WrapComment("// Deprecated: ", depMessage)
     }
+    @WrapComment("// ", $"{Model.Name} {Model.Documentation.ToSentence()}")
     type @(Model.Name) struct {
     @(Model.AddHTTPResponse())
     @(Model.Fields())
@@ -129,11 +127,11 @@ else
         }
     }
     <text>
-    @WrapComment("// ", $"{Model.Name} {Model.Documentation.ToSentence()}")
     @if (Model.Deprecated)
     {
     @:@WrapComment("// Deprecated: ", depMessage)
     }
+    @WrapComment("// ", $"{Model.Name} {Model.Documentation.ToSentence()}")
     type @(Model.Name) struct {
     @(Model.AddHTTPResponse())
     @(Model.Fields())

--- a/test/src/tests/generated/azurereport/client.go
+++ b/test/src/tests/generated/azurereport/client.go
@@ -41,9 +41,9 @@ func NewWithBaseURI(baseURI string) BaseClient {
 }
 
 // GetReport get test coverage report
-//
-// qualifier is if specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The only
-// effect is, that generators that run all tests several times, can distinguish the generated reports.
+// Parameters:
+// qualifier - if specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The
+// only effect is, that generators that run all tests several times, can distinguish the generated reports.
 func (client BaseClient) GetReport(ctx context.Context, qualifier string) (result SetInt32, err error) {
 	req, err := client.GetReportPreparer(ctx, qualifier)
 	if err != nil {

--- a/test/src/tests/generated/body-array/array.go
+++ b/test/src/tests/generated/body-array/array.go
@@ -2591,7 +2591,6 @@ func (client ArrayClient) GetUUIDValidResponder(resp *http.Response) (result Lis
 }
 
 // PutArrayValid put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
-//
 func (client ArrayClient) PutArrayValid(ctx context.Context, arrayBody [][]string) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -2651,7 +2650,6 @@ func (client ArrayClient) PutArrayValidResponder(resp *http.Response) (result au
 }
 
 // PutBooleanTfft set array value empty [true, false, false, true]
-//
 func (client ArrayClient) PutBooleanTfft(ctx context.Context, arrayBody []bool) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -2712,7 +2710,6 @@ func (client ArrayClient) PutBooleanTfftResponder(resp *http.Response) (result a
 
 // PutByteValid put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in
 // base 64
-//
 func (client ArrayClient) PutByteValid(ctx context.Context, arrayBody [][]byte) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -2773,7 +2770,6 @@ func (client ArrayClient) PutByteValidResponder(resp *http.Response) (result aut
 
 // PutComplexValid put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string':
 // '4'}, {'integer': 5, 'string': '6'}]
-//
 func (client ArrayClient) PutComplexValid(ctx context.Context, arrayBody []Product) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -2834,7 +2830,6 @@ func (client ArrayClient) PutComplexValidResponder(resp *http.Response) (result 
 
 // PutDateTimeRfc1123Valid set array value  ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12
 // Oct 1492 10:15:01 GMT']
-//
 func (client ArrayClient) PutDateTimeRfc1123Valid(ctx context.Context, arrayBody []date.TimeRFC1123) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -2894,7 +2889,6 @@ func (client ArrayClient) PutDateTimeRfc1123ValidResponder(resp *http.Response) 
 }
 
 // PutDateTimeValid set array value  ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
-//
 func (client ArrayClient) PutDateTimeValid(ctx context.Context, arrayBody []date.Time) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -2954,7 +2948,6 @@ func (client ArrayClient) PutDateTimeValidResponder(resp *http.Response) (result
 }
 
 // PutDateValid set array value  ['2000-12-01', '1980-01-02', '1492-10-12']
-//
 func (client ArrayClient) PutDateValid(ctx context.Context, arrayBody []date.Date) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3015,7 +3008,6 @@ func (client ArrayClient) PutDateValidResponder(resp *http.Response) (result aut
 
 // PutDictionaryValid get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3':
 // 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
-//
 func (client ArrayClient) PutDictionaryValid(ctx context.Context, arrayBody []map[string]*string) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3075,7 +3067,6 @@ func (client ArrayClient) PutDictionaryValidResponder(resp *http.Response) (resu
 }
 
 // PutDoubleValid set array value [0, -0.01, 1.2e20]
-//
 func (client ArrayClient) PutDoubleValid(ctx context.Context, arrayBody []float64) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3135,7 +3126,6 @@ func (client ArrayClient) PutDoubleValidResponder(resp *http.Response) (result a
 }
 
 // PutDurationValid set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S']
-//
 func (client ArrayClient) PutDurationValid(ctx context.Context, arrayBody []string) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3195,7 +3185,6 @@ func (client ArrayClient) PutDurationValidResponder(resp *http.Response) (result
 }
 
 // PutEmpty set array value empty []
-//
 func (client ArrayClient) PutEmpty(ctx context.Context, arrayBody []string) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3255,7 +3244,6 @@ func (client ArrayClient) PutEmptyResponder(resp *http.Response) (result autores
 }
 
 // PutFloatValid set array value [0, -0.01, 1.2e20]
-//
 func (client ArrayClient) PutFloatValid(ctx context.Context, arrayBody []float64) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3315,7 +3303,6 @@ func (client ArrayClient) PutFloatValidResponder(resp *http.Response) (result au
 }
 
 // PutIntegerValid set array value empty [1, -1, 3, 300]
-//
 func (client ArrayClient) PutIntegerValid(ctx context.Context, arrayBody []int32) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3375,7 +3362,6 @@ func (client ArrayClient) PutIntegerValidResponder(resp *http.Response) (result 
 }
 
 // PutLongValid set array value empty [1, -1, 3, 300]
-//
 func (client ArrayClient) PutLongValid(ctx context.Context, arrayBody []int64) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3435,7 +3421,6 @@ func (client ArrayClient) PutLongValidResponder(resp *http.Response) (result aut
 }
 
 // PutStringValid set array value ['foo1', 'foo2', 'foo3']
-//
 func (client ArrayClient) PutStringValid(ctx context.Context, arrayBody []string) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3496,7 +3481,6 @@ func (client ArrayClient) PutStringValidResponder(resp *http.Response) (result a
 
 // PutUUIDValid set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db',
 // 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
-//
 func (client ArrayClient) PutUUIDValid(ctx context.Context, arrayBody []uuid.UUID) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,

--- a/test/src/tests/generated/body-byte/byte.go
+++ b/test/src/tests/generated/body-byte/byte.go
@@ -238,8 +238,8 @@ func (client ByteClient) GetNullResponder(resp *http.Response) (result ByteArray
 }
 
 // PutNonASCII put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
-//
-// byteBody is base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
+// Parameters:
+// byteBody - base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
 func (client ByteClient) PutNonASCII(ctx context.Context, byteBody []byte) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: byteBody,

--- a/test/src/tests/generated/body-complex/array.go
+++ b/test/src/tests/generated/body-complex/array.go
@@ -185,8 +185,8 @@ func (client ArrayClient) GetValidResponder(resp *http.Response) (result ArrayWr
 }
 
 // PutEmpty put complex types with array property which is empty
-//
-// complexBody is please put an empty array
+// Parameters:
+// complexBody - please put an empty array
 func (client ArrayClient) PutEmpty(ctx context.Context, complexBody ArrayWrapper) (result autorest.Response, err error) {
 	req, err := client.PutEmptyPreparer(ctx, complexBody)
 	if err != nil {
@@ -240,9 +240,9 @@ func (client ArrayClient) PutEmptyResponder(resp *http.Response) (result autores
 }
 
 // PutValid put complex types with array property
-//
-// complexBody is please put an array with 4 items: "1, 2, 3, 4", "", null, "&S#$(*Y", "The quick brown fox jumps
-// over the lazy dog"
+// Parameters:
+// complexBody - please put an array with 4 items: "1, 2, 3, 4", "", null, "&S#$(*Y", "The quick brown fox
+// jumps over the lazy dog"
 func (client ArrayClient) PutValid(ctx context.Context, complexBody ArrayWrapper) (result autorest.Response, err error) {
 	req, err := client.PutValidPreparer(ctx, complexBody)
 	if err != nil {

--- a/test/src/tests/generated/body-complex/basic.go
+++ b/test/src/tests/generated/body-complex/basic.go
@@ -289,8 +289,8 @@ func (client BasicClient) GetValidResponder(resp *http.Response) (result Basic, 
 }
 
 // PutValid please put {id: 2, name: 'abc', color: 'Magenta'}
-//
-// complexBody is please put {id: 2, name: 'abc', color: 'Magenta'}
+// Parameters:
+// complexBody - please put {id: 2, name: 'abc', color: 'Magenta'}
 func (client BasicClient) PutValid(ctx context.Context, complexBody Basic) (result autorest.Response, err error) {
 	req, err := client.PutValidPreparer(ctx, complexBody)
 	if err != nil {

--- a/test/src/tests/generated/body-complex/dictionary.go
+++ b/test/src/tests/generated/body-complex/dictionary.go
@@ -237,8 +237,8 @@ func (client DictionaryClient) GetValidResponder(resp *http.Response) (result Di
 }
 
 // PutEmpty put complex types with dictionary property which is empty
-//
-// complexBody is please put an empty dictionary
+// Parameters:
+// complexBody - please put an empty dictionary
 func (client DictionaryClient) PutEmpty(ctx context.Context, complexBody DictionaryWrapper) (result autorest.Response, err error) {
 	req, err := client.PutEmptyPreparer(ctx, complexBody)
 	if err != nil {
@@ -292,9 +292,9 @@ func (client DictionaryClient) PutEmptyResponder(resp *http.Response) (result au
 }
 
 // PutValid put complex types with dictionary property
-//
-// complexBody is please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel",
-// "exe":"", "":null
+// Parameters:
+// complexBody - please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint",
+// "xls":"excel", "exe":"", "":null
 func (client DictionaryClient) PutValid(ctx context.Context, complexBody DictionaryWrapper) (result autorest.Response, err error) {
 	req, err := client.PutValidPreparer(ctx, complexBody)
 	if err != nil {

--- a/test/src/tests/generated/body-complex/inheritance.go
+++ b/test/src/tests/generated/body-complex/inheritance.go
@@ -81,9 +81,9 @@ func (client InheritanceClient) GetValidResponder(resp *http.Response) (result S
 }
 
 // PutValid put complex types that extend others
-//
-// complexBody is please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2 dogs,
-// the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and
+// Parameters:
+// complexBody - please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2
+// dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and
 // food="french fries".
 func (client InheritanceClient) PutValid(ctx context.Context, complexBody Siamese) (result autorest.Response, err error) {
 	req, err := client.PutValidPreparer(ctx, complexBody)

--- a/test/src/tests/generated/body-complex/polymorphicrecursive.go
+++ b/test/src/tests/generated/body-complex/polymorphicrecursive.go
@@ -82,8 +82,8 @@ func (client PolymorphicrecursiveClient) GetValidResponder(resp *http.Response) 
 }
 
 // PutValid put complex types that are polymorphic and have recursive references
-//
-// complexBody is please put a salmon that looks like this:
+// Parameters:
+// complexBody - please put a salmon that looks like this:
 // {
 // "fishtype": "salmon",
 // "species": "king",

--- a/test/src/tests/generated/body-complex/polymorphism.go
+++ b/test/src/tests/generated/body-complex/polymorphism.go
@@ -136,7 +136,6 @@ func (client PolymorphismClient) GetValidResponder(resp *http.Response) (result 
 
 // PutComplicated put complex types that are polymorphic, but not at the root of the hierarchy; also have additional
 // properties
-//
 func (client PolymorphismClient) PutComplicated(ctx context.Context, complexBody BasicSalmon) (result autorest.Response, err error) {
 	req, err := client.PutComplicatedPreparer(ctx, complexBody)
 	if err != nil {
@@ -190,7 +189,6 @@ func (client PolymorphismClient) PutComplicatedResponder(resp *http.Response) (r
 }
 
 // PutMissingDiscriminator put complex types that are polymorphic, omitting the discriminator
-//
 func (client PolymorphismClient) PutMissingDiscriminator(ctx context.Context, complexBody BasicSalmon) (result SalmonModel, err error) {
 	req, err := client.PutMissingDiscriminatorPreparer(ctx, complexBody)
 	if err != nil {
@@ -245,8 +243,8 @@ func (client PolymorphismClient) PutMissingDiscriminatorResponder(resp *http.Res
 }
 
 // PutValid put complex types that are polymorphic
-//
-// complexBody is please put a salmon that looks like this:
+// Parameters:
+// complexBody - please put a salmon that looks like this:
 // {
 // 'fishtype':'Salmon',
 // 'location':'alaska',
@@ -339,9 +337,9 @@ func (client PolymorphismClient) PutValidResponder(resp *http.Response) (result 
 
 // PutValidMissingRequired put complex types that are polymorphic, attempting to omit required 'birthday' field - the
 // request should not be allowed from the client
-//
-// complexBody is please attempt put a sawshark that looks like this, the client should not allow this data to be
-// sent:
+// Parameters:
+// complexBody - please attempt put a sawshark that looks like this, the client should not allow this data to
+// be sent:
 // {
 // "fishtype": "sawshark",
 // "species": "snaggle toothed",

--- a/test/src/tests/generated/body-complex/primitive.go
+++ b/test/src/tests/generated/body-complex/primitive.go
@@ -601,8 +601,8 @@ func (client PrimitiveClient) GetStringResponder(resp *http.Response) (result St
 }
 
 // PutBool put complex types with bool properties
-//
-// complexBody is please put true and false
+// Parameters:
+// complexBody - please put true and false
 func (client PrimitiveClient) PutBool(ctx context.Context, complexBody BooleanWrapper) (result autorest.Response, err error) {
 	req, err := client.PutBoolPreparer(ctx, complexBody)
 	if err != nil {
@@ -656,8 +656,8 @@ func (client PrimitiveClient) PutBoolResponder(resp *http.Response) (result auto
 }
 
 // PutByte put complex types with byte properties
-//
-// complexBody is please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6)
+// Parameters:
+// complexBody - please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6)
 func (client PrimitiveClient) PutByte(ctx context.Context, complexBody ByteWrapper) (result autorest.Response, err error) {
 	req, err := client.PutBytePreparer(ctx, complexBody)
 	if err != nil {
@@ -711,8 +711,8 @@ func (client PrimitiveClient) PutByteResponder(resp *http.Response) (result auto
 }
 
 // PutDate put complex types with date properties
-//
-// complexBody is please put '0001-01-01' and '2016-02-29'
+// Parameters:
+// complexBody - please put '0001-01-01' and '2016-02-29'
 func (client PrimitiveClient) PutDate(ctx context.Context, complexBody DateWrapper) (result autorest.Response, err error) {
 	req, err := client.PutDatePreparer(ctx, complexBody)
 	if err != nil {
@@ -766,8 +766,8 @@ func (client PrimitiveClient) PutDateResponder(resp *http.Response) (result auto
 }
 
 // PutDateTime put complex types with datetime properties
-//
-// complexBody is please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
+// Parameters:
+// complexBody - please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
 func (client PrimitiveClient) PutDateTime(ctx context.Context, complexBody DatetimeWrapper) (result autorest.Response, err error) {
 	req, err := client.PutDateTimePreparer(ctx, complexBody)
 	if err != nil {
@@ -821,8 +821,8 @@ func (client PrimitiveClient) PutDateTimeResponder(resp *http.Response) (result 
 }
 
 // PutDateTimeRfc1123 put complex types with datetimeRfc1123 properties
-//
-// complexBody is please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'
+// Parameters:
+// complexBody - please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'
 func (client PrimitiveClient) PutDateTimeRfc1123(ctx context.Context, complexBody Datetimerfc1123Wrapper) (result autorest.Response, err error) {
 	req, err := client.PutDateTimeRfc1123Preparer(ctx, complexBody)
 	if err != nil {
@@ -876,8 +876,8 @@ func (client PrimitiveClient) PutDateTimeRfc1123Responder(resp *http.Response) (
 }
 
 // PutDouble put complex types with double properties
-//
-// complexBody is please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005
+// Parameters:
+// complexBody - please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005
 func (client PrimitiveClient) PutDouble(ctx context.Context, complexBody DoubleWrapper) (result autorest.Response, err error) {
 	req, err := client.PutDoublePreparer(ctx, complexBody)
 	if err != nil {
@@ -931,8 +931,8 @@ func (client PrimitiveClient) PutDoubleResponder(resp *http.Response) (result au
 }
 
 // PutDuration put complex types with duration properties
-//
-// complexBody is please put 'P123DT22H14M12.011S'
+// Parameters:
+// complexBody - please put 'P123DT22H14M12.011S'
 func (client PrimitiveClient) PutDuration(ctx context.Context, complexBody DurationWrapper) (result autorest.Response, err error) {
 	req, err := client.PutDurationPreparer(ctx, complexBody)
 	if err != nil {
@@ -986,8 +986,8 @@ func (client PrimitiveClient) PutDurationResponder(resp *http.Response) (result 
 }
 
 // PutFloat put complex types with float properties
-//
-// complexBody is please put 1.05 and -0.003
+// Parameters:
+// complexBody - please put 1.05 and -0.003
 func (client PrimitiveClient) PutFloat(ctx context.Context, complexBody FloatWrapper) (result autorest.Response, err error) {
 	req, err := client.PutFloatPreparer(ctx, complexBody)
 	if err != nil {
@@ -1041,8 +1041,8 @@ func (client PrimitiveClient) PutFloatResponder(resp *http.Response) (result aut
 }
 
 // PutInt put complex types with integer properties
-//
-// complexBody is please put -1 and 2
+// Parameters:
+// complexBody - please put -1 and 2
 func (client PrimitiveClient) PutInt(ctx context.Context, complexBody IntWrapper) (result autorest.Response, err error) {
 	req, err := client.PutIntPreparer(ctx, complexBody)
 	if err != nil {
@@ -1096,8 +1096,8 @@ func (client PrimitiveClient) PutIntResponder(resp *http.Response) (result autor
 }
 
 // PutLong put complex types with long properties
-//
-// complexBody is please put 1099511627775 and -999511627788
+// Parameters:
+// complexBody - please put 1099511627775 and -999511627788
 func (client PrimitiveClient) PutLong(ctx context.Context, complexBody LongWrapper) (result autorest.Response, err error) {
 	req, err := client.PutLongPreparer(ctx, complexBody)
 	if err != nil {
@@ -1151,8 +1151,8 @@ func (client PrimitiveClient) PutLongResponder(resp *http.Response) (result auto
 }
 
 // PutString put complex types with string properties
-//
-// complexBody is please put 'goodrequest', '', and null
+// Parameters:
+// complexBody - please put 'goodrequest', '', and null
 func (client PrimitiveClient) PutString(ctx context.Context, complexBody StringWrapper) (result autorest.Response, err error) {
 	req, err := client.PutStringPreparer(ctx, complexBody)
 	if err != nil {

--- a/test/src/tests/generated/body-complex/readonlyproperty.go
+++ b/test/src/tests/generated/body-complex/readonlyproperty.go
@@ -81,7 +81,6 @@ func (client ReadonlypropertyClient) GetValidResponder(resp *http.Response) (res
 }
 
 // PutValid put complex types that have readonly properties
-//
 func (client ReadonlypropertyClient) PutValid(ctx context.Context, complexBody ReadonlyObj) (result autorest.Response, err error) {
 	req, err := client.PutValidPreparer(ctx, complexBody)
 	if err != nil {

--- a/test/src/tests/generated/body-date/date.go
+++ b/test/src/tests/generated/body-date/date.go
@@ -342,7 +342,6 @@ func (client DateClient) GetUnderflowDateResponder(resp *http.Response) (result 
 }
 
 // PutMaxDate put max date value 9999-12-31
-//
 func (client DateClient) PutMaxDate(ctx context.Context, dateBody date.Date) (result autorest.Response, err error) {
 	req, err := client.PutMaxDatePreparer(ctx, dateBody)
 	if err != nil {
@@ -396,7 +395,6 @@ func (client DateClient) PutMaxDateResponder(resp *http.Response) (result autore
 }
 
 // PutMinDate put min date value 0000-01-01
-//
 func (client DateClient) PutMinDate(ctx context.Context, dateBody date.Date) (result autorest.Response, err error) {
 	req, err := client.PutMinDatePreparer(ctx, dateBody)
 	if err != nil {

--- a/test/src/tests/generated/body-datetime-rfc1123/datetimerfc1123.go
+++ b/test/src/tests/generated/body-datetime-rfc1123/datetimerfc1123.go
@@ -394,7 +394,6 @@ func (client Datetimerfc1123Client) GetUtcUppercaseMaxDateTimeResponder(resp *ht
 }
 
 // PutUtcMaxDateTime put max datetime value Fri, 31 Dec 9999 23:59:59 GMT
-//
 func (client Datetimerfc1123Client) PutUtcMaxDateTime(ctx context.Context, datetimeBody date.TimeRFC1123) (result autorest.Response, err error) {
 	req, err := client.PutUtcMaxDateTimePreparer(ctx, datetimeBody)
 	if err != nil {
@@ -448,7 +447,6 @@ func (client Datetimerfc1123Client) PutUtcMaxDateTimeResponder(resp *http.Respon
 }
 
 // PutUtcMinDateTime put min datetime value Mon, 1 Jan 0001 00:00:00 GMT
-//
 func (client Datetimerfc1123Client) PutUtcMinDateTime(ctx context.Context, datetimeBody date.TimeRFC1123) (result autorest.Response, err error) {
 	req, err := client.PutUtcMinDateTimePreparer(ctx, datetimeBody)
 	if err != nil {

--- a/test/src/tests/generated/body-datetime/datetime.go
+++ b/test/src/tests/generated/body-datetime/datetime.go
@@ -710,7 +710,6 @@ func (client DatetimeClient) GetUtcUppercaseMaxDateTimeResponder(resp *http.Resp
 }
 
 // PutLocalNegativeOffsetMaxDateTime put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999-14:00
-//
 func (client DatetimeClient) PutLocalNegativeOffsetMaxDateTime(ctx context.Context, datetimeBody date.Time) (result autorest.Response, err error) {
 	req, err := client.PutLocalNegativeOffsetMaxDateTimePreparer(ctx, datetimeBody)
 	if err != nil {
@@ -764,7 +763,6 @@ func (client DatetimeClient) PutLocalNegativeOffsetMaxDateTimeResponder(resp *ht
 }
 
 // PutLocalNegativeOffsetMinDateTime put min datetime value 0001-01-01T00:00:00-14:00
-//
 func (client DatetimeClient) PutLocalNegativeOffsetMinDateTime(ctx context.Context, datetimeBody date.Time) (result autorest.Response, err error) {
 	req, err := client.PutLocalNegativeOffsetMinDateTimePreparer(ctx, datetimeBody)
 	if err != nil {
@@ -818,7 +816,6 @@ func (client DatetimeClient) PutLocalNegativeOffsetMinDateTimeResponder(resp *ht
 }
 
 // PutLocalPositiveOffsetMaxDateTime put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999+14:00
-//
 func (client DatetimeClient) PutLocalPositiveOffsetMaxDateTime(ctx context.Context, datetimeBody date.Time) (result autorest.Response, err error) {
 	req, err := client.PutLocalPositiveOffsetMaxDateTimePreparer(ctx, datetimeBody)
 	if err != nil {
@@ -872,7 +869,6 @@ func (client DatetimeClient) PutLocalPositiveOffsetMaxDateTimeResponder(resp *ht
 }
 
 // PutLocalPositiveOffsetMinDateTime put min datetime value 0001-01-01T00:00:00+14:00
-//
 func (client DatetimeClient) PutLocalPositiveOffsetMinDateTime(ctx context.Context, datetimeBody date.Time) (result autorest.Response, err error) {
 	req, err := client.PutLocalPositiveOffsetMinDateTimePreparer(ctx, datetimeBody)
 	if err != nil {
@@ -926,7 +922,6 @@ func (client DatetimeClient) PutLocalPositiveOffsetMinDateTimeResponder(resp *ht
 }
 
 // PutUtcMaxDateTime put max datetime value 9999-12-31T23:59:59.9999999Z
-//
 func (client DatetimeClient) PutUtcMaxDateTime(ctx context.Context, datetimeBody date.Time) (result autorest.Response, err error) {
 	req, err := client.PutUtcMaxDateTimePreparer(ctx, datetimeBody)
 	if err != nil {
@@ -980,7 +975,6 @@ func (client DatetimeClient) PutUtcMaxDateTimeResponder(resp *http.Response) (re
 }
 
 // PutUtcMinDateTime put min datetime value 0001-01-01T00:00:00Z
-//
 func (client DatetimeClient) PutUtcMinDateTime(ctx context.Context, datetimeBody date.Time) (result autorest.Response, err error) {
 	req, err := client.PutUtcMinDateTimePreparer(ctx, datetimeBody)
 	if err != nil {

--- a/test/src/tests/generated/body-dictionary/dictionary.go
+++ b/test/src/tests/generated/body-dictionary/dictionary.go
@@ -2641,7 +2641,6 @@ func (client DictionaryClient) GetStringWithNullResponder(resp *http.Response) (
 }
 
 // PutArrayValid put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
-//
 func (client DictionaryClient) PutArrayValid(ctx context.Context, arrayBody map[string][]string) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -2701,7 +2700,6 @@ func (client DictionaryClient) PutArrayValidResponder(resp *http.Response) (resu
 }
 
 // PutBooleanTfft set dictionary value empty {"0": true, "1": false, "2": false, "3": true }
-//
 func (client DictionaryClient) PutBooleanTfft(ctx context.Context, arrayBody map[string]*bool) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -2762,7 +2760,6 @@ func (client DictionaryClient) PutBooleanTfftResponder(resp *http.Response) (res
 
 // PutByteValid put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each
 // elementencoded in base 64
-//
 func (client DictionaryClient) PutByteValid(ctx context.Context, arrayBody map[string][]byte) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -2823,7 +2820,6 @@ func (client DictionaryClient) PutByteValidResponder(resp *http.Response) (resul
 
 // PutComplexValid put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer":
 // 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
-//
 func (client DictionaryClient) PutComplexValid(ctx context.Context, arrayBody map[string]*Widget) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -2884,7 +2880,6 @@ func (client DictionaryClient) PutComplexValidResponder(resp *http.Response) (re
 
 // PutDateTimeRfc1123Valid set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980
 // 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
-//
 func (client DictionaryClient) PutDateTimeRfc1123Valid(ctx context.Context, arrayBody map[string]*date.TimeRFC1123) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -2945,7 +2940,6 @@ func (client DictionaryClient) PutDateTimeRfc1123ValidResponder(resp *http.Respo
 
 // PutDateTimeValid set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
 // "1492-10-12T10:15:01-08:00"}
-//
 func (client DictionaryClient) PutDateTimeValid(ctx context.Context, arrayBody map[string]*date.Time) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3005,7 +2999,6 @@ func (client DictionaryClient) PutDateTimeValidResponder(resp *http.Response) (r
 }
 
 // PutDateValid set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
-//
 func (client DictionaryClient) PutDateValid(ctx context.Context, arrayBody map[string]*date.Date) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3066,7 +3059,6 @@ func (client DictionaryClient) PutDateValidResponder(resp *http.Response) (resul
 
 // PutDictionaryValid get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2":
 // "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
-//
 func (client DictionaryClient) PutDictionaryValid(ctx context.Context, arrayBody map[string]map[string]*string) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3126,7 +3118,6 @@ func (client DictionaryClient) PutDictionaryValidResponder(resp *http.Response) 
 }
 
 // PutDoubleValid set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-//
 func (client DictionaryClient) PutDoubleValid(ctx context.Context, arrayBody map[string]*float64) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3186,7 +3177,6 @@ func (client DictionaryClient) PutDoubleValidResponder(resp *http.Response) (res
 }
 
 // PutDurationValid set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
-//
 func (client DictionaryClient) PutDurationValid(ctx context.Context, arrayBody map[string]*string) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3246,7 +3236,6 @@ func (client DictionaryClient) PutDurationValidResponder(resp *http.Response) (r
 }
 
 // PutEmpty set dictionary value empty {}
-//
 func (client DictionaryClient) PutEmpty(ctx context.Context, arrayBody map[string]*string) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3306,7 +3295,6 @@ func (client DictionaryClient) PutEmptyResponder(resp *http.Response) (result au
 }
 
 // PutFloatValid set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-//
 func (client DictionaryClient) PutFloatValid(ctx context.Context, arrayBody map[string]*float64) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3366,7 +3354,6 @@ func (client DictionaryClient) PutFloatValidResponder(resp *http.Response) (resu
 }
 
 // PutIntegerValid set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
-//
 func (client DictionaryClient) PutIntegerValid(ctx context.Context, arrayBody map[string]*int32) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3426,7 +3413,6 @@ func (client DictionaryClient) PutIntegerValidResponder(resp *http.Response) (re
 }
 
 // PutLongValid set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
-//
 func (client DictionaryClient) PutLongValid(ctx context.Context, arrayBody map[string]*int64) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,
@@ -3486,7 +3472,6 @@ func (client DictionaryClient) PutLongValidResponder(resp *http.Response) (resul
 }
 
 // PutStringValid set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
-//
 func (client DictionaryClient) PutStringValid(ctx context.Context, arrayBody map[string]*string) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: arrayBody,

--- a/test/src/tests/generated/body-duration/duration.go
+++ b/test/src/tests/generated/body-duration/duration.go
@@ -185,7 +185,6 @@ func (client DurationClient) GetPositiveDurationResponder(resp *http.Response) (
 }
 
 // PutPositiveDuration put a positive duration value
-//
 func (client DurationClient) PutPositiveDuration(ctx context.Context, durationBody string) (result autorest.Response, err error) {
 	req, err := client.PutPositiveDurationPreparer(ctx, durationBody)
 	if err != nil {

--- a/test/src/tests/generated/body-formdata/formdata.go
+++ b/test/src/tests/generated/body-formdata/formdata.go
@@ -30,9 +30,9 @@ func NewFormdataClientWithBaseURI(baseURI string) FormdataClient {
 }
 
 // UploadFile upload file
-//
-// fileContent is file to upload. fileContent will be closed upon successful return. Callers should ensure closure
-// when receiving an error.fileName is file name to upload. Name has to be spelled exactly as written here.
+// Parameters:
+// fileContent - file to upload.
+// fileName - file name to upload. Name has to be spelled exactly as written here.
 func (client FormdataClient) UploadFile(ctx context.Context, fileContent io.ReadCloser, fileName string) (result ReadCloser, err error) {
 	req, err := client.UploadFilePreparer(ctx, fileContent, fileName)
 	if err != nil {
@@ -90,9 +90,8 @@ func (client FormdataClient) UploadFileResponder(resp *http.Response) (result Re
 }
 
 // UploadFileViaBody upload file
-//
-// fileContent is file to upload. fileContent will be closed upon successful return. Callers should ensure closure
-// when receiving an error.
+// Parameters:
+// fileContent - file to upload.
 func (client FormdataClient) UploadFileViaBody(ctx context.Context, fileContent io.ReadCloser) (result ReadCloser, err error) {
 	req, err := client.UploadFileViaBodyPreparer(ctx, fileContent)
 	if err != nil {

--- a/test/src/tests/generated/body-integer/int.go
+++ b/test/src/tests/generated/body-integer/int.go
@@ -498,7 +498,6 @@ func (client IntClient) GetUnixTimeResponder(resp *http.Response) (result UnixTi
 }
 
 // PutMax32 put max int32 value
-//
 func (client IntClient) PutMax32(ctx context.Context, intBody int32) (result autorest.Response, err error) {
 	req, err := client.PutMax32Preparer(ctx, intBody)
 	if err != nil {
@@ -552,7 +551,6 @@ func (client IntClient) PutMax32Responder(resp *http.Response) (result autorest.
 }
 
 // PutMax64 put max int64 value
-//
 func (client IntClient) PutMax64(ctx context.Context, intBody int64) (result autorest.Response, err error) {
 	req, err := client.PutMax64Preparer(ctx, intBody)
 	if err != nil {
@@ -606,7 +604,6 @@ func (client IntClient) PutMax64Responder(resp *http.Response) (result autorest.
 }
 
 // PutMin32 put min int32 value
-//
 func (client IntClient) PutMin32(ctx context.Context, intBody int32) (result autorest.Response, err error) {
 	req, err := client.PutMin32Preparer(ctx, intBody)
 	if err != nil {
@@ -660,7 +657,6 @@ func (client IntClient) PutMin32Responder(resp *http.Response) (result autorest.
 }
 
 // PutMin64 put min int64 value
-//
 func (client IntClient) PutMin64(ctx context.Context, intBody int64) (result autorest.Response, err error) {
 	req, err := client.PutMin64Preparer(ctx, intBody)
 	if err != nil {
@@ -714,7 +710,6 @@ func (client IntClient) PutMin64Responder(resp *http.Response) (result autorest.
 }
 
 // PutUnixTimeDate put datetime encoded as Unix time
-//
 func (client IntClient) PutUnixTimeDate(ctx context.Context, intBody date.UnixTime) (result autorest.Response, err error) {
 	req, err := client.PutUnixTimeDatePreparer(ctx, intBody)
 	if err != nil {

--- a/test/src/tests/generated/body-number/number.go
+++ b/test/src/tests/generated/body-number/number.go
@@ -758,7 +758,6 @@ func (client NumberClient) GetSmallFloatResponder(resp *http.Response) (result F
 }
 
 // PutBigDecimal put big decimal value 2.5976931e+101
-//
 func (client NumberClient) PutBigDecimal(ctx context.Context, numberBody decimal.Decimal) (result autorest.Response, err error) {
 	req, err := client.PutBigDecimalPreparer(ctx, numberBody)
 	if err != nil {
@@ -918,7 +917,6 @@ func (client NumberClient) PutBigDecimalPositiveDecimalResponder(resp *http.Resp
 }
 
 // PutBigDouble put big double value 2.5976931e+101
-//
 func (client NumberClient) PutBigDouble(ctx context.Context, numberBody float64) (result autorest.Response, err error) {
 	req, err := client.PutBigDoublePreparer(ctx, numberBody)
 	if err != nil {
@@ -1078,7 +1076,6 @@ func (client NumberClient) PutBigDoublePositiveDecimalResponder(resp *http.Respo
 }
 
 // PutBigFloat put big float value 3.402823e+20
-//
 func (client NumberClient) PutBigFloat(ctx context.Context, numberBody float64) (result autorest.Response, err error) {
 	req, err := client.PutBigFloatPreparer(ctx, numberBody)
 	if err != nil {
@@ -1132,7 +1129,6 @@ func (client NumberClient) PutBigFloatResponder(resp *http.Response) (result aut
 }
 
 // PutSmallDecimal put small decimal value 2.5976931e-101
-//
 func (client NumberClient) PutSmallDecimal(ctx context.Context, numberBody decimal.Decimal) (result autorest.Response, err error) {
 	req, err := client.PutSmallDecimalPreparer(ctx, numberBody)
 	if err != nil {
@@ -1186,7 +1182,6 @@ func (client NumberClient) PutSmallDecimalResponder(resp *http.Response) (result
 }
 
 // PutSmallDouble put small double value 2.5976931e-101
-//
 func (client NumberClient) PutSmallDouble(ctx context.Context, numberBody float64) (result autorest.Response, err error) {
 	req, err := client.PutSmallDoublePreparer(ctx, numberBody)
 	if err != nil {
@@ -1240,7 +1235,6 @@ func (client NumberClient) PutSmallDoubleResponder(resp *http.Response) (result 
 }
 
 // PutSmallFloat put small float value 3.402823e-20
-//
 func (client NumberClient) PutSmallFloat(ctx context.Context, numberBody float64) (result autorest.Response, err error) {
 	req, err := client.PutSmallFloatPreparer(ctx, numberBody)
 	if err != nil {

--- a/test/src/tests/generated/body-string/enum.go
+++ b/test/src/tests/generated/body-string/enum.go
@@ -186,8 +186,6 @@ func (client EnumClient) GetReferencedConstantResponder(resp *http.Response) (re
 }
 
 // PutNotExpandable sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
-//
-// stringBody is
 func (client EnumClient) PutNotExpandable(ctx context.Context, stringBody Colors) (result autorest.Response, err error) {
 	req, err := client.PutNotExpandablePreparer(ctx, stringBody)
 	if err != nil {
@@ -241,8 +239,6 @@ func (client EnumClient) PutNotExpandableResponder(resp *http.Response) (result 
 }
 
 // PutReferenced sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
-//
-// enumStringBody is
 func (client EnumClient) PutReferenced(ctx context.Context, enumStringBody Colors) (result autorest.Response, err error) {
 	req, err := client.PutReferencedPreparer(ctx, enumStringBody)
 	if err != nil {
@@ -296,7 +292,6 @@ func (client EnumClient) PutReferencedResponder(resp *http.Response) (result aut
 }
 
 // PutReferencedConstant sends value 'green-color' from a constant
-//
 func (client EnumClient) PutReferencedConstant(ctx context.Context, enumStringBody RefColorConstant) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: enumStringBody,

--- a/test/src/tests/generated/body-string/string.go
+++ b/test/src/tests/generated/body-string/string.go
@@ -446,7 +446,6 @@ func (client StringClient) GetWhitespaceResponder(resp *http.Response) (result S
 }
 
 // PutBase64URLEncoded put value that is base64url encoded
-//
 func (client StringClient) PutBase64URLEncoded(ctx context.Context, stringBody string) (result autorest.Response, err error) {
 	req, err := client.PutBase64URLEncodedPreparer(ctx, stringBody)
 	if err != nil {
@@ -606,8 +605,6 @@ func (client StringClient) PutMbcsResponder(resp *http.Response) (result autores
 }
 
 // PutNull set string value null
-//
-// stringBody is
 func (client StringClient) PutNull(ctx context.Context, stringBody string) (result autorest.Response, err error) {
 	req, err := client.PutNullPreparer(ctx, stringBody)
 	if err != nil {

--- a/test/src/tests/generated/custom-baseurl/paths.go
+++ b/test/src/tests/generated/custom-baseurl/paths.go
@@ -24,8 +24,8 @@ func NewPathsClient() PathsClient {
 }
 
 // GetEmpty get a 200 to test a valid base uri
-//
-// accountName is account Name
+// Parameters:
+// accountName - account Name
 func (client PathsClient) GetEmpty(ctx context.Context, accountName string) (result autorest.Response, err error) {
 	req, err := client.GetEmptyPreparer(ctx, accountName)
 	if err != nil {

--- a/test/src/tests/generated/header/header.go
+++ b/test/src/tests/generated/header/header.go
@@ -83,9 +83,9 @@ func (client HeaderClient) CustomRequestIDResponder(resp *http.Response) (result
 
 // ParamBool send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value":
 // false
-//
-// scenario is send a post request with header values "scenario": "true" or "false" value is send a post request
-// with header values true or false
+// Parameters:
+// scenario - send a post request with header values "scenario": "true" or "false"
+// value - send a post request with header values true or false
 func (client HeaderClient) ParamBool(ctx context.Context, scenario string, value bool) (result autorest.Response, err error) {
 	req, err := client.ParamBoolPreparer(ctx, scenario, value)
 	if err != nil {
@@ -139,9 +139,9 @@ func (client HeaderClient) ParamBoolResponder(resp *http.Response) (result autor
 }
 
 // ParamByte send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩"
-//
-// scenario is send a post request with header values "scenario": "valid" value is send a post request with header
-// values "啊齄丂狛狜隣郎隣兀﨩"
+// Parameters:
+// scenario - send a post request with header values "scenario": "valid"
+// value - send a post request with header values "啊齄丂狛狜隣郎隣兀﨩"
 func (client HeaderClient) ParamByte(ctx context.Context, scenario string, value []byte) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: value,
@@ -202,9 +202,9 @@ func (client HeaderClient) ParamByteResponder(resp *http.Response) (result autor
 
 // ParamDate send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min",
 // "value": "0001-01-01"
-//
-// scenario is send a post request with header values "scenario": "valid" or "min" value is send a post request
-// with header values "2010-01-01" or "0001-01-01"
+// Parameters:
+// scenario - send a post request with header values "scenario": "valid" or "min"
+// value - send a post request with header values "2010-01-01" or "0001-01-01"
 func (client HeaderClient) ParamDate(ctx context.Context, scenario string, value date.Date) (result autorest.Response, err error) {
 	req, err := client.ParamDatePreparer(ctx, scenario, value)
 	if err != nil {
@@ -259,9 +259,9 @@ func (client HeaderClient) ParamDateResponder(resp *http.Response) (result autor
 
 // ParamDatetime send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or
 // "scenario": "min", "value": "0001-01-01T00:00:00Z"
-//
-// scenario is send a post request with header values "scenario": "valid" or "min" value is send a post request
-// with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
+// Parameters:
+// scenario - send a post request with header values "scenario": "valid" or "min"
+// value - send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
 func (client HeaderClient) ParamDatetime(ctx context.Context, scenario string, value date.Time) (result autorest.Response, err error) {
 	req, err := client.ParamDatetimePreparer(ctx, scenario, value)
 	if err != nil {
@@ -316,9 +316,10 @@ func (client HeaderClient) ParamDatetimeResponder(resp *http.Response) (result a
 
 // ParamDatetimeRfc1123 send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56
 // GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT"
-//
-// scenario is send a post request with header values "scenario": "valid" or "min" value is send a post request
-// with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
+// Parameters:
+// scenario - send a post request with header values "scenario": "valid" or "min"
+// value - send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00
+// GMT"
 func (client HeaderClient) ParamDatetimeRfc1123(ctx context.Context, scenario string, value *date.TimeRFC1123) (result autorest.Response, err error) {
 	req, err := client.ParamDatetimeRfc1123Preparer(ctx, scenario, value)
 	if err != nil {
@@ -376,9 +377,9 @@ func (client HeaderClient) ParamDatetimeRfc1123Responder(resp *http.Response) (r
 
 // ParamDouble send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative",
 // "value": -3.0
-//
-// scenario is send a post request with header values "scenario": "positive" or "negative" value is send a post
-// request with header values 7e120 or -3.0
+// Parameters:
+// scenario - send a post request with header values "scenario": "positive" or "negative"
+// value - send a post request with header values 7e120 or -3.0
 func (client HeaderClient) ParamDouble(ctx context.Context, scenario string, value float64) (result autorest.Response, err error) {
 	req, err := client.ParamDoublePreparer(ctx, scenario, value)
 	if err != nil {
@@ -432,9 +433,9 @@ func (client HeaderClient) ParamDoubleResponder(resp *http.Response) (result aut
 }
 
 // ParamDuration send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S"
-//
-// scenario is send a post request with header values "scenario": "valid" value is send a post request with header
-// values "P123DT22H14M12.011S"
+// Parameters:
+// scenario - send a post request with header values "scenario": "valid"
+// value - send a post request with header values "P123DT22H14M12.011S"
 func (client HeaderClient) ParamDuration(ctx context.Context, scenario string, value string) (result autorest.Response, err error) {
 	req, err := client.ParamDurationPreparer(ctx, scenario, value)
 	if err != nil {
@@ -489,9 +490,9 @@ func (client HeaderClient) ParamDurationResponder(resp *http.Response) (result a
 
 // ParamEnum send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null",
 // "value": null
-//
-// scenario is send a post request with header values "scenario": "valid" or "null" or "empty" value is send a post
-// request with header values 'GREY'
+// Parameters:
+// scenario - send a post request with header values "scenario": "valid" or "null" or "empty"
+// value - send a post request with header values 'GREY'
 func (client HeaderClient) ParamEnum(ctx context.Context, scenario string, value GreyscaleColors) (result autorest.Response, err error) {
 	req, err := client.ParamEnumPreparer(ctx, scenario, value)
 	if err != nil {
@@ -548,8 +549,8 @@ func (client HeaderClient) ParamEnumResponder(resp *http.Response) (result autor
 }
 
 // ParamExistingKey send a post request with header value "User-Agent": "overwrite"
-//
-// userAgent is send a post request with header value "User-Agent": "overwrite"
+// Parameters:
+// userAgent - send a post request with header value "User-Agent": "overwrite"
 func (client HeaderClient) ParamExistingKey(ctx context.Context, userAgent string) (result autorest.Response, err error) {
 	req, err := client.ParamExistingKeyPreparer(ctx, userAgent)
 	if err != nil {
@@ -603,9 +604,9 @@ func (client HeaderClient) ParamExistingKeyResponder(resp *http.Response) (resul
 
 // ParamFloat send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative",
 // "value": -3.0
-//
-// scenario is send a post request with header values "scenario": "positive" or "negative" value is send a post
-// request with header values 0.07 or -3.0
+// Parameters:
+// scenario - send a post request with header values "scenario": "positive" or "negative"
+// value - send a post request with header values 0.07 or -3.0
 func (client HeaderClient) ParamFloat(ctx context.Context, scenario string, value float64) (result autorest.Response, err error) {
 	req, err := client.ParamFloatPreparer(ctx, scenario, value)
 	if err != nil {
@@ -660,9 +661,9 @@ func (client HeaderClient) ParamFloatResponder(resp *http.Response) (result auto
 
 // ParamInteger send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative",
 // "value": -2
-//
-// scenario is send a post request with header values "scenario": "positive" or "negative" value is send a post
-// request with header values 1 or -2
+// Parameters:
+// scenario - send a post request with header values "scenario": "positive" or "negative"
+// value - send a post request with header values 1 or -2
 func (client HeaderClient) ParamInteger(ctx context.Context, scenario string, value int32) (result autorest.Response, err error) {
 	req, err := client.ParamIntegerPreparer(ctx, scenario, value)
 	if err != nil {
@@ -717,9 +718,9 @@ func (client HeaderClient) ParamIntegerResponder(resp *http.Response) (result au
 
 // ParamLong send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative",
 // "value": -2
-//
-// scenario is send a post request with header values "scenario": "positive" or "negative" value is send a post
-// request with header values 105 or -2
+// Parameters:
+// scenario - send a post request with header values "scenario": "positive" or "negative"
+// value - send a post request with header values 105 or -2
 func (client HeaderClient) ParamLong(ctx context.Context, scenario string, value int64) (result autorest.Response, err error) {
 	req, err := client.ParamLongPreparer(ctx, scenario, value)
 	if err != nil {
@@ -773,8 +774,8 @@ func (client HeaderClient) ParamLongResponder(resp *http.Response) (result autor
 }
 
 // ParamProtectedKey send a post request with header value "Content-Type": "text/html"
-//
-// contentType is send a post request with header value "Content-Type": "text/html"
+// Parameters:
+// contentType - send a post request with header value "Content-Type": "text/html"
 func (client HeaderClient) ParamProtectedKey(ctx context.Context, contentType string) (result autorest.Response, err error) {
 	req, err := client.ParamProtectedKeyPreparer(ctx, contentType)
 	if err != nil {
@@ -828,9 +829,9 @@ func (client HeaderClient) ParamProtectedKeyResponder(resp *http.Response) (resu
 
 // ParamString send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the
 // lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": ""
-//
-// scenario is send a post request with header values "scenario": "valid" or "null" or "empty" value is send a post
-// request with header values "The quick brown fox jumps over the lazy dog" or null or ""
+// Parameters:
+// scenario - send a post request with header values "scenario": "valid" or "null" or "empty"
+// value - send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
 func (client HeaderClient) ParamString(ctx context.Context, scenario string, value string) (result autorest.Response, err error) {
 	req, err := client.ParamStringPreparer(ctx, scenario, value)
 	if err != nil {
@@ -887,8 +888,8 @@ func (client HeaderClient) ParamStringResponder(resp *http.Response) (result aut
 }
 
 // ResponseBool get a response with header value "value": true or false
-//
-// scenario is send a post request with header values "scenario": "true" or "false"
+// Parameters:
+// scenario - send a post request with header values "scenario": "true" or "false"
 func (client HeaderClient) ResponseBool(ctx context.Context, scenario string) (result autorest.Response, err error) {
 	req, err := client.ResponseBoolPreparer(ctx, scenario)
 	if err != nil {
@@ -941,8 +942,8 @@ func (client HeaderClient) ResponseBoolResponder(resp *http.Response) (result au
 }
 
 // ResponseByte get a response with header values "啊齄丂狛狜隣郎隣兀﨩"
-//
-// scenario is send a post request with header values "scenario": "valid"
+// Parameters:
+// scenario - send a post request with header values "scenario": "valid"
 func (client HeaderClient) ResponseByte(ctx context.Context, scenario string) (result autorest.Response, err error) {
 	req, err := client.ResponseBytePreparer(ctx, scenario)
 	if err != nil {
@@ -995,8 +996,8 @@ func (client HeaderClient) ResponseByteResponder(resp *http.Response) (result au
 }
 
 // ResponseDate get a response with header values "2010-01-01" or "0001-01-01"
-//
-// scenario is send a post request with header values "scenario": "valid" or "min"
+// Parameters:
+// scenario - send a post request with header values "scenario": "valid" or "min"
 func (client HeaderClient) ResponseDate(ctx context.Context, scenario string) (result autorest.Response, err error) {
 	req, err := client.ResponseDatePreparer(ctx, scenario)
 	if err != nil {
@@ -1049,8 +1050,8 @@ func (client HeaderClient) ResponseDateResponder(resp *http.Response) (result au
 }
 
 // ResponseDatetime get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
-//
-// scenario is send a post request with header values "scenario": "valid" or "min"
+// Parameters:
+// scenario - send a post request with header values "scenario": "valid" or "min"
 func (client HeaderClient) ResponseDatetime(ctx context.Context, scenario string) (result autorest.Response, err error) {
 	req, err := client.ResponseDatetimePreparer(ctx, scenario)
 	if err != nil {
@@ -1104,8 +1105,8 @@ func (client HeaderClient) ResponseDatetimeResponder(resp *http.Response) (resul
 
 // ResponseDatetimeRfc1123 get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001
 // 00:00:00 GMT"
-//
-// scenario is send a post request with header values "scenario": "valid" or "min"
+// Parameters:
+// scenario - send a post request with header values "scenario": "valid" or "min"
 func (client HeaderClient) ResponseDatetimeRfc1123(ctx context.Context, scenario string) (result autorest.Response, err error) {
 	req, err := client.ResponseDatetimeRfc1123Preparer(ctx, scenario)
 	if err != nil {
@@ -1158,8 +1159,8 @@ func (client HeaderClient) ResponseDatetimeRfc1123Responder(resp *http.Response)
 }
 
 // ResponseDouble get a response with header value "value": 7e120 or -3.0
-//
-// scenario is send a post request with header values "scenario": "positive" or "negative"
+// Parameters:
+// scenario - send a post request with header values "scenario": "positive" or "negative"
 func (client HeaderClient) ResponseDouble(ctx context.Context, scenario string) (result autorest.Response, err error) {
 	req, err := client.ResponseDoublePreparer(ctx, scenario)
 	if err != nil {
@@ -1212,8 +1213,8 @@ func (client HeaderClient) ResponseDoubleResponder(resp *http.Response) (result 
 }
 
 // ResponseDuration get a response with header values "P123DT22H14M12.011S"
-//
-// scenario is send a post request with header values "scenario": "valid"
+// Parameters:
+// scenario - send a post request with header values "scenario": "valid"
 func (client HeaderClient) ResponseDuration(ctx context.Context, scenario string) (result autorest.Response, err error) {
 	req, err := client.ResponseDurationPreparer(ctx, scenario)
 	if err != nil {
@@ -1266,8 +1267,8 @@ func (client HeaderClient) ResponseDurationResponder(resp *http.Response) (resul
 }
 
 // ResponseEnum get a response with header values "GREY" or null
-//
-// scenario is send a post request with header values "scenario": "valid" or "null" or "empty"
+// Parameters:
+// scenario - send a post request with header values "scenario": "valid" or "null" or "empty"
 func (client HeaderClient) ResponseEnum(ctx context.Context, scenario string) (result autorest.Response, err error) {
 	req, err := client.ResponseEnumPreparer(ctx, scenario)
 	if err != nil {
@@ -1371,8 +1372,8 @@ func (client HeaderClient) ResponseExistingKeyResponder(resp *http.Response) (re
 }
 
 // ResponseFloat get a response with header value "value": 0.07 or -3.0
-//
-// scenario is send a post request with header values "scenario": "positive" or "negative"
+// Parameters:
+// scenario - send a post request with header values "scenario": "positive" or "negative"
 func (client HeaderClient) ResponseFloat(ctx context.Context, scenario string) (result autorest.Response, err error) {
 	req, err := client.ResponseFloatPreparer(ctx, scenario)
 	if err != nil {
@@ -1425,8 +1426,8 @@ func (client HeaderClient) ResponseFloatResponder(resp *http.Response) (result a
 }
 
 // ResponseInteger get a response with header value "value": 1 or -2
-//
-// scenario is send a post request with header values "scenario": "positive" or "negative"
+// Parameters:
+// scenario - send a post request with header values "scenario": "positive" or "negative"
 func (client HeaderClient) ResponseInteger(ctx context.Context, scenario string) (result autorest.Response, err error) {
 	req, err := client.ResponseIntegerPreparer(ctx, scenario)
 	if err != nil {
@@ -1479,8 +1480,8 @@ func (client HeaderClient) ResponseIntegerResponder(resp *http.Response) (result
 }
 
 // ResponseLong get a response with header value "value": 105 or -2
-//
-// scenario is send a post request with header values "scenario": "positive" or "negative"
+// Parameters:
+// scenario - send a post request with header values "scenario": "positive" or "negative"
 func (client HeaderClient) ResponseLong(ctx context.Context, scenario string) (result autorest.Response, err error) {
 	req, err := client.ResponseLongPreparer(ctx, scenario)
 	if err != nil {
@@ -1584,8 +1585,8 @@ func (client HeaderClient) ResponseProtectedKeyResponder(resp *http.Response) (r
 }
 
 // ResponseString get a response with header values "The quick brown fox jumps over the lazy dog" or null or ""
-//
-// scenario is send a post request with header values "scenario": "valid" or "null" or "empty"
+// Parameters:
+// scenario - send a post request with header values "scenario": "valid" or "null" or "empty"
 func (client HeaderClient) ResponseString(ctx context.Context, scenario string) (result autorest.Response, err error) {
 	req, err := client.ResponseStringPreparer(ctx, scenario)
 	if err != nil {

--- a/test/src/tests/generated/httpinfrastructure/httpclientfailure.go
+++ b/test/src/tests/generated/httpinfrastructure/httpclientfailure.go
@@ -29,8 +29,8 @@ func NewHTTPClientFailureClientWithBaseURI(baseURI string) HTTPClientFailureClie
 }
 
 // Delete400 return 400 status code - should be represented in the client as an error
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPClientFailureClient) Delete400(ctx context.Context, booleanValue *bool) (result Error, err error) {
 	req, err := client.Delete400Preparer(ctx, booleanValue)
 	if err != nil {
@@ -88,8 +88,8 @@ func (client HTTPClientFailureClient) Delete400Responder(resp *http.Response) (r
 }
 
 // Delete407 return 407 status code - should be represented in the client as an error
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPClientFailureClient) Delete407(ctx context.Context, booleanValue *bool) (result Error, err error) {
 	req, err := client.Delete407Preparer(ctx, booleanValue)
 	if err != nil {
@@ -147,8 +147,8 @@ func (client HTTPClientFailureClient) Delete407Responder(resp *http.Response) (r
 }
 
 // Delete417 return 417 status code - should be represented in the client as an error
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPClientFailureClient) Delete417(ctx context.Context, booleanValue *bool) (result Error, err error) {
 	req, err := client.Delete417Preparer(ctx, booleanValue)
 	if err != nil {
@@ -726,8 +726,8 @@ func (client HTTPClientFailureClient) Head429Responder(resp *http.Response) (res
 }
 
 // Patch400 return 400 status code - should be represented in the client as an error
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPClientFailureClient) Patch400(ctx context.Context, booleanValue *bool) (result Error, err error) {
 	req, err := client.Patch400Preparer(ctx, booleanValue)
 	if err != nil {
@@ -785,8 +785,8 @@ func (client HTTPClientFailureClient) Patch400Responder(resp *http.Response) (re
 }
 
 // Patch405 return 405 status code - should be represented in the client as an error
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPClientFailureClient) Patch405(ctx context.Context, booleanValue *bool) (result Error, err error) {
 	req, err := client.Patch405Preparer(ctx, booleanValue)
 	if err != nil {
@@ -844,8 +844,8 @@ func (client HTTPClientFailureClient) Patch405Responder(resp *http.Response) (re
 }
 
 // Patch414 return 414 status code - should be represented in the client as an error
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPClientFailureClient) Patch414(ctx context.Context, booleanValue *bool) (result Error, err error) {
 	req, err := client.Patch414Preparer(ctx, booleanValue)
 	if err != nil {
@@ -903,8 +903,8 @@ func (client HTTPClientFailureClient) Patch414Responder(resp *http.Response) (re
 }
 
 // Post400 return 400 status code - should be represented in the client as an error
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPClientFailureClient) Post400(ctx context.Context, booleanValue *bool) (result Error, err error) {
 	req, err := client.Post400Preparer(ctx, booleanValue)
 	if err != nil {
@@ -962,8 +962,8 @@ func (client HTTPClientFailureClient) Post400Responder(resp *http.Response) (res
 }
 
 // Post406 return 406 status code - should be represented in the client as an error
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPClientFailureClient) Post406(ctx context.Context, booleanValue *bool) (result Error, err error) {
 	req, err := client.Post406Preparer(ctx, booleanValue)
 	if err != nil {
@@ -1021,8 +1021,8 @@ func (client HTTPClientFailureClient) Post406Responder(resp *http.Response) (res
 }
 
 // Post415 return 415 status code - should be represented in the client as an error
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPClientFailureClient) Post415(ctx context.Context, booleanValue *bool) (result Error, err error) {
 	req, err := client.Post415Preparer(ctx, booleanValue)
 	if err != nil {
@@ -1080,8 +1080,8 @@ func (client HTTPClientFailureClient) Post415Responder(resp *http.Response) (res
 }
 
 // Put400 return 400 status code - should be represented in the client as an error
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPClientFailureClient) Put400(ctx context.Context, booleanValue *bool) (result Error, err error) {
 	req, err := client.Put400Preparer(ctx, booleanValue)
 	if err != nil {
@@ -1139,8 +1139,8 @@ func (client HTTPClientFailureClient) Put400Responder(resp *http.Response) (resu
 }
 
 // Put404 return 404 status code - should be represented in the client as an error
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPClientFailureClient) Put404(ctx context.Context, booleanValue *bool) (result Error, err error) {
 	req, err := client.Put404Preparer(ctx, booleanValue)
 	if err != nil {
@@ -1198,8 +1198,8 @@ func (client HTTPClientFailureClient) Put404Responder(resp *http.Response) (resu
 }
 
 // Put409 return 409 status code - should be represented in the client as an error
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPClientFailureClient) Put409(ctx context.Context, booleanValue *bool) (result Error, err error) {
 	req, err := client.Put409Preparer(ctx, booleanValue)
 	if err != nil {
@@ -1257,8 +1257,8 @@ func (client HTTPClientFailureClient) Put409Responder(resp *http.Response) (resu
 }
 
 // Put413 return 413 status code - should be represented in the client as an error
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPClientFailureClient) Put413(ctx context.Context, booleanValue *bool) (result Error, err error) {
 	req, err := client.Put413Preparer(ctx, booleanValue)
 	if err != nil {

--- a/test/src/tests/generated/httpinfrastructure/httpredirects.go
+++ b/test/src/tests/generated/httpinfrastructure/httpredirects.go
@@ -29,8 +29,8 @@ func NewHTTPRedirectsClientWithBaseURI(baseURI string) HTTPRedirectsClient {
 }
 
 // Delete307 delete redirected with 307, resulting in a 200 after redirect
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPRedirectsClient) Delete307(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Delete307Preparer(ctx, booleanValue)
 	if err != nil {
@@ -497,8 +497,8 @@ func (client HTTPRedirectsClient) Head307Responder(resp *http.Response) (result 
 
 // Patch302 patch true Boolean value in request returns 302.  This request should not be automatically redirected, but
 // should return the received 302 to the caller for evaluation
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPRedirectsClient) Patch302(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Patch302Preparer(ctx, booleanValue)
 	if err != nil {
@@ -555,8 +555,8 @@ func (client HTTPRedirectsClient) Patch302Responder(resp *http.Response) (result
 }
 
 // Patch307 patch redirected with 307, resulting in a 200 after redirect
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPRedirectsClient) Patch307(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Patch307Preparer(ctx, booleanValue)
 	if err != nil {
@@ -614,8 +614,8 @@ func (client HTTPRedirectsClient) Patch307Responder(resp *http.Response) (result
 
 // Post303 post true Boolean value in request returns 303.  This request should be automatically redirected usign a
 // get, ultimately returning a 200 status code
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPRedirectsClient) Post303(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Post303Preparer(ctx, booleanValue)
 	if err != nil {
@@ -672,8 +672,8 @@ func (client HTTPRedirectsClient) Post303Responder(resp *http.Response) (result 
 }
 
 // Post307 post redirected with 307, resulting in a 200 after redirect
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPRedirectsClient) Post307(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Post307Preparer(ctx, booleanValue)
 	if err != nil {
@@ -731,8 +731,8 @@ func (client HTTPRedirectsClient) Post307Responder(resp *http.Response) (result 
 
 // Put301 put true Boolean value in request returns 301.  This request should not be automatically redirected, but
 // should return the received 301 to the caller for evaluation
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPRedirectsClient) Put301(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Put301Preparer(ctx, booleanValue)
 	if err != nil {
@@ -789,8 +789,8 @@ func (client HTTPRedirectsClient) Put301Responder(resp *http.Response) (result a
 }
 
 // Put307 put redirected with 307, resulting in a 200 after redirect
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPRedirectsClient) Put307(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Put307Preparer(ctx, booleanValue)
 	if err != nil {

--- a/test/src/tests/generated/httpinfrastructure/httpretry.go
+++ b/test/src/tests/generated/httpinfrastructure/httpretry.go
@@ -29,8 +29,8 @@ func NewHTTPRetryClientWithBaseURI(baseURI string) HTTPRetryClient {
 }
 
 // Delete503 return 503 status code, then 200 after retry
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPRetryClient) Delete503(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Delete503Preparer(ctx, booleanValue)
 	if err != nil {
@@ -189,8 +189,8 @@ func (client HTTPRetryClient) Head408Responder(resp *http.Response) (result auto
 }
 
 // Patch500 return 500 status code, then 200 after retry
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPRetryClient) Patch500(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Patch500Preparer(ctx, booleanValue)
 	if err != nil {
@@ -247,8 +247,8 @@ func (client HTTPRetryClient) Patch500Responder(resp *http.Response) (result aut
 }
 
 // Patch504 return 504 status code, then 200 after retry
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPRetryClient) Patch504(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Patch504Preparer(ctx, booleanValue)
 	if err != nil {
@@ -305,8 +305,8 @@ func (client HTTPRetryClient) Patch504Responder(resp *http.Response) (result aut
 }
 
 // Post503 return 503 status code, then 200 after retry
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPRetryClient) Post503(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Post503Preparer(ctx, booleanValue)
 	if err != nil {
@@ -363,8 +363,8 @@ func (client HTTPRetryClient) Post503Responder(resp *http.Response) (result auto
 }
 
 // Put500 return 500 status code, then 200 after retry
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPRetryClient) Put500(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Put500Preparer(ctx, booleanValue)
 	if err != nil {
@@ -421,8 +421,8 @@ func (client HTTPRetryClient) Put500Responder(resp *http.Response) (result autor
 }
 
 // Put504 return 504 status code, then 200 after retry
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPRetryClient) Put504(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Put504Preparer(ctx, booleanValue)
 	if err != nil {

--- a/test/src/tests/generated/httpinfrastructure/httpserverfailure.go
+++ b/test/src/tests/generated/httpinfrastructure/httpserverfailure.go
@@ -29,8 +29,8 @@ func NewHTTPServerFailureClientWithBaseURI(baseURI string) HTTPServerFailureClie
 }
 
 // Delete505 return 505 status code - should be represented in the client as an error
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPServerFailureClient) Delete505(ctx context.Context, booleanValue *bool) (result Error, err error) {
 	req, err := client.Delete505Preparer(ctx, booleanValue)
 	if err != nil {
@@ -192,8 +192,8 @@ func (client HTTPServerFailureClient) Head501Responder(resp *http.Response) (res
 }
 
 // Post505 return 505 status code - should be represented in the client as an error
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPServerFailureClient) Post505(ctx context.Context, booleanValue *bool) (result Error, err error) {
 	req, err := client.Post505Preparer(ctx, booleanValue)
 	if err != nil {

--- a/test/src/tests/generated/httpinfrastructure/httpsuccess.go
+++ b/test/src/tests/generated/httpinfrastructure/httpsuccess.go
@@ -29,8 +29,8 @@ func NewHTTPSuccessClientWithBaseURI(baseURI string) HTTPSuccessClient {
 }
 
 // Delete200 delete simple boolean value true returns 200
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPSuccessClient) Delete200(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Delete200Preparer(ctx, booleanValue)
 	if err != nil {
@@ -87,8 +87,8 @@ func (client HTTPSuccessClient) Delete200Responder(resp *http.Response) (result 
 }
 
 // Delete202 delete true Boolean value in request returns 202 (accepted)
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPSuccessClient) Delete202(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Delete202Preparer(ctx, booleanValue)
 	if err != nil {
@@ -145,8 +145,8 @@ func (client HTTPSuccessClient) Delete202Responder(resp *http.Response) (result 
 }
 
 // Delete204 delete true Boolean value in request returns 204 (no content)
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPSuccessClient) Delete204(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Delete204Preparer(ctx, booleanValue)
 	if err != nil {
@@ -408,8 +408,8 @@ func (client HTTPSuccessClient) Head404Responder(resp *http.Response) (result au
 }
 
 // Patch200 patch true Boolean value in request returning 200
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPSuccessClient) Patch200(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Patch200Preparer(ctx, booleanValue)
 	if err != nil {
@@ -466,8 +466,8 @@ func (client HTTPSuccessClient) Patch200Responder(resp *http.Response) (result a
 }
 
 // Patch202 patch true Boolean value in request returns 202
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPSuccessClient) Patch202(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Patch202Preparer(ctx, booleanValue)
 	if err != nil {
@@ -524,8 +524,8 @@ func (client HTTPSuccessClient) Patch202Responder(resp *http.Response) (result a
 }
 
 // Patch204 patch true Boolean value in request returns 204 (no content)
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPSuccessClient) Patch204(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Patch204Preparer(ctx, booleanValue)
 	if err != nil {
@@ -582,8 +582,8 @@ func (client HTTPSuccessClient) Patch204Responder(resp *http.Response) (result a
 }
 
 // Post200 post bollean value true in request that returns a 200
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPSuccessClient) Post200(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Post200Preparer(ctx, booleanValue)
 	if err != nil {
@@ -640,8 +640,8 @@ func (client HTTPSuccessClient) Post200Responder(resp *http.Response) (result au
 }
 
 // Post201 post true Boolean value in request returns 201 (Created)
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPSuccessClient) Post201(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Post201Preparer(ctx, booleanValue)
 	if err != nil {
@@ -698,8 +698,8 @@ func (client HTTPSuccessClient) Post201Responder(resp *http.Response) (result au
 }
 
 // Post202 post true Boolean value in request returns 202 (Accepted)
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPSuccessClient) Post202(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Post202Preparer(ctx, booleanValue)
 	if err != nil {
@@ -756,8 +756,8 @@ func (client HTTPSuccessClient) Post202Responder(resp *http.Response) (result au
 }
 
 // Post204 post true Boolean value in request returns 204 (no content)
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPSuccessClient) Post204(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Post204Preparer(ctx, booleanValue)
 	if err != nil {
@@ -814,8 +814,8 @@ func (client HTTPSuccessClient) Post204Responder(resp *http.Response) (result au
 }
 
 // Put200 put boolean value true returning 200 success
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPSuccessClient) Put200(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Put200Preparer(ctx, booleanValue)
 	if err != nil {
@@ -872,8 +872,8 @@ func (client HTTPSuccessClient) Put200Responder(resp *http.Response) (result aut
 }
 
 // Put201 put true Boolean value in request returns 201
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPSuccessClient) Put201(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Put201Preparer(ctx, booleanValue)
 	if err != nil {
@@ -930,8 +930,8 @@ func (client HTTPSuccessClient) Put201Responder(resp *http.Response) (result aut
 }
 
 // Put202 put true Boolean value in request returns 202 (Accepted)
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPSuccessClient) Put202(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Put202Preparer(ctx, booleanValue)
 	if err != nil {
@@ -988,8 +988,8 @@ func (client HTTPSuccessClient) Put202Responder(resp *http.Response) (result aut
 }
 
 // Put204 put true Boolean value in request returns 204 (no content)
-//
-// booleanValue is simple boolean value true
+// Parameters:
+// booleanValue - simple boolean value true
 func (client HTTPSuccessClient) Put204(ctx context.Context, booleanValue *bool) (result autorest.Response, err error) {
 	req, err := client.Put204Preparer(ctx, booleanValue)
 	if err != nil {

--- a/test/src/tests/generated/lro/lroretrys.go
+++ b/test/src/tests/generated/lro/lroretrys.go
@@ -194,8 +194,8 @@ func (client LRORetrysClient) DeleteProvisioning202Accepted200SucceededResponder
 
 // Post202Retry200 long running post request, service returns a 500, then a 202 to the initial request, with 'Location'
 // and 'Retry-After' headers, Polls return a 200 with a response body after success
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LRORetrysClient) Post202Retry200(ctx context.Context, product *Product) (result LRORetrysPost202Retry200Future, err error) {
 	req, err := client.Post202Retry200Preparer(ctx, product)
 	if err != nil {
@@ -256,8 +256,8 @@ func (client LRORetrysClient) Post202Retry200Responder(resp *http.Response) (res
 // PostAsyncRelativeRetrySucceeded long running post request, service returns a 500, then a 202 to the initial request,
 // with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
 // header for operation status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LRORetrysClient) PostAsyncRelativeRetrySucceeded(ctx context.Context, product *Product) (result LRORetrysPostAsyncRelativeRetrySucceededFuture, err error) {
 	req, err := client.PostAsyncRelativeRetrySucceededPreparer(ctx, product)
 	if err != nil {
@@ -318,8 +318,8 @@ func (client LRORetrysClient) PostAsyncRelativeRetrySucceededResponder(resp *htt
 // Put201CreatingSucceeded200 long running put request, service returns a 500, then a 201 to the initial request, with
 // an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’
 // with ProvisioningState=’Succeeded’
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LRORetrysClient) Put201CreatingSucceeded200(ctx context.Context, product *Product) (result LRORetrysPut201CreatingSucceeded200Future, err error) {
 	req, err := client.Put201CreatingSucceeded200Preparer(ctx, product)
 	if err != nil {
@@ -381,8 +381,8 @@ func (client LRORetrysClient) Put201CreatingSucceeded200Responder(resp *http.Res
 // PutAsyncRelativeRetrySucceeded long running put request, service returns a 500, then a 200 to the initial request,
 // with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
 // header for operation status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LRORetrysClient) PutAsyncRelativeRetrySucceeded(ctx context.Context, product *Product) (result LRORetrysPutAsyncRelativeRetrySucceededFuture, err error) {
 	req, err := client.PutAsyncRelativeRetrySucceededPreparer(ctx, product)
 	if err != nil {

--- a/test/src/tests/generated/lro/lros.go
+++ b/test/src/tests/generated/lro/lros.go
@@ -740,8 +740,8 @@ func (client LROsClient) Post200WithPayloadResponder(resp *http.Response) (resul
 
 // Post202NoRetry204 long running post request, service returns a 202 to the initial request, with 'Location' header,
 // 204 with noresponse body after success
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) Post202NoRetry204(ctx context.Context, product *Product) (result LROsPost202NoRetry204Future, err error) {
 	req, err := client.Post202NoRetry204Preparer(ctx, product)
 	if err != nil {
@@ -802,8 +802,8 @@ func (client LROsClient) Post202NoRetry204Responder(resp *http.Response) (result
 
 // Post202Retry200 long running post request, service returns a 202 to the initial request, with 'Location' and
 // 'Retry-After' headers, Polls return a 200 with a response body after success
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) Post202Retry200(ctx context.Context, product *Product) (result LROsPost202Retry200Future, err error) {
 	req, err := client.Post202Retry200Preparer(ctx, product)
 	if err != nil {
@@ -864,8 +864,8 @@ func (client LROsClient) Post202Retry200Responder(resp *http.Response) (result a
 // PostAsyncNoRetrySucceeded long running post request, service returns a 202 to the initial request, with an entity
 // that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for
 // operation status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) PostAsyncNoRetrySucceeded(ctx context.Context, product *Product) (result LROsPostAsyncNoRetrySucceededFuture, err error) {
 	req, err := client.PostAsyncNoRetrySucceededPreparer(ctx, product)
 	if err != nil {
@@ -927,8 +927,8 @@ func (client LROsClient) PostAsyncNoRetrySucceededResponder(resp *http.Response)
 // PostAsyncRetrycanceled long running post request, service returns a 202 to the initial request, with an entity that
 // contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation
 // status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) PostAsyncRetrycanceled(ctx context.Context, product *Product) (result LROsPostAsyncRetrycanceledFuture, err error) {
 	req, err := client.PostAsyncRetrycanceledPreparer(ctx, product)
 	if err != nil {
@@ -989,8 +989,8 @@ func (client LROsClient) PostAsyncRetrycanceledResponder(resp *http.Response) (r
 // PostAsyncRetryFailed long running post request, service returns a 202 to the initial request, with an entity that
 // contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation
 // status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) PostAsyncRetryFailed(ctx context.Context, product *Product) (result LROsPostAsyncRetryFailedFuture, err error) {
 	req, err := client.PostAsyncRetryFailedPreparer(ctx, product)
 	if err != nil {
@@ -1051,8 +1051,8 @@ func (client LROsClient) PostAsyncRetryFailedResponder(resp *http.Response) (res
 // PostAsyncRetrySucceeded long running post request, service returns a 202 to the initial request, with an entity that
 // contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation
 // status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) PostAsyncRetrySucceeded(ctx context.Context, product *Product) (result LROsPostAsyncRetrySucceededFuture, err error) {
 	req, err := client.PostAsyncRetrySucceededPreparer(ctx, product)
 	if err != nil {
@@ -1114,8 +1114,8 @@ func (client LROsClient) PostAsyncRetrySucceededResponder(resp *http.Response) (
 // Put200Acceptedcanceled200 long running put request, service returns a 201 to the initial request, with an entity
 // that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with
 // ProvisioningState=’Canceled’
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) Put200Acceptedcanceled200(ctx context.Context, product *Product) (result LROsPut200Acceptedcanceled200Future, err error) {
 	req, err := client.Put200Acceptedcanceled200Preparer(ctx, product)
 	if err != nil {
@@ -1176,8 +1176,8 @@ func (client LROsClient) Put200Acceptedcanceled200Responder(resp *http.Response)
 
 // Put200Succeeded long running put request, service returns a 200 to the initial request, with an entity that contains
 // ProvisioningState=’Succeeded’.
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) Put200Succeeded(ctx context.Context, product *Product) (result LROsPut200SucceededFuture, err error) {
 	req, err := client.Put200SucceededPreparer(ctx, product)
 	if err != nil {
@@ -1238,8 +1238,8 @@ func (client LROsClient) Put200SucceededResponder(resp *http.Response) (result P
 
 // Put200SucceededNoState long running put request, service returns a 200 to the initial request, with an entity that
 // does not contain ProvisioningState=’Succeeded’.
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) Put200SucceededNoState(ctx context.Context, product *Product) (result LROsPut200SucceededNoStateFuture, err error) {
 	req, err := client.Put200SucceededNoStatePreparer(ctx, product)
 	if err != nil {
@@ -1301,8 +1301,8 @@ func (client LROsClient) Put200SucceededNoStateResponder(resp *http.Response) (r
 // Put200UpdatingSucceeded204 long running put request, service returns a 201 to the initial request, with an entity
 // that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with
 // ProvisioningState=’Succeeded’
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) Put200UpdatingSucceeded204(ctx context.Context, product *Product) (result LROsPut200UpdatingSucceeded204Future, err error) {
 	req, err := client.Put200UpdatingSucceeded204Preparer(ctx, product)
 	if err != nil {
@@ -1364,8 +1364,8 @@ func (client LROsClient) Put200UpdatingSucceeded204Responder(resp *http.Response
 // Put201CreatingFailed200 long running put request, service returns a 201 to the initial request, with an entity that
 // contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with
 // ProvisioningState=’Failed’
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) Put201CreatingFailed200(ctx context.Context, product *Product) (result LROsPut201CreatingFailed200Future, err error) {
 	req, err := client.Put201CreatingFailed200Preparer(ctx, product)
 	if err != nil {
@@ -1427,8 +1427,8 @@ func (client LROsClient) Put201CreatingFailed200Responder(resp *http.Response) (
 // Put201CreatingSucceeded200 long running put request, service returns a 201 to the initial request, with an entity
 // that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with
 // ProvisioningState=’Succeeded’
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) Put201CreatingSucceeded200(ctx context.Context, product *Product) (result LROsPut201CreatingSucceeded200Future, err error) {
 	req, err := client.Put201CreatingSucceeded200Preparer(ctx, product)
 	if err != nil {
@@ -1489,8 +1489,8 @@ func (client LROsClient) Put201CreatingSucceeded200Responder(resp *http.Response
 
 // Put202Retry200 long running put request, service returns a 202 to the initial request, with a location header that
 // points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) Put202Retry200(ctx context.Context, product *Product) (result LROsPut202Retry200Future, err error) {
 	req, err := client.Put202Retry200Preparer(ctx, product)
 	if err != nil {
@@ -1551,8 +1551,8 @@ func (client LROsClient) Put202Retry200Responder(resp *http.Response) (result Pr
 
 // PutAsyncNoHeaderInRetry long running put request, service returns a 202 to the initial request with
 // Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) PutAsyncNoHeaderInRetry(ctx context.Context, product *Product) (result LROsPutAsyncNoHeaderInRetryFuture, err error) {
 	req, err := client.PutAsyncNoHeaderInRetryPreparer(ctx, product)
 	if err != nil {
@@ -1612,8 +1612,8 @@ func (client LROsClient) PutAsyncNoHeaderInRetryResponder(resp *http.Response) (
 }
 
 // PutAsyncNonResource long running put request with non resource.
-//
-// sku is sku to put
+// Parameters:
+// sku - sku to put
 func (client LROsClient) PutAsyncNonResource(ctx context.Context, sku *Sku) (result LROsPutAsyncNonResourceFuture, err error) {
 	req, err := client.PutAsyncNonResourcePreparer(ctx, sku)
 	if err != nil {
@@ -1675,8 +1675,8 @@ func (client LROsClient) PutAsyncNonResourceResponder(resp *http.Response) (resu
 // PutAsyncNoRetrycanceled long running put request, service returns a 200 to the initial request, with an entity that
 // contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation
 // status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) PutAsyncNoRetrycanceled(ctx context.Context, product *Product) (result LROsPutAsyncNoRetrycanceledFuture, err error) {
 	req, err := client.PutAsyncNoRetrycanceledPreparer(ctx, product)
 	if err != nil {
@@ -1738,8 +1738,8 @@ func (client LROsClient) PutAsyncNoRetrycanceledResponder(resp *http.Response) (
 // PutAsyncNoRetrySucceeded long running put request, service returns a 200 to the initial request, with an entity that
 // contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation
 // status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) PutAsyncNoRetrySucceeded(ctx context.Context, product *Product) (result LROsPutAsyncNoRetrySucceededFuture, err error) {
 	req, err := client.PutAsyncNoRetrySucceededPreparer(ctx, product)
 	if err != nil {
@@ -1801,8 +1801,8 @@ func (client LROsClient) PutAsyncNoRetrySucceededResponder(resp *http.Response) 
 // PutAsyncRetryFailed long running put request, service returns a 200 to the initial request, with an entity that
 // contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation
 // status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) PutAsyncRetryFailed(ctx context.Context, product *Product) (result LROsPutAsyncRetryFailedFuture, err error) {
 	req, err := client.PutAsyncRetryFailedPreparer(ctx, product)
 	if err != nil {
@@ -1864,8 +1864,8 @@ func (client LROsClient) PutAsyncRetryFailedResponder(resp *http.Response) (resu
 // PutAsyncRetrySucceeded long running put request, service returns a 200 to the initial request, with an entity that
 // contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation
 // status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) PutAsyncRetrySucceeded(ctx context.Context, product *Product) (result LROsPutAsyncRetrySucceededFuture, err error) {
 	req, err := client.PutAsyncRetrySucceededPreparer(ctx, product)
 	if err != nil {
@@ -1925,8 +1925,8 @@ func (client LROsClient) PutAsyncRetrySucceededResponder(resp *http.Response) (r
 }
 
 // PutAsyncSubResource long running put request with sub resource.
-//
-// product is sub Product to put
+// Parameters:
+// product - sub Product to put
 func (client LROsClient) PutAsyncSubResource(ctx context.Context, product *SubProduct) (result LROsPutAsyncSubResourceFuture, err error) {
 	req, err := client.PutAsyncSubResourcePreparer(ctx, product)
 	if err != nil {
@@ -1987,8 +1987,8 @@ func (client LROsClient) PutAsyncSubResourceResponder(resp *http.Response) (resu
 
 // PutNoHeaderInRetry long running put request, service returns a 202 to the initial request with location header.
 // Subsequent calls to operation status do not contain location header.
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsClient) PutNoHeaderInRetry(ctx context.Context, product *Product) (result LROsPutNoHeaderInRetryFuture, err error) {
 	req, err := client.PutNoHeaderInRetryPreparer(ctx, product)
 	if err != nil {
@@ -2048,8 +2048,8 @@ func (client LROsClient) PutNoHeaderInRetryResponder(resp *http.Response) (resul
 }
 
 // PutNonResource long running put request with non resource.
-//
-// sku is sku to put
+// Parameters:
+// sku - sku to put
 func (client LROsClient) PutNonResource(ctx context.Context, sku *Sku) (result LROsPutNonResourceFuture, err error) {
 	req, err := client.PutNonResourcePreparer(ctx, sku)
 	if err != nil {
@@ -2109,8 +2109,8 @@ func (client LROsClient) PutNonResourceResponder(resp *http.Response) (result Sk
 }
 
 // PutSubResource long running put request with sub resource.
-//
-// product is sub Product to put
+// Parameters:
+// product - sub Product to put
 func (client LROsClient) PutSubResource(ctx context.Context, product *SubProduct) (result LROsPutSubResourceFuture, err error) {
 	req, err := client.PutSubResourcePreparer(ctx, product)
 	if err != nil {

--- a/test/src/tests/generated/lro/lrosads.go
+++ b/test/src/tests/generated/lro/lrosads.go
@@ -459,8 +459,8 @@ func (client LROSADsClient) DeleteNonRetry400Responder(resp *http.Response) (res
 
 // Post202NoLocation long running post request, service returns a 202 to the initial request, without a location
 // header.
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) Post202NoLocation(ctx context.Context, product *Product) (result LROSADsPost202NoLocationFuture, err error) {
 	req, err := client.Post202NoLocationPreparer(ctx, product)
 	if err != nil {
@@ -519,8 +519,8 @@ func (client LROSADsClient) Post202NoLocationResponder(resp *http.Response) (res
 }
 
 // Post202NonRetry400 long running post request, service returns a 202 with a location header
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) Post202NonRetry400(ctx context.Context, product *Product) (result LROSADsPost202NonRetry400Future, err error) {
 	req, err := client.Post202NonRetry400Preparer(ctx, product)
 	if err != nil {
@@ -580,8 +580,8 @@ func (client LROSADsClient) Post202NonRetry400Responder(resp *http.Response) (re
 
 // Post202RetryInvalidHeader long running post request, service returns a 202 to the initial request, with invalid
 // 'Location' and 'Retry-After' headers.
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) Post202RetryInvalidHeader(ctx context.Context, product *Product) (result LROSADsPost202RetryInvalidHeaderFuture, err error) {
 	req, err := client.Post202RetryInvalidHeaderPreparer(ctx, product)
 	if err != nil {
@@ -641,8 +641,8 @@ func (client LROSADsClient) Post202RetryInvalidHeaderResponder(resp *http.Respon
 
 // PostAsyncRelativeRetry400 long running post request, service returns a 202 to the initial request Poll the endpoint
 // indicated in the Azure-AsyncOperation header for operation status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) PostAsyncRelativeRetry400(ctx context.Context, product *Product) (result LROSADsPostAsyncRelativeRetry400Future, err error) {
 	req, err := client.PostAsyncRelativeRetry400Preparer(ctx, product)
 	if err != nil {
@@ -703,8 +703,8 @@ func (client LROSADsClient) PostAsyncRelativeRetry400Responder(resp *http.Respon
 // PostAsyncRelativeRetryInvalidHeader long running post request, service returns a 202 to the initial request, with an
 // entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is
 // invalid.
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) PostAsyncRelativeRetryInvalidHeader(ctx context.Context, product *Product) (result LROSADsPostAsyncRelativeRetryInvalidHeaderFuture, err error) {
 	req, err := client.PostAsyncRelativeRetryInvalidHeaderPreparer(ctx, product)
 	if err != nil {
@@ -765,8 +765,8 @@ func (client LROSADsClient) PostAsyncRelativeRetryInvalidHeaderResponder(resp *h
 // PostAsyncRelativeRetryInvalidJSONPolling long running post request, service returns a 202 to the initial request,
 // with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
 // header for operation status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) PostAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, product *Product) (result LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture, err error) {
 	req, err := client.PostAsyncRelativeRetryInvalidJSONPollingPreparer(ctx, product)
 	if err != nil {
@@ -827,8 +827,8 @@ func (client LROSADsClient) PostAsyncRelativeRetryInvalidJSONPollingResponder(re
 // PostAsyncRelativeRetryNoPayload long running post request, service returns a 202 to the initial request, with an
 // entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header
 // for operation status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) PostAsyncRelativeRetryNoPayload(ctx context.Context, product *Product) (result LROSADsPostAsyncRelativeRetryNoPayloadFuture, err error) {
 	req, err := client.PostAsyncRelativeRetryNoPayloadPreparer(ctx, product)
 	if err != nil {
@@ -887,8 +887,8 @@ func (client LROSADsClient) PostAsyncRelativeRetryNoPayloadResponder(resp *http.
 }
 
 // PostNonRetry400 long running post request, service returns a 400 with no error body
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) PostNonRetry400(ctx context.Context, product *Product) (result LROSADsPostNonRetry400Future, err error) {
 	req, err := client.PostNonRetry400Preparer(ctx, product)
 	if err != nil {
@@ -948,8 +948,8 @@ func (client LROSADsClient) PostNonRetry400Responder(resp *http.Response) (resul
 
 // Put200InvalidJSON long running put request, service returns a 200 to the initial request, with an entity that is not
 // a valid json
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) Put200InvalidJSON(ctx context.Context, product *Product) (result LROSADsPut200InvalidJSONFuture, err error) {
 	req, err := client.Put200InvalidJSONPreparer(ctx, product)
 	if err != nil {
@@ -1010,8 +1010,8 @@ func (client LROSADsClient) Put200InvalidJSONResponder(resp *http.Response) (res
 
 // PutAsyncRelativeRetry400 long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the
 // endpoint indicated in the Azure-AsyncOperation header for operation status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) PutAsyncRelativeRetry400(ctx context.Context, product *Product) (result LROSADsPutAsyncRelativeRetry400Future, err error) {
 	req, err := client.PutAsyncRelativeRetry400Preparer(ctx, product)
 	if err != nil {
@@ -1073,8 +1073,8 @@ func (client LROSADsClient) PutAsyncRelativeRetry400Responder(resp *http.Respons
 // PutAsyncRelativeRetryInvalidHeader long running put request, service returns a 200 to the initial request, with an
 // entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is
 // invalid.
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) PutAsyncRelativeRetryInvalidHeader(ctx context.Context, product *Product) (result LROSADsPutAsyncRelativeRetryInvalidHeaderFuture, err error) {
 	req, err := client.PutAsyncRelativeRetryInvalidHeaderPreparer(ctx, product)
 	if err != nil {
@@ -1136,8 +1136,8 @@ func (client LROSADsClient) PutAsyncRelativeRetryInvalidHeaderResponder(resp *ht
 // PutAsyncRelativeRetryInvalidJSONPolling long running put request, service returns a 200 to the initial request, with
 // an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header
 // for operation status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) PutAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, product *Product) (result LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture, err error) {
 	req, err := client.PutAsyncRelativeRetryInvalidJSONPollingPreparer(ctx, product)
 	if err != nil {
@@ -1199,8 +1199,8 @@ func (client LROSADsClient) PutAsyncRelativeRetryInvalidJSONPollingResponder(res
 // PutAsyncRelativeRetryNoStatus long running put request, service returns a 200 to the initial request, with an entity
 // that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for
 // operation status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) PutAsyncRelativeRetryNoStatus(ctx context.Context, product *Product) (result LROSADsPutAsyncRelativeRetryNoStatusFuture, err error) {
 	req, err := client.PutAsyncRelativeRetryNoStatusPreparer(ctx, product)
 	if err != nil {
@@ -1262,8 +1262,8 @@ func (client LROSADsClient) PutAsyncRelativeRetryNoStatusResponder(resp *http.Re
 // PutAsyncRelativeRetryNoStatusPayload long running put request, service returns a 200 to the initial request, with an
 // entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header
 // for operation status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) PutAsyncRelativeRetryNoStatusPayload(ctx context.Context, product *Product) (result LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture, err error) {
 	req, err := client.PutAsyncRelativeRetryNoStatusPayloadPreparer(ctx, product)
 	if err != nil {
@@ -1324,8 +1324,8 @@ func (client LROSADsClient) PutAsyncRelativeRetryNoStatusPayloadResponder(resp *
 
 // PutError201NoProvisioningStatePayload long running put request, service returns a 201 to the initial request with no
 // payload
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) PutError201NoProvisioningStatePayload(ctx context.Context, product *Product) (result LROSADsPutError201NoProvisioningStatePayloadFuture, err error) {
 	req, err := client.PutError201NoProvisioningStatePayloadPreparer(ctx, product)
 	if err != nil {
@@ -1386,8 +1386,8 @@ func (client LROSADsClient) PutError201NoProvisioningStatePayloadResponder(resp 
 
 // PutNonRetry201Creating400 long running put request, service returns a Product with 'ProvisioningState' = 'Creating'
 // and 201 response code
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) PutNonRetry201Creating400(ctx context.Context, product *Product) (result LROSADsPutNonRetry201Creating400Future, err error) {
 	req, err := client.PutNonRetry201Creating400Preparer(ctx, product)
 	if err != nil {
@@ -1448,8 +1448,8 @@ func (client LROSADsClient) PutNonRetry201Creating400Responder(resp *http.Respon
 
 // PutNonRetry201Creating400InvalidJSON long running put request, service returns a Product with 'ProvisioningState' =
 // 'Creating' and 201 response code
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) PutNonRetry201Creating400InvalidJSON(ctx context.Context, product *Product) (result LROSADsPutNonRetry201Creating400InvalidJSONFuture, err error) {
 	req, err := client.PutNonRetry201Creating400InvalidJSONPreparer(ctx, product)
 	if err != nil {
@@ -1509,8 +1509,8 @@ func (client LROSADsClient) PutNonRetry201Creating400InvalidJSONResponder(resp *
 }
 
 // PutNonRetry400 long running put request, service returns a 400 to the initial request
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROSADsClient) PutNonRetry400(ctx context.Context, product *Product) (result LROSADsPutNonRetry400Future, err error) {
 	req, err := client.PutNonRetry400Preparer(ctx, product)
 	if err != nil {

--- a/test/src/tests/generated/lro/lroscustomheader.go
+++ b/test/src/tests/generated/lro/lroscustomheader.go
@@ -31,8 +31,8 @@ func NewLROsCustomHeaderClientWithBaseURI(baseURI string) LROsCustomHeaderClient
 // Post202Retry200 x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all
 // requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After'
 // headers, Polls return a 200 with a response body after success
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsCustomHeaderClient) Post202Retry200(ctx context.Context, product *Product) (result LROsCustomHeaderPost202Retry200Future, err error) {
 	req, err := client.Post202Retry200Preparer(ctx, product)
 	if err != nil {
@@ -93,8 +93,8 @@ func (client LROsCustomHeaderClient) Post202Retry200Responder(resp *http.Respons
 // PostAsyncRetrySucceeded x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for
 // all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains
 // ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsCustomHeaderClient) PostAsyncRetrySucceeded(ctx context.Context, product *Product) (result LROsCustomHeaderPostAsyncRetrySucceededFuture, err error) {
 	req, err := client.PostAsyncRetrySucceededPreparer(ctx, product)
 	if err != nil {
@@ -156,8 +156,8 @@ func (client LROsCustomHeaderClient) PostAsyncRetrySucceededResponder(resp *http
 // for all requests. Long running put request, service returns a 201 to the initial request, with an entity that
 // contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with
 // ProvisioningState=’Succeeded’
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsCustomHeaderClient) Put201CreatingSucceeded200(ctx context.Context, product *Product) (result LROsCustomHeaderPut201CreatingSucceeded200Future, err error) {
 	req, err := client.Put201CreatingSucceeded200Preparer(ctx, product)
 	if err != nil {
@@ -219,8 +219,8 @@ func (client LROsCustomHeaderClient) Put201CreatingSucceeded200Responder(resp *h
 // PutAsyncRetrySucceeded x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for
 // all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains
 // ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-//
-// product is product to put
+// Parameters:
+// product - product to put
 func (client LROsCustomHeaderClient) PutAsyncRetrySucceeded(ctx context.Context, product *Product) (result LROsCustomHeaderPutAsyncRetrySucceededFuture, err error) {
 	req, err := client.PutAsyncRetrySucceededPreparer(ctx, product)
 	if err != nil {

--- a/test/src/tests/generated/model-flattening/client.go
+++ b/test/src/tests/generated/model-flattening/client.go
@@ -251,8 +251,8 @@ func (client BaseClient) GetWrappedArrayResponder(resp *http.Response) (result L
 }
 
 // PostFlattenedSimpleProduct put Flattened Simple Product with client flattening true on the parameter
-//
-// simpleBodyProduct is simple body product to post
+// Parameters:
+// simpleBodyProduct - simple body product to post
 func (client BaseClient) PostFlattenedSimpleProduct(ctx context.Context, simpleBodyProduct *SimpleProduct) (result SimpleProduct, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: simpleBodyProduct,
@@ -321,8 +321,8 @@ func (client BaseClient) PostFlattenedSimpleProductResponder(resp *http.Response
 }
 
 // PutArray put External Resource as an Array
-//
-// resourceArray is external Resource as an Array to put
+// Parameters:
+// resourceArray - external Resource as an Array to put
 func (client BaseClient) PutArray(ctx context.Context, resourceArray []Resource) (result autorest.Response, err error) {
 	req, err := client.PutArrayPreparer(ctx, resourceArray)
 	if err != nil {
@@ -379,8 +379,8 @@ func (client BaseClient) PutArrayResponder(resp *http.Response) (result autorest
 }
 
 // PutDictionary put External Resource as a Dictionary
-//
-// resourceDictionary is external Resource as a Dictionary to put
+// Parameters:
+// resourceDictionary - external Resource as a Dictionary to put
 func (client BaseClient) PutDictionary(ctx context.Context, resourceDictionary map[string]*FlattenedProduct) (result autorest.Response, err error) {
 	req, err := client.PutDictionaryPreparer(ctx, resourceDictionary)
 	if err != nil {
@@ -437,8 +437,8 @@ func (client BaseClient) PutDictionaryResponder(resp *http.Response) (result aut
 }
 
 // PutResourceCollection put External Resource as a ResourceCollection
-//
-// resourceComplexObject is external Resource as a ResourceCollection to put
+// Parameters:
+// resourceComplexObject - external Resource as a ResourceCollection to put
 func (client BaseClient) PutResourceCollection(ctx context.Context, resourceComplexObject *ResourceCollection) (result autorest.Response, err error) {
 	req, err := client.PutResourceCollectionPreparer(ctx, resourceComplexObject)
 	if err != nil {
@@ -495,8 +495,8 @@ func (client BaseClient) PutResourceCollectionResponder(resp *http.Response) (re
 }
 
 // PutSimpleProduct put Simple Product with client flattening true on the model
-//
-// simpleBodyProduct is simple body product to put
+// Parameters:
+// simpleBodyProduct - simple body product to put
 func (client BaseClient) PutSimpleProduct(ctx context.Context, simpleBodyProduct *SimpleProduct) (result SimpleProduct, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: simpleBodyProduct,
@@ -565,8 +565,9 @@ func (client BaseClient) PutSimpleProductResponder(resp *http.Response) (result 
 }
 
 // PutSimpleProductWithGrouping put Simple Product with client flattening true on the model
-//
-// name is product name with value 'groupproduct' simpleBodyProduct is simple body product to put
+// Parameters:
+// name - product name with value 'groupproduct'
+// simpleBodyProduct - simple body product to put
 func (client BaseClient) PutSimpleProductWithGrouping(ctx context.Context, name string, simpleBodyProduct *SimpleProduct) (result SimpleProduct, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: simpleBodyProduct,
@@ -640,8 +641,8 @@ func (client BaseClient) PutSimpleProductWithGroupingResponder(resp *http.Respon
 
 // PutWrappedArray no need to have a route in Express server for this operation. Used to verify the type flattened is
 // not removed if it's referenced in an array
-//
-// resourceArray is external Resource as an Array to put
+// Parameters:
+// resourceArray - external Resource as an Array to put
 func (client BaseClient) PutWrappedArray(ctx context.Context, resourceArray []WrappedProduct) (result autorest.Response, err error) {
 	req, err := client.PutWrappedArrayPreparer(ctx, resourceArray)
 	if err != nil {

--- a/test/src/tests/generated/more-custom-base-uri/paths.go
+++ b/test/src/tests/generated/more-custom-base-uri/paths.go
@@ -24,9 +24,11 @@ func NewPathsClient(subscriptionID string) PathsClient {
 }
 
 // GetEmpty get a 200 to test a valid base uri
-//
-// vault is the vault name, e.g. https://myvault secret is secret value. keyName is the key name with value 'key1'.
-// keyVersion is the key version. Default value 'v1'.
+// Parameters:
+// vault - the vault name, e.g. https://myvault
+// secret - secret value.
+// keyName - the key name with value 'key1'.
+// keyVersion - the key version. Default value 'v1'.
 func (client PathsClient) GetEmpty(ctx context.Context, vault string, secret string, keyName string, keyVersion string) (result autorest.Response, err error) {
 	req, err := client.GetEmptyPreparer(ctx, vault, secret, keyName, keyVersion)
 	if err != nil {

--- a/test/src/tests/generated/paging/paging.go
+++ b/test/src/tests/generated/paging/paging.go
@@ -30,9 +30,10 @@ func NewPagingClientWithBaseURI(baseURI string) PagingClient {
 }
 
 // GetMultiplePages a paging operation that includes a nextLink that has 10 pages
-//
-// maxresults is sets the maximum number of items to return in the response. timeout is sets the maximum time that
-// the server can spend processing the request, in seconds. The default is 30 seconds.
+// Parameters:
+// maxresults - sets the maximum number of items to return in the response.
+// timeout - sets the maximum time that the server can spend processing the request, in seconds. The default is
+// 30 seconds.
 func (client PagingClient) GetMultiplePages(ctx context.Context, clientRequestID string, maxresults *int32, timeout *int32) (result ProductResultPage, err error) {
 	result.fn = client.getMultiplePagesNextResults
 	req, err := client.GetMultiplePagesPreparer(ctx, clientRequestID, maxresults, timeout)
@@ -288,8 +289,9 @@ func (client PagingClient) GetMultiplePagesFailureURIComplete(ctx context.Contex
 }
 
 // GetMultiplePagesFragmentNextLink a paging operation that doesn't return a full URL, just a fragment
-//
-// APIVersion is sets the api version to use. tenant is sets the tenant to use.
+// Parameters:
+// APIVersion - sets the api version to use.
+// tenant - sets the tenant to use.
 func (client PagingClient) GetMultiplePagesFragmentNextLink(ctx context.Context, APIVersion string, tenant string) (result OdataProductResultPage, err error) {
 	result.fn = func(lastResult OdataProductResult) (OdataProductResult, error) {
 		if lastResult.OdataNextLink == nil || len(to.String(lastResult.OdataNextLink)) < 1 {
@@ -364,8 +366,9 @@ func (client PagingClient) GetMultiplePagesFragmentNextLinkComplete(ctx context.
 
 // GetMultiplePagesFragmentWithGroupingNextLink a paging operation that doesn't return a full URL, just a fragment with
 // parameters grouped
-//
-// APIVersion is sets the api version to use. tenant is sets the tenant to use.
+// Parameters:
+// APIVersion - sets the api version to use.
+// tenant - sets the tenant to use.
 func (client PagingClient) GetMultiplePagesFragmentWithGroupingNextLink(ctx context.Context, APIVersion string, tenant string) (result OdataProductResultPage, err error) {
 	result.fn = func(lastResult OdataProductResult) (OdataProductResult, error) {
 		if lastResult.OdataNextLink == nil || len(to.String(lastResult.OdataNextLink)) < 1 {
@@ -601,10 +604,11 @@ func (client PagingClient) GetMultiplePagesRetrySecondComplete(ctx context.Conte
 }
 
 // GetMultiplePagesWithOffset a paging operation that includes a nextLink that has 10 pages
-//
-// offset is offset of return value maxresults is sets the maximum number of items to return in the response.
-// timeout is sets the maximum time that the server can spend processing the request, in seconds. The default is 30
-// seconds.
+// Parameters:
+// offset - offset of return value
+// maxresults - sets the maximum number of items to return in the response.
+// timeout - sets the maximum time that the server can spend processing the request, in seconds. The default is
+// 30 seconds.
 func (client PagingClient) GetMultiplePagesWithOffset(ctx context.Context, offset int32, clientRequestID string, maxresults *int32, timeout *int32) (result ProductResultPage, err error) {
 	result.fn = client.getMultiplePagesWithOffsetNextResults
 	req, err := client.GetMultiplePagesWithOffsetPreparer(ctx, offset, clientRequestID, maxresults, timeout)
@@ -704,9 +708,10 @@ func (client PagingClient) GetMultiplePagesWithOffsetComplete(ctx context.Contex
 }
 
 // GetOdataMultiplePages a paging operation that includes a nextLink in odata format that has 10 pages
-//
-// maxresults is sets the maximum number of items to return in the response. timeout is sets the maximum time that
-// the server can spend processing the request, in seconds. The default is 30 seconds.
+// Parameters:
+// maxresults - sets the maximum number of items to return in the response.
+// timeout - sets the maximum time that the server can spend processing the request, in seconds. The default is
+// 30 seconds.
 func (client PagingClient) GetOdataMultiplePages(ctx context.Context, clientRequestID string, maxresults *int32, timeout *int32) (result OdataProductResultPage, err error) {
 	result.fn = client.getOdataMultiplePagesNextResults
 	req, err := client.GetOdataMultiplePagesPreparer(ctx, clientRequestID, maxresults, timeout)
@@ -962,9 +967,10 @@ func (client PagingClient) GetSinglePagesFailureComplete(ctx context.Context) (r
 }
 
 // NextFragment a paging operation that doesn't return a full URL, just a fragment
-//
-// APIVersion is sets the api version to use. tenant is sets the tenant to use. nextLink is next link for list
-// operation.
+// Parameters:
+// APIVersion - sets the api version to use.
+// tenant - sets the tenant to use.
+// nextLink - next link for list operation.
 func (client PagingClient) NextFragment(ctx context.Context, APIVersion string, tenant string, nextLink string) (result OdataProductResult, err error) {
 	req, err := client.NextFragmentPreparer(ctx, APIVersion, tenant, nextLink)
 	if err != nil {
@@ -1027,9 +1033,10 @@ func (client PagingClient) NextFragmentResponder(resp *http.Response) (result Od
 }
 
 // NextFragmentWithGrouping a paging operation that doesn't return a full URL, just a fragment
-//
-// APIVersion is sets the api version to use. tenant is sets the tenant to use. nextLink is next link for list
-// operation.
+// Parameters:
+// APIVersion - sets the api version to use.
+// tenant - sets the tenant to use.
+// nextLink - next link for list operation.
 func (client PagingClient) NextFragmentWithGrouping(ctx context.Context, APIVersion string, tenant string, nextLink string) (result OdataProductResult, err error) {
 	req, err := client.NextFragmentWithGroupingPreparer(ctx, APIVersion, tenant, nextLink)
 	if err != nil {

--- a/test/src/tests/generated/report/client.go
+++ b/test/src/tests/generated/report/client.go
@@ -41,9 +41,9 @@ func NewWithBaseURI(baseURI string) BaseClient {
 }
 
 // GetReport get test coverage report
-//
-// qualifier is if specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The only
-// effect is, that generators that run all tests several times, can distinguish the generated reports.
+// Parameters:
+// qualifier - if specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The
+// only effect is, that generators that run all tests several times, can distinguish the generated reports.
 func (client BaseClient) GetReport(ctx context.Context, qualifier string) (result SetInt32, err error) {
 	req, err := client.GetReportPreparer(ctx, qualifier)
 	if err != nil {

--- a/test/src/tests/generated/required-optional/explicit.go
+++ b/test/src/tests/generated/required-optional/explicit.go
@@ -30,7 +30,6 @@ func NewExplicitClientWithBaseURI(baseURI string, requiredGlobalPath string, req
 }
 
 // PostOptionalArrayHeader test explicitly optional integer. Please put a header 'headerParameter' => null.
-//
 func (client ExplicitClient) PostOptionalArrayHeader(ctx context.Context, headerParameter []string) (result autorest.Response, err error) {
 	req, err := client.PostOptionalArrayHeaderPreparer(ctx, headerParameter)
 	if err != nil {
@@ -86,7 +85,6 @@ func (client ExplicitClient) PostOptionalArrayHeaderResponder(resp *http.Respons
 }
 
 // PostOptionalArrayParameter test explicitly optional array. Please put null.
-//
 func (client ExplicitClient) PostOptionalArrayParameter(ctx context.Context, bodyParameter []string) (result autorest.Response, err error) {
 	req, err := client.PostOptionalArrayParameterPreparer(ctx, bodyParameter)
 	if err != nil {
@@ -143,7 +141,6 @@ func (client ExplicitClient) PostOptionalArrayParameterResponder(resp *http.Resp
 }
 
 // PostOptionalArrayProperty test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
-//
 func (client ExplicitClient) PostOptionalArrayProperty(ctx context.Context, bodyParameter *ArrayOptionalWrapper) (result autorest.Response, err error) {
 	req, err := client.PostOptionalArrayPropertyPreparer(ctx, bodyParameter)
 	if err != nil {
@@ -200,7 +197,6 @@ func (client ExplicitClient) PostOptionalArrayPropertyResponder(resp *http.Respo
 }
 
 // PostOptionalClassParameter test explicitly optional complex object. Please put null.
-//
 func (client ExplicitClient) PostOptionalClassParameter(ctx context.Context, bodyParameter *Product) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: bodyParameter,
@@ -265,7 +261,6 @@ func (client ExplicitClient) PostOptionalClassParameterResponder(resp *http.Resp
 
 // PostOptionalClassProperty test explicitly optional complex object. Please put a valid class-wrapper with 'value' =
 // null.
-//
 func (client ExplicitClient) PostOptionalClassProperty(ctx context.Context, bodyParameter *ClassOptionalWrapper) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: bodyParameter,
@@ -331,7 +326,6 @@ func (client ExplicitClient) PostOptionalClassPropertyResponder(resp *http.Respo
 }
 
 // PostOptionalIntegerHeader test explicitly optional integer. Please put a header 'headerParameter' => null.
-//
 func (client ExplicitClient) PostOptionalIntegerHeader(ctx context.Context, headerParameter *int32) (result autorest.Response, err error) {
 	req, err := client.PostOptionalIntegerHeaderPreparer(ctx, headerParameter)
 	if err != nil {
@@ -387,7 +381,6 @@ func (client ExplicitClient) PostOptionalIntegerHeaderResponder(resp *http.Respo
 }
 
 // PostOptionalIntegerParameter test explicitly optional integer. Please put null.
-//
 func (client ExplicitClient) PostOptionalIntegerParameter(ctx context.Context, bodyParameter *int32) (result autorest.Response, err error) {
 	req, err := client.PostOptionalIntegerParameterPreparer(ctx, bodyParameter)
 	if err != nil {
@@ -444,7 +437,6 @@ func (client ExplicitClient) PostOptionalIntegerParameterResponder(resp *http.Re
 }
 
 // PostOptionalIntegerProperty test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
-//
 func (client ExplicitClient) PostOptionalIntegerProperty(ctx context.Context, bodyParameter *IntOptionalWrapper) (result autorest.Response, err error) {
 	req, err := client.PostOptionalIntegerPropertyPreparer(ctx, bodyParameter)
 	if err != nil {
@@ -501,7 +493,6 @@ func (client ExplicitClient) PostOptionalIntegerPropertyResponder(resp *http.Res
 }
 
 // PostOptionalStringHeader test explicitly optional string. Please put a header 'headerParameter' => null.
-//
 func (client ExplicitClient) PostOptionalStringHeader(ctx context.Context, bodyParameter string) (result autorest.Response, err error) {
 	req, err := client.PostOptionalStringHeaderPreparer(ctx, bodyParameter)
 	if err != nil {
@@ -557,7 +548,6 @@ func (client ExplicitClient) PostOptionalStringHeaderResponder(resp *http.Respon
 }
 
 // PostOptionalStringParameter test explicitly optional string. Please put null.
-//
 func (client ExplicitClient) PostOptionalStringParameter(ctx context.Context, bodyParameter string) (result autorest.Response, err error) {
 	req, err := client.PostOptionalStringParameterPreparer(ctx, bodyParameter)
 	if err != nil {
@@ -614,7 +604,6 @@ func (client ExplicitClient) PostOptionalStringParameterResponder(resp *http.Res
 }
 
 // PostOptionalStringProperty test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
-//
 func (client ExplicitClient) PostOptionalStringProperty(ctx context.Context, bodyParameter *StringOptionalWrapper) (result autorest.Response, err error) {
 	req, err := client.PostOptionalStringPropertyPreparer(ctx, bodyParameter)
 	if err != nil {
@@ -672,7 +661,6 @@ func (client ExplicitClient) PostOptionalStringPropertyResponder(resp *http.Resp
 
 // PostRequiredArrayHeader test explicitly required array. Please put a header 'headerParameter' => null and the client
 // library should throw before the request is sent.
-//
 func (client ExplicitClient) PostRequiredArrayHeader(ctx context.Context, headerParameter []string) (result Error, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: headerParameter,
@@ -733,7 +721,6 @@ func (client ExplicitClient) PostRequiredArrayHeaderResponder(resp *http.Respons
 
 // PostRequiredArrayParameter test explicitly required array. Please put null and the client library should throw
 // before the request is sent.
-//
 func (client ExplicitClient) PostRequiredArrayParameter(ctx context.Context, bodyParameter []string) (result Error, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: bodyParameter,
@@ -795,7 +782,6 @@ func (client ExplicitClient) PostRequiredArrayParameterResponder(resp *http.Resp
 
 // PostRequiredArrayProperty test explicitly required array. Please put a valid array-wrapper with 'value' = null and
 // the client library should throw before the request is sent.
-//
 func (client ExplicitClient) PostRequiredArrayProperty(ctx context.Context, bodyParameter ArrayWrapper) (result Error, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: bodyParameter,
@@ -857,7 +843,6 @@ func (client ExplicitClient) PostRequiredArrayPropertyResponder(resp *http.Respo
 
 // PostRequiredClassParameter test explicitly required complex object. Please put null and the client library should
 // throw before the request is sent.
-//
 func (client ExplicitClient) PostRequiredClassParameter(ctx context.Context, bodyParameter Product) (result Error, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: bodyParameter,
@@ -919,7 +904,6 @@ func (client ExplicitClient) PostRequiredClassParameterResponder(resp *http.Resp
 
 // PostRequiredClassProperty test explicitly required complex object. Please put a valid class-wrapper with 'value' =
 // null and the client library should throw before the request is sent.
-//
 func (client ExplicitClient) PostRequiredClassProperty(ctx context.Context, bodyParameter ClassWrapper) (result Error, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: bodyParameter,
@@ -982,7 +966,6 @@ func (client ExplicitClient) PostRequiredClassPropertyResponder(resp *http.Respo
 
 // PostRequiredIntegerHeader test explicitly required integer. Please put a header 'headerParameter' => null and the
 // client library should throw before the request is sent.
-//
 func (client ExplicitClient) PostRequiredIntegerHeader(ctx context.Context, headerParameter int32) (result Error, err error) {
 	req, err := client.PostRequiredIntegerHeaderPreparer(ctx, headerParameter)
 	if err != nil {
@@ -1037,7 +1020,6 @@ func (client ExplicitClient) PostRequiredIntegerHeaderResponder(resp *http.Respo
 
 // PostRequiredIntegerParameter test explicitly required integer. Please put null and the client library should throw
 // before the request is sent.
-//
 func (client ExplicitClient) PostRequiredIntegerParameter(ctx context.Context, bodyParameter int32) (result Error, err error) {
 	req, err := client.PostRequiredIntegerParameterPreparer(ctx, bodyParameter)
 	if err != nil {
@@ -1093,7 +1075,6 @@ func (client ExplicitClient) PostRequiredIntegerParameterResponder(resp *http.Re
 
 // PostRequiredIntegerProperty test explicitly required integer. Please put a valid int-wrapper with 'value' = null and
 // the client library should throw before the request is sent.
-//
 func (client ExplicitClient) PostRequiredIntegerProperty(ctx context.Context, bodyParameter IntWrapper) (result Error, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: bodyParameter,
@@ -1155,7 +1136,6 @@ func (client ExplicitClient) PostRequiredIntegerPropertyResponder(resp *http.Res
 
 // PostRequiredStringHeader test explicitly required string. Please put a header 'headerParameter' => null and the
 // client library should throw before the request is sent.
-//
 func (client ExplicitClient) PostRequiredStringHeader(ctx context.Context, headerParameter string) (result Error, err error) {
 	req, err := client.PostRequiredStringHeaderPreparer(ctx, headerParameter)
 	if err != nil {
@@ -1210,7 +1190,6 @@ func (client ExplicitClient) PostRequiredStringHeaderResponder(resp *http.Respon
 
 // PostRequiredStringParameter test explicitly required string. Please put null and the client library should throw
 // before the request is sent.
-//
 func (client ExplicitClient) PostRequiredStringParameter(ctx context.Context, bodyParameter string) (result Error, err error) {
 	req, err := client.PostRequiredStringParameterPreparer(ctx, bodyParameter)
 	if err != nil {
@@ -1266,7 +1245,6 @@ func (client ExplicitClient) PostRequiredStringParameterResponder(resp *http.Res
 
 // PostRequiredStringProperty test explicitly required string. Please put a valid string-wrapper with 'value' = null
 // and the client library should throw before the request is sent.
-//
 func (client ExplicitClient) PostRequiredStringProperty(ctx context.Context, bodyParameter StringWrapper) (result Error, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: bodyParameter,

--- a/test/src/tests/generated/required-optional/implicit.go
+++ b/test/src/tests/generated/required-optional/implicit.go
@@ -200,7 +200,6 @@ func (client ImplicitClient) GetRequiredGlobalQueryResponder(resp *http.Response
 }
 
 // GetRequiredPath test implicitly required path parameter
-//
 func (client ImplicitClient) GetRequiredPath(ctx context.Context, pathParameter string) (result Error, err error) {
 	req, err := client.GetRequiredPathPreparer(ctx, pathParameter)
 	if err != nil {
@@ -257,7 +256,6 @@ func (client ImplicitClient) GetRequiredPathResponder(resp *http.Response) (resu
 }
 
 // PutOptionalBody test implicitly optional body parameter
-//
 func (client ImplicitClient) PutOptionalBody(ctx context.Context, bodyParameter string) (result autorest.Response, err error) {
 	req, err := client.PutOptionalBodyPreparer(ctx, bodyParameter)
 	if err != nil {
@@ -314,7 +312,6 @@ func (client ImplicitClient) PutOptionalBodyResponder(resp *http.Response) (resu
 }
 
 // PutOptionalHeader test implicitly optional header parameter
-//
 func (client ImplicitClient) PutOptionalHeader(ctx context.Context, queryParameter string) (result autorest.Response, err error) {
 	req, err := client.PutOptionalHeaderPreparer(ctx, queryParameter)
 	if err != nil {
@@ -370,7 +367,6 @@ func (client ImplicitClient) PutOptionalHeaderResponder(resp *http.Response) (re
 }
 
 // PutOptionalQuery test implicitly optional query parameter
-//
 func (client ImplicitClient) PutOptionalQuery(ctx context.Context, queryParameter string) (result autorest.Response, err error) {
 	req, err := client.PutOptionalQueryPreparer(ctx, queryParameter)
 	if err != nil {

--- a/test/src/tests/generated/url/pathitems.go
+++ b/test/src/tests/generated/url/pathitems.go
@@ -31,10 +31,11 @@ func NewPathItemsClientWithBaseURI(baseURI string, globalStringPath string, glob
 // GetAllWithValues send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath',
 // localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery',
 // localStringQuery='localStringQuery'
-//
-// localStringPath is should contain value 'localStringPath' pathItemStringPath is a string value
-// 'pathItemStringPath' that appears in the path localStringQuery is should contain value 'localStringQuery'
-// pathItemStringQuery is a string value 'pathItemStringQuery' that appears as a query parameter
+// Parameters:
+// localStringPath - should contain value 'localStringPath'
+// pathItemStringPath - a string value 'pathItemStringPath' that appears in the path
+// localStringQuery - should contain value 'localStringQuery'
+// pathItemStringQuery - a string value 'pathItemStringQuery' that appears as a query parameter
 func (client PathItemsClient) GetAllWithValues(ctx context.Context, localStringPath string, pathItemStringPath string, localStringQuery string, pathItemStringQuery string) (result autorest.Response, err error) {
 	req, err := client.GetAllWithValuesPreparer(ctx, localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery)
 	if err != nil {
@@ -106,10 +107,11 @@ func (client PathItemsClient) GetAllWithValuesResponder(resp *http.Response) (re
 // GetGlobalAndLocalQueryNull send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath',
 // localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery',
 // localStringQuery=null
-//
-// localStringPath is should contain value 'localStringPath' pathItemStringPath is a string value
-// 'pathItemStringPath' that appears in the path localStringQuery is should contain null value pathItemStringQuery
-// is a string value 'pathItemStringQuery' that appears as a query parameter
+// Parameters:
+// localStringPath - should contain value 'localStringPath'
+// pathItemStringPath - a string value 'pathItemStringPath' that appears in the path
+// localStringQuery - should contain null value
+// pathItemStringQuery - a string value 'pathItemStringQuery' that appears as a query parameter
 func (client PathItemsClient) GetGlobalAndLocalQueryNull(ctx context.Context, localStringPath string, pathItemStringPath string, localStringQuery string, pathItemStringQuery string) (result autorest.Response, err error) {
 	req, err := client.GetGlobalAndLocalQueryNullPreparer(ctx, localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery)
 	if err != nil {
@@ -181,10 +183,11 @@ func (client PathItemsClient) GetGlobalAndLocalQueryNullResponder(resp *http.Res
 // GetGlobalQueryNull send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath',
 // localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery',
 // localStringQuery='localStringQuery'
-//
-// localStringPath is should contain value 'localStringPath' pathItemStringPath is a string value
-// 'pathItemStringPath' that appears in the path localStringQuery is should contain value 'localStringQuery'
-// pathItemStringQuery is a string value 'pathItemStringQuery' that appears as a query parameter
+// Parameters:
+// localStringPath - should contain value 'localStringPath'
+// pathItemStringPath - a string value 'pathItemStringPath' that appears in the path
+// localStringQuery - should contain value 'localStringQuery'
+// pathItemStringQuery - a string value 'pathItemStringQuery' that appears as a query parameter
 func (client PathItemsClient) GetGlobalQueryNull(ctx context.Context, localStringPath string, pathItemStringPath string, localStringQuery string, pathItemStringQuery string) (result autorest.Response, err error) {
 	req, err := client.GetGlobalQueryNullPreparer(ctx, localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery)
 	if err != nil {
@@ -256,10 +259,11 @@ func (client PathItemsClient) GetGlobalQueryNullResponder(resp *http.Response) (
 // GetLocalPathItemQueryNull send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath',
 // localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null,
 // localStringQuery=null
-//
-// localStringPath is should contain value 'localStringPath' pathItemStringPath is a string value
-// 'pathItemStringPath' that appears in the path localStringQuery is should contain value null pathItemStringQuery
-// is should contain value null
+// Parameters:
+// localStringPath - should contain value 'localStringPath'
+// pathItemStringPath - a string value 'pathItemStringPath' that appears in the path
+// localStringQuery - should contain value null
+// pathItemStringQuery - should contain value null
 func (client PathItemsClient) GetLocalPathItemQueryNull(ctx context.Context, localStringPath string, pathItemStringPath string, localStringQuery string, pathItemStringQuery string) (result autorest.Response, err error) {
 	req, err := client.GetLocalPathItemQueryNullPreparer(ctx, localStringPath, pathItemStringPath, localStringQuery, pathItemStringQuery)
 	if err != nil {

--- a/test/src/tests/generated/url/paths.go
+++ b/test/src/tests/generated/url/paths.go
@@ -32,8 +32,8 @@ func NewPathsClientWithBaseURI(baseURI string, globalStringPath string, globalSt
 
 // ArrayCsvInPath get an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array
 // format
-//
-// arrayPath is an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array
+// Parameters:
+// arrayPath - an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array
 // format
 func (client PathsClient) ArrayCsvInPath(ctx context.Context, arrayPath []string) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
@@ -96,8 +96,8 @@ func (client PathsClient) ArrayCsvInPathResponder(resp *http.Response) (result a
 }
 
 // Base64URL get 'lorem' encoded value as 'bG9yZW0' (base64url)
-//
-// base64URLPath is base64url encoded value
+// Parameters:
+// base64URLPath - base64url encoded value
 func (client PathsClient) Base64URL(ctx context.Context, base64URLPath string) (result autorest.Response, err error) {
 	req, err := client.Base64URLPreparer(ctx, base64URLPath)
 	if err != nil {
@@ -208,8 +208,8 @@ func (client PathsClient) ByteEmptyResponder(resp *http.Response) (result autore
 }
 
 // ByteMultiByte get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-//
-// bytePath is '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+// Parameters:
+// bytePath - '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
 func (client PathsClient) ByteMultiByte(ctx context.Context, bytePath []byte) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: bytePath,
@@ -271,8 +271,8 @@ func (client PathsClient) ByteMultiByteResponder(resp *http.Response) (result au
 }
 
 // ByteNull get null as byte array (should throw)
-//
-// bytePath is null as byte array (should throw)
+// Parameters:
+// bytePath - null as byte array (should throw)
 func (client PathsClient) ByteNull(ctx context.Context, bytePath []byte) (result autorest.Response, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: bytePath,
@@ -334,8 +334,8 @@ func (client PathsClient) ByteNullResponder(resp *http.Response) (result autores
 }
 
 // DateNull get null as date - this should throw or be unusable on the client side, depending on date representation
-//
-// datePath is null as date (should throw)
+// Parameters:
+// datePath - null as date (should throw)
 func (client PathsClient) DateNull(ctx context.Context, datePath date.Date) (result autorest.Response, err error) {
 	req, err := client.DateNullPreparer(ctx, datePath)
 	if err != nil {
@@ -391,8 +391,8 @@ func (client PathsClient) DateNullResponder(resp *http.Response) (result autores
 }
 
 // DateTimeNull get null as date-time, should be disallowed or throw depending on representation of date-time
-//
-// dateTimePath is null as date-time
+// Parameters:
+// dateTimePath - null as date-time
 func (client PathsClient) DateTimeNull(ctx context.Context, dateTimePath date.Time) (result autorest.Response, err error) {
 	req, err := client.DateTimeNullPreparer(ctx, dateTimePath)
 	if err != nil {
@@ -668,8 +668,8 @@ func (client PathsClient) DoubleDecimalPositiveResponder(resp *http.Response) (r
 }
 
 // EnumNull get null (should throw on the client before the request is sent on wire)
-//
-// enumPath is send null should throw
+// Parameters:
+// enumPath - send null should throw
 func (client PathsClient) EnumNull(ctx context.Context, enumPath URIColor) (result autorest.Response, err error) {
 	req, err := client.EnumNullPreparer(ctx, enumPath)
 	if err != nil {
@@ -725,8 +725,8 @@ func (client PathsClient) EnumNullResponder(resp *http.Response) (result autores
 }
 
 // EnumValid get using uri with 'green color' in path parameter
-//
-// enumPath is send the value green
+// Parameters:
+// enumPath - send the value green
 func (client PathsClient) EnumValid(ctx context.Context, enumPath URIColor) (result autorest.Response, err error) {
 	req, err := client.EnumValidPreparer(ctx, enumPath)
 	if err != nil {
@@ -1277,8 +1277,8 @@ func (client PathsClient) StringEmptyResponder(resp *http.Response) (result auto
 }
 
 // StringNull get null (should throw)
-//
-// stringPath is null string value
+// Parameters:
+// stringPath - null string value
 func (client PathsClient) StringNull(ctx context.Context, stringPath string) (result autorest.Response, err error) {
 	req, err := client.StringNullPreparer(ctx, stringPath)
 	if err != nil {
@@ -1444,8 +1444,8 @@ func (client PathsClient) StringURLEncodedResponder(resp *http.Response) (result
 }
 
 // UnixTimeURL get the date 2016-04-13 encoded value as '1460505600' (Unix time)
-//
-// unixTimeURLPath is unix time encoded value
+// Parameters:
+// unixTimeURLPath - unix time encoded value
 func (client PathsClient) UnixTimeURL(ctx context.Context, unixTimeURLPath date.UnixTime) (result autorest.Response, err error) {
 	req, err := client.UnixTimeURLPreparer(ctx, unixTimeURLPath)
 	if err != nil {

--- a/test/src/tests/generated/url/queries.go
+++ b/test/src/tests/generated/url/queries.go
@@ -30,8 +30,8 @@ func NewQueriesClientWithBaseURI(baseURI string, globalStringPath string, global
 }
 
 // ArrayStringCsvEmpty get an empty array [] of string using the csv-array format
-//
-// arrayQuery is an empty array [] of string using the csv-array format
+// Parameters:
+// arrayQuery - an empty array [] of string using the csv-array format
 func (client QueriesClient) ArrayStringCsvEmpty(ctx context.Context, arrayQuery []string) (result autorest.Response, err error) {
 	req, err := client.ArrayStringCsvEmptyPreparer(ctx, arrayQuery)
 	if err != nil {
@@ -89,8 +89,8 @@ func (client QueriesClient) ArrayStringCsvEmptyResponder(resp *http.Response) (r
 }
 
 // ArrayStringCsvNull get a null array of string using the csv-array format
-//
-// arrayQuery is a null array of string using the csv-array format
+// Parameters:
+// arrayQuery - a null array of string using the csv-array format
 func (client QueriesClient) ArrayStringCsvNull(ctx context.Context, arrayQuery []string) (result autorest.Response, err error) {
 	req, err := client.ArrayStringCsvNullPreparer(ctx, arrayQuery)
 	if err != nil {
@@ -149,9 +149,9 @@ func (client QueriesClient) ArrayStringCsvNullResponder(resp *http.Response) (re
 
 // ArrayStringCsvValid get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the
 // csv-array format
-//
-// arrayQuery is an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array
-// format
+// Parameters:
+// arrayQuery - an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the
+// csv-array format
 func (client QueriesClient) ArrayStringCsvValid(ctx context.Context, arrayQuery []string) (result autorest.Response, err error) {
 	req, err := client.ArrayStringCsvValidPreparer(ctx, arrayQuery)
 	if err != nil {
@@ -210,9 +210,9 @@ func (client QueriesClient) ArrayStringCsvValidResponder(resp *http.Response) (r
 
 // ArrayStringPipesValid get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the
 // pipes-array format
-//
-// arrayQuery is an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array
-// format
+// Parameters:
+// arrayQuery - an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the
+// pipes-array format
 func (client QueriesClient) ArrayStringPipesValid(ctx context.Context, arrayQuery []string) (result autorest.Response, err error) {
 	req, err := client.ArrayStringPipesValidPreparer(ctx, arrayQuery)
 	if err != nil {
@@ -271,9 +271,9 @@ func (client QueriesClient) ArrayStringPipesValidResponder(resp *http.Response) 
 
 // ArrayStringSsvValid get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the
 // ssv-array format
-//
-// arrayQuery is an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array
-// format
+// Parameters:
+// arrayQuery - an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the
+// ssv-array format
 func (client QueriesClient) ArrayStringSsvValid(ctx context.Context, arrayQuery []string) (result autorest.Response, err error) {
 	req, err := client.ArrayStringSsvValidPreparer(ctx, arrayQuery)
 	if err != nil {
@@ -332,9 +332,9 @@ func (client QueriesClient) ArrayStringSsvValidResponder(resp *http.Response) (r
 
 // ArrayStringTsvValid get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the
 // tsv-array format
-//
-// arrayQuery is an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array
-// format
+// Parameters:
+// arrayQuery - an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the
+// tsv-array format
 func (client QueriesClient) ArrayStringTsvValid(ctx context.Context, arrayQuery []string) (result autorest.Response, err error) {
 	req, err := client.ArrayStringTsvValidPreparer(ctx, arrayQuery)
 	if err != nil {
@@ -448,8 +448,8 @@ func (client QueriesClient) ByteEmptyResponder(resp *http.Response) (result auto
 }
 
 // ByteMultiByte get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-//
-// byteQuery is '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+// Parameters:
+// byteQuery - '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
 func (client QueriesClient) ByteMultiByte(ctx context.Context, byteQuery []byte) (result autorest.Response, err error) {
 	req, err := client.ByteMultiBytePreparer(ctx, byteQuery)
 	if err != nil {
@@ -507,8 +507,8 @@ func (client QueriesClient) ByteMultiByteResponder(resp *http.Response) (result 
 }
 
 // ByteNull get null as byte array (no query parameters in uri)
-//
-// byteQuery is null as byte array (no query parameters in uri)
+// Parameters:
+// byteQuery - null as byte array (no query parameters in uri)
 func (client QueriesClient) ByteNull(ctx context.Context, byteQuery []byte) (result autorest.Response, err error) {
 	req, err := client.ByteNullPreparer(ctx, byteQuery)
 	if err != nil {
@@ -566,8 +566,8 @@ func (client QueriesClient) ByteNullResponder(resp *http.Response) (result autor
 }
 
 // DateNull get null as date - this should result in no query parameters in uri
-//
-// dateQuery is null as date (no query parameters in uri)
+// Parameters:
+// dateQuery - null as date (no query parameters in uri)
 func (client QueriesClient) DateNull(ctx context.Context, dateQuery *date.Date) (result autorest.Response, err error) {
 	req, err := client.DateNullPreparer(ctx, dateQuery)
 	if err != nil {
@@ -625,8 +625,8 @@ func (client QueriesClient) DateNullResponder(resp *http.Response) (result autor
 }
 
 // DateTimeNull get null as date-time, should result in no query parameters in uri
-//
-// dateTimeQuery is null as date-time (no query parameters)
+// Parameters:
+// dateTimeQuery - null as date-time (no query parameters)
 func (client QueriesClient) DateTimeNull(ctx context.Context, dateTimeQuery *date.Time) (result autorest.Response, err error) {
 	req, err := client.DateTimeNullPreparer(ctx, dateTimeQuery)
 	if err != nil {
@@ -908,8 +908,8 @@ func (client QueriesClient) DoubleDecimalPositiveResponder(resp *http.Response) 
 }
 
 // DoubleNull get null numeric value (no query parameter)
-//
-// doubleQuery is null numeric value
+// Parameters:
+// doubleQuery - null numeric value
 func (client QueriesClient) DoubleNull(ctx context.Context, doubleQuery *float64) (result autorest.Response, err error) {
 	req, err := client.DoubleNullPreparer(ctx, doubleQuery)
 	if err != nil {
@@ -967,8 +967,8 @@ func (client QueriesClient) DoubleNullResponder(resp *http.Response) (result aut
 }
 
 // EnumNull get null (no query parameter in url)
-//
-// enumQuery is null string value
+// Parameters:
+// enumQuery - null string value
 func (client QueriesClient) EnumNull(ctx context.Context, enumQuery URIColor) (result autorest.Response, err error) {
 	req, err := client.EnumNullPreparer(ctx, enumQuery)
 	if err != nil {
@@ -1026,8 +1026,8 @@ func (client QueriesClient) EnumNullResponder(resp *http.Response) (result autor
 }
 
 // EnumValid get using uri with query parameter 'green color'
-//
-// enumQuery is 'green color' enum value
+// Parameters:
+// enumQuery - 'green color' enum value
 func (client QueriesClient) EnumValid(ctx context.Context, enumQuery URIColor) (result autorest.Response, err error) {
 	req, err := client.EnumValidPreparer(ctx, enumQuery)
 	if err != nil {
@@ -1085,8 +1085,8 @@ func (client QueriesClient) EnumValidResponder(resp *http.Response) (result auto
 }
 
 // FloatNull get null numeric value (no query parameter)
-//
-// floatQuery is null numeric value
+// Parameters:
+// floatQuery - null numeric value
 func (client QueriesClient) FloatNull(ctx context.Context, floatQuery *float64) (result autorest.Response, err error) {
 	req, err := client.FloatNullPreparer(ctx, floatQuery)
 	if err != nil {
@@ -1312,8 +1312,8 @@ func (client QueriesClient) GetBooleanFalseResponder(resp *http.Response) (resul
 }
 
 // GetBooleanNull get null Boolean value on query (query string should be absent)
-//
-// boolQuery is null boolean value
+// Parameters:
+// boolQuery - null boolean value
 func (client QueriesClient) GetBooleanNull(ctx context.Context, boolQuery *bool) (result autorest.Response, err error) {
 	req, err := client.GetBooleanNullPreparer(ctx, boolQuery)
 	if err != nil {
@@ -1483,8 +1483,8 @@ func (client QueriesClient) GetIntNegativeOneMillionResponder(resp *http.Respons
 }
 
 // GetIntNull get null integer value (no query parameter)
-//
-// intQuery is null integer value
+// Parameters:
+// intQuery - null integer value
 func (client QueriesClient) GetIntNull(ctx context.Context, intQuery *int32) (result autorest.Response, err error) {
 	req, err := client.GetIntNullPreparer(ctx, intQuery)
 	if err != nil {
@@ -1598,8 +1598,8 @@ func (client QueriesClient) GetIntOneMillionResponder(resp *http.Response) (resu
 }
 
 // GetLongNull get 'null 64 bit integer value (no query param in uri)
-//
-// longQuery is null 64 bit integer value
+// Parameters:
+// longQuery - null 64 bit integer value
 func (client QueriesClient) GetLongNull(ctx context.Context, longQuery *int64) (result autorest.Response, err error) {
 	req, err := client.GetLongNullPreparer(ctx, longQuery)
 	if err != nil {
@@ -1825,8 +1825,8 @@ func (client QueriesClient) StringEmptyResponder(resp *http.Response) (result au
 }
 
 // StringNull get null (no query parameter in url)
-//
-// stringQuery is null string value
+// Parameters:
+// stringQuery - null string value
 func (client QueriesClient) StringNull(ctx context.Context, stringQuery string) (result autorest.Response, err error) {
 	req, err := client.StringNullPreparer(ctx, stringQuery)
 	if err != nil {

--- a/test/src/tests/generated/validation/client.go
+++ b/test/src/tests/generated/validation/client.go
@@ -99,7 +99,6 @@ func (client BaseClient) GetWithConstantInPathResponder(resp *http.Response) (re
 }
 
 // PostWithConstantInBody sends the post with constant in body request.
-//
 func (client BaseClient) PostWithConstantInBody(ctx context.Context, body *Product) (result Product, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: body,
@@ -187,9 +186,9 @@ func (client BaseClient) PostWithConstantInBodyResponder(resp *http.Response) (r
 }
 
 // ValidationOfBody validates body parameters on the method. See swagger for details.
-//
-// resourceGroupName is required string between 3 and 10 chars with pattern [a-zA-Z0-9]+. ID is required int
-// multiple of 10 from 100 to 1000.
+// Parameters:
+// resourceGroupName - required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+// ID - required int multiple of 10 from 100 to 1000.
 func (client BaseClient) ValidationOfBody(ctx context.Context, resourceGroupName string, ID int32, body *Product) (result Product, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: resourceGroupName,
@@ -293,9 +292,9 @@ func (client BaseClient) ValidationOfBodyResponder(resp *http.Response) (result 
 }
 
 // ValidationOfMethodParameters validates input parameters on the method. See swagger for details.
-//
-// resourceGroupName is required string between 3 and 10 chars with pattern [a-zA-Z0-9]+. ID is required int
-// multiple of 10 from 100 to 1000.
+// Parameters:
+// resourceGroupName - required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
+// ID - required int multiple of 10 from 100 to 1000.
 func (client BaseClient) ValidationOfMethodParameters(ctx context.Context, resourceGroupName string, ID int32) (result Product, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: resourceGroupName,


### PR DESCRIPTION
Moved the deprecation tag to the begging of the block as that's where
most tooling expects it to be.
Reorganized parameter docs to place each param in its own sentence.