### PR TITLE
Fix *Complete() method for LROs to return iterator

### DIFF
--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -370,13 +370,14 @@ namespace AutoRest.Go.Model
             }
 
             // this is the future to return from the method
-            var future = GetOrAddFuture(new FutureTypeGo(method));
+            var future = GetOrAddFuture(new FutureTypeGo(method, method.ReturnValue().Body));
 
             // if this is a pageable method create a future type for the
             // "list all" method wrapped in our custom response type
             if (method.IsPageable)
             {
-                var listAllFuture = GetOrAddFuture(new FutureTypeGo(CodeNamerGo.Instance.GetFutureTypeName($"{method.Group}{method.Name}All"), method));
+                var listAllFuture = GetOrAddFuture(new FutureTypeGo(CodeNamerGo.Instance.GetFutureTypeName($"{method.Group}{method.Name}All"), method,
+                    ((PageTypeGo)method.ReturnValue().Body).IteratorType));
                 method.ReturnType = new LroPagedResponseGo(future, listAllFuture, method.ReturnType.Headers);
             }
             else

--- a/src/Model/FutureTypeGo.cs
+++ b/src/Model/FutureTypeGo.cs
@@ -15,29 +15,13 @@ namespace AutoRest.Go.Model
         /// Creates a new future type for the specified method.
         /// </summary>
         /// <param name="method">The method that will return a future.</param>
-        public FutureTypeGo(MethodGo method) : this(CodeNamerGo.Instance.GetFutureTypeName(method), method)
-        {
-            if (!method.IsLongRunningOperation())
-            {
-                throw new InvalidOperationException($"method {method.Owner}.{method.Name} is not a long-running operation");
-            }
-
-            CodeModel = method.CodeModel;
-            Documentation = "An abstraction for monitoring and retrieving the results of a long-running operation.";
-            ClientTypeName = method.Owner;
-            ResultType = method.ReturnValue().Body;
-            ResponderMethodName = method.ResponderMethodName;
-            if (method.Deprecated)
-            {
-                DeprecationMessage = "The method for this type has been deprecated.";
-            }
-        }
+        public FutureTypeGo(MethodGo method, IModelType resultType) : this(CodeNamerGo.Instance.GetFutureTypeName(method), method, resultType) {}
 
         /// <summary>
         /// Creates a new future type for the specified method using the specified name.
         /// </summary>
         /// <param name="method">The method that will return a future.</param>
