### PR TITLE
Ensure single slash in package fqdn

### DIFF
--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -117,7 +117,7 @@ namespace AutoRest.Go.Model
 
                 if (!string.IsNullOrEmpty(sdkPath))
                 {
-                    return $"{sdkFqdnPrefix}/{outDir.Split(sdkPath, StringSplitOptions.None).Last()}";
+                    return $"{sdkFqdnPrefix}/{outDir.Split(sdkPath, StringSplitOptions.None).Last()}".Replace("//", "/");
                 }
                 else if (!Path.IsPathRooted(outDir))
                 {


### PR DESCRIPTION
- we could have just removed the slash but preferred to make sure its only 1 to avoid any issue coming from the config readme where it has or not the /