### PR TITLE
Misc codegen fixes

### DIFF
--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -15,6 +15,8 @@ namespace AutoRest.Go
     {
         public const string NullConstraint = "Null";
 
+        public const string EmptyConstraint = "Empty";
+
         public const string ReadOnlyConstraint = "ReadOnly";
 
         private static readonly Regex IsApiVersionPattern = new Regex(@"^api[^a-zA-Z0-9_]?version", RegexOptions.IgnoreCase);
@@ -536,6 +538,8 @@ namespace AutoRest.Go
             {
                 if (p.CheckNull() || isCompositeProperties)
                     y.AddRange(x.AddChain(name, NullConstraint, p.IsRequired));
+                else if (!p.IsRequired && p.ModelType.PrimaryType(KnownPrimaryType.String))
+                    y.AddRange(x.AddChain(name, EmptyConstraint, p.IsRequired));
                 else
                     y.AddRange(x);
             }
@@ -659,6 +663,19 @@ namespace AutoRest.Go
                 || (t is PrimaryType primaryType
                    && primaryType.KnownPrimaryType == KnownPrimaryType.ByteArray)
                 || t is SequenceType;
+        }
+
+        /// <summary>
+        /// Returns true if the specified type is a numeric type.
+        /// </summary>
+        /// <param name="t"></param>
+        /// <returns></returns>
+        public static bool IsNumericType(this IModelType t)
+        {
+            return t.PrimaryType(KnownPrimaryType.Decimal) ||
+                t.PrimaryType(KnownPrimaryType.Double) ||
+                t.PrimaryType(KnownPrimaryType.Int) ||
+                t.PrimaryType(KnownPrimaryType.Long);
         }
 
         /// <summary>

--- a/src/Model/ParameterGo.cs
+++ b/src/Model/ParameterGo.cs
@@ -128,7 +128,10 @@ namespace AutoRest.Go.Model
 
         public bool RequiresUrlEncoding()
         {
-            return (Location == Core.Model.ParameterLocation.Query || Location == Core.Model.ParameterLocation.Path) && !Extensions.ContainsKey(SwaggerExtensions.SkipUrlEncodingExtension);
+            return (Location == Core.Model.ParameterLocation.Query ||
+                    Location == Core.Model.ParameterLocation.Path ||
+                    Location == Core.Model.ParameterLocation.Header)
+                && !Extensions.ContainsKey(SwaggerExtensions.SkipUrlEncodingExtension);
         }
 
         /// <summary>
@@ -418,10 +421,14 @@ namespace AutoRest.Go.Model
                     ancestors.Remove(p.ModelType.Name);
                 }
                 else
+                {
                     x.AddRange(p.ValidateType(name, method));
+                }
 
                 if (x.Count != 0)
+                {
                     v.Add($"{{ TargetValue: {name},\n Constraints: []validation.Constraint{{{string.Join(",\n", x)}}}}}");
+                }
             }
             return string.Join(",\n", v);
         }

--- a/src/Model/ParameterGo.cs
+++ b/src/Model/ParameterGo.cs
@@ -128,10 +128,7 @@ namespace AutoRest.Go.Model
 
         public bool RequiresUrlEncoding()
         {
-            return (Location == Core.Model.ParameterLocation.Query ||
-                    Location == Core.Model.ParameterLocation.Path ||
-                    Location == Core.Model.ParameterLocation.Header)
-                && !Extensions.ContainsKey(SwaggerExtensions.SkipUrlEncodingExtension);
+            return (Location == Core.Model.ParameterLocation.Query || Location == Core.Model.ParameterLocation.Path) && !Extensions.ContainsKey(SwaggerExtensions.SkipUrlEncodingExtension);
         }
 
         /// <summary>

