### PR TITLE
Ensure client parameters match their definition

### DIFF
--- a/autorest.go.sln
+++ b/autorest.go.sln
@@ -16,18 +16,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x64.Build.0 = Debug|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x86.Build.0 = Debug|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|x64.ActiveCfg = Release|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|x64.Build.0 = Release|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|x86.ActiveCfg = Release|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|x86.Build.0 = Release|Any CPU    
 		{9E857E16-E227-5321-7699-CFA9D292D0B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9E857E16-E227-5321-7699-CFA9D292D0B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9E857E16-E227-5321-7699-CFA9D292D0B6}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -40,8 +28,22 @@ Global
 		{9E857E16-E227-5321-7699-CFA9D292D0B6}.Release|x64.Build.0 = Release|Any CPU
 		{9E857E16-E227-5321-7699-CFA9D292D0B6}.Release|x86.ActiveCfg = Release|Any CPU
 		{9E857E16-E227-5321-7699-CFA9D292D0B6}.Release|x86.Build.0 = Release|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x64.Build.0 = Debug|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x86.Build.0 = Debug|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|x64.ActiveCfg = Release|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|x64.Build.0 = Release|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {31B61C0E-3267-4EE4-AA24-CC73141DCB19}
 	EndGlobalSection
 EndGlobal

--- a/src/Model/ParameterGo.cs
+++ b/src/Model/ParameterGo.cs
@@ -156,7 +156,32 @@ namespace AutoRest.Go.Model
             }
             else if (IsClientProperty)
             {
-                value = "client." + CodeNamerGo.Instance.GetPropertyName(Name.Value);
+                var propName = CodeNamerGo.Instance.GetPropertyName(Name.Value);
+                // verify that the calculated name matches the property name
+                bool found = false;
+                foreach (var clientProp in Method.CodeModel.Properties)
+                {
+                    // prefer an exact match
+                    if (clientProp.Name == propName)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found)
+                {
+                    // didn't find an exact match, find the closest match.  we hit this case if
+                    // the front-end decided to add a suffix (e.g. '1') to the client property name.
+                    foreach (var clientProp in Method.CodeModel.Properties)
+                    {
+                        if (clientProp.Name.ToString().IndexOf(propName) > -1)
+                        {
+                            propName = clientProp.Name;
+                            break;
+                        }
+                    }
+                }
+                value = "client." + propName;
             }
             else
             {


### PR DESCRIPTION
When generating client property names in preparers ensure that the
calculated client property name matches the actual property name.