### PR TITLE
Make endpoint a required parameter once again

### DIFF
--- a/test/autorest/bytegroup/bytegroup_test.go
+++ b/test/autorest/bytegroup/bytegroup_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func getByteClient(t *testing.T) *bytegroup.ByteClient {
-	client, err := bytegroup.NewByteClient(nil)
+	client, err := bytegroup.NewByteClient(bytegroup.DefaultEndpoint, nil)
 	if err != nil {
 		t.Fatalf("failed to create byte client: %v", err)
 	}

--- a/test/autorest/generated/bytegroup/byte.go
+++ b/test/autorest/generated/bytegroup/byte.go
@@ -11,6 +11,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
+// DefaultEndpoint is the default endpoint used for the byteclient service.
+const DefaultEndpoint = "http://localhost:3000"
+
 // ByteClient is the test Infrastructure for AutoRest Swagger BAT
 type ByteClient struct {
 	s azinternal.Service
@@ -21,7 +24,6 @@ type ByteClient struct {
 // ByteClientOptions ...
 type ByteClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
-	// Leave this as nil to use the default HTTP transport.
 	HTTPClient azcore.Transport
 
 	// LogOptions configures the built-in request logging policy behavior.
@@ -34,23 +36,31 @@ type ByteClientOptions struct {
 	Telemetry azcore.TelemetryOptions
 }
 
+// DefaultByteClientOptions creates a ByteClientOptions type initialized with default values.
+func DefaultByteClientOptions() ByteClientOptions {
+	return ByteClientOptions{
+		HTTPClient: azcore.DefaultHTTPClientTransport(),
+		Retry:      azcore.DefaultRetryOptions(),
+	}
+}
+
 // NewByteClient creates an instance of the ByteClient client.
-func NewByteClient(options *ByteClientOptions) (*ByteClient, error) {
+func NewByteClient(endpoint string, options *ByteClientOptions) (*ByteClient, error) {
 	if options == nil {
-		options = &ByteClientOptions{}
+		o := DefaultByteClientOptions()
+		options = &o
 	}
 	p := azcore.NewPipeline(options.HTTPClient,
 		azcore.NewTelemetryPolicy(options.Telemetry),
 		azcore.NewUniqueRequestIDPolicy(),
-		azcore.NewRetryPolicy(options.Retry),
+		azcore.NewRetryPolicy(&options.Retry),
 		azcore.NewRequestLogPolicy(options.LogOptions))
-	return NewByteClientWithPipeline(p)
+	return NewByteClientWithPipeline(endpoint, p)
 }
 
 // NewByteClientWithPipeline creates an instance of the ByteClient client.
-func NewByteClientWithPipeline(p azcore.Pipeline) (*ByteClient, error) {
-	// TODO: custom endpoint (sovereign clouds)
-	u, err := url.Parse("http://localhost:3000")
+func NewByteClientWithPipeline(endpoint string, p azcore.Pipeline) (*ByteClient, error) {
+	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/bytegroup/internal/bytegroup/models.go
+++ b/test/autorest/generated/bytegroup/internal/bytegroup/models.go
@@ -3,6 +3,26 @@
 
 package bytegroup
 
+import "github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+// Error ...
+type Error struct {
+	Status  int32
+	Message string
+}
+
+func newError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
+func (e Error) Error() string {
+	return e.Message
+}
+
 // GetEmptyResponse ...
 type GetEmptyResponse struct {
 	StatusCode int

--- a/test/autorest/generated/bytegroup/internal/bytegroup/service.go
+++ b/test/autorest/generated/bytegroup/internal/bytegroup/service.go
@@ -17,14 +17,13 @@ type Service struct{}
 // GetEmptyCreateRequest creates the GetEmpty request.
 func (Service) GetEmptyCreateRequest(u url.URL) (*azcore.Request, error) {
 	u.Path = path.Join(u.Path, "/byte/empty")
-	// TODO: this makes two copies
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
 // GetEmptyHandleResponse handles the GetEmpty response.
 func (Service) GetEmptyHandleResponse(resp *azcore.Response) (*GetEmptyResponse, error) {
-	if err := resp.CheckStatusCode(http.StatusOK); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, newError(resp)
 	}
 	result := GetEmptyResponse{StatusCode: resp.StatusCode}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
@@ -38,8 +37,8 @@ func (Service) GetInvalidCreateRequest(u url.URL) (*azcore.Request, error) {
 
 // GetInvalidHandleResponse handles the GetInvalid response.
 func (Service) GetInvalidHandleResponse(resp *azcore.Response) (*GetInvalidResponse, error) {
-	if err := resp.CheckStatusCode(http.StatusOK); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, newError(resp)
 	}
 	result := GetInvalidResponse{StatusCode: resp.StatusCode}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
@@ -53,8 +52,8 @@ func (Service) GetNonASCIICreateRequest(u url.URL) (*azcore.Request, error) {
 
 // GetNonASCIIHandleResponse handles the GetNonASCII response.
 func (Service) GetNonASCIIHandleResponse(resp *azcore.Response) (*GetNonASCIIResponse, error) {
-	if err := resp.CheckStatusCode(http.StatusOK); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, newError(resp)
 	}
 	result := GetNonASCIIResponse{StatusCode: resp.StatusCode}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
@@ -68,8 +67,8 @@ func (Service) GetNullCreateRequest(u url.URL) (*azcore.Request, error) {
 
 // GetNullHandleResponse handles the GetNull response.
 func (Service) GetNullHandleResponse(resp *azcore.Response) (*GetNullResponse, error) {
-	if err := resp.CheckStatusCode(http.StatusOK); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, newError(resp)
 	}
 	result := GetNullResponse{StatusCode: resp.StatusCode}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
@@ -88,8 +87,8 @@ func (Service) PutNonASCIICreateRequest(u url.URL, byteBody []byte) (*azcore.Req
 
 // PutNonASCIIHandleResponse handles the PutNonASCII response.
 func (Service) PutNonASCIIHandleResponse(resp *azcore.Response) (*PutNonASCIIResponse, error) {
-	if err := resp.CheckStatusCode(http.StatusOK); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, newError(resp)
 	}
 	return &PutNonASCIIResponse{StatusCode: resp.StatusCode}, nil
 }

--- a/test/autorest/generated/bytegroup/models.go
+++ b/test/autorest/generated/bytegroup/models.go
@@ -5,6 +5,9 @@ package bytegroup
 
 import azinternal "generatortests/autorest/generated/bytegroup/internal/bytegroup"
 
+// Error ...
+type Error = azinternal.Error
+
 // GetEmptyResponse ...
 type GetEmptyResponse = azinternal.GetEmptyResponse
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -2,4 +2,4 @@ module generatortests
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.2.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.3.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,4 +1,4 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.2.0 h1:aIVXdTBOibe5h5FDZMsgSJFVqVixPPdbWAQ+9QvDSGs=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.2.0/go.mod h1:UKq2za3CMGx75vfPM9tPSuTBNODR4hX1qAeb+GRoDkc=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.3.0 h1:EcVbHX9mW2L7/91WD0nvwdcCiy2bqz1RzUUiM2FJsYM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.3.0/go.mod h1:UKq2za3CMGx75vfPM9tPSuTBNODR4hX1qAeb+GRoDkc=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.1.0 h1:sgOdyT1ZAW3nErwCuvlGrkeP03pTtbRBW5MGCXWGZws=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.1.0/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=


### PR DESCRIPTION
Added DefaultByteClientOptions() to create initialized defaults.
Updated azcore to latest version and refactored.
Create Error type from swagger specification and return an instance of
it when the endpoint returns a non-success status code.