### PR TITLE
Fix future/pageable types.

### DIFF
--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -142,13 +142,9 @@ namespace AutoRest.Go.Model
                 {
                     imports.Add(PrimaryTypeGo.GetImportLine("github.com/Azure/go-autorest/autorest/azure"));
                     // if any of the futures return the non-default response then we need the net/http package
-                    foreach (var ftg in futureModels)
+                    if (futureModels.Any(fm => !fm.IsDefaultReturnType))
                     {
-                        if (!ftg.IsDefaultReturnType)
-                        {
-                            imports.Add(PrimaryTypeGo.GetImportLine("net/http"));
-                            break;
-                        }
+                        imports.Add(PrimaryTypeGo.GetImportLine("net/http"));
                     }
                 }
                 ModelTypes.Cast<CompositeTypeGo>()

--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -137,10 +137,19 @@ namespace AutoRest.Go.Model
                 {
                     imports.Add(PrimaryTypeGo.GetImportLine("github.com/Azure/go-autorest/autorest"));
                 }
-                if (ModelTypes.Any(mt => mt is FutureTypeGo))
+                var futureModels = ModelTypes.Where(mt => mt is FutureTypeGo).Cast<FutureTypeGo>();
+                if (futureModels.Any())
                 {
                     imports.Add(PrimaryTypeGo.GetImportLine("github.com/Azure/go-autorest/autorest/azure"));
-                    imports.Add(PrimaryTypeGo.GetImportLine("net/http"));
+                    // if any of the futures return the non-default response then we need the net/http package
+                    foreach (var ftg in futureModels)
+                    {
+                        if (!ftg.IsDefaultReturnType)
+                        {
+                            imports.Add(PrimaryTypeGo.GetImportLine("net/http"));
+                            break;
+                        }
+                    }
                 }
                 ModelTypes.Cast<CompositeTypeGo>()
                     .ForEach(mt =>

--- a/src/Model/FutureTypeGo.cs
+++ b/src/Model/FutureTypeGo.cs
@@ -84,6 +84,11 @@ namespace AutoRest.Go.Model
         }
 
         /// <summary>
+        /// Returns true if the result type is the default response type.
+        /// </summary>
+        public bool IsDefaultReturnType => ResultType == null;
+
+        /// <summary>
         /// Gets the name of the responder method associated with this future.
         /// </summary>
         public string ResponderMethodName { get; }

--- a/src/Templates/MethodTemplate.cshtml
+++ b/src/Templates/MethodTemplate.cshtml
@@ -361,7 +361,6 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature) (@M
             var future @Model.MethodReturnType
             future, err = client.@(Model.Name)(@(Model.HelperInvocationParameters()))
             result.Future = future.Future
-            result.req = future.req
             </text>
         }
         else

--- a/src/Templates/ModelTemplate.cshtml
+++ b/src/Templates/ModelTemplate.cshtml
@@ -426,9 +426,9 @@ else
     var resultVar = ftg.ResultTypeName.ToShortName();
     var resultVarTarget = resultVar;
     var futureTypeName = $"{Model.CodeModel.Namespace}.{Model.Name}";
-    if (ftg.ResultType is IteratorTypeGo itg)
+    if (ftg.ResultType is PageTypeGo ptg)
     {
-        resultVarTarget = $"{resultVarTarget}.{itg.PageField}";
+        resultVarTarget = $"{resultVarTarget}.{ptg.ResultFieldName}";
     }
     <text>
     // Result returns the result of the asynchronous operation.
@@ -444,11 +444,11 @@ else
         err = azure.NewAsyncOpIncompleteError("@futureTypeName")
         return
     }
-    @if (ftg.ResultTypeName == MethodGo.DefaultReturnType)
+    @if (ftg.IsDefaultReturnType)
     {
         // for default return types (i.e. autorest.Response)
         // assign the raw HTTP response to the *http.Response field
-    @:@(resultVar).Response = future.Response()
+    @:@(resultVarTarget).Response = future.Response()
     }
     else
     {
@@ -457,10 +457,10 @@ else
         // in it we need an extra ".Response" :(
     <text>
     sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-    if @(resultVar).Response.Response, err = future.GetResult(sender); err == nil && @(resultVar).Response.Response.StatusCode != http.StatusNoContent {
-        @resultVar, err = client.@(ftg.ResponderMethodName)(@(resultVar).Response.Response)
+    if @(resultVarTarget).Response.Response, err = future.GetResult(sender); err == nil && @(resultVarTarget).Response.Response.StatusCode != http.StatusNoContent {
+        @resultVar, err = client.@(ftg.ResponderMethodName)(@(resultVarTarget).Response.Response)
         if err != nil {
-            err = autorest.NewErrorWithError(err, "@futureTypeName", "Result", @(resultVar).Response.Response, "Failure responding to request")
+            err = autorest.NewErrorWithError(err, "@futureTypeName", "Result", @(resultVarTarget).Response.Response, "Failure responding to request")
         }
     }
     </text>


### PR DESCRIPTION
The previous LRO changes were incomplete, they missed the case where
futures intersect with pageable types.
Avoid importing the net/http package when it's not needed.