### PR TITLE
Fix XML unmarshalling

### DIFF
--- a/src/Templates/MethodTemplate.cshtml
+++ b/src/Templates/MethodTemplate.cshtml
@@ -183,6 +183,7 @@ func (client @(Model.MethodGroup.ClientName)) @(opIdCamelCase)Responder(resp pip
         return result, NewResponseError(err, resp.Response(), "failed to read response body")
     }
     if len(b) > 0 {
+        b = removeBOM(b)
         err = @(Model.CodeModel.Cast().Encoding).Unmarshal(b, @unmarshalInto)
         if err != nil {
             return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")

--- a/src/Templates/ResponderPolicy.cshtml
+++ b/src/Templates/ResponderPolicy.cshtml
@@ -14,6 +14,7 @@ package @Model.Namespace
 @EmptyLine
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"io/ioutil"
@@ -78,4 +79,10 @@ func validateResponse(resp pipeline.Response, successStatusCodes ...int) error {
 	    }
     }
 	return responseError
+}
+
+// removes any BOM from the byte slice
+func removeBOM(b []byte) []byte {
+    // UTF8
+    return bytes.TrimPrefix(b, []byte("\xef\xbb\xbf"))
 }

--- a/src/Templates/ResponseError.cshtml
+++ b/src/Templates/ResponseError.cshtml
@@ -25,15 +25,6 @@ import (
 // if you want to provide custom error handling set this variable to your constructor function
 var responseErrorFactory func(cause error, response *http.Response, description string) error
 
-// ResponseError identifies a responder-generated network or response parsing error.
-type ResponseError interface {
-	// Error exposes the Error(), Temporary() and Timeout() methods.
-	net.Error // Includes the Go error interface
-@EmptyLine
-	// Response returns the HTTP response. You may examine this but you should not modify it.
-	Response() *http.Response
-}
-
 // NewResponseError creates an error object that implements the error interface.
 func NewResponseError(cause error, response *http.Response, description string) error {
 	if responseErrorFactory != nil {

--- a/test/src/tests/generated/azurereport/client.go
+++ b/test/src/tests/generated/azurereport/client.go
@@ -103,6 +103,7 @@ func (client ManagementClient) getReportResponder(resp pipeline.Response) (pipel
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")

--- a/test/src/tests/generated/azurereport/responder_policy.go
+++ b/test/src/tests/generated/azurereport/responder_policy.go
@@ -7,6 +7,7 @@ package azurereport
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"github.com/Azure/azure-pipeline-go/pipeline"
@@ -67,4 +68,10 @@ func validateResponse(resp pipeline.Response, successStatusCodes ...int) error {
 		}
 	}
 	return responseError
+}
+
+// removes any BOM from the byte slice
+func removeBOM(b []byte) []byte {
+	// UTF8
+	return bytes.TrimPrefix(b, []byte("\xef\xbb\xbf"))
 }

--- a/test/src/tests/generated/azurereport/response_error.go
+++ b/test/src/tests/generated/azurereport/response_error.go
@@ -17,15 +17,6 @@ import (
 // if you want to provide custom error handling set this variable to your constructor function
 var responseErrorFactory func(cause error, response *http.Response, description string) error
 
-// ResponseError identifies a responder-generated network or response parsing error.
-type ResponseError interface {
-	// Error exposes the Error(), Temporary() and Timeout() methods.
-	net.Error // Includes the Go error interface
-
-	// Response returns the HTTP response. You may examine this but you should not modify it.
-	Response() *http.Response
-}
-
 // NewResponseError creates an error object that implements the error interface.
 func NewResponseError(cause error, response *http.Response, description string) error {
 	if responseErrorFactory != nil {

--- a/test/src/tests/generated/body-boolean/bool.go
+++ b/test/src/tests/generated/body-boolean/bool.go
@@ -68,6 +68,7 @@ func (client BoolClient) getFalseResponder(resp pipeline.Response) (pipeline.Res
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -118,6 +119,7 @@ func (client BoolClient) getInvalidResponder(resp pipeline.Response) (pipeline.R
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -168,6 +170,7 @@ func (client BoolClient) getNullResponder(resp pipeline.Response) (pipeline.Resp
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -218,6 +221,7 @@ func (client BoolClient) getTrueResponder(resp pipeline.Response) (pipeline.Resp
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")

--- a/test/src/tests/generated/body-boolean/responder_policy.go
+++ b/test/src/tests/generated/body-boolean/responder_policy.go
@@ -7,6 +7,7 @@ package booleangroup
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"github.com/Azure/azure-pipeline-go/pipeline"
@@ -67,4 +68,10 @@ func validateResponse(resp pipeline.Response, successStatusCodes ...int) error {
 		}
 	}
 	return responseError
+}
+
+// removes any BOM from the byte slice
+func removeBOM(b []byte) []byte {
+	// UTF8
+	return bytes.TrimPrefix(b, []byte("\xef\xbb\xbf"))
 }

--- a/test/src/tests/generated/body-boolean/response_error.go
+++ b/test/src/tests/generated/body-boolean/response_error.go
@@ -17,15 +17,6 @@ import (
 // if you want to provide custom error handling set this variable to your constructor function
 var responseErrorFactory func(cause error, response *http.Response, description string) error
 
-// ResponseError identifies a responder-generated network or response parsing error.
-type ResponseError interface {
-	// Error exposes the Error(), Temporary() and Timeout() methods.
-	net.Error // Includes the Go error interface
-
-	// Response returns the HTTP response. You may examine this but you should not modify it.
-	Response() *http.Response
-}
-
 // NewResponseError creates an error object that implements the error interface.
 func NewResponseError(cause error, response *http.Response, description string) error {
 	if responseErrorFactory != nil {

--- a/test/src/tests/generated/body-byte/byte.go
+++ b/test/src/tests/generated/body-byte/byte.go
@@ -68,6 +68,7 @@ func (client ByteClient) getEmptyResponder(resp pipeline.Response) (pipeline.Res
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -118,6 +119,7 @@ func (client ByteClient) getInvalidResponder(resp pipeline.Response) (pipeline.R
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -168,6 +170,7 @@ func (client ByteClient) getNonASCIIResponder(resp pipeline.Response) (pipeline.
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -218,6 +221,7 @@ func (client ByteClient) getNullResponder(resp pipeline.Response) (pipeline.Resp
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")

--- a/test/src/tests/generated/body-byte/responder_policy.go
+++ b/test/src/tests/generated/body-byte/responder_policy.go
@@ -7,6 +7,7 @@ package bytegroup
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"github.com/Azure/azure-pipeline-go/pipeline"
@@ -67,4 +68,10 @@ func validateResponse(resp pipeline.Response, successStatusCodes ...int) error {
 		}
 	}
 	return responseError
+}
+
+// removes any BOM from the byte slice
+func removeBOM(b []byte) []byte {
+	// UTF8
+	return bytes.TrimPrefix(b, []byte("\xef\xbb\xbf"))
 }

--- a/test/src/tests/generated/body-byte/response_error.go
+++ b/test/src/tests/generated/body-byte/response_error.go
@@ -17,15 +17,6 @@ import (
 // if you want to provide custom error handling set this variable to your constructor function
 var responseErrorFactory func(cause error, response *http.Response, description string) error
 
-// ResponseError identifies a responder-generated network or response parsing error.
-type ResponseError interface {
-	// Error exposes the Error(), Temporary() and Timeout() methods.
-	net.Error // Includes the Go error interface
-
-	// Response returns the HTTP response. You may examine this but you should not modify it.
-	Response() *http.Response
-}
-
 // NewResponseError creates an error object that implements the error interface.
 func NewResponseError(cause error, response *http.Response, description string) error {
 	if responseErrorFactory != nil {

--- a/test/src/tests/generated/body-integer/int.go
+++ b/test/src/tests/generated/body-integer/int.go
@@ -69,6 +69,7 @@ func (client IntClient) getInvalidResponder(resp pipeline.Response) (pipeline.Re
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -119,6 +120,7 @@ func (client IntClient) getInvalidUnixTimeResponder(resp pipeline.Response) (pip
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -169,6 +171,7 @@ func (client IntClient) getNullResponder(resp pipeline.Response) (pipeline.Respo
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -219,6 +222,7 @@ func (client IntClient) getNullUnixTimeResponder(resp pipeline.Response) (pipeli
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -269,6 +273,7 @@ func (client IntClient) getOverflowInt32Responder(resp pipeline.Response) (pipel
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -319,6 +324,7 @@ func (client IntClient) getOverflowInt64Responder(resp pipeline.Response) (pipel
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -369,6 +375,7 @@ func (client IntClient) getUnderflowInt32Responder(resp pipeline.Response) (pipe
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -419,6 +426,7 @@ func (client IntClient) getUnderflowInt64Responder(resp pipeline.Response) (pipe
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -469,6 +477,7 @@ func (client IntClient) getUnixTimeResponder(resp pipeline.Response) (pipeline.R
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")

--- a/test/src/tests/generated/body-integer/responder_policy.go
+++ b/test/src/tests/generated/body-integer/responder_policy.go
@@ -7,6 +7,7 @@ package integergroup
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"github.com/Azure/azure-pipeline-go/pipeline"
@@ -67,4 +68,10 @@ func validateResponse(resp pipeline.Response, successStatusCodes ...int) error {
 		}
 	}
 	return responseError
+}
+
+// removes any BOM from the byte slice
+func removeBOM(b []byte) []byte {
+	// UTF8
+	return bytes.TrimPrefix(b, []byte("\xef\xbb\xbf"))
 }

--- a/test/src/tests/generated/body-integer/response_error.go
+++ b/test/src/tests/generated/body-integer/response_error.go
@@ -17,15 +17,6 @@ import (
 // if you want to provide custom error handling set this variable to your constructor function
 var responseErrorFactory func(cause error, response *http.Response, description string) error
 
-// ResponseError identifies a responder-generated network or response parsing error.
-type ResponseError interface {
-	// Error exposes the Error(), Temporary() and Timeout() methods.
-	net.Error // Includes the Go error interface
-
-	// Response returns the HTTP response. You may examine this but you should not modify it.
-	Response() *http.Response
-}
-
 // NewResponseError creates an error object that implements the error interface.
 func NewResponseError(cause error, response *http.Response, description string) error {
 	if responseErrorFactory != nil {

--- a/test/src/tests/generated/body-string/enum.go
+++ b/test/src/tests/generated/body-string/enum.go
@@ -68,6 +68,7 @@ func (client EnumClient) getNotExpandableResponder(resp pipeline.Response) (pipe
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -118,6 +119,7 @@ func (client EnumClient) getReferencedResponder(resp pipeline.Response) (pipelin
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -168,6 +170,7 @@ func (client EnumClient) getReferencedConstantResponder(resp pipeline.Response) 
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")

--- a/test/src/tests/generated/body-string/responder_policy.go
+++ b/test/src/tests/generated/body-string/responder_policy.go
@@ -7,6 +7,7 @@ package stringgroup
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"github.com/Azure/azure-pipeline-go/pipeline"
@@ -67,4 +68,10 @@ func validateResponse(resp pipeline.Response, successStatusCodes ...int) error {
 		}
 	}
 	return responseError
+}
+
+// removes any BOM from the byte slice
+func removeBOM(b []byte) []byte {
+	// UTF8
+	return bytes.TrimPrefix(b, []byte("\xef\xbb\xbf"))
 }

--- a/test/src/tests/generated/body-string/response_error.go
+++ b/test/src/tests/generated/body-string/response_error.go
@@ -17,15 +17,6 @@ import (
 // if you want to provide custom error handling set this variable to your constructor function
 var responseErrorFactory func(cause error, response *http.Response, description string) error
 
-// ResponseError identifies a responder-generated network or response parsing error.
-type ResponseError interface {
-	// Error exposes the Error(), Temporary() and Timeout() methods.
-	net.Error // Includes the Go error interface
-
-	// Response returns the HTTP response. You may examine this but you should not modify it.
-	Response() *http.Response
-}
-
 // NewResponseError creates an error object that implements the error interface.
 func NewResponseError(cause error, response *http.Response, description string) error {
 	if responseErrorFactory != nil {

--- a/test/src/tests/generated/body-string/string.go
+++ b/test/src/tests/generated/body-string/string.go
@@ -68,6 +68,7 @@ func (client StringClient) getBase64EncodedResponder(resp pipeline.Response) (pi
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -118,6 +119,7 @@ func (client StringClient) getBase64URLEncodedResponder(resp pipeline.Response) 
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -168,6 +170,7 @@ func (client StringClient) getEmptyResponder(resp pipeline.Response) (pipeline.R
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -218,6 +221,7 @@ func (client StringClient) getMbcsResponder(resp pipeline.Response) (pipeline.Re
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -268,6 +272,7 @@ func (client StringClient) getNotProvidedResponder(resp pipeline.Response) (pipe
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -318,6 +323,7 @@ func (client StringClient) getNullResponder(resp pipeline.Response) (pipeline.Re
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -368,6 +374,7 @@ func (client StringClient) getNullBase64URLEncodedResponder(resp pipeline.Respon
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -419,6 +426,7 @@ func (client StringClient) getWhitespaceResponder(resp pipeline.Response) (pipel
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")

--- a/test/src/tests/generated/httpinfrastructure/http_client_failure.go
+++ b/test/src/tests/generated/httpinfrastructure/http_client_failure.go
@@ -78,6 +78,7 @@ func (client HTTPClientFailureClient) delete400Responder(resp pipeline.Response)
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -139,6 +140,7 @@ func (client HTTPClientFailureClient) delete407Responder(resp pipeline.Response)
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -200,6 +202,7 @@ func (client HTTPClientFailureClient) delete417Responder(resp pipeline.Response)
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -250,6 +253,7 @@ func (client HTTPClientFailureClient) get400Responder(resp pipeline.Response) (p
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -300,6 +304,7 @@ func (client HTTPClientFailureClient) get402Responder(resp pipeline.Response) (p
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -350,6 +355,7 @@ func (client HTTPClientFailureClient) get403Responder(resp pipeline.Response) (p
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -400,6 +406,7 @@ func (client HTTPClientFailureClient) get411Responder(resp pipeline.Response) (p
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -450,6 +457,7 @@ func (client HTTPClientFailureClient) get412Responder(resp pipeline.Response) (p
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -500,6 +508,7 @@ func (client HTTPClientFailureClient) get416Responder(resp pipeline.Response) (p
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -550,6 +559,7 @@ func (client HTTPClientFailureClient) head400Responder(resp pipeline.Response) (
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -600,6 +610,7 @@ func (client HTTPClientFailureClient) head401Responder(resp pipeline.Response) (
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -650,6 +661,7 @@ func (client HTTPClientFailureClient) head410Responder(resp pipeline.Response) (
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -700,6 +712,7 @@ func (client HTTPClientFailureClient) head429Responder(resp pipeline.Response) (
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -761,6 +774,7 @@ func (client HTTPClientFailureClient) patch400Responder(resp pipeline.Response) 
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -822,6 +836,7 @@ func (client HTTPClientFailureClient) patch405Responder(resp pipeline.Response) 
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -883,6 +898,7 @@ func (client HTTPClientFailureClient) patch414Responder(resp pipeline.Response) 
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -944,6 +960,7 @@ func (client HTTPClientFailureClient) post400Responder(resp pipeline.Response) (
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -1005,6 +1022,7 @@ func (client HTTPClientFailureClient) post406Responder(resp pipeline.Response) (
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -1066,6 +1084,7 @@ func (client HTTPClientFailureClient) post415Responder(resp pipeline.Response) (
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -1127,6 +1146,7 @@ func (client HTTPClientFailureClient) put400Responder(resp pipeline.Response) (p
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -1188,6 +1208,7 @@ func (client HTTPClientFailureClient) put404Responder(resp pipeline.Response) (p
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -1249,6 +1270,7 @@ func (client HTTPClientFailureClient) put409Responder(resp pipeline.Response) (p
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -1310,6 +1332,7 @@ func (client HTTPClientFailureClient) put413Responder(resp pipeline.Response) (p
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")

--- a/test/src/tests/generated/httpinfrastructure/http_failure.go
+++ b/test/src/tests/generated/httpinfrastructure/http_failure.go
@@ -66,6 +66,7 @@ func (client HTTPFailureClient) getEmptyErrorResponder(resp pipeline.Response) (
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -116,6 +117,7 @@ func (client HTTPFailureClient) getNoModelEmptyResponder(resp pipeline.Response)
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -166,6 +168,7 @@ func (client HTTPFailureClient) getNoModelErrorResponder(resp pipeline.Response)
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")

--- a/test/src/tests/generated/httpinfrastructure/http_redirects.go
+++ b/test/src/tests/generated/httpinfrastructure/http_redirects.go
@@ -116,6 +116,7 @@ func (client HTTPRedirectsClient) get300Responder(resp pipeline.Response) (pipel
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")

--- a/test/src/tests/generated/httpinfrastructure/http_server_failure.go
+++ b/test/src/tests/generated/httpinfrastructure/http_server_failure.go
@@ -78,6 +78,7 @@ func (client HTTPServerFailureClient) delete505Responder(resp pipeline.Response)
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -128,6 +129,7 @@ func (client HTTPServerFailureClient) get501Responder(resp pipeline.Response) (p
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -178,6 +180,7 @@ func (client HTTPServerFailureClient) head501Responder(resp pipeline.Response) (
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -239,6 +242,7 @@ func (client HTTPServerFailureClient) post505Responder(resp pipeline.Response) (
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")

--- a/test/src/tests/generated/httpinfrastructure/http_success.go
+++ b/test/src/tests/generated/httpinfrastructure/http_success.go
@@ -212,6 +212,7 @@ func (client HTTPSuccessClient) get200Responder(resp pipeline.Response) (pipelin
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")

--- a/test/src/tests/generated/httpinfrastructure/multiple_responses.go
+++ b/test/src/tests/generated/httpinfrastructure/multiple_responses.go
@@ -67,6 +67,7 @@ func (client MultipleResponsesClient) get200Model201ModelDefaultError200ValidRes
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -118,6 +119,7 @@ func (client MultipleResponsesClient) get200Model201ModelDefaultError201ValidRes
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -169,6 +171,7 @@ func (client MultipleResponsesClient) get200Model201ModelDefaultError400ValidRes
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -219,6 +222,7 @@ func (client MultipleResponsesClient) get200Model204NoModelDefaultError200ValidR
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -269,6 +273,7 @@ func (client MultipleResponsesClient) get200Model204NoModelDefaultError201Invali
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -319,6 +324,7 @@ func (client MultipleResponsesClient) get200Model204NoModelDefaultError202NoneRe
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -369,6 +375,7 @@ func (client MultipleResponsesClient) get200Model204NoModelDefaultError204ValidR
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -420,6 +427,7 @@ func (client MultipleResponsesClient) get200Model204NoModelDefaultError400ValidR
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -470,6 +478,7 @@ func (client MultipleResponsesClient) get200ModelA200InvalidResponder(resp pipel
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -521,6 +530,7 @@ func (client MultipleResponsesClient) get200ModelA200NoneResponder(resp pipeline
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -571,6 +581,7 @@ func (client MultipleResponsesClient) get200ModelA200ValidResponder(resp pipelin
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -621,6 +632,7 @@ func (client MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -671,6 +683,7 @@ func (client MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -722,6 +735,7 @@ func (client MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -772,6 +786,7 @@ func (client MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -822,6 +837,7 @@ func (client MultipleResponsesClient) get200ModelA202ValidResponder(resp pipelin
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -872,6 +888,7 @@ func (client MultipleResponsesClient) get200ModelA400InvalidResponder(resp pipel
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -922,6 +939,7 @@ func (client MultipleResponsesClient) get200ModelA400NoneResponder(resp pipeline
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -972,6 +990,7 @@ func (client MultipleResponsesClient) get200ModelA400ValidResponder(resp pipelin
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -1282,6 +1301,7 @@ func (client MultipleResponsesClient) getDefaultModelA200NoneResponder(resp pipe
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -1332,6 +1352,7 @@ func (client MultipleResponsesClient) getDefaultModelA200ValidResponder(resp pip
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -1382,6 +1403,7 @@ func (client MultipleResponsesClient) getDefaultModelA400NoneResponder(resp pipe
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
@@ -1432,6 +1454,7 @@ func (client MultipleResponsesClient) getDefaultModelA400ValidResponder(resp pip
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, result)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")

--- a/test/src/tests/generated/httpinfrastructure/responder_policy.go
+++ b/test/src/tests/generated/httpinfrastructure/responder_policy.go
@@ -7,6 +7,7 @@ package httpinfrastructuregroup
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"github.com/Azure/azure-pipeline-go/pipeline"
@@ -67,4 +68,10 @@ func validateResponse(resp pipeline.Response, successStatusCodes ...int) error {
 		}
 	}
 	return responseError
+}
+
+// removes any BOM from the byte slice
+func removeBOM(b []byte) []byte {
+	// UTF8
+	return bytes.TrimPrefix(b, []byte("\xef\xbb\xbf"))
 }

--- a/test/src/tests/generated/httpinfrastructure/response_error.go
+++ b/test/src/tests/generated/httpinfrastructure/response_error.go
@@ -17,15 +17,6 @@ import (
 // if you want to provide custom error handling set this variable to your constructor function
 var responseErrorFactory func(cause error, response *http.Response, description string) error
 
-// ResponseError identifies a responder-generated network or response parsing error.
-type ResponseError interface {
-	// Error exposes the Error(), Temporary() and Timeout() methods.
-	net.Error // Includes the Go error interface
-
-	// Response returns the HTTP response. You may examine this but you should not modify it.
-	Response() *http.Response
-}
-
 // NewResponseError creates an error object that implements the error interface.
 func NewResponseError(cause error, response *http.Response, description string) error {
 	if responseErrorFactory != nil {

--- a/test/src/tests/generated/report/client.go
+++ b/test/src/tests/generated/report/client.go
@@ -103,6 +103,7 @@ func (client ManagementClient) getReportResponder(resp pipeline.Response) (pipel
 		return result, NewResponseError(err, resp.Response(), "failed to read response body")
 	}
 	if len(b) > 0 {
+		b = removeBOM(b)
 		err = json.Unmarshal(b, &result.Value)
 		if err != nil {
 			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")

--- a/test/src/tests/generated/report/responder_policy.go
+++ b/test/src/tests/generated/report/responder_policy.go
@@ -7,6 +7,7 @@ package report
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"github.com/Azure/azure-pipeline-go/pipeline"
@@ -67,4 +68,10 @@ func validateResponse(resp pipeline.Response, successStatusCodes ...int) error {
 		}
 	}
 	return responseError
+}
+
+// removes any BOM from the byte slice
+func removeBOM(b []byte) []byte {
+	// UTF8
+	return bytes.TrimPrefix(b, []byte("\xef\xbb\xbf"))
 }

--- a/test/src/tests/generated/report/response_error.go
+++ b/test/src/tests/generated/report/response_error.go
@@ -17,15 +17,6 @@ import (
 // if you want to provide custom error handling set this variable to your constructor function
 var responseErrorFactory func(cause error, response *http.Response, description string) error
 
-// ResponseError identifies a responder-generated network or response parsing error.
-type ResponseError interface {
-	// Error exposes the Error(), Temporary() and Timeout() methods.
-	net.Error // Includes the Go error interface
-
-	// Response returns the HTTP response. You may examine this but you should not modify it.
-	Response() *http.Response
-}
-
 // NewResponseError creates an error object that implements the error interface.
 func NewResponseError(cause error, response *http.Response, description string) error {
 	if responseErrorFactory != nil {


### PR DESCRIPTION
Avoid type name collisions for XML wrapper types.
Remove UTF8 BOM from byte slice before unmarshalling.
Remove unnecessary ResponseError interface.