### PR TITLE
Check object for nil before marshalling

### DIFF
--- a/src/Templates/ModelTemplate.cshtml
+++ b/src/Templates/ModelTemplate.cshtml
@@ -155,7 +155,8 @@
 
         @foreach (var property in Model.AllProperties.Where(p => !string.IsNullOrEmpty(p.SerializedName)))
         {
-            if (property.IsPointer || property.ModelType is DictionaryTypeGo)
+            // must check object for nil to avoid inserting `"foo": null` into the JSON
+            if (property.IsPointer || property.ModelType is DictionaryTypeGo || property.ModelType.IsPrimaryType(KnownPrimaryType.Object))
             {
                 @:if(@(Model.Name.FixedValue.ToVariableName()).@(property.FieldName) != nil) {
                 @:objectMap["@(property.SerializedName)"] = @(Model.Name.FixedValue.ToVariableName()).@(property.FieldName)


### PR DESCRIPTION
Check objects for nil before marshalling; this avoids inserting a
`"foo": null` into the JSON which some services reject.