### PR TITLE
Update LRO codegen to use latest go-autorest features

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Azure/autorest.go/blob/master/README.md",
   "devDependencies": {
-    "@microsoft.azure/autorest.testserver": "^2.4.2",
+    "@microsoft.azure/autorest.testserver": "^2.5.12",
     "@microsoft.azure/autorest.modeler": "2.3.47",
     "autorest": "^2.0.4222",
     "coffee-script": "^1.11.1",

--- a/src/Model/FutureTypeGo.cs
+++ b/src/Model/FutureTypeGo.cs
@@ -53,7 +53,7 @@ namespace AutoRest.Go.Model
 
         public override string Fields()
         {
-            return "    azure.Future\n    req *http.Request";
+            return "    azure.Future";
         }
 
         /// <summary>

--- a/src/Templates/MethodTemplate.cshtml
+++ b/src/Templates/MethodTemplate.cshtml
@@ -144,7 +144,7 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
             @:}
         }
         @:@EmptyLine
-}
+    }
 
     @if (Model.FormDataParameters.Any())
     {
@@ -221,15 +221,17 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
     @if (Model.IsLongRunningOperation())
     {
         <text>
-        sender := autorest.DecorateSender(client, @Model.SendDecorators.EmitAsArguments())
-        future.Future = azure.NewFuture(req)
-        future.req = req
-        _, err = future.Done(sender)
+        var resp *http.Response
+        resp, err = autorest.SendWithSender(client, req,
+            @(Model.SendDecorators.EmitAsArguments()))
         if err != nil {
-        return
+            return
         }
-        err = autorest.Respond(future.Response(),
-        azure.WithErrorUnlessStatusCode(@(string.Join(",", Model.ResponseCodes.ToArray()))))
+        err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(@(string.Join(",", Model.ResponseCodes.ToArray()))))
+        if err != nil {
+            return
+        }
+        future.Future, err = azure.NewFutureFromResponse(resp)
         return
         </text>
     }

