### PR TITLE
Don't send read-only properties over the wire

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Azure/autorest.go/blob/master/README.md",
   "devDependencies": {
-    "@microsoft.azure/autorest.testserver": "^2.6.0",
+    "@microsoft.azure/autorest.testserver": "^2.6.1",
     "@microsoft.azure/autorest.modeler": "^2.3.54",
     "autorest": "^2.0.4222",
     "coffee-script": "^1.11.1",

--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -272,7 +272,16 @@ namespace AutoRest.Go.Model
                 }
                 if (!string.IsNullOrWhiteSpace(property.Documentation))
                 {
-                    indented.Append($"{property.FieldName} - {property.Documentation}".ToCommentBlock());
+                    var ro = "";
+                    if (property.IsReadOnly)
+                    {
+                        ro = "READ-ONLY; ";
+                    }
+                    indented.Append($"{property.FieldName} - {ro}{property.Documentation}".ToCommentBlock());
+                }
+                else if (property.IsReadOnly)
+                {
+                    indented.Append($"// {property.FieldName} - READ-ONLY\n");
                 }
 
                 indented.AppendLine(property.Field);

--- a/src/Templates/MethodTemplate.cshtml
+++ b/src/Templates/MethodTemplate.cshtml
@@ -190,6 +190,17 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature()) (
             @EmptyLine
         </text>
     }
+    @if (Model.BodyParameter != null && Model.BodyParameter.ModelType is CompositeTypeGo ctg)
+    {
+        // set all read-only properties to nil so they aren't sent over the wire
+        foreach (var p in ctg.Properties)
+        {
+            if (p.IsReadOnly)
+            {
+                @:@(Model.BodyParameter.Name).@(p.Name) = nil
+            }
+        }
+    }
     preparer := autorest.CreatePreparer(
     @(Model.PrepareDecorators.EmitAsArguments()))
 