--- a/src/Templates/MethodTemplate.cshtml
+++ b/src/Templates/MethodTemplate.cshtml
@@ -227,11 +227,17 @@ func (client @(Model.Owner)) @(Model.Name)(@Model.MethodParametersSignature()) (
 
     @foreach (var p in Model.OptionalHeaderParameters)
     {
+        var deref = string.Empty;
+        if (p.ModelType.IsNumericType())
+        {
+            // optional numeric values are passed as pointers
+            deref = "*";
+        }
         <text>
             if @(p.GetEmptyCheck(p.GetParameterName(), false)) {
             preparer = autorest.DecoratePreparer(preparer,
-            @(string.Format("autorest.WithHeader(\"{0}\",autorest.String({1}))",
-                                      p.SerializedName, p.GetParameterName())))
+            @(string.Format("autorest.WithHeader(\"{0}\",autorest.String({1}{2}))",
+                                      p.SerializedName, deref, p.GetParameterName())))
             @if (p.DefaultValue.Value != null)
             {
                 @: } else {

--- a/test/src/tests/generated/optionalgroup/explicit.go
+++ b/test/src/tests/generated/optionalgroup/explicit.go
@@ -417,7 +417,7 @@ func (client ExplicitClient) PostOptionalIntegerHeaderPreparer(ctx context.Conte
 		autorest.WithPath("/reqopt/optional/integer/header"))
 	if headerParameter != nil {
 		preparer = autorest.DecoratePreparer(preparer,
-			autorest.WithHeader("headerParameter", autorest.String(headerParameter)))
+			autorest.WithHeader("headerParameter", autorest.String(*headerParameter)))
 	}
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }

--- a/test/src/tests/generated/paginggroup/paging.go
+++ b/test/src/tests/generated/paginggroup/paging.go
@@ -80,11 +80,11 @@ func (client PagingClient) GetMultiplePagesPreparer(ctx context.Context, clientR
 	}
 	if maxresults != nil {
 		preparer = autorest.DecoratePreparer(preparer,
-			autorest.WithHeader("maxresults", autorest.String(maxresults)))
+			autorest.WithHeader("maxresults", autorest.String(*maxresults)))
 	}
 	if timeout != nil {
 		preparer = autorest.DecoratePreparer(preparer,
-			autorest.WithHeader("timeout", autorest.String(timeout)))
+			autorest.WithHeader("timeout", autorest.String(*timeout)))
 	} else {
 		preparer = autorest.DecoratePreparer(preparer,
 			autorest.WithHeader("timeout", autorest.String(30)))
@@ -585,11 +585,11 @@ func (client PagingClient) GetMultiplePagesLROPreparer(ctx context.Context, clie
 	}
 	if maxresults != nil {
 		preparer = autorest.DecoratePreparer(preparer,
-			autorest.WithHeader("maxresults", autorest.String(maxresults)))
+			autorest.WithHeader("maxresults", autorest.String(*maxresults)))
 	}
 	if timeout != nil {
 		preparer = autorest.DecoratePreparer(preparer,
-			autorest.WithHeader("timeout", autorest.String(timeout)))
+			autorest.WithHeader("timeout", autorest.String(*timeout)))
 	} else {
 		preparer = autorest.DecoratePreparer(preparer,
 			autorest.WithHeader("timeout", autorest.String(30)))
@@ -922,11 +922,11 @@ func (client PagingClient) GetMultiplePagesWithOffsetPreparer(ctx context.Contex
 	}
 	if maxresults != nil {
 		preparer = autorest.DecoratePreparer(preparer,
-			autorest.WithHeader("maxresults", autorest.String(maxresults)))
+			autorest.WithHeader("maxresults", autorest.String(*maxresults)))
 	}
 	if timeout != nil {
 		preparer = autorest.DecoratePreparer(preparer,
-			autorest.WithHeader("timeout", autorest.String(timeout)))
+			autorest.WithHeader("timeout", autorest.String(*timeout)))
 	} else {
 		preparer = autorest.DecoratePreparer(preparer,
 			autorest.WithHeader("timeout", autorest.String(30)))
@@ -1041,11 +1041,11 @@ func (client PagingClient) GetOdataMultiplePagesPreparer(ctx context.Context, cl
 	}
 	if maxresults != nil {
 		preparer = autorest.DecoratePreparer(preparer,
-			autorest.WithHeader("maxresults", autorest.String(maxresults)))
+			autorest.WithHeader("maxresults", autorest.String(*maxresults)))
 	}
 	if timeout != nil {
 		preparer = autorest.DecoratePreparer(preparer,
-			autorest.WithHeader("timeout", autorest.String(timeout)))
+			autorest.WithHeader("timeout", autorest.String(*timeout)))
 	} else {
 		preparer = autorest.DecoratePreparer(preparer,
 			autorest.WithHeader("timeout", autorest.String(30)))


### PR DESCRIPTION
For optional string parameters with constraints, add the Empty
constraint allowing it to be empty.
Dereference pointer types so the actual value is converted to string.