### PR TITLE
Custom marshalling/unmarshalling for byte arrays

### DIFF
--- a/autorest.go.sln
+++ b/autorest.go.sln
@@ -16,18 +16,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x64.Build.0 = Debug|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x86.Build.0 = Debug|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|x64.ActiveCfg = Release|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|x64.Build.0 = Release|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|x86.ActiveCfg = Release|Any CPU
-		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|x86.Build.0 = Release|Any CPU    
 		{9E857E16-E227-5321-7699-CFA9D292D0B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9E857E16-E227-5321-7699-CFA9D292D0B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9E857E16-E227-5321-7699-CFA9D292D0B6}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -40,8 +28,22 @@ Global
 		{9E857E16-E227-5321-7699-CFA9D292D0B6}.Release|x64.Build.0 = Release|Any CPU
 		{9E857E16-E227-5321-7699-CFA9D292D0B6}.Release|x86.ActiveCfg = Release|Any CPU
 		{9E857E16-E227-5321-7699-CFA9D292D0B6}.Release|x86.Build.0 = Release|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x64.Build.0 = Debug|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Debug|x86.Build.0 = Debug|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|x64.ActiveCfg = Release|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|x64.Build.0 = Release|Any CPU
+		{9E857E16-1000-2000-3000-CFA9D292D0B6}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5E272CF5-C0C3-45E8-A242-C34930033161}
 	EndGlobalSection
 EndGlobal

--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -300,7 +300,8 @@ namespace AutoRest.Go.Model
         /// Returns a collection of composite types that require datetime handleing in a custom marshaller and/or
         /// unmarshaller. Can be empty if there are no types requriring marshallers.
         /// </summary>
-        public IEnumerable<CompositeTypeGo> RequiresDateTimeCustomHandling=> ModelTypes.Cast<CompositeTypeGo>().Where(m => m.IsDateTimeCustomHandlingRequired);
+        public IEnumerable<CompositeTypeGo> RequiresCustomMarshalling=> ModelTypes.Cast<CompositeTypeGo>().Where(
+            m => m.IsDateTimeCustomHandlingRequired || m.IsBase64EncodingRequired);
 
         /// <summary>
         /// Returns the encoding type used for serialization (e.g. xml or json).

--- a/src/Templates/Marshalling.cshtml
+++ b/src/Templates/Marshalling.cshtml
@@ -8,6 +8,9 @@
 
 @inherits AutoRest.Core.Template<AutoRest.Go.Model.CodeModelGo>
 
+@if (Model.ModelTypes.Cast<CompositeTypeGo>().Where(m => m.IsDateTimeCustomHandlingRequired).Any())
+{
+<text>
 const (
 	rfc3339Format = "2006-01-02T15:04:05.0000000Z07:00"
 )
@@ -46,8 +49,33 @@ func (t *timeRFC3339) UnmarshalText(data []byte) (err error) {
 	t.Time, err = time.Parse(rfc3339Format, string(data))
 	return
 }
+</text>
+}
+@if (Model.ModelTypes.Cast<CompositeTypeGo>().Where(m => m.IsBase64EncodingRequired).Any())
+{
+<text>
+// internal type used for marshalling base64 encoded strings
+type base64Encoded struct {
+	b []byte
+}
 
-@foreach (var ct in Model.RequiresDateTimeCustomHandling)
+// MarshalText implements the encoding.TextMarshaler interface for base64Encoded.
+func (c base64Encoded) MarshalText() ([]byte, error) {
+	return []byte(base64.StdEncoding.EncodeToString(c.b)), nil
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface for base64Encoded.
+func (c *base64Encoded) UnmarshalText(data []byte) error {
+	b, err := base64.StdEncoding.DecodeString(string(data))
+	if err != nil {
+		return err
+	}
+	c.b = b
+	return nil
+}
+</text>
+}
+@foreach (var ct in Model.RequiresCustomMarshalling)
 {
     var internalName = ct.Name.ToCamelCase();
 <text>

--- a/src/Templates/MarshallingJson.cshtml
+++ b/src/Templates/MarshallingJson.cshtml
@@ -158,3 +158,28 @@ else
         }
         </text>
     }