--- a/src/Templates/ModelTemplate.cshtml
+++ b/src/Templates/ModelTemplate.cshtml
@@ -446,10 +446,15 @@ else
     }
     @if (ftg.ResultTypeName == MethodGo.DefaultReturnType)
     {
+        // for default return types (i.e. autorest.Response)
+        // assign the raw HTTP response to the *http.Response field
     @:@(resultVar).Response = future.Response()
     }
     else
     {
+        // modeled return types embed autorest.Resposne as an anonymous field
+        // so in order to assign the raw HTTP response to the *http.Response field
+        // in it we need an extra ".Response" :(
     <text>
     sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
     if @(resultVar).Response.Response, err = future.GetResult(sender); err == nil && @(resultVar).Response.Response.StatusCode != http.StatusNoContent {

--- a/src/Templates/ModelTemplate.cshtml
+++ b/src/Templates/ModelTemplate.cshtml
@@ -426,14 +426,14 @@ else
     var resultVar = ftg.ResultTypeName.ToShortName();
     var resultVarTarget = resultVar;
     var futureTypeName = $"{Model.CodeModel.Namespace}.{Model.Name}";
-    if (ftg.ResultType is IteratorTypeGo)
+    if (ftg.ResultType is IteratorTypeGo itg)
     {
-        resultVarTarget = $"{resultVarTarget}.{ftg.ResultType.Cast<IteratorTypeGo>().PageField}";
+        resultVarTarget = $"{resultVarTarget}.{itg.PageField}";
     }
     <text>
     // Result returns the result of the asynchronous operation.
     // If the operation has not completed it will return an error.
-    func (future @Model.Name) Result(client @ftg.ClientTypeName) (@resultVar @ftg.ResultTypeName, err error) {
+    func (future *@Model.Name) Result(client @ftg.ClientTypeName) (@resultVar @ftg.ResultTypeName, err error) {
     var done bool
     done, err = future.Done(client)
     if err != nil {
@@ -441,36 +441,26 @@ else
         return
     }
     if !done {
-        return @resultVar, azure.NewAsyncOpIncompleteError("@futureTypeName")
-    }
-    if future.PollingMethod() == azure.PollingLocation {
-        @resultVarTarget, err = client.@(ftg.ResponderMethodName)(future.Response())
-        if err != nil {
-            err = autorest.NewErrorWithError(err, "@futureTypeName", "Result", future.Response(), "Failure responding to request")
-        }
+        err = azure.NewAsyncOpIncompleteError("@futureTypeName")
         return
     }
-    var req *http.Request
-    var resp *http.Response
-    if future.PollingURL() != "" {
-        req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+    @if (ftg.ResultTypeName == MethodGo.DefaultReturnType)
+    {
+    @:@(resultVar).Response = future.Response()
+    }
+    else
+    {
+    <text>
+    sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+    if @(resultVar).Response.Response, err = future.GetResult(sender); err == nil && @(resultVar).Response.Response.StatusCode != http.StatusNoContent {
+        @resultVar, err = client.@(ftg.ResponderMethodName)(@(resultVar).Response.Response)
         if err != nil {
-            return
+            err = autorest.NewErrorWithError(err, "@futureTypeName", "Result", @(resultVar).Response.Response, "Failure responding to request")
         }
-    } else {
-        req = autorest.ChangeToGet(future.req)
     }
-    resp, err = autorest.SendWithSender(client, req,
-    autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-    if err != nil {
-        err = autorest.NewErrorWithError(err, "@futureTypeName", "Result", resp, "Failure sending request")
-        return
-    }
-    @resultVarTarget, err = client.@(ftg.ResponderMethodName)(resp)
-    if err != nil {
-        err = autorest.NewErrorWithError(err, "@futureTypeName", "Result", resp, "Failure responding to request")
+    </text>
     }
     return
-    }
+}
     </text>
 }

--- a/test/src/tests/Gopkg.lock
+++ b/test/src/tests/Gopkg.lock
@@ -3,15 +3,22 @@
 
 [[projects]]
   name = "github.com/Azure/go-autorest"
-  packages = ["autorest","autorest/adal","autorest/azure","autorest/date","autorest/to","autorest/validation"]
-  revision = "5a06e9ddbe3c22262059b8e061777b9934f982bd"
-  version = "v10.1.0"
+  packages = [
+    "autorest",
+    "autorest/adal",
+    "autorest/azure",
+    "autorest/date",
+    "autorest/to",
+    "autorest/validation"
+  ]
+  revision = "aa2a4534ab680e938d933870f58f23f77e0e208e"
+  version = "v10.9.0"
 
 [[projects]]
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
-  revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
-  version = "v3.1.0"
+  revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
+  version = "v3.2.0"
 
 [[projects]]
   name = "github.com/satori/go.uuid"
@@ -22,8 +29,8 @@
 [[projects]]
   name = "github.com/shopspring/decimal"
   packages = ["."]
-  revision = "9ca7f51822d222ae4e246f070f9aad863599bd1a"
-  version = "1.0.0"
+  revision = "69b3a8ad1f5f2c8bd855cb6506d18593064a346b"
+  version = "1.0.1"
 
 [[projects]]
   branch = "v1"
@@ -34,6 +41,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2d94dae623e39f83b9a0d422b69f182c46eb9839eaf9a03588ba16c4ec1c2ced"
+  inputs-digest = "1acc242dfe17f51d49d3477e977271b5bd1bd54f3f7d7f32db1b28009f612acf"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/test/src/tests/Gopkg.toml
+++ b/test/src/tests/Gopkg.toml
@@ -22,7 +22,7 @@
 
 [[constraint]]
   name = "github.com/Azure/go-autorest"
-  version = "10.1.0"
+  version = "10.9.0"
 
 [[constraint]]
   name = "github.com/satori/go.uuid"

--- a/test/src/tests/acceptancetests/lrogrouptest/lro_test.go
+++ b/test/src/tests/acceptancetests/lrogrouptest/lro_test.go
@@ -635,6 +635,11 @@ func (s *LROSuite) TestSADsPutNonRetry400(c *chk.C) {
 
 // custom header client
 
+// NOTE: at this time the Go SDK doesn't expose means to include custom headers in LROs.
+//       while you can add it to the initial request by calling the preparer and sender
+//       explicitly (see below) there is no way to include the custom header data in the
+//       LRO polling request.  as a result these tests will all fail so they are empty for now.
+
 func (s *LROSuite) TestCustomHeaderPost202Retry200(c *chk.C) {
 	/*req, err := lroCustomHeaderClient.Post202Retry200Preparer(context.Background(), &lrogroup.Product{})
 	c.Assert(err, chk.IsNil)

--- a/test/src/tests/acceptancetests/lrogrouptest/lro_test.go
+++ b/test/src/tests/acceptancetests/lrogrouptest/lro_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/go-autorest/autorest/to"
 	chk "gopkg.in/check.v1"
 
 	"tests/acceptancetests/utils"
-	. "tests/generated/lro"
+	"tests/generated/lro"
 )
 
 func Test(t *testing.T) { chk.TestingT(t) }
@@ -23,38 +24,113 @@ var lrosClient = getLROsClient()
 var lroSADSClient = getLROSADsClient()
 var lroCustomHeaderClient = getLROsCustomHeaderClient()
 
-func getLRORetrysClient() LRORetrysClient {
-	c := NewLRORetrysClient()
+func getLRORetrysClient() lrogroup.LRORetrysClient {
+	c := lrogroup.NewLRORetrysClient()
 	c.RetryDuration = 1
+	c.PollingDelay = time.Second
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
-func getLROsClient() LROsClient {
-	c := NewLROsClient()
+func getLROsClient() lrogroup.LROsClient {
+	c := lrogroup.NewLROsClient()
 	c.RetryDuration = 1
+	c.PollingDelay = time.Second
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
-func getLROSADsClient() LROSADsClient {
-	c := NewLROSADsClient()
+func getLROSADsClient() lrogroup.LROSADsClient {
+	c := lrogroup.NewLROSADsClient()
 	c.RetryDuration = 1
+	c.PollingDelay = time.Second
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
 
-func getLROsCustomHeaderClient() LROsCustomHeaderClient {
-	c := NewLROsCustomHeaderClient()
+func getLROsCustomHeaderClient() lrogroup.LROsCustomHeaderClient {
+	c := lrogroup.NewLROsCustomHeaderClient()
 	c.RetryDuration = 1
+	c.PollingDelay = time.Second
 	c.BaseURI = utils.GetBaseURI()
 	return c
 }
+
+// retry client
+
+func (s *LROSuite) TestRetryDelete202Retry200(c *chk.C) {
+	future, err := lroRetryClient.Delete202Retry200(context.Background())
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lroRetryClient.Client)
+	c.Assert(err, chk.IsNil)
+	r, err := future.Result(lroRetryClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.StatusCode, chk.Equals, http.StatusOK)
+}
+
+func (s *LROSuite) TestRetryDeleteAsyncRelativeRetrySucceeded(c *chk.C) {
+	future, err := lroRetryClient.DeleteAsyncRelativeRetrySucceeded(context.Background())
+	c.Assert(err, chk.IsNil)
+	c.Assert(future.Response().StatusCode, chk.Equals, http.StatusAccepted)
+	err = future.WaitForCompletionRef(context.Background(), lroRetryClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *LROSuite) TestRetryDeleteProvisioning202Accepted200Succeeded(c *chk.C) {
+	future, err := lroRetryClient.DeleteProvisioning202Accepted200Succeeded(context.Background())
+	c.Assert(err, chk.IsNil)
+	c.Assert(future.Response().StatusCode, chk.Equals, http.StatusAccepted)
+	err = future.WaitForCompletionRef(context.Background(), lroRetryClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *LROSuite) TestRetryPost202Retry200(c *chk.C) {
+	future, err := lroRetryClient.Post202Retry200(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lroRetryClient.Client)
+	c.Assert(err, chk.IsNil)
+	r, err := future.Result(lroRetryClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.StatusCode, chk.Equals, http.StatusOK)
+}
+
+func (s *LROSuite) TestRetryPostAsyncRelativeRetrySucceeded(c *chk.C) {
+	future, err := lroRetryClient.PostAsyncRelativeRetrySucceeded(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lroRetryClient.Client)
+	c.Assert(err, chk.IsNil)
+	r, err := future.Result(lroRetryClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.StatusCode, chk.Equals, http.StatusOK)
+}
+
+func (s *LROSuite) TestRetryPut201CreatingSucceeded200(c *chk.C) {
+	future, err := lroRetryClient.Put201CreatingSucceeded200(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lroRetryClient.Client)
+	c.Assert(err, chk.IsNil)
+	r, err := future.Result(lroRetryClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.StatusCode, chk.Equals, http.StatusOK)
+	c.Assert(r.Name, chk.NotNil)
+}
+
+func (s *LROSuite) TestRetryPutAsyncRelativeRetrySucceeded(c *chk.C) {
+	future, err := lroRetryClient.PutAsyncRelativeRetrySucceeded(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lroRetryClient.Client)
+	c.Assert(err, chk.IsNil)
+	r, err := future.Result(lroRetryClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.StatusCode, chk.Equals, http.StatusOK)
+	c.Assert(r.Name, chk.NotNil)
+}
+
+// vanilla client
 
 func (s *LROSuite) TestDelete202NoRetry204(c *chk.C) {
 	future, err := lrosClient.Delete202NoRetry204(context.Background())
 	c.Assert(err, chk.IsNil)
-
 	for done, err := future.Done(lrosClient); !done; done, err = future.Done(lrosClient) {
 		c.Assert(err, chk.IsNil)
 	}
@@ -62,33 +138,524 @@ func (s *LROSuite) TestDelete202NoRetry204(c *chk.C) {
 }
 
 func (s *LROSuite) TestDelete202Retry200(c *chk.C) {
-	future, err := lroRetryClient.Delete202Retry200(context.Background())
+	future, err := lrosClient.Delete202Retry200(context.Background())
 	c.Assert(err, chk.IsNil)
 	c.Assert(future.Response().StatusCode, chk.Equals, http.StatusAccepted)
-
-	done, err := future.Done(lroRetryClient)
-	c.Assert(done, chk.Equals, false)
-	c.Assert(err, chk.NotNil)
-	c.Assert(future.Response().StatusCode, chk.Equals, http.StatusInternalServerError)
-
-	for done, err := future.Done(lroRetryClient); !done; done, err = future.Done(lroRetryClient) {
-		c.Assert(err, chk.IsNil)
-		if future.Response().StatusCode == http.StatusInternalServerError {
-			continue
-		}
-		dur, ok := future.GetPollingDelay()
-		c.Assert(ok, chk.Equals, true)
-		time.Sleep(dur)
-	}
-	c.Assert(future.Response().StatusCode, chk.Equals, http.StatusOK)
+	done, err := future.Done(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(done, chk.Equals, true)
+	p, err := future.Result(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(p.Name, chk.IsNil)
 }
 
-func (s *LROSuite) TestDelete202NonRetry400(c *chk.C) {
+func (s *LROSuite) TestDelete204Succeeded(c *chk.C) {
+	future, err := lrosClient.Delete204Succeeded(context.Background())
+	c.Assert(err, chk.IsNil)
+	done, err := future.Done(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(done, chk.Equals, true)
+	r, err := future.Result(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.StatusCode, chk.Equals, http.StatusNoContent)
+}
+
+func (s *LROSuite) TestDeleteAsyncNoHeaderInRetry(c *chk.C) {
+	future, err := lrosClient.DeleteAsyncNoHeaderInRetry(context.Background())
+	c.Assert(err, chk.IsNil)
+	c.Assert(future.Response().StatusCode, chk.Equals, http.StatusAccepted)
+	done, err := future.Done(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(done, chk.Equals, false)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+	r, err := future.Result(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.StatusCode, chk.Equals, http.StatusOK)
+}
+
+func (s *LROSuite) TestDeleteAsyncNoRetrySucceeded(c *chk.C) {
+	future, err := lrosClient.DeleteAsyncNoRetrySucceeded(context.Background())
+	c.Assert(err, chk.IsNil)
+	done, err := future.Done(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(done, chk.Equals, false)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+	r, err := future.Result(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.StatusCode, chk.Equals, http.StatusOK)
+}
+
+func (s *LROSuite) TestDeleteAsyncRetrycanceled(c *chk.C) {
+	future, err := lrosClient.DeleteAsyncRetrycanceled(context.Background())
+	c.Assert(err, chk.IsNil)
+	done, err := future.Done(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(done, chk.Equals, false)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.NotNil)
+	r, err := future.Result(lrosClient)
+	c.Assert(err, chk.NotNil)
+	c.Assert(r.Response, chk.IsNil)
+}
+
+func (s *LROSuite) TestDeleteAsyncRetryFailed(c *chk.C) {
+	future, err := lrosClient.DeleteAsyncRetryFailed(context.Background())
+	c.Assert(err, chk.IsNil)
+	done, err := future.Done(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(done, chk.Equals, false)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.NotNil)
+	r, err := future.Result(lrosClient)
+	c.Assert(err, chk.NotNil)
+	c.Assert(r.Response, chk.IsNil)
+}
+
+func (s *LROSuite) TestDeleteAsyncRetrySucceeded(c *chk.C) {
+	future, err := lrosClient.DeleteAsyncRetrySucceeded(context.Background())
+	c.Assert(err, chk.IsNil)
+	done, err := future.Done(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(done, chk.Equals, false)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+	r, err := future.Result(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.StatusCode, chk.Equals, http.StatusOK)
+}
+
+func (s *LROSuite) TestDeleteNoHeaderInRetry(c *chk.C) {
+	future, err := lrosClient.DeleteNoHeaderInRetry(context.Background())
+	c.Assert(err, chk.IsNil)
+	done, err := future.Done(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(done, chk.Equals, false)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+	r, err := future.Result(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.StatusCode, chk.Equals, http.StatusNoContent)
+}
+
+func (s *LROSuite) TestDeleteProvisioning202Accepted200Succeeded(c *chk.C) {
+	future, err := lrosClient.DeleteProvisioning202Accepted200Succeeded(context.Background())
+	c.Assert(err, chk.IsNil)
+	done, err := future.Done(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(done, chk.Equals, true)
+	r, err := future.Result(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.StatusCode, chk.Equals, http.StatusOK)
+	c.Assert(r.Name, chk.NotNil)
+}
+
+func (s *LROSuite) TestDeleteProvisioning202Deletingcanceled200(c *chk.C) {
+	future, err := lrosClient.DeleteProvisioning202Deletingcanceled200(context.Background())
+	c.Assert(err, chk.IsNil)
+	done, err := future.Done(lrosClient)
+	c.Assert(err, chk.NotNil)
+	c.Assert(done, chk.Equals, true)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.NotNil)
+	r, err := future.Result(lrosClient)
+	c.Assert(err, chk.NotNil)
+	c.Assert(r.Response, chk.NotNil)
+}
+
+func (s *LROSuite) TestDeleteProvisioning202DeletingFailed200(c *chk.C) {
+	future, err := lrosClient.DeleteProvisioning202DeletingFailed200(context.Background())
+	c.Assert(err, chk.IsNil)
+	done, err := future.Done(lrosClient)
+	c.Assert(err, chk.NotNil)
+	c.Assert(done, chk.Equals, true)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.NotNil)
+	r, err := future.Result(lrosClient)
+	c.Assert(err, chk.NotNil)
+	c.Assert(r.Response, chk.NotNil)
+}
+
+func (s *LROSuite) TestPost200WithPayload(c *chk.C) {
+	future, err := lrosClient.Post200WithPayload(context.Background())
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+	r, err := future.Result(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.ID, chk.NotNil)
+}
+
+func (s *LROSuite) TestPost202NoRetry204(c *chk.C) {
+	future, err := lrosClient.Post202NoRetry204(context.Background(), &lrogroup.Product{
+		Location: to.StringPtr("West US"),
+	})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+	r, err := future.Result(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.Response.StatusCode, chk.Equals, http.StatusNoContent)
+	c.Assert(r.ID, chk.IsNil)
+}
+
+func (s *LROSuite) TestPost202Retry200(c *chk.C) {
+	future, err := lrosClient.Post202Retry200(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+	r, err := future.Result(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.StatusCode, chk.Equals, http.StatusOK)
+}
+
+func (s *LROSuite) TestPostAsyncNoRetrySucceeded(c *chk.C) {
+	future, err := lrosClient.PostAsyncNoRetrySucceeded(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+	r, err := future.Result(lrosClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.ID, chk.NotNil)
+}
+
+func (s *LROSuite) TestPostAsyncRetrycanceled(c *chk.C) {
+	future, err := lrosClient.PostAsyncRetrycanceled(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestPostAsyncRetryFailed(c *chk.C) {
+	future, err := lrosClient.PostAsyncRetryFailed(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestPostAsyncRetrySucceeded(c *chk.C) {
+	future, err := lrosClient.PostAsyncRetrySucceeded(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *LROSuite) TestPut200Acceptedcanceled200(c *chk.C) {
+	future, err := lrosClient.Put200Acceptedcanceled200(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestPut200Succeeded(c *chk.C) {
+	future, err := lrosClient.Put200Succeeded(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *LROSuite) TestPut200SucceededNoState(c *chk.C) {
+	future, err := lrosClient.Put200SucceededNoState(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *LROSuite) TestPut200UpdatingSucceeded204(c *chk.C) {
+	future, err := lrosClient.Put200UpdatingSucceeded204(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *LROSuite) TestPut201CreatingFailed200(c *chk.C) {
+	future, err := lrosClient.Put201CreatingFailed200(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestPut201CreatingSucceeded200(c *chk.C) {
+	future, err := lrosClient.Put201CreatingSucceeded200(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *LROSuite) TestPut202Retry200(c *chk.C) {
+	future, err := lrosClient.Put202Retry200(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *LROSuite) TestPutAsyncNoHeaderInRetry(c *chk.C) {
+	future, err := lrosClient.PutAsyncNoHeaderInRetry(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *LROSuite) TestPutAsyncNonResource(c *chk.C) {
+	future, err := lrosClient.PutAsyncNonResource(context.Background(), &lrogroup.Sku{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *LROSuite) TestPutAsyncNoRetrycanceled(c *chk.C) {
+	future, err := lrosClient.PutAsyncNoRetrycanceled(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestPutAsyncNoRetrySucceeded(c *chk.C) {
+	future, err := lrosClient.PutAsyncNoRetrySucceeded(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *LROSuite) TestPutAsyncRetryFailed(c *chk.C) {
+	future, err := lrosClient.PutAsyncRetryFailed(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestPutAsyncRetrySucceeded(c *chk.C) {
+	future, err := lrosClient.PutAsyncRetrySucceeded(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *LROSuite) TestPutAsyncSubResource(c *chk.C) {
+	future, err := lrosClient.PutAsyncSubResource(context.Background(), &lrogroup.SubProduct{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *LROSuite) TestPutNoHeaderInRetry(c *chk.C) {
+	future, err := lrosClient.PutNoHeaderInRetry(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *LROSuite) TestPutNonResource(c *chk.C) {
+	future, err := lrosClient.PutNonResource(context.Background(), &lrogroup.Sku{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+func (s *LROSuite) TestPutSubResource(c *chk.C) {
+	future, err := lrosClient.PutSubResource(context.Background(), &lrogroup.SubProduct{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lrosClient.Client)
+	c.Assert(err, chk.IsNil)
+}
+
+// sads client
+
+func (s *LROSuite) TestSADsDelete202NonRetry400(c *chk.C) {
 	future, err := lroSADSClient.Delete202NonRetry400(context.Background())
 	c.Assert(err, chk.IsNil)
-
 	done, err := future.Done(lroSADSClient)
 	c.Assert(done, chk.Equals, false)
 	c.Assert(err, chk.NotNil)
 	c.Assert(future.Response().StatusCode, chk.Equals, 400)
+}
+
+func (s *LROSuite) TestSADsDelete202RetryInvalidHeader(c *chk.C) {
+	_, err := lroSADSClient.Delete202RetryInvalidHeader(context.Background())
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsDelete204Succeeded(c *chk.C) {
+	future, err := lroSADSClient.Delete204Succeeded(context.Background())
+	c.Assert(err, chk.IsNil)
+	done, err := future.Done(lroSADSClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(done, chk.Equals, true)
+}
+
+func (s *LROSuite) TestSADsDeleteAsyncRelativeRetry400(c *chk.C) {
+	future, err := lroSADSClient.DeleteAsyncRelativeRetry400(context.Background())
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lroSADSClient.Client)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsDeleteAsyncRelativeRetryInvalidHeader(c *chk.C) {
+	_, err := lroSADSClient.DeleteAsyncRelativeRetryInvalidHeader(context.Background())
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsDeleteAsyncRelativeRetryInvalidJSONPolling(c *chk.C) {
+	future, err := lroSADSClient.DeleteAsyncRelativeRetryInvalidJSONPolling(context.Background())
+	c.Assert(err, chk.IsNil)
+	_, err = future.Done(lroSADSClient)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsDeleteAsyncRelativeRetryNoStatus(c *chk.C) {
+	future, err := lroSADSClient.DeleteAsyncRelativeRetryNoStatus(context.Background())
+	c.Assert(err, chk.IsNil)
+	_, err = future.Done(lroSADSClient)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsDeleteNonRetry400(c *chk.C) {
+	_, err := lroSADSClient.DeleteNonRetry400(context.Background())
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPost202NoLocation(c *chk.C) {
+	_, err := lroSADSClient.Post202NoLocation(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPost202NonRetry400(c *chk.C) {
+	future, err := lroSADSClient.Post202NonRetry400(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	b, err := future.Done(lroSADSClient)
+	c.Assert(err, chk.NotNil)
+	c.Assert(b, chk.Equals, false)
+}
+
+func (s *LROSuite) TestSADsPost202RetryInvalidHeader(c *chk.C) {
+	_, err := lroSADSClient.Post202RetryInvalidHeader(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPostAsyncRelativeRetry400(c *chk.C) {
+	future, err := lroSADSClient.PostAsyncRelativeRetry400(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	b, err := future.Done(lroSADSClient)
+	c.Assert(err, chk.NotNil)
+	c.Assert(b, chk.Equals, false)
+}
+
+func (s *LROSuite) TestSADsPostAsyncRelativeRetryInvalidHeader(c *chk.C) {
+	_, err := lroSADSClient.PostAsyncRelativeRetryInvalidHeader(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPostAsyncRelativeRetryInvalidJSONPolling(c *chk.C) {
+	future, err := lroSADSClient.PostAsyncRelativeRetryInvalidJSONPolling(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	_, err = future.Done(lroSADSClient)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPostAsyncRelativeRetryNoPayload(c *chk.C) {
+	future, err := lroSADSClient.PostAsyncRelativeRetryNoPayload(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	_, err = future.Done(lroSADSClient)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPostNonRetry400(c *chk.C) {
+	future, err := lroSADSClient.PostNonRetry400(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.NotNil)
+	_, err = future.Done(lroSADSClient)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPut200InvalidJSON(c *chk.C) {
+	_, err := lroSADSClient.Put200InvalidJSON(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPutAsyncRelativeRetry400(c *chk.C) {
+	future, err := lroSADSClient.PutAsyncRelativeRetry400(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lroSADSClient.Client)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPutAsyncRelativeRetryInvalidHeader(c *chk.C) {
+	future, err := lroSADSClient.PutAsyncRelativeRetryInvalidHeader(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lroSADSClient.Client)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPutAsyncRelativeRetryInvalidJSONPolling(c *chk.C) {
+	future, err := lroSADSClient.PutAsyncRelativeRetryInvalidJSONPolling(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lroSADSClient.Client)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPutAsyncRelativeRetryNoStatus(c *chk.C) {
+	future, err := lroSADSClient.PutAsyncRelativeRetryNoStatus(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lroSADSClient.Client)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPutAsyncRelativeRetryNoStatusPayload(c *chk.C) {
+	future, err := lroSADSClient.PutAsyncRelativeRetryNoStatusPayload(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lroSADSClient.Client)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPutError201NoProvisioningStatePayload(c *chk.C) {
+	future, err := lroSADSClient.PutError201NoProvisioningStatePayload(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	_, err = future.Result(lroSADSClient)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPutNonRetry201Creating400(c *chk.C) {
+	future, err := lroSADSClient.PutNonRetry201Creating400(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lroSADSClient.Client)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPutNonRetry201Creating400InvalidJSON(c *chk.C) {
+	future, err := lroSADSClient.PutNonRetry201Creating400InvalidJSON(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lroSADSClient.Client)
+	c.Assert(err, chk.NotNil)
+}
+
+func (s *LROSuite) TestSADsPutNonRetry400(c *chk.C) {
+	_, err := lroSADSClient.PutNonRetry400(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.NotNil)
+}
+
+// custom header client
+
+func (s *LROSuite) TestCustomHeaderPost202Retry200(c *chk.C) {
+	/*req, err := lroCustomHeaderClient.Post202Retry200Preparer(context.Background(), &lrogroup.Product{})
+	c.Assert(err, chk.IsNil)
+	req.Header.Add("x-ms-client-request-id", "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0")
+	future, err := lroCustomHeaderClient.Post202Retry200Sender(req)
+	c.Assert(err, chk.IsNil)
+	err = future.WaitForCompletionRef(context.Background(), lroCustomHeaderClient.Client)
+	c.Assert(err, chk.IsNil)
+	r, err := future.Result(lroCustomHeaderClient)
+	c.Assert(err, chk.IsNil)
+	c.Assert(r.StatusCode, chk.Equals, http.StatusOK)*/
+}
+
+func (s *LROSuite) TestCustomHeaderPostAsyncRetrySucceeded(c *chk.C) {
+	// TODO
+}
+
+func (s *LROSuite) TestCustomHeaderPut201CreatingSucceeded200(c *chk.C) {
+	// TODO
+}
+
+func (s *LROSuite) TestCustomHeaderPutAsyncRetrySucceeded(c *chk.C) {
+	// TODO
 }

--- a/test/src/tests/generated/lro/lroretrys.go
+++ b/test/src/tests/generated/lro/lroretrys.go
@@ -58,15 +58,17 @@ func (client LRORetrysClient) Delete202Retry200Preparer(ctx context.Context) (*h
 // Delete202Retry200Sender sends the Delete202Retry200 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LRORetrysClient) Delete202Retry200Sender(req *http.Request) (future LRORetrysDelete202Retry200Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -112,15 +114,17 @@ func (client LRORetrysClient) DeleteAsyncRelativeRetrySucceededPreparer(ctx cont
 // DeleteAsyncRelativeRetrySucceededSender sends the DeleteAsyncRelativeRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LRORetrysClient) DeleteAsyncRelativeRetrySucceededSender(req *http.Request) (future LRORetrysDeleteAsyncRelativeRetrySucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -167,15 +171,17 @@ func (client LRORetrysClient) DeleteProvisioning202Accepted200SucceededPreparer(
 // DeleteProvisioning202Accepted200SucceededSender sends the DeleteProvisioning202Accepted200Succeeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LRORetrysClient) DeleteProvisioning202Accepted200SucceededSender(req *http.Request) (future LRORetrysDeleteProvisioning202Accepted200SucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -229,15 +235,17 @@ func (client LRORetrysClient) Post202Retry200Preparer(ctx context.Context, produ
 // Post202Retry200Sender sends the Post202Retry200 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LRORetrysClient) Post202Retry200Sender(req *http.Request) (future LRORetrysPost202Retry200Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -291,15 +299,17 @@ func (client LRORetrysClient) PostAsyncRelativeRetrySucceededPreparer(ctx contex
 // PostAsyncRelativeRetrySucceededSender sends the PostAsyncRelativeRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LRORetrysClient) PostAsyncRelativeRetrySucceededSender(req *http.Request) (future LRORetrysPostAsyncRelativeRetrySucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -353,15 +363,17 @@ func (client LRORetrysClient) Put201CreatingSucceeded200Preparer(ctx context.Con
 // Put201CreatingSucceeded200Sender sends the Put201CreatingSucceeded200 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LRORetrysClient) Put201CreatingSucceeded200Sender(req *http.Request) (future LRORetrysPut201CreatingSucceeded200Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -416,15 +428,17 @@ func (client LRORetrysClient) PutAsyncRelativeRetrySucceededPreparer(ctx context
 // PutAsyncRelativeRetrySucceededSender sends the PutAsyncRelativeRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LRORetrysClient) PutAsyncRelativeRetrySucceededSender(req *http.Request) (future LRORetrysPutAsyncRelativeRetrySucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 

--- a/test/src/tests/generated/lro/lros.go
+++ b/test/src/tests/generated/lro/lros.go
@@ -58,15 +58,17 @@ func (client LROsClient) Delete202NoRetry204Preparer(ctx context.Context) (*http
 // Delete202NoRetry204Sender sends the Delete202NoRetry204 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) Delete202NoRetry204Sender(req *http.Request) (future LROsDelete202NoRetry204Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -113,15 +115,17 @@ func (client LROsClient) Delete202Retry200Preparer(ctx context.Context) (*http.R
 // Delete202Retry200Sender sends the Delete202Retry200 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) Delete202Retry200Sender(req *http.Request) (future LROsDelete202Retry200Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -167,15 +171,17 @@ func (client LROsClient) Delete204SucceededPreparer(ctx context.Context) (*http.
 // Delete204SucceededSender sends the Delete204Succeeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) Delete204SucceededSender(req *http.Request) (future LROsDelete204SucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -221,15 +227,17 @@ func (client LROsClient) DeleteAsyncNoHeaderInRetryPreparer(ctx context.Context)
 // DeleteAsyncNoHeaderInRetrySender sends the DeleteAsyncNoHeaderInRetry request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) DeleteAsyncNoHeaderInRetrySender(req *http.Request) (future LROsDeleteAsyncNoHeaderInRetryFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -275,15 +283,17 @@ func (client LROsClient) DeleteAsyncNoRetrySucceededPreparer(ctx context.Context
 // DeleteAsyncNoRetrySucceededSender sends the DeleteAsyncNoRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) DeleteAsyncNoRetrySucceededSender(req *http.Request) (future LROsDeleteAsyncNoRetrySucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -329,15 +339,17 @@ func (client LROsClient) DeleteAsyncRetrycanceledPreparer(ctx context.Context) (
 // DeleteAsyncRetrycanceledSender sends the DeleteAsyncRetrycanceled request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) DeleteAsyncRetrycanceledSender(req *http.Request) (future LROsDeleteAsyncRetrycanceledFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -383,15 +395,17 @@ func (client LROsClient) DeleteAsyncRetryFailedPreparer(ctx context.Context) (*h
 // DeleteAsyncRetryFailedSender sends the DeleteAsyncRetryFailed request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) DeleteAsyncRetryFailedSender(req *http.Request) (future LROsDeleteAsyncRetryFailedFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -437,15 +451,17 @@ func (client LROsClient) DeleteAsyncRetrySucceededPreparer(ctx context.Context) 
 // DeleteAsyncRetrySucceededSender sends the DeleteAsyncRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) DeleteAsyncRetrySucceededSender(req *http.Request) (future LROsDeleteAsyncRetrySucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -491,15 +507,17 @@ func (client LROsClient) DeleteNoHeaderInRetryPreparer(ctx context.Context) (*ht
 // DeleteNoHeaderInRetrySender sends the DeleteNoHeaderInRetry request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) DeleteNoHeaderInRetrySender(req *http.Request) (future LROsDeleteNoHeaderInRetryFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -546,15 +564,17 @@ func (client LROsClient) DeleteProvisioning202Accepted200SucceededPreparer(ctx c
 // DeleteProvisioning202Accepted200SucceededSender sends the DeleteProvisioning202Accepted200Succeeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) DeleteProvisioning202Accepted200SucceededSender(req *http.Request) (future LROsDeleteProvisioning202Accepted200SucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -602,15 +622,17 @@ func (client LROsClient) DeleteProvisioning202Deletingcanceled200Preparer(ctx co
 // DeleteProvisioning202Deletingcanceled200Sender sends the DeleteProvisioning202Deletingcanceled200 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) DeleteProvisioning202Deletingcanceled200Sender(req *http.Request) (future LROsDeleteProvisioning202Deletingcanceled200Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -658,15 +680,17 @@ func (client LROsClient) DeleteProvisioning202DeletingFailed200Preparer(ctx cont
 // DeleteProvisioning202DeletingFailed200Sender sends the DeleteProvisioning202DeletingFailed200 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) DeleteProvisioning202DeletingFailed200Sender(req *http.Request) (future LROsDeleteProvisioning202DeletingFailed200Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -713,15 +737,17 @@ func (client LROsClient) Post200WithPayloadPreparer(ctx context.Context) (*http.
 // Post200WithPayloadSender sends the Post200WithPayload request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) Post200WithPayloadSender(req *http.Request) (future LROsPost200WithPayloadFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -775,15 +801,17 @@ func (client LROsClient) Post202NoRetry204Preparer(ctx context.Context, product 
 // Post202NoRetry204Sender sends the Post202NoRetry204 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) Post202NoRetry204Sender(req *http.Request) (future LROsPost202NoRetry204Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -837,15 +865,17 @@ func (client LROsClient) Post202Retry200Preparer(ctx context.Context, product *P
 // Post202Retry200Sender sends the Post202Retry200 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) Post202Retry200Sender(req *http.Request) (future LROsPost202Retry200Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -899,15 +929,17 @@ func (client LROsClient) PostAsyncNoRetrySucceededPreparer(ctx context.Context, 
 // PostAsyncNoRetrySucceededSender sends the PostAsyncNoRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) PostAsyncNoRetrySucceededSender(req *http.Request) (future LROsPostAsyncNoRetrySucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -962,15 +994,17 @@ func (client LROsClient) PostAsyncRetrycanceledPreparer(ctx context.Context, pro
 // PostAsyncRetrycanceledSender sends the PostAsyncRetrycanceled request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) PostAsyncRetrycanceledSender(req *http.Request) (future LROsPostAsyncRetrycanceledFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1024,15 +1058,17 @@ func (client LROsClient) PostAsyncRetryFailedPreparer(ctx context.Context, produ
 // PostAsyncRetryFailedSender sends the PostAsyncRetryFailed request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) PostAsyncRetryFailedSender(req *http.Request) (future LROsPostAsyncRetryFailedFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1086,15 +1122,17 @@ func (client LROsClient) PostAsyncRetrySucceededPreparer(ctx context.Context, pr
 // PostAsyncRetrySucceededSender sends the PostAsyncRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) PostAsyncRetrySucceededSender(req *http.Request) (future LROsPostAsyncRetrySucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1149,15 +1187,17 @@ func (client LROsClient) Put200Acceptedcanceled200Preparer(ctx context.Context, 
 // Put200Acceptedcanceled200Sender sends the Put200Acceptedcanceled200 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) Put200Acceptedcanceled200Sender(req *http.Request) (future LROsPut200Acceptedcanceled200Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1211,15 +1251,17 @@ func (client LROsClient) Put200SucceededPreparer(ctx context.Context, product *P
 // Put200SucceededSender sends the Put200Succeeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) Put200SucceededSender(req *http.Request) (future LROsPut200SucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1273,15 +1315,17 @@ func (client LROsClient) Put200SucceededNoStatePreparer(ctx context.Context, pro
 // Put200SucceededNoStateSender sends the Put200SucceededNoState request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) Put200SucceededNoStateSender(req *http.Request) (future LROsPut200SucceededNoStateFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1336,15 +1380,17 @@ func (client LROsClient) Put200UpdatingSucceeded204Preparer(ctx context.Context,
 // Put200UpdatingSucceeded204Sender sends the Put200UpdatingSucceeded204 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) Put200UpdatingSucceeded204Sender(req *http.Request) (future LROsPut200UpdatingSucceeded204Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1399,15 +1445,17 @@ func (client LROsClient) Put201CreatingFailed200Preparer(ctx context.Context, pr
 // Put201CreatingFailed200Sender sends the Put201CreatingFailed200 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) Put201CreatingFailed200Sender(req *http.Request) (future LROsPut201CreatingFailed200Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1462,15 +1510,17 @@ func (client LROsClient) Put201CreatingSucceeded200Preparer(ctx context.Context,
 // Put201CreatingSucceeded200Sender sends the Put201CreatingSucceeded200 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) Put201CreatingSucceeded200Sender(req *http.Request) (future LROsPut201CreatingSucceeded200Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1524,15 +1574,17 @@ func (client LROsClient) Put202Retry200Preparer(ctx context.Context, product *Pr
 // Put202Retry200Sender sends the Put202Retry200 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) Put202Retry200Sender(req *http.Request) (future LROsPut202Retry200Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1586,15 +1638,17 @@ func (client LROsClient) PutAsyncNoHeaderInRetryPreparer(ctx context.Context, pr
 // PutAsyncNoHeaderInRetrySender sends the PutAsyncNoHeaderInRetry request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) PutAsyncNoHeaderInRetrySender(req *http.Request) (future LROsPutAsyncNoHeaderInRetryFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1647,15 +1701,17 @@ func (client LROsClient) PutAsyncNonResourcePreparer(ctx context.Context, sku *S
 // PutAsyncNonResourceSender sends the PutAsyncNonResource request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) PutAsyncNonResourceSender(req *http.Request) (future LROsPutAsyncNonResourceFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1710,15 +1766,17 @@ func (client LROsClient) PutAsyncNoRetrycanceledPreparer(ctx context.Context, pr
 // PutAsyncNoRetrycanceledSender sends the PutAsyncNoRetrycanceled request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) PutAsyncNoRetrycanceledSender(req *http.Request) (future LROsPutAsyncNoRetrycanceledFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1773,15 +1831,17 @@ func (client LROsClient) PutAsyncNoRetrySucceededPreparer(ctx context.Context, p
 // PutAsyncNoRetrySucceededSender sends the PutAsyncNoRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) PutAsyncNoRetrySucceededSender(req *http.Request) (future LROsPutAsyncNoRetrySucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1836,15 +1896,17 @@ func (client LROsClient) PutAsyncRetryFailedPreparer(ctx context.Context, produc
 // PutAsyncRetryFailedSender sends the PutAsyncRetryFailed request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) PutAsyncRetryFailedSender(req *http.Request) (future LROsPutAsyncRetryFailedFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1899,15 +1961,17 @@ func (client LROsClient) PutAsyncRetrySucceededPreparer(ctx context.Context, pro
 // PutAsyncRetrySucceededSender sends the PutAsyncRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) PutAsyncRetrySucceededSender(req *http.Request) (future LROsPutAsyncRetrySucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1960,15 +2024,17 @@ func (client LROsClient) PutAsyncSubResourcePreparer(ctx context.Context, produc
 // PutAsyncSubResourceSender sends the PutAsyncSubResource request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) PutAsyncSubResourceSender(req *http.Request) (future LROsPutAsyncSubResourceFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -2022,15 +2088,17 @@ func (client LROsClient) PutNoHeaderInRetryPreparer(ctx context.Context, product
 // PutNoHeaderInRetrySender sends the PutNoHeaderInRetry request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) PutNoHeaderInRetrySender(req *http.Request) (future LROsPutNoHeaderInRetryFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -2083,15 +2151,17 @@ func (client LROsClient) PutNonResourcePreparer(ctx context.Context, sku *Sku) (
 // PutNonResourceSender sends the PutNonResource request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) PutNonResourceSender(req *http.Request) (future LROsPutNonResourceFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -2144,15 +2214,17 @@ func (client LROsClient) PutSubResourcePreparer(ctx context.Context, product *Su
 // PutSubResourceSender sends the PutSubResource request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsClient) PutSubResourceSender(req *http.Request) (future LROsPutSubResourceFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 

--- a/test/src/tests/generated/lro/lrosads.go
+++ b/test/src/tests/generated/lro/lrosads.go
@@ -57,15 +57,17 @@ func (client LROSADsClient) Delete202NonRetry400Preparer(ctx context.Context) (*
 // Delete202NonRetry400Sender sends the Delete202NonRetry400 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) Delete202NonRetry400Sender(req *http.Request) (future LROSADsDelete202NonRetry400Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -111,15 +113,17 @@ func (client LROSADsClient) Delete202RetryInvalidHeaderPreparer(ctx context.Cont
 // Delete202RetryInvalidHeaderSender sends the Delete202RetryInvalidHeader request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) Delete202RetryInvalidHeaderSender(req *http.Request) (future LROSADsDelete202RetryInvalidHeaderFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -164,15 +168,17 @@ func (client LROSADsClient) Delete204SucceededPreparer(ctx context.Context) (*ht
 // Delete204SucceededSender sends the Delete204Succeeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) Delete204SucceededSender(req *http.Request) (future LROSADsDelete204SucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -218,15 +224,17 @@ func (client LROSADsClient) DeleteAsyncRelativeRetry400Preparer(ctx context.Cont
 // DeleteAsyncRelativeRetry400Sender sends the DeleteAsyncRelativeRetry400 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) DeleteAsyncRelativeRetry400Sender(req *http.Request) (future LROSADsDeleteAsyncRelativeRetry400Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -272,15 +280,17 @@ func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidHeaderPreparer(ctx co
 // DeleteAsyncRelativeRetryInvalidHeaderSender sends the DeleteAsyncRelativeRetryInvalidHeader request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidHeaderSender(req *http.Request) (future LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -326,15 +336,17 @@ func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidJSONPollingPreparer(c
 // DeleteAsyncRelativeRetryInvalidJSONPollingSender sends the DeleteAsyncRelativeRetryInvalidJSONPolling request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidJSONPollingSender(req *http.Request) (future LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -380,15 +392,17 @@ func (client LROSADsClient) DeleteAsyncRelativeRetryNoStatusPreparer(ctx context
 // DeleteAsyncRelativeRetryNoStatusSender sends the DeleteAsyncRelativeRetryNoStatus request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) DeleteAsyncRelativeRetryNoStatusSender(req *http.Request) (future LROSADsDeleteAsyncRelativeRetryNoStatusFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -433,15 +447,17 @@ func (client LROSADsClient) DeleteNonRetry400Preparer(ctx context.Context) (*htt
 // DeleteNonRetry400Sender sends the DeleteNonRetry400 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) DeleteNonRetry400Sender(req *http.Request) (future LROSADsDeleteNonRetry400Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -494,15 +510,17 @@ func (client LROSADsClient) Post202NoLocationPreparer(ctx context.Context, produ
 // Post202NoLocationSender sends the Post202NoLocation request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) Post202NoLocationSender(req *http.Request) (future LROSADsPost202NoLocationFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -554,15 +572,17 @@ func (client LROSADsClient) Post202NonRetry400Preparer(ctx context.Context, prod
 // Post202NonRetry400Sender sends the Post202NonRetry400 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) Post202NonRetry400Sender(req *http.Request) (future LROSADsPost202NonRetry400Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -615,15 +635,17 @@ func (client LROSADsClient) Post202RetryInvalidHeaderPreparer(ctx context.Contex
 // Post202RetryInvalidHeaderSender sends the Post202RetryInvalidHeader request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) Post202RetryInvalidHeaderSender(req *http.Request) (future LROSADsPost202RetryInvalidHeaderFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -676,15 +698,17 @@ func (client LROSADsClient) PostAsyncRelativeRetry400Preparer(ctx context.Contex
 // PostAsyncRelativeRetry400Sender sends the PostAsyncRelativeRetry400 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) PostAsyncRelativeRetry400Sender(req *http.Request) (future LROSADsPostAsyncRelativeRetry400Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -738,15 +762,17 @@ func (client LROSADsClient) PostAsyncRelativeRetryInvalidHeaderPreparer(ctx cont
 // PostAsyncRelativeRetryInvalidHeaderSender sends the PostAsyncRelativeRetryInvalidHeader request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) PostAsyncRelativeRetryInvalidHeaderSender(req *http.Request) (future LROSADsPostAsyncRelativeRetryInvalidHeaderFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -800,15 +826,17 @@ func (client LROSADsClient) PostAsyncRelativeRetryInvalidJSONPollingPreparer(ctx
 // PostAsyncRelativeRetryInvalidJSONPollingSender sends the PostAsyncRelativeRetryInvalidJSONPolling request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) PostAsyncRelativeRetryInvalidJSONPollingSender(req *http.Request) (future LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -862,15 +890,17 @@ func (client LROSADsClient) PostAsyncRelativeRetryNoPayloadPreparer(ctx context.
 // PostAsyncRelativeRetryNoPayloadSender sends the PostAsyncRelativeRetryNoPayload request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) PostAsyncRelativeRetryNoPayloadSender(req *http.Request) (future LROSADsPostAsyncRelativeRetryNoPayloadFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -922,15 +952,17 @@ func (client LROSADsClient) PostNonRetry400Preparer(ctx context.Context, product
 // PostNonRetry400Sender sends the PostNonRetry400 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) PostNonRetry400Sender(req *http.Request) (future LROSADsPostNonRetry400Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -983,15 +1015,17 @@ func (client LROSADsClient) Put200InvalidJSONPreparer(ctx context.Context, produ
 // Put200InvalidJSONSender sends the Put200InvalidJSON request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) Put200InvalidJSONSender(req *http.Request) (future LROSADsPut200InvalidJSONFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1045,15 +1079,17 @@ func (client LROSADsClient) PutAsyncRelativeRetry400Preparer(ctx context.Context
 // PutAsyncRelativeRetry400Sender sends the PutAsyncRelativeRetry400 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) PutAsyncRelativeRetry400Sender(req *http.Request) (future LROSADsPutAsyncRelativeRetry400Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1108,15 +1144,17 @@ func (client LROSADsClient) PutAsyncRelativeRetryInvalidHeaderPreparer(ctx conte
 // PutAsyncRelativeRetryInvalidHeaderSender sends the PutAsyncRelativeRetryInvalidHeader request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) PutAsyncRelativeRetryInvalidHeaderSender(req *http.Request) (future LROSADsPutAsyncRelativeRetryInvalidHeaderFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1171,15 +1209,17 @@ func (client LROSADsClient) PutAsyncRelativeRetryInvalidJSONPollingPreparer(ctx 
 // PutAsyncRelativeRetryInvalidJSONPollingSender sends the PutAsyncRelativeRetryInvalidJSONPolling request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) PutAsyncRelativeRetryInvalidJSONPollingSender(req *http.Request) (future LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1234,15 +1274,17 @@ func (client LROSADsClient) PutAsyncRelativeRetryNoStatusPreparer(ctx context.Co
 // PutAsyncRelativeRetryNoStatusSender sends the PutAsyncRelativeRetryNoStatus request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) PutAsyncRelativeRetryNoStatusSender(req *http.Request) (future LROSADsPutAsyncRelativeRetryNoStatusFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1297,15 +1339,17 @@ func (client LROSADsClient) PutAsyncRelativeRetryNoStatusPayloadPreparer(ctx con
 // PutAsyncRelativeRetryNoStatusPayloadSender sends the PutAsyncRelativeRetryNoStatusPayload request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) PutAsyncRelativeRetryNoStatusPayloadSender(req *http.Request) (future LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1359,15 +1403,17 @@ func (client LROSADsClient) PutError201NoProvisioningStatePayloadPreparer(ctx co
 // PutError201NoProvisioningStatePayloadSender sends the PutError201NoProvisioningStatePayload request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) PutError201NoProvisioningStatePayloadSender(req *http.Request) (future LROSADsPutError201NoProvisioningStatePayloadFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1421,15 +1467,17 @@ func (client LROSADsClient) PutNonRetry201Creating400Preparer(ctx context.Contex
 // PutNonRetry201Creating400Sender sends the PutNonRetry201Creating400 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) PutNonRetry201Creating400Sender(req *http.Request) (future LROSADsPutNonRetry201Creating400Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1483,15 +1531,17 @@ func (client LROSADsClient) PutNonRetry201Creating400InvalidJSONPreparer(ctx con
 // PutNonRetry201Creating400InvalidJSONSender sends the PutNonRetry201Creating400InvalidJSON request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) PutNonRetry201Creating400InvalidJSONSender(req *http.Request) (future LROSADsPutNonRetry201Creating400InvalidJSONFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -1544,15 +1594,17 @@ func (client LROSADsClient) PutNonRetry400Preparer(ctx context.Context, product 
 // PutNonRetry400Sender sends the PutNonRetry400 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROSADsClient) PutNonRetry400Sender(req *http.Request) (future LROSADsPutNonRetry400Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 

--- a/test/src/tests/generated/lro/lroscustomheader.go
+++ b/test/src/tests/generated/lro/lroscustomheader.go
@@ -66,15 +66,17 @@ func (client LROsCustomHeaderClient) Post202Retry200Preparer(ctx context.Context
 // Post202Retry200Sender sends the Post202Retry200 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsCustomHeaderClient) Post202Retry200Sender(req *http.Request) (future LROsCustomHeaderPost202Retry200Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -128,15 +130,17 @@ func (client LROsCustomHeaderClient) PostAsyncRetrySucceededPreparer(ctx context
 // PostAsyncRetrySucceededSender sends the PostAsyncRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsCustomHeaderClient) PostAsyncRetrySucceededSender(req *http.Request) (future LROsCustomHeaderPostAsyncRetrySucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -191,15 +195,17 @@ func (client LROsCustomHeaderClient) Put201CreatingSucceeded200Preparer(ctx cont
 // Put201CreatingSucceeded200Sender sends the Put201CreatingSucceeded200 request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsCustomHeaderClient) Put201CreatingSucceeded200Sender(req *http.Request) (future LROsCustomHeaderPut201CreatingSucceeded200Future, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 
@@ -254,15 +260,17 @@ func (client LROsCustomHeaderClient) PutAsyncRetrySucceededPreparer(ctx context.
 // PutAsyncRetrySucceededSender sends the PutAsyncRetrySucceeded request. The method will close the
 // http.Response Body if it receives an error.
 func (client LROsCustomHeaderClient) PutAsyncRetrySucceededSender(req *http.Request) (future LROsCustomHeaderPutAsyncRetrySucceededFuture, err error) {
-	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	future.Future = azure.NewFuture(req)
-	future.req = req
-	_, err = future.Done(sender)
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(future.Response(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
 	return
 }
 

--- a/test/src/tests/generated/lro/models.go
+++ b/test/src/tests/generated/lro/models.go
@@ -122,12 +122,11 @@ type CloudError struct {
 // operation.
 type LRORetrysDelete202Retry200Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LRORetrysDelete202Retry200Future) Result(client LRORetrysClient) (ar autorest.Response, err error) {
+func (future *LRORetrysDelete202Retry200Future) Result(client LRORetrysClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -135,35 +134,10 @@ func (future LRORetrysDelete202Retry200Future) Result(client LRORetrysClient) (a
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LRORetrysDelete202Retry200Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.Delete202Retry200Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysDelete202Retry200Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LRORetrysDelete202Retry200Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysDelete202Retry200Future", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.Delete202Retry200Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysDelete202Retry200Future", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -171,12 +145,11 @@ func (future LRORetrysDelete202Retry200Future) Result(client LRORetrysClient) (a
 // long-running operation.
 type LRORetrysDeleteAsyncRelativeRetrySucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LRORetrysDeleteAsyncRelativeRetrySucceededFuture) Result(client LRORetrysClient) (ar autorest.Response, err error) {
+func (future *LRORetrysDeleteAsyncRelativeRetrySucceededFuture) Result(client LRORetrysClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -184,35 +157,10 @@ func (future LRORetrysDeleteAsyncRelativeRetrySucceededFuture) Result(client LRO
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LRORetrysDeleteAsyncRelativeRetrySucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.DeleteAsyncRelativeRetrySucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysDeleteAsyncRelativeRetrySucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LRORetrysDeleteAsyncRelativeRetrySucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysDeleteAsyncRelativeRetrySucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.DeleteAsyncRelativeRetrySucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysDeleteAsyncRelativeRetrySucceededFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -220,12 +168,11 @@ func (future LRORetrysDeleteAsyncRelativeRetrySucceededFuture) Result(client LRO
 // results of a long-running operation.
 type LRORetrysDeleteProvisioning202Accepted200SucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LRORetrysDeleteProvisioning202Accepted200SucceededFuture) Result(client LRORetrysClient) (p Product, err error) {
+func (future *LRORetrysDeleteProvisioning202Accepted200SucceededFuture) Result(client LRORetrysClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -233,34 +180,15 @@ func (future LRORetrysDeleteProvisioning202Accepted200SucceededFuture) Result(cl
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LRORetrysDeleteProvisioning202Accepted200SucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.DeleteProvisioning202Accepted200SucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysDeleteProvisioning202Accepted200SucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LRORetrysDeleteProvisioning202Accepted200SucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.DeleteProvisioning202Accepted200SucceededResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysDeleteProvisioning202Accepted200SucceededFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysDeleteProvisioning202Accepted200SucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.DeleteProvisioning202Accepted200SucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysDeleteProvisioning202Accepted200SucceededFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -269,12 +197,11 @@ func (future LRORetrysDeleteProvisioning202Accepted200SucceededFuture) Result(cl
 // operation.
 type LRORetrysPost202Retry200Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LRORetrysPost202Retry200Future) Result(client LRORetrysClient) (ar autorest.Response, err error) {
+func (future *LRORetrysPost202Retry200Future) Result(client LRORetrysClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -282,35 +209,10 @@ func (future LRORetrysPost202Retry200Future) Result(client LRORetrysClient) (ar 
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LRORetrysPost202Retry200Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.Post202Retry200Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysPost202Retry200Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LRORetrysPost202Retry200Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysPost202Retry200Future", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.Post202Retry200Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysPost202Retry200Future", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -318,12 +220,11 @@ func (future LRORetrysPost202Retry200Future) Result(client LRORetrysClient) (ar 
 // long-running operation.
 type LRORetrysPostAsyncRelativeRetrySucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LRORetrysPostAsyncRelativeRetrySucceededFuture) Result(client LRORetrysClient) (ar autorest.Response, err error) {
+func (future *LRORetrysPostAsyncRelativeRetrySucceededFuture) Result(client LRORetrysClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -331,35 +232,10 @@ func (future LRORetrysPostAsyncRelativeRetrySucceededFuture) Result(client LRORe
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LRORetrysPostAsyncRelativeRetrySucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.PostAsyncRelativeRetrySucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysPostAsyncRelativeRetrySucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LRORetrysPostAsyncRelativeRetrySucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysPostAsyncRelativeRetrySucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.PostAsyncRelativeRetrySucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysPostAsyncRelativeRetrySucceededFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -367,12 +243,11 @@ func (future LRORetrysPostAsyncRelativeRetrySucceededFuture) Result(client LRORe
 // long-running operation.
 type LRORetrysPut201CreatingSucceeded200Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LRORetrysPut201CreatingSucceeded200Future) Result(client LRORetrysClient) (p Product, err error) {
+func (future *LRORetrysPut201CreatingSucceeded200Future) Result(client LRORetrysClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -380,34 +255,15 @@ func (future LRORetrysPut201CreatingSucceeded200Future) Result(client LRORetrysC
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LRORetrysPut201CreatingSucceeded200Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.Put201CreatingSucceeded200Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysPut201CreatingSucceeded200Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LRORetrysPut201CreatingSucceeded200Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.Put201CreatingSucceeded200Responder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysPut201CreatingSucceeded200Future", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysPut201CreatingSucceeded200Future", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.Put201CreatingSucceeded200Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysPut201CreatingSucceeded200Future", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -416,12 +272,11 @@ func (future LRORetrysPut201CreatingSucceeded200Future) Result(client LRORetrysC
 // long-running operation.
 type LRORetrysPutAsyncRelativeRetrySucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LRORetrysPutAsyncRelativeRetrySucceededFuture) Result(client LRORetrysClient) (p Product, err error) {
+func (future *LRORetrysPutAsyncRelativeRetrySucceededFuture) Result(client LRORetrysClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -429,34 +284,15 @@ func (future LRORetrysPutAsyncRelativeRetrySucceededFuture) Result(client LRORet
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LRORetrysPutAsyncRelativeRetrySucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutAsyncRelativeRetrySucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysPutAsyncRelativeRetrySucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LRORetrysPutAsyncRelativeRetrySucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutAsyncRelativeRetrySucceededResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysPutAsyncRelativeRetrySucceededFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysPutAsyncRelativeRetrySucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutAsyncRelativeRetrySucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysPutAsyncRelativeRetrySucceededFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -465,12 +301,11 @@ func (future LRORetrysPutAsyncRelativeRetrySucceededFuture) Result(client LRORet
 // operation.
 type LROSADsDelete202NonRetry400Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDelete202NonRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsDelete202NonRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -478,35 +313,10 @@ func (future LROSADsDelete202NonRetry400Future) Result(client LROSADsClient) (ar
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDelete202NonRetry400Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.Delete202NonRetry400Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDelete202NonRetry400Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDelete202NonRetry400Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDelete202NonRetry400Future", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.Delete202NonRetry400Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDelete202NonRetry400Future", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -514,12 +324,11 @@ func (future LROSADsDelete202NonRetry400Future) Result(client LROSADsClient) (ar
 // long-running operation.
 type LROSADsDelete202RetryInvalidHeaderFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDelete202RetryInvalidHeaderFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsDelete202RetryInvalidHeaderFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -527,35 +336,10 @@ func (future LROSADsDelete202RetryInvalidHeaderFuture) Result(client LROSADsClie
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDelete202RetryInvalidHeaderFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.Delete202RetryInvalidHeaderResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDelete202RetryInvalidHeaderFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDelete202RetryInvalidHeaderFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDelete202RetryInvalidHeaderFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.Delete202RetryInvalidHeaderResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDelete202RetryInvalidHeaderFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -563,12 +347,11 @@ func (future LROSADsDelete202RetryInvalidHeaderFuture) Result(client LROSADsClie
 // operation.
 type LROSADsDelete204SucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDelete204SucceededFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsDelete204SucceededFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -576,35 +359,10 @@ func (future LROSADsDelete204SucceededFuture) Result(client LROSADsClient) (ar a
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDelete204SucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.Delete204SucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDelete204SucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDelete204SucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDelete204SucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.Delete204SucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDelete204SucceededFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -612,12 +370,11 @@ func (future LROSADsDelete204SucceededFuture) Result(client LROSADsClient) (ar a
 // long-running operation.
 type LROSADsDeleteAsyncRelativeRetry400Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDeleteAsyncRelativeRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsDeleteAsyncRelativeRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -625,35 +382,10 @@ func (future LROSADsDeleteAsyncRelativeRetry400Future) Result(client LROSADsClie
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDeleteAsyncRelativeRetry400Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.DeleteAsyncRelativeRetry400Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDeleteAsyncRelativeRetry400Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDeleteAsyncRelativeRetry400Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDeleteAsyncRelativeRetry400Future", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.DeleteAsyncRelativeRetry400Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDeleteAsyncRelativeRetry400Future", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -661,12 +393,11 @@ func (future LROSADsDeleteAsyncRelativeRetry400Future) Result(client LROSADsClie
 // long-running operation.
 type LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -674,35 +405,10 @@ func (future LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture) Result(client L
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.DeleteAsyncRelativeRetryInvalidHeaderResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.DeleteAsyncRelativeRetryInvalidHeaderResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -710,12 +416,11 @@ func (future LROSADsDeleteAsyncRelativeRetryInvalidHeaderFuture) Result(client L
 // of a long-running operation.
 type LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -723,35 +428,10 @@ func (future LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture) Result(cli
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.DeleteAsyncRelativeRetryInvalidJSONPollingResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.DeleteAsyncRelativeRetryInvalidJSONPollingResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -759,12 +439,11 @@ func (future LROSADsDeleteAsyncRelativeRetryInvalidJSONPollingFuture) Result(cli
 // long-running operation.
 type LROSADsDeleteAsyncRelativeRetryNoStatusFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDeleteAsyncRelativeRetryNoStatusFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsDeleteAsyncRelativeRetryNoStatusFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -772,35 +451,10 @@ func (future LROSADsDeleteAsyncRelativeRetryNoStatusFuture) Result(client LROSAD
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDeleteAsyncRelativeRetryNoStatusFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.DeleteAsyncRelativeRetryNoStatusResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDeleteAsyncRelativeRetryNoStatusFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDeleteAsyncRelativeRetryNoStatusFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDeleteAsyncRelativeRetryNoStatusFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.DeleteAsyncRelativeRetryNoStatusResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDeleteAsyncRelativeRetryNoStatusFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -808,12 +462,11 @@ func (future LROSADsDeleteAsyncRelativeRetryNoStatusFuture) Result(client LROSAD
 // operation.
 type LROSADsDeleteNonRetry400Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsDeleteNonRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsDeleteNonRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -821,35 +474,10 @@ func (future LROSADsDeleteNonRetry400Future) Result(client LROSADsClient) (ar au
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDeleteNonRetry400Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.DeleteNonRetry400Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDeleteNonRetry400Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsDeleteNonRetry400Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDeleteNonRetry400Future", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.DeleteNonRetry400Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsDeleteNonRetry400Future", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -857,12 +485,11 @@ func (future LROSADsDeleteNonRetry400Future) Result(client LROSADsClient) (ar au
 // operation.
 type LROSADsPost202NoLocationFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPost202NoLocationFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsPost202NoLocationFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -870,35 +497,10 @@ func (future LROSADsPost202NoLocationFuture) Result(client LROSADsClient) (ar au
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPost202NoLocationFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.Post202NoLocationResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPost202NoLocationFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPost202NoLocationFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPost202NoLocationFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.Post202NoLocationResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPost202NoLocationFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -906,12 +508,11 @@ func (future LROSADsPost202NoLocationFuture) Result(client LROSADsClient) (ar au
 // operation.
 type LROSADsPost202NonRetry400Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPost202NonRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsPost202NonRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -919,35 +520,10 @@ func (future LROSADsPost202NonRetry400Future) Result(client LROSADsClient) (ar a
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPost202NonRetry400Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.Post202NonRetry400Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPost202NonRetry400Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPost202NonRetry400Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPost202NonRetry400Future", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.Post202NonRetry400Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPost202NonRetry400Future", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -955,12 +531,11 @@ func (future LROSADsPost202NonRetry400Future) Result(client LROSADsClient) (ar a
 // long-running operation.
 type LROSADsPost202RetryInvalidHeaderFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPost202RetryInvalidHeaderFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsPost202RetryInvalidHeaderFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -968,35 +543,10 @@ func (future LROSADsPost202RetryInvalidHeaderFuture) Result(client LROSADsClient
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPost202RetryInvalidHeaderFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.Post202RetryInvalidHeaderResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPost202RetryInvalidHeaderFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPost202RetryInvalidHeaderFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPost202RetryInvalidHeaderFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.Post202RetryInvalidHeaderResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPost202RetryInvalidHeaderFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -1004,12 +554,11 @@ func (future LROSADsPost202RetryInvalidHeaderFuture) Result(client LROSADsClient
 // long-running operation.
 type LROSADsPostAsyncRelativeRetry400Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPostAsyncRelativeRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsPostAsyncRelativeRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1017,35 +566,10 @@ func (future LROSADsPostAsyncRelativeRetry400Future) Result(client LROSADsClient
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPostAsyncRelativeRetry400Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.PostAsyncRelativeRetry400Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPostAsyncRelativeRetry400Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPostAsyncRelativeRetry400Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPostAsyncRelativeRetry400Future", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.PostAsyncRelativeRetry400Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPostAsyncRelativeRetry400Future", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -1053,12 +577,11 @@ func (future LROSADsPostAsyncRelativeRetry400Future) Result(client LROSADsClient
 // long-running operation.
 type LROSADsPostAsyncRelativeRetryInvalidHeaderFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPostAsyncRelativeRetryInvalidHeaderFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsPostAsyncRelativeRetryInvalidHeaderFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1066,35 +589,10 @@ func (future LROSADsPostAsyncRelativeRetryInvalidHeaderFuture) Result(client LRO
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPostAsyncRelativeRetryInvalidHeaderFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.PostAsyncRelativeRetryInvalidHeaderResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPostAsyncRelativeRetryInvalidHeaderFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPostAsyncRelativeRetryInvalidHeaderFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPostAsyncRelativeRetryInvalidHeaderFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.PostAsyncRelativeRetryInvalidHeaderResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPostAsyncRelativeRetryInvalidHeaderFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -1102,12 +600,11 @@ func (future LROSADsPostAsyncRelativeRetryInvalidHeaderFuture) Result(client LRO
 // of a long-running operation.
 type LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1115,35 +612,10 @@ func (future LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture) Result(clien
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.PostAsyncRelativeRetryInvalidJSONPollingResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.PostAsyncRelativeRetryInvalidJSONPollingResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -1151,12 +623,11 @@ func (future LROSADsPostAsyncRelativeRetryInvalidJSONPollingFuture) Result(clien
 // long-running operation.
 type LROSADsPostAsyncRelativeRetryNoPayloadFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPostAsyncRelativeRetryNoPayloadFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsPostAsyncRelativeRetryNoPayloadFuture) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1164,35 +635,10 @@ func (future LROSADsPostAsyncRelativeRetryNoPayloadFuture) Result(client LROSADs
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPostAsyncRelativeRetryNoPayloadFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.PostAsyncRelativeRetryNoPayloadResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPostAsyncRelativeRetryNoPayloadFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPostAsyncRelativeRetryNoPayloadFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPostAsyncRelativeRetryNoPayloadFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.PostAsyncRelativeRetryNoPayloadResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPostAsyncRelativeRetryNoPayloadFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -1200,12 +646,11 @@ func (future LROSADsPostAsyncRelativeRetryNoPayloadFuture) Result(client LROSADs
 // operation.
 type LROSADsPostNonRetry400Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPostNonRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
+func (future *LROSADsPostNonRetry400Future) Result(client LROSADsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1213,35 +658,10 @@ func (future LROSADsPostNonRetry400Future) Result(client LROSADsClient) (ar auto
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPostNonRetry400Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.PostNonRetry400Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPostNonRetry400Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPostNonRetry400Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPostNonRetry400Future", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.PostNonRetry400Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPostNonRetry400Future", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -1249,12 +669,11 @@ func (future LROSADsPostNonRetry400Future) Result(client LROSADsClient) (ar auto
 // operation.
 type LROSADsPut200InvalidJSONFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPut200InvalidJSONFuture) Result(client LROSADsClient) (p Product, err error) {
+func (future *LROSADsPut200InvalidJSONFuture) Result(client LROSADsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1262,34 +681,15 @@ func (future LROSADsPut200InvalidJSONFuture) Result(client LROSADsClient) (p Pro
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPut200InvalidJSONFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.Put200InvalidJSONResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPut200InvalidJSONFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPut200InvalidJSONFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.Put200InvalidJSONResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPut200InvalidJSONFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPut200InvalidJSONFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.Put200InvalidJSONResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPut200InvalidJSONFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -1298,12 +698,11 @@ func (future LROSADsPut200InvalidJSONFuture) Result(client LROSADsClient) (p Pro
 // operation.
 type LROSADsPutAsyncRelativeRetry400Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutAsyncRelativeRetry400Future) Result(client LROSADsClient) (p Product, err error) {
+func (future *LROSADsPutAsyncRelativeRetry400Future) Result(client LROSADsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1311,34 +710,15 @@ func (future LROSADsPutAsyncRelativeRetry400Future) Result(client LROSADsClient)
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutAsyncRelativeRetry400Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutAsyncRelativeRetry400Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetry400Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutAsyncRelativeRetry400Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutAsyncRelativeRetry400Responder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetry400Future", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetry400Future", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutAsyncRelativeRetry400Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetry400Future", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -1347,12 +727,11 @@ func (future LROSADsPutAsyncRelativeRetry400Future) Result(client LROSADsClient)
 // long-running operation.
 type LROSADsPutAsyncRelativeRetryInvalidHeaderFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutAsyncRelativeRetryInvalidHeaderFuture) Result(client LROSADsClient) (p Product, err error) {
+func (future *LROSADsPutAsyncRelativeRetryInvalidHeaderFuture) Result(client LROSADsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1360,34 +739,15 @@ func (future LROSADsPutAsyncRelativeRetryInvalidHeaderFuture) Result(client LROS
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutAsyncRelativeRetryInvalidHeaderFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutAsyncRelativeRetryInvalidHeaderResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryInvalidHeaderFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutAsyncRelativeRetryInvalidHeaderFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutAsyncRelativeRetryInvalidHeaderResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryInvalidHeaderFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryInvalidHeaderFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutAsyncRelativeRetryInvalidHeaderResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryInvalidHeaderFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -1396,12 +756,11 @@ func (future LROSADsPutAsyncRelativeRetryInvalidHeaderFuture) Result(client LROS
 // a long-running operation.
 type LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture) Result(client LROSADsClient) (p Product, err error) {
+func (future *LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture) Result(client LROSADsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1409,34 +768,15 @@ func (future LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture) Result(client
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutAsyncRelativeRetryInvalidJSONPollingResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutAsyncRelativeRetryInvalidJSONPollingResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutAsyncRelativeRetryInvalidJSONPollingResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -1445,12 +785,11 @@ func (future LROSADsPutAsyncRelativeRetryInvalidJSONPollingFuture) Result(client
 // long-running operation.
 type LROSADsPutAsyncRelativeRetryNoStatusFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutAsyncRelativeRetryNoStatusFuture) Result(client LROSADsClient) (p Product, err error) {
+func (future *LROSADsPutAsyncRelativeRetryNoStatusFuture) Result(client LROSADsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1458,34 +797,15 @@ func (future LROSADsPutAsyncRelativeRetryNoStatusFuture) Result(client LROSADsCl
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutAsyncRelativeRetryNoStatusFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutAsyncRelativeRetryNoStatusResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryNoStatusFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutAsyncRelativeRetryNoStatusFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutAsyncRelativeRetryNoStatusResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryNoStatusFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryNoStatusFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutAsyncRelativeRetryNoStatusResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryNoStatusFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -1494,12 +814,11 @@ func (future LROSADsPutAsyncRelativeRetryNoStatusFuture) Result(client LROSADsCl
 // long-running operation.
 type LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture) Result(client LROSADsClient) (p Product, err error) {
+func (future *LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture) Result(client LROSADsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1507,34 +826,15 @@ func (future LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture) Result(client LR
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutAsyncRelativeRetryNoStatusPayloadResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutAsyncRelativeRetryNoStatusPayloadResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutAsyncRelativeRetryNoStatusPayloadResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -1543,12 +843,11 @@ func (future LROSADsPutAsyncRelativeRetryNoStatusPayloadFuture) Result(client LR
 // long-running operation.
 type LROSADsPutError201NoProvisioningStatePayloadFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutError201NoProvisioningStatePayloadFuture) Result(client LROSADsClient) (p Product, err error) {
+func (future *LROSADsPutError201NoProvisioningStatePayloadFuture) Result(client LROSADsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1556,34 +855,15 @@ func (future LROSADsPutError201NoProvisioningStatePayloadFuture) Result(client L
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutError201NoProvisioningStatePayloadFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutError201NoProvisioningStatePayloadResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutError201NoProvisioningStatePayloadFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutError201NoProvisioningStatePayloadFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutError201NoProvisioningStatePayloadResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutError201NoProvisioningStatePayloadFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutError201NoProvisioningStatePayloadFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutError201NoProvisioningStatePayloadResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutError201NoProvisioningStatePayloadFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -1592,12 +872,11 @@ func (future LROSADsPutError201NoProvisioningStatePayloadFuture) Result(client L
 // long-running operation.
 type LROSADsPutNonRetry201Creating400Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutNonRetry201Creating400Future) Result(client LROSADsClient) (p Product, err error) {
+func (future *LROSADsPutNonRetry201Creating400Future) Result(client LROSADsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1605,34 +884,15 @@ func (future LROSADsPutNonRetry201Creating400Future) Result(client LROSADsClient
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutNonRetry201Creating400Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutNonRetry201Creating400Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutNonRetry201Creating400Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutNonRetry201Creating400Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutNonRetry201Creating400Responder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutNonRetry201Creating400Future", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutNonRetry201Creating400Future", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutNonRetry201Creating400Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutNonRetry201Creating400Future", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -1641,12 +901,11 @@ func (future LROSADsPutNonRetry201Creating400Future) Result(client LROSADsClient
 // long-running operation.
 type LROSADsPutNonRetry201Creating400InvalidJSONFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutNonRetry201Creating400InvalidJSONFuture) Result(client LROSADsClient) (p Product, err error) {
+func (future *LROSADsPutNonRetry201Creating400InvalidJSONFuture) Result(client LROSADsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1654,34 +913,15 @@ func (future LROSADsPutNonRetry201Creating400InvalidJSONFuture) Result(client LR
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutNonRetry201Creating400InvalidJSONFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutNonRetry201Creating400InvalidJSONResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutNonRetry201Creating400InvalidJSONFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutNonRetry201Creating400InvalidJSONFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutNonRetry201Creating400InvalidJSONResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutNonRetry201Creating400InvalidJSONFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutNonRetry201Creating400InvalidJSONFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutNonRetry201Creating400InvalidJSONResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutNonRetry201Creating400InvalidJSONFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -1690,12 +930,11 @@ func (future LROSADsPutNonRetry201Creating400InvalidJSONFuture) Result(client LR
 // operation.
 type LROSADsPutNonRetry400Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROSADsPutNonRetry400Future) Result(client LROSADsClient) (p Product, err error) {
+func (future *LROSADsPutNonRetry400Future) Result(client LROSADsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1703,34 +942,15 @@ func (future LROSADsPutNonRetry400Future) Result(client LROSADsClient) (p Produc
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutNonRetry400Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutNonRetry400Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutNonRetry400Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROSADsPutNonRetry400Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutNonRetry400Responder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutNonRetry400Future", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutNonRetry400Future", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutNonRetry400Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsPutNonRetry400Future", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -1739,12 +959,11 @@ func (future LROSADsPutNonRetry400Future) Result(client LROSADsClient) (p Produc
 // operation.
 type LROsCustomHeaderPost202Retry200Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsCustomHeaderPost202Retry200Future) Result(client LROsCustomHeaderClient) (ar autorest.Response, err error) {
+func (future *LROsCustomHeaderPost202Retry200Future) Result(client LROsCustomHeaderClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1752,35 +971,10 @@ func (future LROsCustomHeaderPost202Retry200Future) Result(client LROsCustomHead
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROsCustomHeaderPost202Retry200Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.Post202Retry200Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderPost202Retry200Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsCustomHeaderPost202Retry200Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderPost202Retry200Future", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.Post202Retry200Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderPost202Retry200Future", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -1788,12 +982,11 @@ func (future LROsCustomHeaderPost202Retry200Future) Result(client LROsCustomHead
 // long-running operation.
 type LROsCustomHeaderPostAsyncRetrySucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsCustomHeaderPostAsyncRetrySucceededFuture) Result(client LROsCustomHeaderClient) (ar autorest.Response, err error) {
+func (future *LROsCustomHeaderPostAsyncRetrySucceededFuture) Result(client LROsCustomHeaderClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1801,35 +994,10 @@ func (future LROsCustomHeaderPostAsyncRetrySucceededFuture) Result(client LROsCu
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROsCustomHeaderPostAsyncRetrySucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.PostAsyncRetrySucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderPostAsyncRetrySucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsCustomHeaderPostAsyncRetrySucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderPostAsyncRetrySucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.PostAsyncRetrySucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderPostAsyncRetrySucceededFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -1837,12 +1005,11 @@ func (future LROsCustomHeaderPostAsyncRetrySucceededFuture) Result(client LROsCu
 // long-running operation.
 type LROsCustomHeaderPut201CreatingSucceeded200Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsCustomHeaderPut201CreatingSucceeded200Future) Result(client LROsCustomHeaderClient) (p Product, err error) {
+func (future *LROsCustomHeaderPut201CreatingSucceeded200Future) Result(client LROsCustomHeaderClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1850,34 +1017,15 @@ func (future LROsCustomHeaderPut201CreatingSucceeded200Future) Result(client LRO
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsCustomHeaderPut201CreatingSucceeded200Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.Put201CreatingSucceeded200Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderPut201CreatingSucceeded200Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsCustomHeaderPut201CreatingSucceeded200Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.Put201CreatingSucceeded200Responder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderPut201CreatingSucceeded200Future", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderPut201CreatingSucceeded200Future", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.Put201CreatingSucceeded200Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderPut201CreatingSucceeded200Future", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -1886,12 +1034,11 @@ func (future LROsCustomHeaderPut201CreatingSucceeded200Future) Result(client LRO
 // long-running operation.
 type LROsCustomHeaderPutAsyncRetrySucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsCustomHeaderPutAsyncRetrySucceededFuture) Result(client LROsCustomHeaderClient) (p Product, err error) {
+func (future *LROsCustomHeaderPutAsyncRetrySucceededFuture) Result(client LROsCustomHeaderClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1899,34 +1046,15 @@ func (future LROsCustomHeaderPutAsyncRetrySucceededFuture) Result(client LROsCus
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsCustomHeaderPutAsyncRetrySucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutAsyncRetrySucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderPutAsyncRetrySucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsCustomHeaderPutAsyncRetrySucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutAsyncRetrySucceededResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderPutAsyncRetrySucceededFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderPutAsyncRetrySucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutAsyncRetrySucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderPutAsyncRetrySucceededFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -1935,12 +1063,11 @@ func (future LROsCustomHeaderPutAsyncRetrySucceededFuture) Result(client LROsCus
 // operation.
 type LROsDelete202NoRetry204Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDelete202NoRetry204Future) Result(client LROsClient) (p Product, err error) {
+func (future *LROsDelete202NoRetry204Future) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1948,34 +1075,15 @@ func (future LROsDelete202NoRetry204Future) Result(client LROsClient) (p Product
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsDelete202NoRetry204Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.Delete202NoRetry204Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsDelete202NoRetry204Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsDelete202NoRetry204Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.Delete202NoRetry204Responder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsDelete202NoRetry204Future", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDelete202NoRetry204Future", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.Delete202NoRetry204Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDelete202NoRetry204Future", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -1984,12 +1092,11 @@ func (future LROsDelete202NoRetry204Future) Result(client LROsClient) (p Product
 // operation.
 type LROsDelete202Retry200Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDelete202Retry200Future) Result(client LROsClient) (p Product, err error) {
+func (future *LROsDelete202Retry200Future) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -1997,34 +1104,15 @@ func (future LROsDelete202Retry200Future) Result(client LROsClient) (p Product, 
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsDelete202Retry200Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.Delete202Retry200Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsDelete202Retry200Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsDelete202Retry200Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.Delete202Retry200Responder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsDelete202Retry200Future", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDelete202Retry200Future", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.Delete202Retry200Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDelete202Retry200Future", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -2033,12 +1121,11 @@ func (future LROsDelete202Retry200Future) Result(client LROsClient) (p Product, 
 // operation.
 type LROsDelete204SucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDelete204SucceededFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+func (future *LROsDelete204SucceededFuture) Result(client LROsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2046,35 +1133,10 @@ func (future LROsDelete204SucceededFuture) Result(client LROsClient) (ar autores
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROsDelete204SucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.Delete204SucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsDelete204SucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsDelete204SucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDelete204SucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.Delete204SucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDelete204SucceededFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -2082,12 +1144,11 @@ func (future LROsDelete204SucceededFuture) Result(client LROsClient) (ar autores
 // operation.
 type LROsDeleteAsyncNoHeaderInRetryFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteAsyncNoHeaderInRetryFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+func (future *LROsDeleteAsyncNoHeaderInRetryFuture) Result(client LROsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2095,35 +1156,10 @@ func (future LROsDeleteAsyncNoHeaderInRetryFuture) Result(client LROsClient) (ar
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteAsyncNoHeaderInRetryFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.DeleteAsyncNoHeaderInRetryResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteAsyncNoHeaderInRetryFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteAsyncNoHeaderInRetryFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteAsyncNoHeaderInRetryFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.DeleteAsyncNoHeaderInRetryResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteAsyncNoHeaderInRetryFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -2131,12 +1167,11 @@ func (future LROsDeleteAsyncNoHeaderInRetryFuture) Result(client LROsClient) (ar
 // operation.
 type LROsDeleteAsyncNoRetrySucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteAsyncNoRetrySucceededFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+func (future *LROsDeleteAsyncNoRetrySucceededFuture) Result(client LROsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2144,35 +1179,10 @@ func (future LROsDeleteAsyncNoRetrySucceededFuture) Result(client LROsClient) (a
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteAsyncNoRetrySucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.DeleteAsyncNoRetrySucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteAsyncNoRetrySucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteAsyncNoRetrySucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteAsyncNoRetrySucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.DeleteAsyncNoRetrySucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteAsyncNoRetrySucceededFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -2180,12 +1190,11 @@ func (future LROsDeleteAsyncNoRetrySucceededFuture) Result(client LROsClient) (a
 // operation.
 type LROsDeleteAsyncRetrycanceledFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteAsyncRetrycanceledFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+func (future *LROsDeleteAsyncRetrycanceledFuture) Result(client LROsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2193,35 +1202,10 @@ func (future LROsDeleteAsyncRetrycanceledFuture) Result(client LROsClient) (ar a
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteAsyncRetrycanceledFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.DeleteAsyncRetrycanceledResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteAsyncRetrycanceledFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteAsyncRetrycanceledFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteAsyncRetrycanceledFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.DeleteAsyncRetrycanceledResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteAsyncRetrycanceledFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -2229,12 +1213,11 @@ func (future LROsDeleteAsyncRetrycanceledFuture) Result(client LROsClient) (ar a
 // operation.
 type LROsDeleteAsyncRetryFailedFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteAsyncRetryFailedFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+func (future *LROsDeleteAsyncRetryFailedFuture) Result(client LROsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2242,35 +1225,10 @@ func (future LROsDeleteAsyncRetryFailedFuture) Result(client LROsClient) (ar aut
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteAsyncRetryFailedFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.DeleteAsyncRetryFailedResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteAsyncRetryFailedFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteAsyncRetryFailedFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteAsyncRetryFailedFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.DeleteAsyncRetryFailedResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteAsyncRetryFailedFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -2278,12 +1236,11 @@ func (future LROsDeleteAsyncRetryFailedFuture) Result(client LROsClient) (ar aut
 // operation.
 type LROsDeleteAsyncRetrySucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteAsyncRetrySucceededFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+func (future *LROsDeleteAsyncRetrySucceededFuture) Result(client LROsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2291,35 +1248,10 @@ func (future LROsDeleteAsyncRetrySucceededFuture) Result(client LROsClient) (ar 
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteAsyncRetrySucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.DeleteAsyncRetrySucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteAsyncRetrySucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteAsyncRetrySucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteAsyncRetrySucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.DeleteAsyncRetrySucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteAsyncRetrySucceededFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -2327,12 +1259,11 @@ func (future LROsDeleteAsyncRetrySucceededFuture) Result(client LROsClient) (ar 
 // operation.
 type LROsDeleteNoHeaderInRetryFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteNoHeaderInRetryFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+func (future *LROsDeleteNoHeaderInRetryFuture) Result(client LROsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2340,35 +1271,10 @@ func (future LROsDeleteNoHeaderInRetryFuture) Result(client LROsClient) (ar auto
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteNoHeaderInRetryFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.DeleteNoHeaderInRetryResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteNoHeaderInRetryFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteNoHeaderInRetryFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteNoHeaderInRetryFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.DeleteNoHeaderInRetryResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteNoHeaderInRetryFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -2376,12 +1282,11 @@ func (future LROsDeleteNoHeaderInRetryFuture) Result(client LROsClient) (ar auto
 // a long-running operation.
 type LROsDeleteProvisioning202Accepted200SucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteProvisioning202Accepted200SucceededFuture) Result(client LROsClient) (p Product, err error) {
+func (future *LROsDeleteProvisioning202Accepted200SucceededFuture) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2389,34 +1294,15 @@ func (future LROsDeleteProvisioning202Accepted200SucceededFuture) Result(client 
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteProvisioning202Accepted200SucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.DeleteProvisioning202Accepted200SucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteProvisioning202Accepted200SucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteProvisioning202Accepted200SucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.DeleteProvisioning202Accepted200SucceededResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteProvisioning202Accepted200SucceededFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteProvisioning202Accepted200SucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.DeleteProvisioning202Accepted200SucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteProvisioning202Accepted200SucceededFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -2425,12 +1311,11 @@ func (future LROsDeleteProvisioning202Accepted200SucceededFuture) Result(client 
 // long-running operation.
 type LROsDeleteProvisioning202Deletingcanceled200Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteProvisioning202Deletingcanceled200Future) Result(client LROsClient) (p Product, err error) {
+func (future *LROsDeleteProvisioning202Deletingcanceled200Future) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2438,34 +1323,15 @@ func (future LROsDeleteProvisioning202Deletingcanceled200Future) Result(client L
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteProvisioning202Deletingcanceled200Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.DeleteProvisioning202Deletingcanceled200Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteProvisioning202Deletingcanceled200Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteProvisioning202Deletingcanceled200Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.DeleteProvisioning202Deletingcanceled200Responder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteProvisioning202Deletingcanceled200Future", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteProvisioning202Deletingcanceled200Future", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.DeleteProvisioning202Deletingcanceled200Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteProvisioning202Deletingcanceled200Future", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -2474,12 +1340,11 @@ func (future LROsDeleteProvisioning202Deletingcanceled200Future) Result(client L
 // long-running operation.
 type LROsDeleteProvisioning202DeletingFailed200Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsDeleteProvisioning202DeletingFailed200Future) Result(client LROsClient) (p Product, err error) {
+func (future *LROsDeleteProvisioning202DeletingFailed200Future) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2487,34 +1352,15 @@ func (future LROsDeleteProvisioning202DeletingFailed200Future) Result(client LRO
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteProvisioning202DeletingFailed200Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.DeleteProvisioning202DeletingFailed200Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteProvisioning202DeletingFailed200Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsDeleteProvisioning202DeletingFailed200Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.DeleteProvisioning202DeletingFailed200Responder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteProvisioning202DeletingFailed200Future", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteProvisioning202DeletingFailed200Future", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.DeleteProvisioning202DeletingFailed200Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsDeleteProvisioning202DeletingFailed200Future", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -2523,12 +1369,11 @@ func (future LROsDeleteProvisioning202DeletingFailed200Future) Result(client LRO
 // operation.
 type LROsPost200WithPayloadFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPost200WithPayloadFuture) Result(client LROsClient) (s Sku, err error) {
+func (future *LROsPost200WithPayloadFuture) Result(client LROsClient) (s Sku, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2536,34 +1381,15 @@ func (future LROsPost200WithPayloadFuture) Result(client LROsClient) (s Sku, err
 		return
 	}
 	if !done {
-		return s, azure.NewAsyncOpIncompleteError("lrogroup.LROsPost200WithPayloadFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		s, err = client.Post200WithPayloadResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPost200WithPayloadFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPost200WithPayloadFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if s.Response.Response, err = future.GetResult(sender); err == nil && s.Response.Response.StatusCode != http.StatusNoContent {
+		s, err = client.Post200WithPayloadResponder(s.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPost200WithPayloadFuture", "Result", s.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPost200WithPayloadFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	s, err = client.Post200WithPayloadResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPost200WithPayloadFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -2572,12 +1398,11 @@ func (future LROsPost200WithPayloadFuture) Result(client LROsClient) (s Sku, err
 // operation.
 type LROsPost202NoRetry204Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPost202NoRetry204Future) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPost202NoRetry204Future) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2585,34 +1410,15 @@ func (future LROsPost202NoRetry204Future) Result(client LROsClient) (p Product, 
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPost202NoRetry204Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.Post202NoRetry204Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPost202NoRetry204Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPost202NoRetry204Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.Post202NoRetry204Responder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPost202NoRetry204Future", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPost202NoRetry204Future", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.Post202NoRetry204Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPost202NoRetry204Future", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -2620,12 +1426,11 @@ func (future LROsPost202NoRetry204Future) Result(client LROsClient) (p Product, 
 // LROsPost202Retry200Future an abstraction for monitoring and retrieving the results of a long-running operation.
 type LROsPost202Retry200Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPost202Retry200Future) Result(client LROsClient) (ar autorest.Response, err error) {
+func (future *LROsPost202Retry200Future) Result(client LROsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2633,35 +1438,10 @@ func (future LROsPost202Retry200Future) Result(client LROsClient) (ar autorest.R
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROsPost202Retry200Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.Post202Retry200Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPost202Retry200Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPost202Retry200Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPost202Retry200Future", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.Post202Retry200Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPost202Retry200Future", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -2669,12 +1449,11 @@ func (future LROsPost202Retry200Future) Result(client LROsClient) (ar autorest.R
 // operation.
 type LROsPostAsyncNoRetrySucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPostAsyncNoRetrySucceededFuture) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPostAsyncNoRetrySucceededFuture) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2682,34 +1461,15 @@ func (future LROsPostAsyncNoRetrySucceededFuture) Result(client LROsClient) (p P
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPostAsyncNoRetrySucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PostAsyncNoRetrySucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPostAsyncNoRetrySucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPostAsyncNoRetrySucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PostAsyncNoRetrySucceededResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPostAsyncNoRetrySucceededFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPostAsyncNoRetrySucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PostAsyncNoRetrySucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPostAsyncNoRetrySucceededFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -2718,12 +1478,11 @@ func (future LROsPostAsyncNoRetrySucceededFuture) Result(client LROsClient) (p P
 // operation.
 type LROsPostAsyncRetrycanceledFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPostAsyncRetrycanceledFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+func (future *LROsPostAsyncRetrycanceledFuture) Result(client LROsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2731,35 +1490,10 @@ func (future LROsPostAsyncRetrycanceledFuture) Result(client LROsClient) (ar aut
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROsPostAsyncRetrycanceledFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.PostAsyncRetrycanceledResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPostAsyncRetrycanceledFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPostAsyncRetrycanceledFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPostAsyncRetrycanceledFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.PostAsyncRetrycanceledResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPostAsyncRetrycanceledFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -2767,12 +1501,11 @@ func (future LROsPostAsyncRetrycanceledFuture) Result(client LROsClient) (ar aut
 // operation.
 type LROsPostAsyncRetryFailedFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPostAsyncRetryFailedFuture) Result(client LROsClient) (ar autorest.Response, err error) {
+func (future *LROsPostAsyncRetryFailedFuture) Result(client LROsClient) (ar autorest.Response, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2780,35 +1513,10 @@ func (future LROsPostAsyncRetryFailedFuture) Result(client LROsClient) (ar autor
 		return
 	}
 	if !done {
-		return ar, azure.NewAsyncOpIncompleteError("lrogroup.LROsPostAsyncRetryFailedFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		ar, err = client.PostAsyncRetryFailedResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPostAsyncRetryFailedFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPostAsyncRetryFailedFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
-		if err != nil {
-			return
-		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPostAsyncRetryFailedFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	ar, err = client.PostAsyncRetryFailedResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPostAsyncRetryFailedFuture", "Result", resp, "Failure responding to request")
-	}
+	ar.Response = future.Response()
 	return
 }
 
@@ -2816,12 +1524,11 @@ func (future LROsPostAsyncRetryFailedFuture) Result(client LROsClient) (ar autor
 // operation.
 type LROsPostAsyncRetrySucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPostAsyncRetrySucceededFuture) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPostAsyncRetrySucceededFuture) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2829,34 +1536,15 @@ func (future LROsPostAsyncRetrySucceededFuture) Result(client LROsClient) (p Pro
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPostAsyncRetrySucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PostAsyncRetrySucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPostAsyncRetrySucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPostAsyncRetrySucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PostAsyncRetrySucceededResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPostAsyncRetrySucceededFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPostAsyncRetrySucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PostAsyncRetrySucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPostAsyncRetrySucceededFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -2865,12 +1553,11 @@ func (future LROsPostAsyncRetrySucceededFuture) Result(client LROsClient) (p Pro
 // operation.
 type LROsPut200Acceptedcanceled200Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPut200Acceptedcanceled200Future) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPut200Acceptedcanceled200Future) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2878,34 +1565,15 @@ func (future LROsPut200Acceptedcanceled200Future) Result(client LROsClient) (p P
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPut200Acceptedcanceled200Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.Put200Acceptedcanceled200Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200Acceptedcanceled200Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPut200Acceptedcanceled200Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.Put200Acceptedcanceled200Responder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200Acceptedcanceled200Future", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200Acceptedcanceled200Future", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.Put200Acceptedcanceled200Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200Acceptedcanceled200Future", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -2913,12 +1581,11 @@ func (future LROsPut200Acceptedcanceled200Future) Result(client LROsClient) (p P
 // LROsPut200SucceededFuture an abstraction for monitoring and retrieving the results of a long-running operation.
 type LROsPut200SucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPut200SucceededFuture) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPut200SucceededFuture) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2926,34 +1593,15 @@ func (future LROsPut200SucceededFuture) Result(client LROsClient) (p Product, er
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPut200SucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.Put200SucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200SucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPut200SucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.Put200SucceededResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200SucceededFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200SucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.Put200SucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200SucceededFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -2962,12 +1610,11 @@ func (future LROsPut200SucceededFuture) Result(client LROsClient) (p Product, er
 // operation.
 type LROsPut200SucceededNoStateFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPut200SucceededNoStateFuture) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPut200SucceededNoStateFuture) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -2975,34 +1622,15 @@ func (future LROsPut200SucceededNoStateFuture) Result(client LROsClient) (p Prod
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPut200SucceededNoStateFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.Put200SucceededNoStateResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200SucceededNoStateFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPut200SucceededNoStateFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.Put200SucceededNoStateResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200SucceededNoStateFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200SucceededNoStateFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.Put200SucceededNoStateResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200SucceededNoStateFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -3011,12 +1639,11 @@ func (future LROsPut200SucceededNoStateFuture) Result(client LROsClient) (p Prod
 // operation.
 type LROsPut200UpdatingSucceeded204Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPut200UpdatingSucceeded204Future) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPut200UpdatingSucceeded204Future) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -3024,34 +1651,15 @@ func (future LROsPut200UpdatingSucceeded204Future) Result(client LROsClient) (p 
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPut200UpdatingSucceeded204Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.Put200UpdatingSucceeded204Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200UpdatingSucceeded204Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPut200UpdatingSucceeded204Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.Put200UpdatingSucceeded204Responder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200UpdatingSucceeded204Future", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200UpdatingSucceeded204Future", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.Put200UpdatingSucceeded204Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPut200UpdatingSucceeded204Future", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -3060,12 +1668,11 @@ func (future LROsPut200UpdatingSucceeded204Future) Result(client LROsClient) (p 
 // operation.
 type LROsPut201CreatingFailed200Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPut201CreatingFailed200Future) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPut201CreatingFailed200Future) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -3073,34 +1680,15 @@ func (future LROsPut201CreatingFailed200Future) Result(client LROsClient) (p Pro
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPut201CreatingFailed200Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.Put201CreatingFailed200Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPut201CreatingFailed200Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPut201CreatingFailed200Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.Put201CreatingFailed200Responder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPut201CreatingFailed200Future", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPut201CreatingFailed200Future", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.Put201CreatingFailed200Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPut201CreatingFailed200Future", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -3109,12 +1697,11 @@ func (future LROsPut201CreatingFailed200Future) Result(client LROsClient) (p Pro
 // operation.
 type LROsPut201CreatingSucceeded200Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPut201CreatingSucceeded200Future) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPut201CreatingSucceeded200Future) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -3122,34 +1709,15 @@ func (future LROsPut201CreatingSucceeded200Future) Result(client LROsClient) (p 
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPut201CreatingSucceeded200Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.Put201CreatingSucceeded200Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPut201CreatingSucceeded200Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPut201CreatingSucceeded200Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.Put201CreatingSucceeded200Responder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPut201CreatingSucceeded200Future", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPut201CreatingSucceeded200Future", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.Put201CreatingSucceeded200Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPut201CreatingSucceeded200Future", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -3157,12 +1725,11 @@ func (future LROsPut201CreatingSucceeded200Future) Result(client LROsClient) (p 
 // LROsPut202Retry200Future an abstraction for monitoring and retrieving the results of a long-running operation.
 type LROsPut202Retry200Future struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPut202Retry200Future) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPut202Retry200Future) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -3170,34 +1737,15 @@ func (future LROsPut202Retry200Future) Result(client LROsClient) (p Product, err
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPut202Retry200Future")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.Put202Retry200Responder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPut202Retry200Future", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPut202Retry200Future")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.Put202Retry200Responder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPut202Retry200Future", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPut202Retry200Future", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.Put202Retry200Responder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPut202Retry200Future", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -3206,12 +1754,11 @@ func (future LROsPut202Retry200Future) Result(client LROsClient) (p Product, err
 // operation.
 type LROsPutAsyncNoHeaderInRetryFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutAsyncNoHeaderInRetryFuture) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPutAsyncNoHeaderInRetryFuture) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -3219,34 +1766,15 @@ func (future LROsPutAsyncNoHeaderInRetryFuture) Result(client LROsClient) (p Pro
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPutAsyncNoHeaderInRetryFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutAsyncNoHeaderInRetryResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNoHeaderInRetryFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPutAsyncNoHeaderInRetryFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutAsyncNoHeaderInRetryResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNoHeaderInRetryFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNoHeaderInRetryFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutAsyncNoHeaderInRetryResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNoHeaderInRetryFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -3255,12 +1783,11 @@ func (future LROsPutAsyncNoHeaderInRetryFuture) Result(client LROsClient) (p Pro
 // operation.
 type LROsPutAsyncNonResourceFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutAsyncNonResourceFuture) Result(client LROsClient) (s Sku, err error) {
+func (future *LROsPutAsyncNonResourceFuture) Result(client LROsClient) (s Sku, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -3268,34 +1795,15 @@ func (future LROsPutAsyncNonResourceFuture) Result(client LROsClient) (s Sku, er
 		return
 	}
 	if !done {
-		return s, azure.NewAsyncOpIncompleteError("lrogroup.LROsPutAsyncNonResourceFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		s, err = client.PutAsyncNonResourceResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNonResourceFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPutAsyncNonResourceFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if s.Response.Response, err = future.GetResult(sender); err == nil && s.Response.Response.StatusCode != http.StatusNoContent {
+		s, err = client.PutAsyncNonResourceResponder(s.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNonResourceFuture", "Result", s.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNonResourceFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	s, err = client.PutAsyncNonResourceResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNonResourceFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -3304,12 +1812,11 @@ func (future LROsPutAsyncNonResourceFuture) Result(client LROsClient) (s Sku, er
 // operation.
 type LROsPutAsyncNoRetrycanceledFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutAsyncNoRetrycanceledFuture) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPutAsyncNoRetrycanceledFuture) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -3317,34 +1824,15 @@ func (future LROsPutAsyncNoRetrycanceledFuture) Result(client LROsClient) (p Pro
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPutAsyncNoRetrycanceledFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutAsyncNoRetrycanceledResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNoRetrycanceledFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPutAsyncNoRetrycanceledFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutAsyncNoRetrycanceledResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNoRetrycanceledFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNoRetrycanceledFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutAsyncNoRetrycanceledResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNoRetrycanceledFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -3353,12 +1841,11 @@ func (future LROsPutAsyncNoRetrycanceledFuture) Result(client LROsClient) (p Pro
 // operation.
 type LROsPutAsyncNoRetrySucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutAsyncNoRetrySucceededFuture) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPutAsyncNoRetrySucceededFuture) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -3366,34 +1853,15 @@ func (future LROsPutAsyncNoRetrySucceededFuture) Result(client LROsClient) (p Pr
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPutAsyncNoRetrySucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutAsyncNoRetrySucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNoRetrySucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPutAsyncNoRetrySucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutAsyncNoRetrySucceededResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNoRetrySucceededFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNoRetrySucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutAsyncNoRetrySucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncNoRetrySucceededFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -3402,12 +1870,11 @@ func (future LROsPutAsyncNoRetrySucceededFuture) Result(client LROsClient) (p Pr
 // operation.
 type LROsPutAsyncRetryFailedFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutAsyncRetryFailedFuture) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPutAsyncRetryFailedFuture) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -3415,34 +1882,15 @@ func (future LROsPutAsyncRetryFailedFuture) Result(client LROsClient) (p Product
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPutAsyncRetryFailedFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutAsyncRetryFailedResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncRetryFailedFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPutAsyncRetryFailedFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutAsyncRetryFailedResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncRetryFailedFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncRetryFailedFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutAsyncRetryFailedResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncRetryFailedFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -3451,12 +1899,11 @@ func (future LROsPutAsyncRetryFailedFuture) Result(client LROsClient) (p Product
 // operation.
 type LROsPutAsyncRetrySucceededFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutAsyncRetrySucceededFuture) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPutAsyncRetrySucceededFuture) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -3464,34 +1911,15 @@ func (future LROsPutAsyncRetrySucceededFuture) Result(client LROsClient) (p Prod
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPutAsyncRetrySucceededFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutAsyncRetrySucceededResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncRetrySucceededFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPutAsyncRetrySucceededFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutAsyncRetrySucceededResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncRetrySucceededFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncRetrySucceededFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutAsyncRetrySucceededResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncRetrySucceededFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -3500,12 +1928,11 @@ func (future LROsPutAsyncRetrySucceededFuture) Result(client LROsClient) (p Prod
 // operation.
 type LROsPutAsyncSubResourceFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutAsyncSubResourceFuture) Result(client LROsClient) (sp SubProduct, err error) {
+func (future *LROsPutAsyncSubResourceFuture) Result(client LROsClient) (sp SubProduct, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -3513,34 +1940,15 @@ func (future LROsPutAsyncSubResourceFuture) Result(client LROsClient) (sp SubPro
 		return
 	}
 	if !done {
-		return sp, azure.NewAsyncOpIncompleteError("lrogroup.LROsPutAsyncSubResourceFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		sp, err = client.PutAsyncSubResourceResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncSubResourceFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPutAsyncSubResourceFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if sp.Response.Response, err = future.GetResult(sender); err == nil && sp.Response.Response.StatusCode != http.StatusNoContent {
+		sp, err = client.PutAsyncSubResourceResponder(sp.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncSubResourceFuture", "Result", sp.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncSubResourceFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	sp, err = client.PutAsyncSubResourceResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutAsyncSubResourceFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -3549,12 +1957,11 @@ func (future LROsPutAsyncSubResourceFuture) Result(client LROsClient) (sp SubPro
 // operation.
 type LROsPutNoHeaderInRetryFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutNoHeaderInRetryFuture) Result(client LROsClient) (p Product, err error) {
+func (future *LROsPutNoHeaderInRetryFuture) Result(client LROsClient) (p Product, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -3562,34 +1969,15 @@ func (future LROsPutNoHeaderInRetryFuture) Result(client LROsClient) (p Product,
 		return
 	}
 	if !done {
-		return p, azure.NewAsyncOpIncompleteError("lrogroup.LROsPutNoHeaderInRetryFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		p, err = client.PutNoHeaderInRetryResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutNoHeaderInRetryFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPutNoHeaderInRetryFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if p.Response.Response, err = future.GetResult(sender); err == nil && p.Response.Response.StatusCode != http.StatusNoContent {
+		p, err = client.PutNoHeaderInRetryResponder(p.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutNoHeaderInRetryFuture", "Result", p.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutNoHeaderInRetryFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	p, err = client.PutNoHeaderInRetryResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutNoHeaderInRetryFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -3597,12 +1985,11 @@ func (future LROsPutNoHeaderInRetryFuture) Result(client LROsClient) (p Product,
 // LROsPutNonResourceFuture an abstraction for monitoring and retrieving the results of a long-running operation.
 type LROsPutNonResourceFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutNonResourceFuture) Result(client LROsClient) (s Sku, err error) {
+func (future *LROsPutNonResourceFuture) Result(client LROsClient) (s Sku, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -3610,34 +1997,15 @@ func (future LROsPutNonResourceFuture) Result(client LROsClient) (s Sku, err err
 		return
 	}
 	if !done {
-		return s, azure.NewAsyncOpIncompleteError("lrogroup.LROsPutNonResourceFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		s, err = client.PutNonResourceResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutNonResourceFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPutNonResourceFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if s.Response.Response, err = future.GetResult(sender); err == nil && s.Response.Response.StatusCode != http.StatusNoContent {
+		s, err = client.PutNonResourceResponder(s.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutNonResourceFuture", "Result", s.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutNonResourceFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	s, err = client.PutNonResourceResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutNonResourceFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }
@@ -3645,12 +2013,11 @@ func (future LROsPutNonResourceFuture) Result(client LROsClient) (s Sku, err err
 // LROsPutSubResourceFuture an abstraction for monitoring and retrieving the results of a long-running operation.
 type LROsPutSubResourceFuture struct {
 	azure.Future
-	req *http.Request
 }
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future LROsPutSubResourceFuture) Result(client LROsClient) (sp SubProduct, err error) {
+func (future *LROsPutSubResourceFuture) Result(client LROsClient) (sp SubProduct, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -3658,34 +2025,15 @@ func (future LROsPutSubResourceFuture) Result(client LROsClient) (sp SubProduct,
 		return
 	}
 	if !done {
-		return sp, azure.NewAsyncOpIncompleteError("lrogroup.LROsPutSubResourceFuture")
-	}
-	if future.PollingMethod() == azure.PollingLocation {
-		sp, err = client.PutSubResourceResponder(future.Response())
-		if err != nil {
-			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutSubResourceFuture", "Result", future.Response(), "Failure responding to request")
-		}
+		err = azure.NewAsyncOpIncompleteError("lrogroup.LROsPutSubResourceFuture")
 		return
 	}
-	var req *http.Request
-	var resp *http.Response
-	if future.PollingURL() != "" {
-		req, err = http.NewRequest(http.MethodGet, future.PollingURL(), nil)
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if sp.Response.Response, err = future.GetResult(sender); err == nil && sp.Response.Response.StatusCode != http.StatusNoContent {
+		sp, err = client.PutSubResourceResponder(sp.Response.Response)
 		if err != nil {
-			return
+			err = autorest.NewErrorWithError(err, "lrogroup.LROsPutSubResourceFuture", "Result", sp.Response.Response, "Failure responding to request")
 		}
-	} else {
-		req = autorest.ChangeToGet(future.req)
-	}
-	resp, err = autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutSubResourceFuture", "Result", resp, "Failure sending request")
-		return
-	}
-	sp, err = client.PutSubResourceResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsPutSubResourceFuture", "Result", resp, "Failure responding to request")
 	}
 	return
 }


### PR DESCRIPTION
Codegen for LROs has been updated to use azure.NewFutureFromResponse
when creating a Future.
The Result method on generated future types uses Future's new internal
logic for retrieving the final result.
Added missing LRO tests and updated dependencies.