### PR TITLE
Don't hard-code the 'Value' field in response types

### DIFF
--- a/src/generator/convenience/client.ts
+++ b/src/generator/convenience/client.ts
@@ -98,7 +98,7 @@ export async function generateClient(session: Session<CodeModel>): Promise<strin
 
 function getDefaultEndpoint(params?: Parameter[]) {
   for (const param of values(params)) {
-    if (param.language.go!.name === '$host') {
+    if (param.language.go!.name === '$host' || param.language.go!.name === 'host') {
       return param.clientDefaultValue;
     }
   }

--- a/src/generator/protocol/models.ts
+++ b/src/generator/protocol/models.ts
@@ -74,7 +74,12 @@ class StructDef {
         // for constants we use the underlying type name
         typeName = (<ConstantSchema>prop.schema).valueType.language.go!.name;
       }
-      text += `\t${prop.language.go!.name} ${this.byref(prop)}${typeName} \`json:"${prop.serializedName},omitempty"\`\n`;
+      let tag = ` \`json:"${prop.serializedName},omitempty"\``;
+      if (this.Language.responseType) {
+        // tags aren't required for response types
+        tag = '';
+      }
+      text += `\t${prop.language.go!.name} ${this.byref(prop)}${typeName}${tag}\n`;
     }
     text += '}\n\n';
     if (this.Language.errorType) {

--- a/src/generator/protocol/operations.ts
+++ b/src/generator/protocol/operations.ts
@@ -5,7 +5,7 @@
 
 import { Session } from '@azure-tools/autorest-extension-base';
 import { comment, pascalCase } from '@azure-tools/codegen'
-import { CodeModel, ConstantSchema, ImplementationLocation, Language, Operation, Parameter, Protocols, SchemaType } from '@azure-tools/codemodel';
+import { CodeModel, ConstantSchema, ImplementationLocation, Language, Operation, Parameter, Protocols, SchemaResponse, SchemaType } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';
 import { ContentPreamble, generateParamsSig, generateParameterInfo, genereateReturnsInfo, ImportManager, MethodSig, ParamInfo, SortAscending } from '../common/helpers';
 import { OperationNaming } from '../../namer/namer';
@@ -143,7 +143,7 @@ function createProtocolResponse(client: string, op: Operation): string {
     text += `\treturn &${respObj}, nil\n`;
   } else {
     text += `\tresult := ${respObj}\n`;
-    text += `\treturn &result, resp.UnmarshalAs${getMediaType(resp.protocol)}(&result.Value)\n`;
+    text += `\treturn &result, resp.UnmarshalAs${getMediaType(resp.protocol)}(&result.${(<SchemaResponse>resp).schema.language.go!.responseValue})\n`;
   }
   text += '}\n\n';
   return text;

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -114,13 +114,21 @@ function createResponseType(op: Operation) {
   // create the `type FooResponse struct` response
   // type with a `StatusCode int` field
   const resp = op.responses![0];
+  resp.language.go!.responseType = true;
   resp.language.go!.properties = [
     newProperty('StatusCode', 'StatusCode contains the HTTP status code.', newNumber('int', 'TODO', SchemaType.Integer, 32), true)
   ];
   // if the response defines a schema then add it as a field to the response type
   if (isSchemaResponse(resp)) {
+    // for operations that return scalar types we use a fixed field name 'Value'
+    let propName = 'Value';
+    if (resp.schema.type === SchemaType.Object) {
+      // for object types use the type's name as the field name
+      propName = resp.schema.language.go!.name;
+    }
     resp.schema.language.go!.name = schemaTypeToGoType(resp.schema);
-    (<Array<Property>>resp.language.go!.properties).push(newProperty('Value', resp.schema.language.go!.description, resp.schema, noByRef(resp.schema.type)));
+    resp.schema.language.go!.responseValue = propName;
+    (<Array<Property>>resp.language.go!.properties).push(newProperty(propName, resp.schema.language.go!.description, resp.schema, noByRef(resp.schema.type)));
   }
 }
 

--- a/test/autorest/generated/bytegroup/internal/bytegroup/models.go
+++ b/test/autorest/generated/bytegroup/internal/bytegroup/models.go
@@ -5,7 +5,10 @@
 
 package bytegroup
 
-import "github.com/Azure/azure-sdk-for-go/sdk/azcore"
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
 
 // ByteGetEmptyResponse contains the response from method Byte.GetEmpty.
 type ByteGetEmptyResponse struct {
@@ -46,8 +49,8 @@ type BytePutNonASCIIResponse struct {
 }
 
 type Error struct {
-	Message *string
-	Status *int32
+	Message *string `json:"message,omitempty"`
+	Status *int32 `json:"status,omitempty"`
 }
 
 func newError(resp *azcore.Response) error {
@@ -59,6 +62,16 @@ func newError(resp *azcore.Response) error {
 }
 
 func (e Error) Error() string {
-	return "TODO"
+	msg := ""
+	if e.Message != nil {
+		msg += fmt.Sprintf("Message: %v\n", *e.Message)
+	}
+	if e.Status != nil {
+		msg += fmt.Sprintf("Status: %v\n", *e.Status)
+	}
+	if msg == "" {
+		msg = "missing error info"
+	}
+	return msg
 }
 


### PR DESCRIPTION
Use the name 'Value' only for operations that return scalar types.  For
all others use the type's name.
Check for 'host' when calculating the default endpoint.
Omit tags for response types.