### PR TITLE
Fix another case of client parameter naming

### DIFF
--- a/src/Model/MethodGo.cs
+++ b/src/Model/MethodGo.cs
@@ -396,7 +396,7 @@ namespace AutoRest.Go.Model
                         }
                         else if (param.IsClientProperty)
                         {
-                            value = $"client.{param.Name.ToPascalCase()}";
+                            value = param.GetClientPropertryName();
                         }
                         else
                         {


### PR DESCRIPTION
Nothing is impacted by this at present, just a preventative fix while we're familiar with the issue.