### PR TITLE
Simplify GetClientPropertyName()

### DIFF
--- a/src/Model/ParameterGo.cs
+++ b/src/Model/ParameterGo.cs
@@ -265,18 +265,7 @@ namespace AutoRest.Go.Model
         /// </summary>
         internal string GetClientPropertryName()
         {
-            var propName = CodeNamerGo.Instance.GetPropertyName(Name.Value);
-
-            // verify that the calculated name matches the property name
-            bool found = Method.CodeModel.Properties.Any(clientProp => clientProp.Name == propName);
-
-            // didn't find an exact match, find the closest match.  we hit this case if
-            // the front-end decided to add a suffix (e.g. '1') to the client property name.
-            if (!found)
-            {
-                propName = Method.CodeModel.Properties.First(clientProp => Regex.IsMatch(clientProp.Name, $"{propName}\\d")).Name;
-            }
-            return $"client.{propName}";
+            return $"client.{ClientProperty.Name}";
         }
     }
 


### PR DESCRIPTION
Use ClientProperty.Name instead of trying to calculate it.  The
calculation is broken for cases where names are camel-cased due to
invalid characters that were removed during naming.  I.e. user.name is
converted to UserName during initial naming; this will translate to a
parameter name of username which incorrectly camel-cases to Username
using the old algorithm.