### PR TITLE
Support generation of go.mod files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+.DS_Store
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - 1.11.x
   - 1.12.x
 env:
-  - NODE_VERSION="8.9.4"
+  - NODE_VERSION="10.15.3"
 before_install:
   - nvm install $NODE_VERSION
 install:

--- a/src/CodeGeneratorGo.cs
+++ b/src/CodeGeneratorGo.cs
@@ -120,13 +120,22 @@ namespace AutoRest.Go
                 }
                 // module name is everything to the right of the start of the module root
                 var gomodTemplate = new GoModTemplate { Model = new GoMod(normalized.Substring(i)) };
-                await Write(gomodTemplate, "go.mod");
+                await Write(gomodTemplate, $"{StagingDir()}go.mod");
             }
         }
 
         private string FormatFileName(string fileName)
         {
-            return $"{fileName}{ImplementationFileExtension}";
+            return $"{StagingDir()}{fileName}{ImplementationFileExtension}";
+        }
+
+        private string StagingDir()
+        {
+            if (!Settings.Instance.Host.GetValue<bool>("stage").Result)
+            {
+                return "";
+            }
+            return "stage/";
         }
     }
 }

--- a/src/CodeGeneratorGo.cs
+++ b/src/CodeGeneratorGo.cs
@@ -107,6 +107,21 @@ namespace AutoRest.Go
             // Version
             var versionTemplate = new VersionTemplate { Model = codeModel };
             await Write(versionTemplate, FormatFileName("version"));
+
+            // go.mod file, opt-in by specifying the gomod-root arg
+            var modRoot = Settings.Instance.Host.GetValue<string>("gomod-root").Result;
+            if (!string.IsNullOrWhiteSpace(modRoot))
+            {
+                var normalized = Settings.Instance.Host.GetValue<string>("output-folder").Result.Replace('\\', '/');
+                var i = normalized.IndexOf(modRoot);
+                if (i == -1)
+                {
+                    throw new Exception($"didn't find module root '{modRoot}' in output path '{normalized}'");
+                }
+                // module name is everything to the right of the start of the module root
+                var gomodTemplate = new GoModTemplate { Model = new GoMod(normalized.Substring(i)) };
+                await Write(gomodTemplate, "go.mod");
+            }
         }
 
         private string FormatFileName(string fileName)

--- a/src/CodeGeneratorGo.cs
+++ b/src/CodeGeneratorGo.cs
@@ -29,6 +29,11 @@ namespace AutoRest.Go
             get { return ".go"; }
         }
 
+        public CodeGeneratorGo()
+        {
+            Extensions.ResetState();
+        }
+
         /// <summary>
         /// Generates Go code for service client.
         /// </summary>

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -29,6 +29,15 @@ namespace AutoRest.Go
             { "containerservice", "containerservices" }
         };
 
+        /// <summary>
+        /// Resets variant static data.  Call between batches.
+        /// </summary>
+        public static void ResetState()
+        {
+            s_interfaceNames.Clear();
+            s_wordMap.Clear();
+        }
+
         // contains a map from a model type to its corresponding interface name
         private static Dictionary<IModelType, string> s_interfaceNames = new Dictionary<IModelType, string>();
 

--- a/src/Model/GoMod.cs
+++ b/src/Model/GoMod.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace AutoRest.Go.Model
+{
+    public class GoMod
+    {
+        public GoMod(string goMod)
+        {
+            Module = goMod;
+        }
+
+        public string Module { get; }
+    }
+}

--- a/src/Model/MethodGroupGo.cs
+++ b/src/Model/MethodGroupGo.cs
@@ -11,8 +11,6 @@ namespace AutoRest.Go.Model
 {
     public class MethodGroupGo : MethodGroup
     {
-        private static HashSet<string> s_AllNames = new HashSet<string>();
-
         public string ClientName { get; private set; }
         public string Documentation { get; private set; }
         public string PackageName { get; private set; }
@@ -34,30 +32,16 @@ namespace AutoRest.Go.Model
         {
         }
 
-        internal void Transform(CodeModelGo cmg)
+        internal void Transform(CodeModelGo cmg, HashSet<string> allNames)
         {
             var originalName = Name.Value;
             Name = Name.Value.TrimPackageName(cmg.Namespace);
 
-            // use the API version as the prefix to the group name; this is because
-            // in batch mode the generator isn't recycled per batch so you can end up
-            // with erroneous collisions.  note that for composite packages (web)
-            // there will be no API version so fall back to using the batch tag.
-            var prefix = cmg.ApiVersion;
-            if (string.IsNullOrWhiteSpace(prefix))
-            {
-                prefix = cmg.Tag;
-            }
-
-            // keep a list of all method group names as trimming the package name
-            // can introduce collisions.  if there's a collision append "Group" to
-            // the name.  unfortunately we can't do this in the namer as we don't
-            // have access to the package name.
-            if (s_AllNames.Contains($"{prefix}_{Name.Value}"))
+            if (allNames.Contains($"{Name.Value}"))
             {
                 Name += "Group";
             }
-            s_AllNames.Add($"{prefix}_{Name.Value}");
+            allNames.Add($"{Name.Value}");
 
             if (Name != originalName)
             {

--- a/src/Model/PageTypeGo.cs
+++ b/src/Model/PageTypeGo.cs
@@ -28,7 +28,12 @@ namespace AutoRest.Go.Model
 
             CodeModel = method.CodeModel;
             ContentType = (CompositeTypeGo)method.ReturnType.Body;
-            ElementType = ContentType.Properties.FirstOrDefault(p => p.ModelType is SequenceTypeGo).ModelType.Cast<SequenceTypeGo>().ElementType;
+            var returnSeq = ContentType.Properties.FirstOrDefault(p => p.ModelType is SequenceTypeGo);
+            if (returnSeq == null)
+            {
+                throw new InvalidOperationException($"pageable return type {ContentType.Name} for method {method.Owner}.{method.Name} does not contain an array");
+            }
+            ElementType = returnSeq.ModelType.Cast<SequenceTypeGo>().ElementType;
 
             Documentation = $"Contains a page of {ReturnTypeName} values.";
             PreparerNeeded = !method.NextMethodExists(CodeModel.Methods.Cast<MethodGo>());

--- a/src/Templates/GoModTemplate.cshtml
+++ b/src/Templates/GoModTemplate.cshtml
@@ -1,0 +1,5 @@
+﻿@inherits AutoRest.Core.Template<AutoRest.Go.Model.GoMod>
+
+module @Model.Module
+@EmptyLine
+go 1.12

--- a/src/TransformerGo.cs
+++ b/src/TransformerGo.cs
@@ -259,9 +259,12 @@ namespace AutoRest.Go
 
         private static void TransformMethods(CodeModelGo cmg)
         {
-            foreach (var mg in cmg.MethodGroups)
             {
-                mg.Transform(cmg);
+                var allNames = new HashSet<string>();
+                foreach (var mg in cmg.MethodGroups)
+                {
+                    mg.Transform(cmg, allNames);
+                }
             }
 
             var wrapperTypes = new Dictionary<string, CompositeTypeGo>();


### PR DESCRIPTION
Disabled by default.  By specifying --gomod-root arg a module name
will be calculated based on the root value and the output directory.