### PR TITLE
Break the possibleFunc of enums into multiple lines

### DIFF
--- a/src/Templates/EnumTemplate.cshtml
+++ b/src/Templates/EnumTemplate.cshtml
@@ -62,7 +62,7 @@ type @Model.Name string
     )
     // @possibleFuncName returns an array of possible values for the @Model.Name const type.
     func @(possibleFuncName)() []@Model.Name {
-        return []@(Model.Name){@(string.Join(',', orderedValues))}
+        return []@(Model.Name){@(string.Join(",\n", orderedValues))}
     }
     </text>
 }


### PR DESCRIPTION
Break the function that returns all possible enum values as an array to organize its code into multiple lines in order to avoid possible merge conflict in integration prs in the SDK repo