### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,16 @@ go:
   - 1.8.x
   - 1.9.x
   - 1.10.x
+  - 1.11.x
   - master
 matrix:
   allow_failures:
     - go: master
 env:
-  - NODE_VERSION="8.9.4" DEP_VERSION="0.4.1"
+  - NODE_VERSION="8.9.4" DEP_RELEASE_TAG=v0.5.0
 before_install:
   - nvm install $NODE_VERSION
-  - curl -L -o $GOPATH/bin/dep https://github.com/golang/dep/releases/download/v$DEP_VERSION/dep-linux-amd64 && chmod +x $GOPATH/bin/dep
+  - curl -sSL https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 install:
   - sudo apt-get install libunwind8
   - npm install

--- a/test/src/tests/Gopkg.lock
+++ b/test/src/tests/Gopkg.lock
@@ -2,6 +2,7 @@
 
 
 [[projects]]
+  digest = "1:bea962ecd1dd8cf351ee534204936ae9d1088e14363c48ccb8981ab0d126fc73"
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
@@ -9,38 +10,74 @@
     "autorest/azure",
     "autorest/date",
     "autorest/to",
-    "autorest/validation"
+    "autorest/validation",
+    "logger",
+    "version",
   ]
-  revision = "f04d503958a4fe854c1b41667c73f8813c9dd9c3"
-  version = "v10.11.2"
+  pruneopts = ""
+  revision = "a35eae345f69bbfbe3b8fa0b1d3fe98f8430b21a"
+  version = "v10.15.3"
 
 [[projects]]
+  digest = "1:6098222470fe0172157ce9bbef5d2200df4edde17ee649c5d6e48330e4afa4c6"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = ""
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
+  digest = "1:3108ec0946181c60040ff51b811908f89d03e521e2b4ade5ef5c65b3c0e911ae"
+  name = "github.com/kr/pretty"
+  packages = ["."]
+  pruneopts = ""
+  revision = "73f6ac0b30a98e433b289500d779f50c1a6f0712"
+  version = "v0.1.0"
+
+[[projects]]
+  digest = "1:11b056b4421396ab14e384ab8ab8c2079b03f1e51aa5eb4d9b81f9e0d1aa8fbf"
+  name = "github.com/kr/text"
+  packages = ["."]
+  pruneopts = ""
+  revision = "e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f"
+  version = "v0.1.0"
+
+[[projects]]
+  digest = "1:7f569d906bdd20d906b606415b7d794f798f91a62fcfb6a4daa6d50690fb7a3f"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:615c827f6a892973a587c754ae5fad7acfc4352657aff23d0238fe0ba2a154df"
   name = "github.com/shopspring/decimal"
   packages = ["."]
-  revision = "69b3a8ad1f5f2c8bd855cb6506d18593064a346b"
-  version = "1.0.1"
+  pruneopts = ""
+  revision = "cd690d0c9e2447b1ef2a129a6b7b49077da89b8e"
+  version = "1.1.0"
 
 [[projects]]
   branch = "v1"
+  digest = "1:1d01f96bc2293b56c3dec797b8f976d7613fb30ce92bfbc994130404f7f7f031"
   name = "gopkg.in/check.v1"
   packages = ["."]
-  revision = "20d25e2804050c1cd24a7eea1e7a6447dd0e74ec"
+  pruneopts = ""
+  revision = "788fd78401277ebd861206a03c884797c6ec5541"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "18f1b6ccb84fa98feb280b3051d8e2a7a977d27eaac32fa872c65bef26e8f888"
+  input-imports = [
+    "github.com/Azure/go-autorest/autorest",
+    "github.com/Azure/go-autorest/autorest/azure",
+    "github.com/Azure/go-autorest/autorest/date",
+    "github.com/Azure/go-autorest/autorest/to",
+    "github.com/Azure/go-autorest/autorest/validation",
+    "github.com/satori/go.uuid",
+    "github.com/shopspring/decimal",
+    "gopkg.in/check.v1",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/test/src/tests/Gopkg.toml
+++ b/test/src/tests/Gopkg.toml
@@ -22,7 +22,7 @@
 
 [[constraint]]
   name = "github.com/Azure/go-autorest"
-  version = "10.11.2"
+  version = "10.15.3"
 
 [[constraint]]
   name = "github.com/satori/go.uuid"

--- a/test/src/tests/acceptancetests/lrogrouptest/lro_test.go
+++ b/test/src/tests/acceptancetests/lrogrouptest/lro_test.go
@@ -580,9 +580,7 @@ func (s *LROSuite) TestSADsPutAsyncRelativeRetry400(c *chk.C) {
 }
 
 func (s *LROSuite) TestSADsPutAsyncRelativeRetryInvalidHeader(c *chk.C) {
-	future, err := lroSADSClient.PutAsyncRelativeRetryInvalidHeader(context.Background(), &lrogroup.Product{})
-	c.Assert(err, chk.IsNil)
-	err = future.WaitForCompletionRef(context.Background(), lroSADSClient.Client)
+	_, err := lroSADSClient.PutAsyncRelativeRetryInvalidHeader(context.Background(), &lrogroup.Product{})
 	c.Assert(err, chk.NotNil)
 }
 


### PR DESCRIPTION
Add Go 1.11 to CI matrix.
Switch to using dep install shell script with v0.5.0.
Updated go-autorest to 10.15.3 and other dependencies.
LRO fix in go-autorest required small change to one LRO test.