### PR TITLE
Adding transform for operation parameters

### DIFF
--- a/src/generator/common/helpers.ts
+++ b/src/generator/common/helpers.ts
@@ -5,7 +5,7 @@
 
 import { Session } from '@azure-tools/autorest-extension-base';
 import { comment } from '@azure-tools/codegen';
-import { CodeModel, ChoiceValue, ImplementationLocation, Language, Operation, Schema, Schemas, SchemaType, ArraySchema } from '@azure-tools/codemodel';
+import { CodeModel, ChoiceValue, ImplementationLocation, Language, Operation, Schema, Schemas, SchemaType, ArraySchema, DictionarySchema } from '@azure-tools/codemodel';
 import { length, values } from '@azure-tools/linq';
 
 type importEntry = { imp: string, alias?: string };
@@ -53,6 +53,8 @@ export class ImportManager {
     switch (schema.type) {
       case SchemaType.Array: 
         this.addImportForSchemaType((<ArraySchema>schema).elementType);
+      case SchemaType.Dictionary:
+        this.addImportForSchemaType((<DictionarySchema>schema).elementType);
       case SchemaType.Date:
       case SchemaType.DateTime:
       case SchemaType.UnixTime:

--- a/src/generator/common/helpers.ts
+++ b/src/generator/common/helpers.ts
@@ -5,7 +5,7 @@
 
 import { Session } from '@azure-tools/autorest-extension-base';
 import { comment } from '@azure-tools/codegen';
-import { CodeModel, ChoiceValue, ImplementationLocation, Language, Operation, Schema, Schemas, SchemaType } from '@azure-tools/codemodel';
+import { CodeModel, ChoiceValue, ImplementationLocation, Language, Operation, Schema, Schemas, SchemaType, ArraySchema } from '@azure-tools/codemodel';
 import { length, values } from '@azure-tools/linq';
 
 type importEntry = { imp: string, alias?: string };
@@ -51,6 +51,8 @@ export class ImportManager {
 
   addImportForSchemaType(schema: Schema) {
     switch (schema.type) {
+      case SchemaType.Array: 
+        this.addImportForSchemaType((<ArraySchema>schema).elementType);
       case SchemaType.Date:
       case SchemaType.DateTime:
       case SchemaType.UnixTime:

--- a/src/namer/namer.ts
+++ b/src/namer/namer.ts
@@ -17,7 +17,7 @@ export async function namer(host: Host) {
     const session = await startSession<CodeModel>(host, {}, codeModelSchema);
 
     await process(session);
-    
+
     // output the model to the pipeline
     host.WriteFile('code-model-v4.yaml', serialize(session.model), undefined, 'code-model-v4');
 

--- a/src/namer/namer.ts
+++ b/src/namer/namer.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *  --------------------------------------------------------------------------------------------  */
 
-import { serialize, pascalCase } from '@azure-tools/codegen'
+import { serialize, pascalCase, camelCase } from '@azure-tools/codegen'
 import { Host, startSession, Session } from '@azure-tools/autorest-extension-base'
 import { codeModelSchema, CodeModel, Language, ObjectSchema, SchemaType, Schema } from '@azure-tools/codemodel'
 import { length, visitor, clone, values } from '@azure-tools/linq'
@@ -17,7 +17,7 @@ export async function namer(host: Host) {
     const session = await startSession<CodeModel>(host, {}, codeModelSchema);
 
     await process(session);
-
+    
     // output the model to the pipeline
     host.WriteFile('code-model-v4.yaml', serialize(session.model), undefined, 'code-model-v4');
 
@@ -91,7 +91,7 @@ async function process(session: Session<CodeModel>) {
       details.name = getEscapedReservedName(capitalizeAcronyms(pascalCase(details.name)), 'Method');
       for (const param of values(op.request.parameters)) {
         const paramDetails = <Language>param.language.go;
-        paramDetails.name = getEscapedReservedName(paramDetails.name, 'Parameter');
+        paramDetails.name = getEscapedReservedName(camelCase(paramDetails.name), 'Parameter');
       }
       details.protocolNaming = new protocolMethods(details.name);
       // fix up response type name and description

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -85,7 +85,7 @@ function processOperationRequests(session: Session<CodeModel>) {
   for (const group of values(session.model.operationGroups)) {
     for (const op of values(group.operations)) {
       for (const param of values(op.request.parameters)) {
-        param.schema.language.go!.name = schemaTypeToGoType(param.schema)
+        param.schema.language.go!.name = schemaTypeToGoType(param.schema);
       }
     }
   }

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -80,6 +80,7 @@ function schemaTypeToGoType(schema: Schema): string {
   }
 }
 
+// we will transform operation request parameter schema types to Go types
 function processOperationRequests(session: Session<CodeModel>) {
   for (const group of values(session.model.operationGroups)) {
     for (const op of values(group.operations)) {

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -5,7 +5,7 @@
 
 import { serialize } from '@azure-tools/codegen';
 import { Host, startSession, Session } from '@azure-tools/autorest-extension-base';
-import { ArraySchema, codeModelSchema, CodeModel, Language, SchemaType, NumberSchema, Operation, OperationGroup, SchemaResponse, Property, Response, Schema, DictionarySchema } from '@azure-tools/codemodel';
+import { ArraySchema, codeModelSchema, CodeModel, Language, SchemaType, NumberSchema, Operation, SchemaResponse, Property, Response, Schema, DictionarySchema } from '@azure-tools/codemodel';
 import { length, values } from '@azure-tools/linq';
 
 // The transformer adds Go-specific information to the code model.
@@ -29,6 +29,7 @@ export async function transform(host: Host) {
 }
 
 async function process(session: Session<CodeModel>) {
+  processOperationRequests(session);
   processOperationResponses(session);
   // fix up struct field types
   for (const obj of values(session.model.schemas.objects)) {
@@ -46,13 +47,8 @@ function schemaTypeToGoType(schema: Schema): string {
   switch (schema.type) {
     case SchemaType.Array:
       const arraySchema = <ArraySchema>schema;
-      switch (arraySchema.elementType.type) {
-        case SchemaType.String:
-          return '[]string';
-        default:
-          const elem = <Schema>arraySchema.elementType;
-          return `[]${schemaTypeToGoType(elem)}`;
-      }
+      const arrayElem = <Schema>arraySchema.elementType;
+      return `[]${schemaTypeToGoType(arrayElem)}`;
     case SchemaType.Boolean:
       return 'bool';
     case SchemaType.ByteArray:
@@ -62,8 +58,8 @@ function schemaTypeToGoType(schema: Schema): string {
       return 'time.Time';
     case SchemaType.Dictionary:
       const dictSchema = <DictionarySchema>schema;
-      const elem = <Schema>dictSchema.elementType;
-      return `map[string]*${schemaTypeToGoType(elem)}`;
+      const dictElem = <Schema>dictSchema.elementType;
+      return `map[string]*${schemaTypeToGoType(dictElem)}`;
     case SchemaType.Duration:
       return 'time.Duration';
     case SchemaType.Integer:
@@ -81,6 +77,16 @@ function schemaTypeToGoType(schema: Schema): string {
       return 'string';
     default:
       return schema.language.go!.name;
+  }
+}
+
+function processOperationRequests(session: Session<CodeModel>) {
+  for (const group of values(session.model.operationGroups)) {
+    for (const op of values(group.operations)) {
+      for (const param of values(op.request.parameters)) {
+        param.schema.language.go!.name = schemaTypeToGoType(param.schema)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This PR includes:
A transform for operationGroup operation parameter types from schema types to Go types. 
Simplified switch for schemaTypeToGoType
Added camelCase for naming params