--- a/src/Templates/ModelTemplate.cshtml
+++ b/src/Templates/ModelTemplate.cshtml
@@ -155,6 +155,11 @@
 
         @foreach (var property in Model.AllProperties.Where(p => !string.IsNullOrEmpty(p.SerializedName)))
         {
+            if (property.IsReadOnly)
+            {
+                // don't send read-only fields across the wire
+                continue;
+            }
             // must check object for nil to avoid inserting `"foo": null` into the JSON
             if (property.IsPointer || property.ModelType is DictionaryTypeGo || property.ModelType.IsPrimaryType(KnownPrimaryType.Object))
             {

--- a/test/src/tests/generated/additionalproperties/models.go
+++ b/test/src/tests/generated/additionalproperties/models.go
@@ -22,7 +22,8 @@ type CatAPTrue struct {
 	AdditionalProperties map[string]interface{} `json:""`
 	ID                   *int32                 `json:"id,omitempty"`
 	Name                 *string                `json:"name,omitempty"`
-	Status               *bool                  `json:"status,omitempty"`
+	// Status - READ-ONLY
+	Status *bool `json:"status,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for CatAPTrue.
@@ -36,9 +37,6 @@ func (cat CatAPTrue) MarshalJSON() ([]byte, error) {
 	}
 	if cat.Name != nil {
 		objectMap["name"] = cat.Name
-	}
-	if cat.Status != nil {
-		objectMap["status"] = cat.Status
 	}
 	for k, v := range cat.AdditionalProperties {
 		objectMap[k] = v
@@ -117,9 +115,10 @@ type Error struct {
 
 // PetAPInProperties ...
 type PetAPInProperties struct {
-	autorest.Response    `json:"-"`
-	ID                   *int32              `json:"id,omitempty"`
-	Name                 *string             `json:"name,omitempty"`
+	autorest.Response `json:"-"`
+	ID                *int32  `json:"id,omitempty"`
+	Name              *string `json:"name,omitempty"`
+	// Status - READ-ONLY
 	Status               *bool               `json:"status,omitempty"`
 	AdditionalProperties map[string]*float64 `json:"additionalProperties"`
 }
@@ -133,9 +132,6 @@ func (paip PetAPInProperties) MarshalJSON() ([]byte, error) {
 	if paip.Name != nil {
 		objectMap["name"] = paip.Name
 	}
-	if paip.Status != nil {
-		objectMap["status"] = paip.Status
-	}
 	if paip.AdditionalProperties != nil {
 		objectMap["additionalProperties"] = paip.AdditionalProperties
 	}
@@ -146,9 +142,10 @@ func (paip PetAPInProperties) MarshalJSON() ([]byte, error) {
 type PetAPInPropertiesWithAPString struct {
 	autorest.Response `json:"-"`
 	// AdditionalProperties - Unmatched properties from the message are deserialized this collection
-	AdditionalProperties  map[string]*string  `json:""`
-	ID                    *int32              `json:"id,omitempty"`
-	Name                  *string             `json:"name,omitempty"`
+	AdditionalProperties map[string]*string `json:""`
+	ID                   *int32             `json:"id,omitempty"`
+	Name                 *string            `json:"name,omitempty"`
+	// Status - READ-ONLY
 	Status                *bool               `json:"status,omitempty"`
 	OdataLocation         *string             `json:"@odata.location,omitempty"`
 	AdditionalProperties1 map[string]*float64 `json:"additionalProperties"`
@@ -162,9 +159,6 @@ func (paipwas PetAPInPropertiesWithAPString) MarshalJSON() ([]byte, error) {
 	}
 	if paipwas.Name != nil {
 		objectMap["name"] = paipwas.Name
-	}
-	if paipwas.Status != nil {
-		objectMap["status"] = paipwas.Status
 	}
 	if paipwas.OdataLocation != nil {
 		objectMap["@odata.location"] = paipwas.OdataLocation
@@ -257,7 +251,8 @@ type PetAPObject struct {
 	AdditionalProperties map[string]interface{} `json:""`
 	ID                   *int32                 `json:"id,omitempty"`
 	Name                 *string                `json:"name,omitempty"`
-	Status               *bool                  `json:"status,omitempty"`
+	// Status - READ-ONLY
+	Status *bool `json:"status,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for PetAPObject.
@@ -268,9 +263,6 @@ func (pao PetAPObject) MarshalJSON() ([]byte, error) {
 	}
 	if pao.Name != nil {
 		objectMap["name"] = pao.Name
-	}
-	if pao.Status != nil {
-		objectMap["status"] = pao.Status
 	}
 	for k, v := range pao.AdditionalProperties {
 		objectMap[k] = v
@@ -339,7 +331,8 @@ type PetAPString struct {
 	AdditionalProperties map[string]*string `json:""`
 	ID                   *int32             `json:"id,omitempty"`
 	Name                 *string            `json:"name,omitempty"`
-	Status               *bool              `json:"status,omitempty"`
+	// Status - READ-ONLY
+	Status *bool `json:"status,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for PetAPString.
@@ -350,9 +343,6 @@ func (pas PetAPString) MarshalJSON() ([]byte, error) {
 	}
 	if pas.Name != nil {
 		objectMap["name"] = pas.Name
-	}
-	if pas.Status != nil {
-		objectMap["status"] = pas.Status
 	}
 	for k, v := range pas.AdditionalProperties {
 		objectMap[k] = v
@@ -421,7 +411,8 @@ type PetAPTrue struct {
 	AdditionalProperties map[string]interface{} `json:""`
 	ID                   *int32                 `json:"id,omitempty"`
 	Name                 *string                `json:"name,omitempty"`
-	Status               *bool                  `json:"status,omitempty"`
+	// Status - READ-ONLY
+	Status *bool `json:"status,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for PetAPTrue.
@@ -432,9 +423,6 @@ func (pat PetAPTrue) MarshalJSON() ([]byte, error) {
 	}
 	if pat.Name != nil {
 		objectMap["name"] = pat.Name
-	}
-	if pat.Status != nil {
-		objectMap["status"] = pat.Status
 	}
 	for k, v := range pat.AdditionalProperties {
 		objectMap[k] = v

--- a/test/src/tests/generated/additionalproperties/pets.go
+++ b/test/src/tests/generated/additionalproperties/pets.go
@@ -71,6 +71,7 @@ func (client PetsClient) CreateAPInProperties(ctx context.Context, createParamet
 
 // CreateAPInPropertiesPreparer prepares the CreateAPInProperties request.
 func (client PetsClient) CreateAPInPropertiesPreparer(ctx context.Context, createParameters PetAPInProperties) (*http.Request, error) {
+	createParameters.Status = nil
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPut(),
@@ -142,6 +143,7 @@ func (client PetsClient) CreateAPInPropertiesWithAPString(ctx context.Context, c
 
 // CreateAPInPropertiesWithAPStringPreparer prepares the CreateAPInPropertiesWithAPString request.
 func (client PetsClient) CreateAPInPropertiesWithAPStringPreparer(ctx context.Context, createParameters PetAPInPropertiesWithAPString) (*http.Request, error) {
+	createParameters.Status = nil
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPut(),
@@ -212,6 +214,7 @@ func (client PetsClient) CreateAPObject(ctx context.Context, createParameters Pe
 
 // CreateAPObjectPreparer prepares the CreateAPObject request.
 func (client PetsClient) CreateAPObjectPreparer(ctx context.Context, createParameters PetAPObject) (*http.Request, error) {
+	createParameters.Status = nil
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPut(),
@@ -282,6 +285,7 @@ func (client PetsClient) CreateAPString(ctx context.Context, createParameters Pe
 
 // CreateAPStringPreparer prepares the CreateAPString request.
 func (client PetsClient) CreateAPStringPreparer(ctx context.Context, createParameters PetAPString) (*http.Request, error) {
+	createParameters.Status = nil
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPut(),
@@ -352,6 +356,7 @@ func (client PetsClient) CreateAPTrue(ctx context.Context, createParameters PetA
 
 // CreateAPTruePreparer prepares the CreateAPTrue request.
 func (client PetsClient) CreateAPTruePreparer(ctx context.Context, createParameters PetAPTrue) (*http.Request, error) {
+	createParameters.Status = nil
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPut(),

--- a/test/src/tests/generated/complexgroup/complexgroupapi/interfaces.go
+++ b/test/src/tests/generated/complexgroup/complexgroupapi/interfaces.go
@@ -86,6 +86,7 @@ var _ InheritanceClientAPI = (*complexgroup.InheritanceClient)(nil)
 // PolymorphismClientAPI contains the set of methods on the PolymorphismClient type.
 type PolymorphismClientAPI interface {
 	GetComplicated(ctx context.Context) (result complexgroup.SalmonModel, err error)
+	GetDotSyntax(ctx context.Context) (result complexgroup.DotFishModel, err error)
 	GetValid(ctx context.Context) (result complexgroup.FishModel, err error)
 	PutComplicated(ctx context.Context, complexBody complexgroup.BasicSalmon) (result autorest.Response, err error)
 	PutMissingDiscriminator(ctx context.Context, complexBody complexgroup.BasicSalmon) (result complexgroup.SalmonModel, err error)

--- a/test/src/tests/generated/complexgroup/models.go
+++ b/test/src/tests/generated/complexgroup/models.go
@@ -34,29 +34,44 @@ func PossibleCMYKColorsValues() []CMYKColors {
 	return []CMYKColors{BlacK, Cyan, Magenta, YELLOW}
 }
 
-// Fishtype enumerates the values for fishtype.
-type Fishtype string
+// FishType enumerates the values for fish type.
+type FishType string
+
+const (
+	// FishTypeDotFish ...
+	FishTypeDotFish FishType = "DotFish"
+	// FishTypeDotSalmon ...
+	FishTypeDotSalmon FishType = "DotSalmon"
+)
+
+// PossibleFishTypeValues returns an array of possible values for the FishType const type.
+func PossibleFishTypeValues() []FishType {
+	return []FishType{FishTypeDotFish, FishTypeDotSalmon}
+}
+
+// FishtypeBasicFish enumerates the values for fishtype basic fish.
+type FishtypeBasicFish string
 
 const (
 	// FishtypeCookiecuttershark ...
-	FishtypeCookiecuttershark Fishtype = "cookiecuttershark"
+	FishtypeCookiecuttershark FishtypeBasicFish = "cookiecuttershark"
 	// FishtypeFish ...
-	FishtypeFish Fishtype = "Fish"
+	FishtypeFish FishtypeBasicFish = "Fish"
 	// FishtypeGoblin ...
-	FishtypeGoblin Fishtype = "goblin"
+	FishtypeGoblin FishtypeBasicFish = "goblin"
 	// FishtypeSalmon ...
-	FishtypeSalmon Fishtype = "salmon"
+	FishtypeSalmon FishtypeBasicFish = "salmon"
 	// FishtypeSawshark ...
-	FishtypeSawshark Fishtype = "sawshark"
+	FishtypeSawshark FishtypeBasicFish = "sawshark"
 	// FishtypeShark ...
-	FishtypeShark Fishtype = "shark"
+	FishtypeShark FishtypeBasicFish = "shark"
 	// FishtypeSmartSalmon ...
-	FishtypeSmartSalmon Fishtype = "smart_salmon"
+	FishtypeSmartSalmon FishtypeBasicFish = "smart_salmon"
 )
 
-// PossibleFishtypeValues returns an array of possible values for the Fishtype const type.
-func PossibleFishtypeValues() []Fishtype {
-	return []Fishtype{FishtypeCookiecuttershark, FishtypeFish, FishtypeGoblin, FishtypeSalmon, FishtypeSawshark, FishtypeShark, FishtypeSmartSalmon}
+// PossibleFishtypeBasicFishValues returns an array of possible values for the FishtypeBasicFish const type.
+func PossibleFishtypeBasicFishValues() []FishtypeBasicFish {
+	return []FishtypeBasicFish{FishtypeCookiecuttershark, FishtypeFish, FishtypeGoblin, FishtypeSalmon, FishtypeSawshark, FishtypeShark, FishtypeSmartSalmon}
 }
 
 // GoblinSharkColor enumerates the values for goblin shark color.
@@ -150,7 +165,7 @@ type Cookiecuttershark struct {
 	Length   *float64     `json:"length,omitempty"`
 	Siblings *[]BasicFish `json:"siblings,omitempty"`
 	// Fishtype - Possible values include: 'FishtypeFish', 'FishtypeSalmon', 'FishtypeSmartSalmon', 'FishtypeShark', 'FishtypeSawshark', 'FishtypeGoblin', 'FishtypeCookiecuttershark'
-	Fishtype Fishtype `json:"fishtype,omitempty"`
+	Fishtype FishtypeBasicFish `json:"fishtype,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for Cookiecuttershark.
@@ -283,7 +298,7 @@ func (c *Cookiecuttershark) UnmarshalJSON(body []byte) error {
 			}
 		case "fishtype":
 			if v != nil {
-				var fishtype Fishtype
+				var fishtype FishtypeBasicFish
 				err = json.Unmarshal(*v, &fishtype)
 				if err != nil {
 					return err
@@ -339,6 +354,145 @@ type Dog struct {
 	Name *string `json:"name,omitempty"`
 }
 
+// BasicDotFish ...
+type BasicDotFish interface {
+	AsDotSalmon() (*DotSalmon, bool)
+	AsDotFish() (*DotFish, bool)
+}
+
+// DotFish ...
+type DotFish struct {
+	autorest.Response `json:"-"`
+	Species           *string `json:"species,omitempty"`
+	// FishType - Possible values include: 'FishTypeDotFish', 'FishTypeDotSalmon'
+	FishType FishType `json:"fish.type,omitempty"`
+}
+
+func unmarshalBasicDotFish(body []byte) (BasicDotFish, error) {
+	var m map[string]interface{}
+	err := json.Unmarshal(body, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	switch m["fish.type"] {
+	case string(FishTypeDotSalmon):
+		var ds DotSalmon
+		err := json.Unmarshal(body, &ds)
+		return ds, err
+	default:
+		var df DotFish
+		err := json.Unmarshal(body, &df)
+		return df, err
+	}
+}
+func unmarshalBasicDotFishArray(body []byte) ([]BasicDotFish, error) {
+	var rawMessages []*json.RawMessage
+	err := json.Unmarshal(body, &rawMessages)
+	if err != nil {
+		return nil, err
+	}
+
+	dfArray := make([]BasicDotFish, len(rawMessages))
+
+	for index, rawMessage := range rawMessages {
+		df, err := unmarshalBasicDotFish(*rawMessage)
+		if err != nil {
+			return nil, err
+		}
+		dfArray[index] = df
+	}
+	return dfArray, nil
+}
+
+// MarshalJSON is the custom marshaler for DotFish.
+func (df DotFish) MarshalJSON() ([]byte, error) {
+	df.FishType = FishTypeDotFish
+	objectMap := make(map[string]interface{})
+	if df.Species != nil {
+		objectMap["species"] = df.Species
+	}
+	if df.FishType != "" {
+		objectMap["fish.type"] = df.FishType
+	}
+	return json.Marshal(objectMap)
+}
+
+// AsDotSalmon is the BasicDotFish implementation for DotFish.
+func (df DotFish) AsDotSalmon() (*DotSalmon, bool) {
+	return nil, false
+}
+
+// AsDotFish is the BasicDotFish implementation for DotFish.
+func (df DotFish) AsDotFish() (*DotFish, bool) {
+	return &df, true
+}
+
+// AsBasicDotFish is the BasicDotFish implementation for DotFish.
+func (df DotFish) AsBasicDotFish() (BasicDotFish, bool) {
+	return &df, true
+}
+
+// DotFishModel ...
+type DotFishModel struct {
+	autorest.Response `json:"-"`
+	Value             BasicDotFish `json:"value,omitempty"`
+}
+
+// UnmarshalJSON is the custom unmarshaler for DotFishModel struct.
+func (dfm *DotFishModel) UnmarshalJSON(body []byte) error {
+	df, err := unmarshalBasicDotFish(body)
+	if err != nil {
+		return err
+	}
+	dfm.Value = df
+
+	return nil
+}
+
+// DotSalmon ...
+type DotSalmon struct {
+	Location *string `json:"location,omitempty"`
+	Iswild   *bool   `json:"iswild,omitempty"`
+	Species  *string `json:"species,omitempty"`
+	// FishType - Possible values include: 'FishTypeDotFish', 'FishTypeDotSalmon'
+	FishType FishType `json:"fish.type,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for DotSalmon.
+func (ds DotSalmon) MarshalJSON() ([]byte, error) {
+	ds.FishType = FishTypeDotSalmon
+	objectMap := make(map[string]interface{})
+	if ds.Location != nil {
+		objectMap["location"] = ds.Location
+	}
+	if ds.Iswild != nil {
+		objectMap["iswild"] = ds.Iswild
+	}
+	if ds.Species != nil {
+		objectMap["species"] = ds.Species
+	}
+	if ds.FishType != "" {
+		objectMap["fish.type"] = ds.FishType
+	}
+	return json.Marshal(objectMap)
+}
+
+// AsDotSalmon is the BasicDotFish implementation for DotSalmon.
+func (ds DotSalmon) AsDotSalmon() (*DotSalmon, bool) {
+	return &ds, true
+}
+
+// AsDotFish is the BasicDotFish implementation for DotSalmon.
+func (ds DotSalmon) AsDotFish() (*DotFish, bool) {
+	return nil, false
+}
+
+// AsBasicDotFish is the BasicDotFish implementation for DotSalmon.
+func (ds DotSalmon) AsBasicDotFish() (BasicDotFish, bool) {
+	return &ds, true
+}
+
 // DoubleWrapper ...
 type DoubleWrapper struct {
 	autorest.Response                                                               `json:"-"`
@@ -378,7 +532,7 @@ type Fish struct {
 	Length            *float64     `json:"length,omitempty"`
 	Siblings          *[]BasicFish `json:"siblings,omitempty"`
 	// Fishtype - Possible values include: 'FishtypeFish', 'FishtypeSalmon', 'FishtypeSmartSalmon', 'FishtypeShark', 'FishtypeSawshark', 'FishtypeGoblin', 'FishtypeCookiecuttershark'
-	Fishtype Fishtype `json:"fishtype,omitempty"`
+	Fishtype FishtypeBasicFish `json:"fishtype,omitempty"`
 }
 
 func unmarshalBasicFish(body []byte) (BasicFish, error) {
@@ -544,7 +698,7 @@ func (f *Fish) UnmarshalJSON(body []byte) error {
 			}
 		case "fishtype":
 			if v != nil {
-				var fishtype Fishtype
+				var fishtype FishtypeBasicFish
 				err = json.Unmarshal(*v, &fishtype)
 				if err != nil {
 					return err
@@ -592,7 +746,7 @@ type Goblinshark struct {
 	Length   *float64         `json:"length,omitempty"`
 	Siblings *[]BasicFish     `json:"siblings,omitempty"`
 	// Fishtype - Possible values include: 'FishtypeFish', 'FishtypeSalmon', 'FishtypeSmartSalmon', 'FishtypeShark', 'FishtypeSawshark', 'FishtypeGoblin', 'FishtypeCookiecuttershark'
-	Fishtype Fishtype `json:"fishtype,omitempty"`
+	Fishtype FishtypeBasicFish `json:"fishtype,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for Goblinshark.
@@ -749,7 +903,7 @@ func (g *Goblinshark) UnmarshalJSON(body []byte) error {
 			}
 		case "fishtype":
 			if v != nil {
-				var fishtype Fishtype
+				var fishtype FishtypeBasicFish
 				err = json.Unmarshal(*v, &fishtype)
 				if err != nil {
 					return err
@@ -995,7 +1149,7 @@ type Salmon struct {
 	Length            *float64     `json:"length,omitempty"`
 	Siblings          *[]BasicFish `json:"siblings,omitempty"`
 	// Fishtype - Possible values include: 'FishtypeFish', 'FishtypeSalmon', 'FishtypeSmartSalmon', 'FishtypeShark', 'FishtypeSawshark', 'FishtypeGoblin', 'FishtypeCookiecuttershark'
-	Fishtype Fishtype `json:"fishtype,omitempty"`
+	Fishtype FishtypeBasicFish `json:"fishtype,omitempty"`
 }
 
 func unmarshalBasicSalmon(body []byte) (BasicSalmon, error) {
@@ -1165,7 +1319,7 @@ func (s *Salmon) UnmarshalJSON(body []byte) error {
 			}
 		case "fishtype":
 			if v != nil {
-				var fishtype Fishtype
+				var fishtype FishtypeBasicFish
 				err = json.Unmarshal(*v, &fishtype)
 				if err != nil {
 					return err
@@ -1204,7 +1358,7 @@ type Sawshark struct {
 	Length   *float64     `json:"length,omitempty"`
 	Siblings *[]BasicFish `json:"siblings,omitempty"`
 	// Fishtype - Possible values include: 'FishtypeFish', 'FishtypeSalmon', 'FishtypeSmartSalmon', 'FishtypeShark', 'FishtypeSawshark', 'FishtypeGoblin', 'FishtypeCookiecuttershark'
-	Fishtype Fishtype `json:"fishtype,omitempty"`
+	Fishtype FishtypeBasicFish `json:"fishtype,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for Sawshark.
@@ -1349,7 +1503,7 @@ func (s *Sawshark) UnmarshalJSON(body []byte) error {
 			}
 		case "fishtype":
 			if v != nil {
-				var fishtype Fishtype
+				var fishtype FishtypeBasicFish
 				err = json.Unmarshal(*v, &fishtype)
 				if err != nil {
 					return err
@@ -1378,7 +1532,7 @@ type Shark struct {
 	Length   *float64     `json:"length,omitempty"`
 	Siblings *[]BasicFish `json:"siblings,omitempty"`
 	// Fishtype - Possible values include: 'FishtypeFish', 'FishtypeSalmon', 'FishtypeSmartSalmon', 'FishtypeShark', 'FishtypeSawshark', 'FishtypeGoblin', 'FishtypeCookiecuttershark'
-	Fishtype Fishtype `json:"fishtype,omitempty"`
+	Fishtype FishtypeBasicFish `json:"fishtype,omitempty"`
 }
 
 func unmarshalBasicShark(body []byte) (BasicShark, error) {
@@ -1556,7 +1710,7 @@ func (s *Shark) UnmarshalJSON(body []byte) error {
 			}
 		case "fishtype":
 			if v != nil {
-				var fishtype Fishtype
+				var fishtype FishtypeBasicFish
 				err = json.Unmarshal(*v, &fishtype)
 				if err != nil {
 					return err
@@ -1590,7 +1744,7 @@ type SmartSalmon struct {
 	Length               *float64               `json:"length,omitempty"`
 	Siblings             *[]BasicFish           `json:"siblings,omitempty"`
 	// Fishtype - Possible values include: 'FishtypeFish', 'FishtypeSalmon', 'FishtypeSmartSalmon', 'FishtypeShark', 'FishtypeSawshark', 'FishtypeGoblin', 'FishtypeCookiecuttershark'
-	Fishtype Fishtype `json:"fishtype,omitempty"`
+	Fishtype FishtypeBasicFish `json:"fishtype,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for SmartSalmon.
@@ -1750,7 +1904,7 @@ func (s *SmartSalmon) UnmarshalJSON(body []byte) error {
 			}
 		case "fishtype":
 			if v != nil {
-				var fishtype Fishtype
+				var fishtype FishtypeBasicFish
 				err = json.Unmarshal(*v, &fishtype)
 				if err != nil {
 					return err

--- a/test/src/tests/generated/complexgroup/models.go
+++ b/test/src/tests/generated/complexgroup/models.go
@@ -975,8 +975,9 @@ type Pet struct {
 // ReadonlyObj ...
 type ReadonlyObj struct {
 	autorest.Response `json:"-"`
-	ID                *string `json:"id,omitempty"`
-	Size              *int32  `json:"size,omitempty"`
+	// ID - READ-ONLY
+	ID   *string `json:"id,omitempty"`
+	Size *int32  `json:"size,omitempty"`
 }
 
 // BasicSalmon ...

--- a/test/src/tests/generated/complexgroup/polymorphism.go
+++ b/test/src/tests/generated/complexgroup/polymorphism.go
@@ -93,6 +93,68 @@ func (client PolymorphismClient) GetComplicatedResponder(resp *http.Response) (r
 	return
 }
 
+// GetDotSyntax get complex types that are polymorphic, JSON key contains a dot
+func (client PolymorphismClient) GetDotSyntax(ctx context.Context) (result DotFishModel, err error) {
+	if tracing.IsEnabled() {
+		ctx = tracing.StartSpan(ctx, fqdn+"/PolymorphismClient.GetDotSyntax")
+		defer func() {
+			sc := -1
+			if result.Response.Response != nil {
+				sc = result.Response.Response.StatusCode
+			}
+			tracing.EndSpan(ctx, sc, err)
+		}()
+	}
+	req, err := client.GetDotSyntaxPreparer(ctx)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "complexgroup.PolymorphismClient", "GetDotSyntax", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.GetDotSyntaxSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "complexgroup.PolymorphismClient", "GetDotSyntax", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.GetDotSyntaxResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "complexgroup.PolymorphismClient", "GetDotSyntax", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// GetDotSyntaxPreparer prepares the GetDotSyntax request.
+func (client PolymorphismClient) GetDotSyntaxPreparer(ctx context.Context) (*http.Request, error) {
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPath("/complex/polymorphism/dotsyntax"))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// GetDotSyntaxSender sends the GetDotSyntax request. The method will close the
+// http.Response Body if it receives an error.
+func (client PolymorphismClient) GetDotSyntaxSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+}
+
+// GetDotSyntaxResponder handles the response to the GetDotSyntax request. The method always
+// closes the http.Response Body.
+func (client PolymorphismClient) GetDotSyntaxResponder(resp *http.Response) (result DotFishModel, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
 // GetValid get complex types that are polymorphic
 func (client PolymorphismClient) GetValid(ctx context.Context) (result FishModel, err error) {
 	if tracing.IsEnabled() {

--- a/test/src/tests/generated/complexgroup/readonlyproperty.go
+++ b/test/src/tests/generated/complexgroup/readonlyproperty.go
@@ -126,6 +126,7 @@ func (client ReadonlypropertyClient) PutValid(ctx context.Context, complexBody R
 
 // PutValidPreparer prepares the PutValid request.
 func (client ReadonlypropertyClient) PutValidPreparer(ctx context.Context, complexBody ReadonlyObj) (*http.Request, error) {
+	complexBody.ID = nil
 	preparer := autorest.CreatePreparer(
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPut(),

--- a/test/src/tests/generated/lrogroup/models.go
+++ b/test/src/tests/generated/lrogroup/models.go
@@ -2152,14 +2152,14 @@ type OperationResultError struct {
 type Product struct {
 	autorest.Response  `json:"-"`
 	*ProductProperties `json:"properties,omitempty"`
-	// ID - Resource Id
+	// ID - READ-ONLY; Resource Id
 	ID *string `json:"id,omitempty"`
-	// Type - Resource Type
+	// Type - READ-ONLY; Resource Type
 	Type *string            `json:"type,omitempty"`
 	Tags map[string]*string `json:"tags"`
 	// Location - Resource Location
 	Location *string `json:"location,omitempty"`
-	// Name - Resource Name
+	// Name - READ-ONLY; Resource Name
 	Name *string `json:"name,omitempty"`
 }
 
@@ -2169,20 +2169,11 @@ func (p Product) MarshalJSON() ([]byte, error) {
 	if p.ProductProperties != nil {
 		objectMap["properties"] = p.ProductProperties
 	}
-	if p.ID != nil {
-		objectMap["id"] = p.ID
-	}
-	if p.Type != nil {
-		objectMap["type"] = p.Type
-	}
 	if p.Tags != nil {
 		objectMap["tags"] = p.Tags
 	}
 	if p.Location != nil {
 		objectMap["location"] = p.Location
-	}
-	if p.Name != nil {
-		objectMap["name"] = p.Name
 	}
 	return json.Marshal(objectMap)
 }
@@ -2259,40 +2250,31 @@ func (p *Product) UnmarshalJSON(body []byte) error {
 // ProductProperties ...
 type ProductProperties struct {
 	ProvisioningState *string `json:"provisioningState,omitempty"`
-	// ProvisioningStateValues - Possible values include: 'Succeeded', 'Failed', 'Canceled', 'Accepted', 'Creating', 'Created', 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
+	// ProvisioningStateValues - READ-ONLY; Possible values include: 'Succeeded', 'Failed', 'Canceled', 'Accepted', 'Creating', 'Created', 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
 	ProvisioningStateValues ProvisioningStateValues `json:"provisioningStateValues,omitempty"`
 }
 
 // Resource ...
 type Resource struct {
-	// ID - Resource Id
+	// ID - READ-ONLY; Resource Id
 	ID *string `json:"id,omitempty"`
-	// Type - Resource Type
+	// Type - READ-ONLY; Resource Type
 	Type *string            `json:"type,omitempty"`
 	Tags map[string]*string `json:"tags"`
 	// Location - Resource Location
 	Location *string `json:"location,omitempty"`
-	// Name - Resource Name
+	// Name - READ-ONLY; Resource Name
 	Name *string `json:"name,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for Resource.
 func (r Resource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	if r.ID != nil {
-		objectMap["id"] = r.ID
-	}
-	if r.Type != nil {
-		objectMap["type"] = r.Type
-	}
 	if r.Tags != nil {
 		objectMap["tags"] = r.Tags
 	}
 	if r.Location != nil {
 		objectMap["location"] = r.Location
-	}
-	if r.Name != nil {
-		objectMap["name"] = r.Name
 	}
 	return json.Marshal(objectMap)
 }
@@ -2308,7 +2290,7 @@ type Sku struct {
 type SubProduct struct {
 	autorest.Response     `json:"-"`
 	*SubProductProperties `json:"properties,omitempty"`
-	// ID - Sub Resource Id
+	// ID - READ-ONLY; Sub Resource Id
 	ID *string `json:"id,omitempty"`
 }
 
@@ -2317,9 +2299,6 @@ func (sp SubProduct) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	if sp.SubProductProperties != nil {
 		objectMap["properties"] = sp.SubProductProperties
-	}
-	if sp.ID != nil {
-		objectMap["id"] = sp.ID
 	}
 	return json.Marshal(objectMap)
 }
@@ -2360,12 +2339,12 @@ func (sp *SubProduct) UnmarshalJSON(body []byte) error {
 // SubProductProperties ...
 type SubProductProperties struct {
 	ProvisioningState *string `json:"provisioningState,omitempty"`
-	// ProvisioningStateValues - Possible values include: 'ProvisioningStateValues1Succeeded', 'ProvisioningStateValues1Failed', 'ProvisioningStateValues1Canceled', 'ProvisioningStateValues1Accepted', 'ProvisioningStateValues1Creating', 'ProvisioningStateValues1Created', 'ProvisioningStateValues1Updating', 'ProvisioningStateValues1Updated', 'ProvisioningStateValues1Deleting', 'ProvisioningStateValues1Deleted', 'ProvisioningStateValues1OK'
+	// ProvisioningStateValues - READ-ONLY; Possible values include: 'ProvisioningStateValues1Succeeded', 'ProvisioningStateValues1Failed', 'ProvisioningStateValues1Canceled', 'ProvisioningStateValues1Accepted', 'ProvisioningStateValues1Creating', 'ProvisioningStateValues1Created', 'ProvisioningStateValues1Updating', 'ProvisioningStateValues1Updated', 'ProvisioningStateValues1Deleting', 'ProvisioningStateValues1Deleted', 'ProvisioningStateValues1OK'
 	ProvisioningStateValues ProvisioningStateValues1 `json:"provisioningStateValues,omitempty"`
 }
 
 // SubResource ...
 type SubResource struct {
-	// ID - Sub Resource Id
+	// ID - READ-ONLY; Sub Resource Id
 	ID *string `json:"id,omitempty"`
 }

--- a/test/src/tests/generated/modelflatteninggroup/models.go
+++ b/test/src/tests/generated/modelflatteninggroup/models.go
@@ -122,14 +122,14 @@ func (e *Error) UnmarshalJSON(body []byte) error {
 // FlattenedProduct flattened product.
 type FlattenedProduct struct {
 	*FlattenedProductProperties `json:"properties,omitempty"`
-	// ID - Resource Id
+	// ID - READ-ONLY; Resource Id
 	ID *string `json:"id,omitempty"`
-	// Type - Resource Type
+	// Type - READ-ONLY; Resource Type
 	Type *string            `json:"type,omitempty"`
 	Tags map[string]*string `json:"tags"`
 	// Location - Resource Location
 	Location *string `json:"location,omitempty"`
-	// Name - Resource Name
+	// Name - READ-ONLY; Resource Name
 	Name *string `json:"name,omitempty"`
 }
 
@@ -139,20 +139,11 @@ func (fp FlattenedProduct) MarshalJSON() ([]byte, error) {
 	if fp.FlattenedProductProperties != nil {
 		objectMap["properties"] = fp.FlattenedProductProperties
 	}
-	if fp.ID != nil {
-		objectMap["id"] = fp.ID
-	}
-	if fp.Type != nil {
-		objectMap["type"] = fp.Type
-	}
 	if fp.Tags != nil {
 		objectMap["tags"] = fp.Tags
 	}
 	if fp.Location != nil {
 		objectMap["location"] = fp.Location
-	}
-	if fp.Name != nil {
-		objectMap["name"] = fp.Name
 	}
 	return json.Marshal(objectMap)
 }
@@ -230,7 +221,7 @@ func (fp *FlattenedProduct) UnmarshalJSON(body []byte) error {
 type FlattenedProductProperties struct {
 	PName *string `json:"p.name,omitempty"`
 	Type  *string `json:"type,omitempty"`
-	// ProvisioningStateValues - Possible values include: 'Succeeded', 'Failed', 'Canceled', 'Accepted', 'Creating', 'Created', 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
+	// ProvisioningStateValues - READ-ONLY; Possible values include: 'Succeeded', 'Failed', 'Canceled', 'Accepted', 'Creating', 'Created', 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
 	ProvisioningStateValues ProvisioningStateValues `json:"provisioningStateValues,omitempty"`
 	ProvisioningState       *string                 `json:"provisioningState,omitempty"`
 }
@@ -301,34 +292,25 @@ func (pw *ProductWrapper) UnmarshalJSON(body []byte) error {
 
 // Resource ...
 type Resource struct {
-	// ID - Resource Id
+	// ID - READ-ONLY; Resource Id
 	ID *string `json:"id,omitempty"`
-	// Type - Resource Type
+	// Type - READ-ONLY; Resource Type
 	Type *string            `json:"type,omitempty"`
 	Tags map[string]*string `json:"tags"`
 	// Location - Resource Location
 	Location *string `json:"location,omitempty"`
-	// Name - Resource Name
+	// Name - READ-ONLY; Resource Name
 	Name *string `json:"name,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for Resource.
 func (r Resource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	if r.ID != nil {
-		objectMap["id"] = r.ID
-	}
-	if r.Type != nil {
-		objectMap["type"] = r.Type
-	}
 	if r.Tags != nil {
 		objectMap["tags"] = r.Tags
 	}
 	if r.Location != nil {
 		objectMap["location"] = r.Location
-	}
-	if r.Name != nil {
-		objectMap["name"] = r.Name
 	}
 	return json.Marshal(objectMap)
 }


### PR DESCRIPTION
Upcoming changes to some services will reject API calls that send values
for read-only properties.  Set all read-only properties to nil in the
preparer and omit them from custom marshalling.  Emit a comment
indicating that a field is read-only.