### PR TITLE
Add doc comment for base64url formatted properties.

### DIFF
--- a/src/Model/PrimaryTypeGo.cs
+++ b/src/Model/PrimaryTypeGo.cs
@@ -64,7 +64,7 @@ namespace AutoRest.Go.Model
                 switch (KnownPrimaryType)
                 {
                     case KnownPrimaryType.Base64Url:
-                        // TODO: add support
+                        // TODO: add support (once support is added remove the new definition for Documentation in PropertyGo.cs)
                         return "string";
 
                     case KnownPrimaryType.ByteArray:

--- a/src/Model/PropertyGo.cs
+++ b/src/Model/PropertyGo.cs
@@ -9,8 +9,36 @@ namespace AutoRest.Go.Model
 {
     public class PropertyGo : Property
     {
+        private const string Base64UrlDoc = "a URL-encoded base64 string";
+
         public PropertyGo()
         {
+        }
+
+        /// <summary>
+        /// Gets or sets the documentation.
+        /// </summary>
+        public new Fixable<string> Documentation
+        {
+            get
+            {
+                if (ModelType is PrimaryTypeGo ptg && ptg.KnownFormat == KnownFormat.base64url)
+                {
+                    // we don't properly support the base64url type so add some extra
+                    // docs stating that the type should be a URL-encoded base64 string.
+                    // NOTE: once proper support is added remove this code.
+                    if (base.Documentation.IsNullOrEmpty())
+                    {
+                        return Base64UrlDoc;
+                    }
+                    else
+                    {
+                        return $"{base.Documentation} ({Base64UrlDoc})";
+                    }
+                }
+                return base.Documentation;
+            }
+            set { base.Documentation = value; }
         }
 
         public string JsonTag(bool omitEmpty = true)

--- a/test/src/tests/generated/body-string/models.go
+++ b/test/src/tests/generated/body-string/models.go
@@ -30,7 +30,8 @@ func PossibleColorsValues() []Colors {
 // Base64URL ...
 type Base64URL struct {
 	autorest.Response `json:"-"`
-	Value             *string `json:"value,omitempty"`
+	// Value - a URL-encoded base64 string
+	Value *string `json:"value,omitempty"`
 }
 
 // Error ...


### PR DESCRIPTION
Current codegen emits base64url formatted types as strings so it's not
clear that the contents should be URL/base64 encoded.  Until we have
proper support emit an extra comment stating the string's format.