-        public FutureTypeGo(string methodName, MethodGo method) : base(methodName)
+        public FutureTypeGo(string methodName, MethodGo method, IModelType resultType) : base(methodName)
         {
             if (!method.IsLongRunningOperation())
             {
@@ -47,8 +31,12 @@ namespace AutoRest.Go.Model
             CodeModel = method.CodeModel;
             Documentation = "An abstraction for monitoring and retrieving the results of a long-running operation.";
             ClientTypeName = method.Owner;
-            ResultType = method.ReturnValue().Body;
+            ResultType = resultType;
             ResponderMethodName = method.ResponderMethodName;
+            if (method.Deprecated)
+            {
+                DeprecationMessage = "The method for this type has been deprecated.";
+            }
         }
 
         public override string Fields()

--- a/src/Templates/ModelTemplate.cshtml
+++ b/src/Templates/ModelTemplate.cshtml
@@ -424,6 +424,7 @@ else
 {
     var ftg = Model as FutureTypeGo;
     var resultVar = ftg.ResultTypeName.ToShortName();
+    var resultResp = resultVar;
     var resultVarTarget = resultVar;
     var futureTypeName = $"{Model.CodeModel.Namespace}.{Model.Name}";
     if (ftg.ResultType is PageTypeGo ptg)
@@ -433,6 +434,7 @@ else
     else if (ftg.ResultType is IteratorTypeGo itg)
     {
         resultVarTarget = $"{resultVarTarget}.{itg.PageField}.{itg.PageType.ResultFieldName}";
+        resultResp = $"{resultResp}.{itg.PageField}";
     }
     <text>
     // Result returns the result of the asynchronous operation.
@@ -462,7 +464,7 @@ else
     <text>
     sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
     if @(resultVarTarget).Response.Response, err = future.GetResult(sender); err == nil && @(resultVarTarget).Response.Response.StatusCode != http.StatusNoContent {
-        @resultVar, err = client.@(ftg.ResponderMethodName)(@(resultVarTarget).Response.Response)
+        @resultResp, err = client.@(ftg.ResponderMethodName)(@(resultVarTarget).Response.Response)
         if err != nil {
             err = autorest.NewErrorWithError(err, "@futureTypeName", "Result", @(resultVarTarget).Response.Response, "Failure responding to request")
         }

--- a/src/Templates/ModelTemplate.cshtml
+++ b/src/Templates/ModelTemplate.cshtml
@@ -430,6 +430,10 @@ else
     {
         resultVarTarget = $"{resultVarTarget}.{ptg.ResultFieldName}";
     }
+    else if (ftg.ResultType is IteratorTypeGo itg)
+    {
+        resultVarTarget = $"{resultVarTarget}.{itg.PageField}.{itg.PageType.ResultFieldName}";
+    }
     <text>
     // Result returns the result of the asynchronous operation.
     // If the operation has not completed it will return an error.

--- a/test/src/tests/acceptancetests/paginggrouptest/paging_test.go
+++ b/test/src/tests/acceptancetests/paginggrouptest/paging_test.go
@@ -217,4 +217,14 @@ func (s *PagingGroupSuite) TestGetMultiplePagesLRO(c *chk.C) {
 		count++
 	}
 	c.Assert(count, chk.Equals, 10)
+	// iterator
+	futureIter, err := pagingClient.GetMultiplePagesLROComplete(context.Background(), clientID, nil, nil)
+	c.Assert(err, chk.IsNil)
+	count = 0
+	for iter, err := futureIter.Result(pagingClient); iter.NotDone(); err = iter.Next() {
+		c.Assert(err, chk.IsNil)
+		c.Assert(iter.Value().Properties, chk.NotNil)
+		count++
+	}
+	c.Assert(count, chk.Equals, 10)
 }

--- a/test/src/tests/generated/paging/models.go
+++ b/test/src/tests/generated/paging/models.go
@@ -173,7 +173,7 @@ func (future *PagingGetMultiplePagesLROAllFuture) Result(client PagingClient) (p
 	}
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
 	if pri.page.pr.Response.Response, err = future.GetResult(sender); err == nil && pri.page.pr.Response.Response.StatusCode != http.StatusNoContent {
-		pri, err = client.GetMultiplePagesLROResponder(pri.page.pr.Response.Response)
+		pri.page, err = client.GetMultiplePagesLROResponder(pri.page.pr.Response.Response)
 		if err != nil {
 			err = autorest.NewErrorWithError(err, "paginggroup.PagingGetMultiplePagesLROAllFuture", "Result", pri.page.pr.Response.Response, "Failure responding to request")
 		}

--- a/test/src/tests/generated/paging/models.go
+++ b/test/src/tests/generated/paging/models.go
@@ -160,7 +160,7 @@ type PagingGetMultiplePagesLROAllFuture struct {
 
 // Result returns the result of the asynchronous operation.
 // If the operation has not completed it will return an error.
-func (future *PagingGetMultiplePagesLROAllFuture) Result(client PagingClient) (prp ProductResultPage, err error) {
+func (future *PagingGetMultiplePagesLROAllFuture) Result(client PagingClient) (pri ProductResultIterator, err error) {
 	var done bool
 	done, err = future.Done(client)
 	if err != nil {
@@ -172,10 +172,10 @@ func (future *PagingGetMultiplePagesLROAllFuture) Result(client PagingClient) (p
 		return
 	}
 	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
-	if prp.pr.Response.Response, err = future.GetResult(sender); err == nil && prp.pr.Response.Response.StatusCode != http.StatusNoContent {
-		prp, err = client.GetMultiplePagesLROResponder(prp.pr.Response.Response)
+	if pri.page.pr.Response.Response, err = future.GetResult(sender); err == nil && pri.page.pr.Response.Response.StatusCode != http.StatusNoContent {
+		pri, err = client.GetMultiplePagesLROResponder(pri.page.pr.Response.Response)
 		if err != nil {
-			err = autorest.NewErrorWithError(err, "paginggroup.PagingGetMultiplePagesLROAllFuture", "Result", prp.pr.Response.Response, "Failure responding to request")
+			err = autorest.NewErrorWithError(err, "paginggroup.PagingGetMultiplePagesLROAllFuture", "Result", pri.page.pr.Response.Response, "Failure responding to request")
 		}
 	}
 	return


### PR DESCRIPTION
Fixed *Complete() method on LROs to return an iterator instead of a page
(this is how it works for non-LROs).