+@if (Model.IsDateTimeCustomHandlingRequired || Model.IsBase64EncodingRequired)
+{
+    var internalName = Model.Name.ToCamelCase();
+    var rec = Model.Name.ToString().ToShortName();
+    var local = $"{rec}2";
+<text>
+    // MarshalJSON implements the json.Marshaler interface for @Model.Name.
+    func (@rec @Model.Name) MarshalJSON() ([]byte, error) {
+        if reflect.TypeOf((*@Model.Name)(nil)).Elem().Size() != reflect.TypeOf((*@internalName)(nil)).Elem().Size() {
+            panic("size mismatch between @Model.Name and @internalName")
+        }
+        @local := (*@internalName)(unsafe.Pointer(&@rec))
+        return json.Marshal(*@local)
+    }
+
+    // UnmarshalJSON implements the json.Unmarshaler interface for @Model.Name.
+    func (@rec *@Model.Name) UnmarshalJSON(b []byte) error {
+        if reflect.TypeOf((*@Model.Name)(nil)).Elem().Size() != reflect.TypeOf((*@internalName)(nil)).Elem().Size() {
+            panic("size mismatch between @Model.Name and @internalName")
+        }
+        @local := (*@internalName)(unsafe.Pointer(@rec))
+        return json.Unmarshal(b, @local)
+    }
+</text>
+}

--- a/src/Templates/MarshallingXml.cshtml
+++ b/src/Templates/MarshallingXml.cshtml
@@ -167,7 +167,7 @@
     </text>
 }
 
