### PR TITLE
Fix interface name collisions

### DIFF
--- a/src/CodeNamerGo.cs
+++ b/src/CodeNamerGo.cs
@@ -54,7 +54,7 @@ namespace AutoRest.Go
 
         // CommonInitialisms are those "words" within a name that Golint expects to be uppercase.
         // See https://github.com/golang/lint/blob/master/lint.go for detail.
-        private HashSet<string> CommonInitialisms => new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+        private HashSet<string> _commonInitialisms = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
                                                             "Acl",
                                                             "Api",
                                                             "Ascii",
@@ -503,7 +503,7 @@ namespace AutoRest.Go
             for (int i = 0; i < words.Length; i++)
             {
                 string word = words[i];
-                if (CommonInitialisms.Contains(word))
+                if (_commonInitialisms.Contains(word))
                 {
                     word = word.ToUpper();
                 }
@@ -512,7 +512,7 @@ namespace AutoRest.Go
                     // This ensures that names like `ClusterUsersGroupDNs`
                     // get propery cased to `ClusterUsersGroupDNS`
                     var concat = words[i] + words[i + 1];
-                    if (CommonInitialisms.Contains(concat.ToLower()))
+                    if (_commonInitialisms.Contains(concat.ToLower()))
                     {
                         word = concat.ToUpper();
                         i++;

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -32,6 +32,9 @@ namespace AutoRest.Go
         // contains a map from a model type to its corresponding interface name
         private static Dictionary<IModelType, string> s_interfaceNames = new Dictionary<IModelType, string>();
 
+        // contains a map from a one-word string to multiple words e.g. "FooBarBaz" => ["Foo", "Bar", "Baz"]
+        private static Dictionary<string, string[]> s_wordMap = new Dictionary<string, string[]>();
+
         /////////////////////////////////////////////////////////////////////////////////////////
         //
         // General Extensions
@@ -110,7 +113,11 @@ namespace AutoRest.Go
         /// <returns></returns>
         public static string[] ToWords(this string value)
         {
-            return WordSplitPattern.Split(value).Where(s => !string.IsNullOrEmpty(s)).ToArray();
+            if (!s_wordMap.ContainsKey(value))
+            {
+                s_wordMap.Add(value, WordSplitPattern.Split(value).Where(s => !string.IsNullOrEmpty(s)).ToArray());
+            }
+            return s_wordMap[value];
         }
 
         /// <summary>

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -29,6 +29,9 @@ namespace AutoRest.Go
             { "containerservice", "containerservices" }
         };
 
+        // contains a map from a model type to its corresponding interface name
+        private static Dictionary<IModelType, string> s_interfaceNames = new Dictionary<IModelType, string>();
+
         /////////////////////////////////////////////////////////////////////////////////////////
         //
         // General Extensions
@@ -370,9 +373,19 @@ namespace AutoRest.Go
         /// <returns></returns>
         public static string GetInterfaceName(this IModelType type, bool includePkgName = false)
         {
+            // this function is called in a *LOT* of places so is perf sensitive
+            if (!s_interfaceNames.ContainsKey(type))
+            {
+                var baseName = $"Basic{type.Name}";
+                if (type.CodeModel.AllModelTypes.Any(mt => mt.Name == baseName))
+                {
+                    baseName = $"Basic{baseName}";
+                }
+                s_interfaceNames.Add(type, baseName);
+            }
             return includePkgName
-                ? $"{type.CodeModel.Namespace}.Basic{type.Name}"
-                : $"Basic{type.Name}";
+                ? $"{type.CodeModel.Namespace}.{s_interfaceNames[type]}"
+                : s_interfaceNames[type];
         }
 
         /// <summary>

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -383,12 +383,12 @@ namespace AutoRest.Go
             // this function is called in a *LOT* of places so is perf sensitive
             if (!s_interfaceNames.ContainsKey(type))
             {
-                var baseName = $"Basic{type.Name}";
-                if (type.CodeModel.AllModelTypes.Any(mt => mt.Name == baseName))
+                var interfaceName = $"Basic{type.Name}";
+                if (type.CodeModel.AllModelTypes.Any(mt => mt.Name == interfaceName))
                 {
-                    baseName = $"Basic{baseName}";
+                    interfaceName = $"Basic{interfaceName}";
                 }
-                s_interfaceNames.Add(type, baseName);
+                s_interfaceNames.Add(type, interfaceName);
             }
             return includePkgName
                 ? $"{type.CodeModel.Namespace}.{s_interfaceNames[type]}"

--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -281,7 +281,7 @@ namespace AutoRest.Go.Model
             return indented.ToString();
         }
 
-        public IModelType GetElementType(IModelType type)
+        private IModelType GetElementType(IModelType type)
         {
             if (type is SequenceTypeGo sequenceType)
             {


### PR DESCRIPTION
If an interface name collides add an extra "Basic" prefix.
Fixed perf issue with common initialisms.
Updated autorest.common dependency.