### PR TITLE
Treat inclusiveMinimum as an int64

### DIFF
--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -711,9 +711,10 @@ namespace AutoRest.Go
             {
                 value = $"`{constraintValue}`";
             }
-            else if (constraintName == Constraint.InclusiveMaximum.ToString())
+            else if (constraintName == Constraint.InclusiveMaximum.ToString() ||
+                     constraintName == Constraint.InclusiveMinimum.ToString())
             {
-                // swagger spec states that InclusiveMaximum should be an integer
+                // swagger spec states that InclusiveMaximum should be a number
                 // however the validation code supports int64 and float64.  to be
                 // on the safe side handle both cases here.
                 if (constraintValue.IndexOf('.') > -1)

--- a/test/src/tests/generated/validationgroup/client.go
+++ b/test/src/tests/generated/validationgroup/client.go
@@ -228,7 +228,7 @@ func (client BaseClient) ValidationOfBody(ctx context.Context, resourceGroupName
 				{Target: "resourceGroupName", Name: validation.Pattern, Rule: `[a-zA-Z0-9]+`, Chain: nil}}},
 		{TargetValue: ID,
 			Constraints: []validation.Constraint{{Target: "ID", Name: validation.InclusiveMaximum, Rule: int64(1000), Chain: nil},
-				{Target: "ID", Name: validation.InclusiveMinimum, Rule: 100, Chain: nil},
+				{Target: "ID", Name: validation.InclusiveMinimum, Rule: int64(100), Chain: nil},
 				{Target: "ID", Name: validation.MultipleOf, Rule: 10, Chain: nil}}},
 		{TargetValue: body,
 			Constraints: []validation.Constraint{{Target: "body", Name: validation.Null, Rule: false,
@@ -344,7 +344,7 @@ func (client BaseClient) ValidationOfMethodParameters(ctx context.Context, resou
 				{Target: "resourceGroupName", Name: validation.Pattern, Rule: `[a-zA-Z0-9]+`, Chain: nil}}},
 		{TargetValue: ID,
 			Constraints: []validation.Constraint{{Target: "ID", Name: validation.InclusiveMaximum, Rule: int64(1000), Chain: nil},
-				{Target: "ID", Name: validation.InclusiveMinimum, Rule: 100, Chain: nil},
+				{Target: "ID", Name: validation.InclusiveMinimum, Rule: int64(100), Chain: nil},
 				{Target: "ID", Name: validation.MultipleOf, Rule: 10, Chain: nil}}}}); err != nil {
 		return result, validation.NewError("validationgroup.BaseClient", "ValidationOfMethodParameters", err.Error())
 	}


### PR DESCRIPTION
Apply fix from https://github.com/Azure/autorest.go/pull/134 to inclusiveMinimum