-@if (Model.IsDateTimeCustomHandlingRequired)
+@if (Model.IsDateTimeCustomHandlingRequired || Model.IsBase64EncodingRequired)
 {
     var internalName = Model.Name.ToCamelCase();
     var rec = Model.Name.ToString().ToShortName();

--- a/src/Templates/ModelsTemplate.cshtml
+++ b/src/Templates/ModelsTemplate.cshtml
@@ -122,7 +122,7 @@ func joinConst(s interface{}, sep string) string {
         @EmptyLine
     </text>
 }
-@if (Model.RequiresDateTimeCustomHandling.Any())
+@if (Model.RequiresCustomMarshalling.Any())
 {
     <text>
         @(Include(new Marshalling(), Model))

--- a/test/src/tests/generated/body-array/array.go
+++ b/test/src/tests/generated/body-array/array.go
@@ -1721,6 +1721,57 @@ func (client ArrayClient) getEmptyResponder(resp pipeline.Response) (pipeline.Re
 	return result, nil
 }
 
+// GetEnumValid get enum array value ['foo1', 'foo2', 'foo3']
+func (client ArrayClient) GetEnumValid(ctx context.Context) (*GetEnumValidResponse, error) {
+	req, err := client.getEnumValidPreparer()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Pipeline().Do(ctx, responderPolicyFactory{responder: client.getEnumValidResponder}, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*GetEnumValidResponse), err
+}
+
+// getEnumValidPreparer prepares the GetEnumValid request.
+func (client ArrayClient) getEnumValidPreparer() (pipeline.Request, error) {
+	u := client.url
+	u.Path = "/array/prim/enum/foo1.foo2.foo3"
+	req, err := pipeline.NewRequest("GET", u, nil)
+	if err != nil {
+		return req, pipeline.NewError(err, "failed to create request")
+	}
+	params := req.URL.Query()
+	req.URL.RawQuery = params.Encode()
+	return req, nil
+}
+
+// getEnumValidResponder handles the response to the GetEnumValid request.
+func (client ArrayClient) getEnumValidResponder(resp pipeline.Response) (pipeline.Response, error) {
+	err := validateResponse(resp, http.StatusOK)
+	if resp == nil {
+		return nil, err
+	}
+	result := &GetEnumValidResponse{rawResponse: resp.Response()}
+	if err != nil {
+		return result, err
+	}
+	defer resp.Response().Body.Close()
+	b, err := ioutil.ReadAll(resp.Response().Body)
+	if err != nil {
+		return result, NewResponseError(err, resp.Response(), "failed to read response body")
+	}
+	if len(b) > 0 {
+		b = removeBOM(b)
+		err = json.Unmarshal(b, &result.Items)
+		if err != nil {
+			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
+		}
+	}
+	return result, nil
+}
+
 // GetFloatInvalidNull get float array value [0.0, null, -1.2e20]
 func (client ArrayClient) GetFloatInvalidNull(ctx context.Context) (*GetFloatInvalidNullResponse, error) {
 	req, err := client.getFloatInvalidNullPreparer()
@@ -2264,6 +2315,57 @@ func (client ArrayClient) getNullResponder(resp pipeline.Response) (pipeline.Res
 		return nil, err
 	}
 	result := &GetNullResponse{rawResponse: resp.Response()}
+	if err != nil {
+		return result, err
+	}
+	defer resp.Response().Body.Close()
+	b, err := ioutil.ReadAll(resp.Response().Body)
+	if err != nil {
+		return result, NewResponseError(err, resp.Response(), "failed to read response body")
+	}
+	if len(b) > 0 {
+		b = removeBOM(b)
+		err = json.Unmarshal(b, &result.Items)
+		if err != nil {
+			return result, NewResponseError(err, resp.Response(), "failed to unmarshal response body")
+		}
+	}
+	return result, nil
+}
+
+// GetStringEnumValid get enum array value ['foo1', 'foo2', 'foo3']
+func (client ArrayClient) GetStringEnumValid(ctx context.Context) (*GetStringEnumValidResponse, error) {
+	req, err := client.getStringEnumValidPreparer()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Pipeline().Do(ctx, responderPolicyFactory{responder: client.getStringEnumValidResponder}, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*GetStringEnumValidResponse), err
+}
+
+// getStringEnumValidPreparer prepares the GetStringEnumValid request.
+func (client ArrayClient) getStringEnumValidPreparer() (pipeline.Request, error) {
+	u := client.url
+	u.Path = "/array/prim/string-enum/foo1.foo2.foo3"
+	req, err := pipeline.NewRequest("GET", u, nil)
+	if err != nil {
+		return req, pipeline.NewError(err, "failed to create request")
+	}
+	params := req.URL.Query()
+	req.URL.RawQuery = params.Encode()
+	return req, nil
+}
+
+// getStringEnumValidResponder handles the response to the GetStringEnumValid request.
+func (client ArrayClient) getStringEnumValidResponder(resp pipeline.Response) (pipeline.Response, error) {
+	err := validateResponse(resp, http.StatusOK)
+	if resp == nil {
+		return nil, err
+	}
+	result := &GetStringEnumValidResponse{rawResponse: resp.Response()}
 	if err != nil {
 		return result, err
 	}
@@ -3114,6 +3216,58 @@ func (client ArrayClient) putEmptyResponder(resp pipeline.Response) (pipeline.Re
 	return resp, err
 }
 
+// PutEnumValid set array value ['foo1', 'foo2', 'foo3']
+//
+func (client ArrayClient) PutEnumValid(ctx context.Context, arrayBody []FooEnumType) (*http.Response, error) {
+	if err := validate([]validation{
+		{targetValue: arrayBody,
+			constraints: []constraint{{target: "arrayBody", name: null, rule: true, chain: nil}}}}); err != nil {
+		return nil, err
+	}
+	req, err := client.putEnumValidPreparer(arrayBody)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Pipeline().Do(ctx, responderPolicyFactory{responder: client.putEnumValidResponder}, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Response(), err
+}
+
+// putEnumValidPreparer prepares the PutEnumValid request.
+func (client ArrayClient) putEnumValidPreparer(arrayBody []FooEnumType) (pipeline.Request, error) {
+	u := client.url
+	u.Path = "/array/prim/enum/foo1.foo2.foo3"
+	req, err := pipeline.NewRequest("PUT", u, nil)
+	if err != nil {
+		return req, pipeline.NewError(err, "failed to create request")
+	}
+	params := req.URL.Query()
+	req.URL.RawQuery = params.Encode()
+	b, err := json.Marshal(arrayBody)
+	if err != nil {
+		return req, pipeline.NewError(err, "failed to marshal request body")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	err = req.SetBody(bytes.NewReader(b))
+	if err != nil {
+		return req, pipeline.NewError(err, "failed to set request body")
+	}
+	return req, nil
+}
+
+// putEnumValidResponder handles the response to the PutEnumValid request.
+func (client ArrayClient) putEnumValidResponder(resp pipeline.Response) (pipeline.Response, error) {
+	err := validateResponse(resp, http.StatusOK)
+	if resp == nil {
+		return nil, err
+	}
+	io.Copy(ioutil.Discard, resp.Response().Body)
+	resp.Response().Body.Close()
+	return resp, err
+}
+
 // PutFloatValid set array value [0, -0.01, 1.2e20]
 //
 func (client ArrayClient) PutFloatValid(ctx context.Context, arrayBody []float64) (*http.Response, error) {
@@ -3261,6 +3415,58 @@ func (client ArrayClient) putLongValidPreparer(arrayBody []int64) (pipeline.Requ
 
 // putLongValidResponder handles the response to the PutLongValid request.
 func (client ArrayClient) putLongValidResponder(resp pipeline.Response) (pipeline.Response, error) {
+	err := validateResponse(resp, http.StatusOK)
+	if resp == nil {
+		return nil, err
+	}
+	io.Copy(ioutil.Discard, resp.Response().Body)
+	resp.Response().Body.Close()
+	return resp, err
+}
+
+// PutStringEnumValid set array value ['foo1', 'foo2', 'foo3']
+//
+func (client ArrayClient) PutStringEnumValid(ctx context.Context, arrayBody []string) (*http.Response, error) {
+	if err := validate([]validation{
+		{targetValue: arrayBody,
+			constraints: []constraint{{target: "arrayBody", name: null, rule: true, chain: nil}}}}); err != nil {
+		return nil, err
+	}
+	req, err := client.putStringEnumValidPreparer(arrayBody)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Pipeline().Do(ctx, responderPolicyFactory{responder: client.putStringEnumValidResponder}, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Response(), err
+}
+
+// putStringEnumValidPreparer prepares the PutStringEnumValid request.
+func (client ArrayClient) putStringEnumValidPreparer(arrayBody []string) (pipeline.Request, error) {
+	u := client.url
+	u.Path = "/array/prim/string-enum/foo1.foo2.foo3"
+	req, err := pipeline.NewRequest("PUT", u, nil)
+	if err != nil {
+		return req, pipeline.NewError(err, "failed to create request")
+	}
+	params := req.URL.Query()
+	req.URL.RawQuery = params.Encode()
+	b, err := json.Marshal(arrayBody)
+	if err != nil {
+		return req, pipeline.NewError(err, "failed to marshal request body")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	err = req.SetBody(bytes.NewReader(b))
+	if err != nil {
+		return req, pipeline.NewError(err, "failed to set request body")
+	}
+	return req, nil
+}
+
+// putStringEnumValidResponder handles the response to the PutStringEnumValid request.
+func (client ArrayClient) putStringEnumValidResponder(resp pipeline.Response) (pipeline.Response, error) {
 	err := validateResponse(resp, http.StatusOK)
 	if resp == nil {
 		return nil, err

--- a/test/src/tests/generated/body-array/models.go
+++ b/test/src/tests/generated/body-array/models.go
@@ -27,6 +27,25 @@ func joinConst(s interface{}, sep string) string {
 	return strings.Join(ss, sep)
 }
 
+// FooEnumType enumerates the values for foo enum type.
+type FooEnumType string
+
+const (
+	// FooEnumFoo1 ...
+	FooEnumFoo1 FooEnumType = "foo1"
+	// FooEnumFoo2 ...
+	FooEnumFoo2 FooEnumType = "foo2"
+	// FooEnumFoo3 ...
+	FooEnumFoo3 FooEnumType = "foo3"
+	// FooEnumNone represents an empty FooEnumType.
+	FooEnumNone FooEnumType = ""
+)
+
+// PossibleFooEnumTypeValues returns an array of possible values for the FooEnumType const type.
+func PossibleFooEnumTypeValues() []FooEnumType {
+	return []FooEnumType{FooEnumFoo1, FooEnumFoo2, FooEnumFoo3, FooEnumNone}
+}
+
 // Error ...
 type Error struct {
 	Status  *int32  `json:"status,omitempty"`
@@ -726,6 +745,27 @@ func (ger GetEmptyResponse) Status() string {
 	return ger.rawResponse.Status
 }
 
+// GetEnumValidResponse ...
+type GetEnumValidResponse struct {
+	rawResponse *http.Response
+	Items       []FooEnumType `json:"items,omitempty"`
+}
+
+// Response returns the raw HTTP response object.
+func (gevr GetEnumValidResponse) Response() *http.Response {
+	return gevr.rawResponse
+}
+
+// StatusCode returns the HTTP status code of the response, e.g. 200.
+func (gevr GetEnumValidResponse) StatusCode() int {
+	return gevr.rawResponse.StatusCode
+}
+
+// Status returns the HTTP status message of the response, e.g. "200 OK".
+func (gevr GetEnumValidResponse) Status() string {
+	return gevr.rawResponse.Status
+}
+
 // GetFloatInvalidNullResponse ...
 type GetFloatInvalidNullResponse struct {
 	rawResponse *http.Response
@@ -955,6 +995,27 @@ func (gnr GetNullResponse) StatusCode() int {
 // Status returns the HTTP status message of the response, e.g. "200 OK".
 func (gnr GetNullResponse) Status() string {
 	return gnr.rawResponse.Status
+}
+
+// GetStringEnumValidResponse ...
+type GetStringEnumValidResponse struct {
+	rawResponse *http.Response
+	Items       []string `json:"items,omitempty"`
+}
+
+// Response returns the raw HTTP response object.
+func (gsevr GetStringEnumValidResponse) Response() *http.Response {
+	return gsevr.rawResponse
+}
+
+// StatusCode returns the HTTP status code of the response, e.g. 200.
+func (gsevr GetStringEnumValidResponse) StatusCode() int {
+	return gsevr.rawResponse.StatusCode
+}
+
+// Status returns the HTTP status message of the response, e.g. "200 OK".
+func (gsevr GetStringEnumValidResponse) Status() string {
+	return gsevr.rawResponse.Status
 }
 
 // GetStringValidResponse ...

--- a/test/src/tests/generated/body-byte/models.go
+++ b/test/src/tests/generated/body-byte/models.go
@@ -7,9 +7,12 @@ package bytegroup
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"reflect"
 	"strings"
+	"unsafe"
 )
 
 // concatenates a slice of const values with the specified separator between each item
@@ -37,6 +40,24 @@ type GetEmptyResponse struct {
 	Value       []byte `json:"value,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaler interface for GetEmptyResponse.
+func (ger GetEmptyResponse) MarshalJSON() ([]byte, error) {
+	if reflect.TypeOf((*GetEmptyResponse)(nil)).Elem().Size() != reflect.TypeOf((*getEmptyResponse)(nil)).Elem().Size() {
+		panic("size mismatch between GetEmptyResponse and getEmptyResponse")
+	}
+	ger2 := (*getEmptyResponse)(unsafe.Pointer(&ger))
+	return json.Marshal(*ger2)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for GetEmptyResponse.
+func (ger *GetEmptyResponse) UnmarshalJSON(b []byte) error {
+	if reflect.TypeOf((*GetEmptyResponse)(nil)).Elem().Size() != reflect.TypeOf((*getEmptyResponse)(nil)).Elem().Size() {
+		panic("size mismatch between GetEmptyResponse and getEmptyResponse")
+	}
+	ger2 := (*getEmptyResponse)(unsafe.Pointer(ger))
+	return json.Unmarshal(b, ger2)
+}
+
 // Response returns the raw HTTP response object.
 func (ger GetEmptyResponse) Response() *http.Response {
 	return ger.rawResponse
@@ -56,6 +77,24 @@ func (ger GetEmptyResponse) Status() string {
 type GetInvalidResponse struct {
 	rawResponse *http.Response
 	Value       []byte `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaler interface for GetInvalidResponse.
+func (gir GetInvalidResponse) MarshalJSON() ([]byte, error) {
+	if reflect.TypeOf((*GetInvalidResponse)(nil)).Elem().Size() != reflect.TypeOf((*getInvalidResponse)(nil)).Elem().Size() {
+		panic("size mismatch between GetInvalidResponse and getInvalidResponse")
+	}
+	gir2 := (*getInvalidResponse)(unsafe.Pointer(&gir))
+	return json.Marshal(*gir2)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for GetInvalidResponse.
+func (gir *GetInvalidResponse) UnmarshalJSON(b []byte) error {
+	if reflect.TypeOf((*GetInvalidResponse)(nil)).Elem().Size() != reflect.TypeOf((*getInvalidResponse)(nil)).Elem().Size() {
+		panic("size mismatch between GetInvalidResponse and getInvalidResponse")
+	}
+	gir2 := (*getInvalidResponse)(unsafe.Pointer(gir))
+	return json.Unmarshal(b, gir2)
 }
 
 // Response returns the raw HTTP response object.
@@ -79,6 +118,24 @@ type GetNonASCIIResponse struct {
 	Value       []byte `json:"value,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaler interface for GetNonASCIIResponse.
+func (gnar GetNonASCIIResponse) MarshalJSON() ([]byte, error) {
+	if reflect.TypeOf((*GetNonASCIIResponse)(nil)).Elem().Size() != reflect.TypeOf((*getNonASCIIResponse)(nil)).Elem().Size() {
+		panic("size mismatch between GetNonASCIIResponse and getNonASCIIResponse")
+	}
+	gnar2 := (*getNonASCIIResponse)(unsafe.Pointer(&gnar))
+	return json.Marshal(*gnar2)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for GetNonASCIIResponse.
+func (gnar *GetNonASCIIResponse) UnmarshalJSON(b []byte) error {
+	if reflect.TypeOf((*GetNonASCIIResponse)(nil)).Elem().Size() != reflect.TypeOf((*getNonASCIIResponse)(nil)).Elem().Size() {
+		panic("size mismatch between GetNonASCIIResponse and getNonASCIIResponse")
+	}
+	gnar2 := (*getNonASCIIResponse)(unsafe.Pointer(gnar))
+	return json.Unmarshal(b, gnar2)
+}
+
 // Response returns the raw HTTP response object.
 func (gnar GetNonASCIIResponse) Response() *http.Response {
 	return gnar.rawResponse
@@ -100,6 +157,24 @@ type GetNullResponse struct {
 	Value       []byte `json:"value,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaler interface for GetNullResponse.
+func (gnr GetNullResponse) MarshalJSON() ([]byte, error) {
+	if reflect.TypeOf((*GetNullResponse)(nil)).Elem().Size() != reflect.TypeOf((*getNullResponse)(nil)).Elem().Size() {
+		panic("size mismatch between GetNullResponse and getNullResponse")
+	}
+	gnr2 := (*getNullResponse)(unsafe.Pointer(&gnr))
+	return json.Marshal(*gnr2)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for GetNullResponse.
+func (gnr *GetNullResponse) UnmarshalJSON(b []byte) error {
+	if reflect.TypeOf((*GetNullResponse)(nil)).Elem().Size() != reflect.TypeOf((*getNullResponse)(nil)).Elem().Size() {
+		panic("size mismatch between GetNullResponse and getNullResponse")
+	}
+	gnr2 := (*getNullResponse)(unsafe.Pointer(gnr))
+	return json.Unmarshal(b, gnr2)
+}
+
 // Response returns the raw HTTP response object.
 func (gnr GetNullResponse) Response() *http.Response {
 	return gnr.rawResponse
@@ -113,4 +188,44 @@ func (gnr GetNullResponse) StatusCode() int {
 // Status returns the HTTP status message of the response, e.g. "200 OK".
 func (gnr GetNullResponse) Status() string {
 	return gnr.rawResponse.Status
+}
+
+// internal type used for marshalling base64 encoded strings
+type base64Encoded struct {
+	b []byte
+}
+
+// MarshalText implements the encoding.TextMarshaler interface for base64Encoded.
+func (c base64Encoded) MarshalText() ([]byte, error) {
+	return []byte(base64.StdEncoding.EncodeToString(c.b)), nil
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface for base64Encoded.
+func (c *base64Encoded) UnmarshalText(data []byte) error {
+	b, err := base64.StdEncoding.DecodeString(string(data))
+	if err != nil {
+		return err
+	}
+	c.b = b
+	return nil
+}
+
+// internal type used for marshalling
+type getNullResponse struct {
+	Value base64Encoded `json:"value,omitempty"`
+}
+
+// internal type used for marshalling
+type getEmptyResponse struct {
+	Value base64Encoded `json:"value,omitempty"`
+}
+
+// internal type used for marshalling
+type getNonASCIIResponse struct {
+	Value base64Encoded `json:"value,omitempty"`
+}
+
+// internal type used for marshalling
+type getInvalidResponse struct {
+	Value base64Encoded `json:"value,omitempty"`
 }


### PR DESCRIPTION
Per spec, byte arrays represent base-64 encoded data however we
currently expose the string itself as the byte array which is incorrect.
Added a base64Encoded type for custom marshalling/unmarshalling which
is used in the internal types.