### PR TITLE
Separating complexgroup tests into separate files

### DIFF
--- a/test/autorest/complexgroup/basic_test.go
+++ b/test/autorest/complexgroup/basic_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package complexgrouptest
+
+import (
+	"context"
+	"generatortests/autorest/generated/complexgroup"
+	"net/http"
+	"testing"
+)
+
+func getBasicOperations(t *testing.T) complexgroup.BasicOperations {
+	client, err := complexgroup.NewDefaultClient(nil)
+	if err != nil {
+		t.Fatalf("failed to create complex client: %v", err)
+	}
+	return client.BasicOperations()
+}
+
+func TestBasicGetValid(t *testing.T) {
+	client := getBasicOperations(t)
+	result, err := client.GetValid(context.Background())
+	if err != nil {
+		t.Fatalf("GetValid: %v", err)
+	}
+	var v complexgroup.CMYKColors
+	colors := complexgroup.PossibleCMYKColorsValues()
+	for _, c := range colors {
+		if string(c) == "YELLOW" {
+			v = c
+			break
+		}
+	}
+	i, s := int32(2), "abc"
+	expected := &complexgroup.BasicGetValidResponse{
+		StatusCode: http.StatusOK,
+		Basic:      &complexgroup.Basic{ID: &i, Name: &s, Color: &v},
+	}
+	deepEqualOrFatal(t, result, expected)
+}
+
+func TestBasicPutValid(t *testing.T) {
+	client := getBasicOperations(t)
+	var v complexgroup.CMYKColors
+	colors := complexgroup.PossibleCMYKColorsValues()
+	for _, c := range colors {
+		if string(c) == "Magenta" {
+			v = c
+			break
+		}
+	}
+	i, s := int32(2), "abc"
+	result, err := client.PutValid(context.Background(), complexgroup.Basic{ID: &i, Name: &s, Color: &v})
+	if err != nil {
+		t.Fatalf("PutValid: %v", err)
+	}
+	expected := &complexgroup.BasicPutValidResponse{
+		StatusCode: http.StatusOK,
+	}
+	deepEqualOrFatal(t, result, expected)
+}
+
+// TODO check this
+func TestBasicGetInvalid(t *testing.T) {
+	client := getBasicOperations(t)
+	result, err := client.GetInvalid(context.Background())
+	if err == nil {
+		t.Fatalf("GetInvalid expected an error")
+	}
+	var expected *complexgroup.BasicGetInvalidResponse
+	expected = nil
+	deepEqualOrFatal(t, result, expected)
+}
+
+func TestBasicGetEmpty(t *testing.T) {
+	client := getBasicOperations(t)
+	result, err := client.GetEmpty(context.Background())
+	if err != nil {
+		t.Fatalf("GetEmpty: %v", err)
+	}
+	expected := &complexgroup.BasicGetEmptyResponse{
+		StatusCode: http.StatusOK,
+		Basic:      &complexgroup.Basic{},
+	}
+	deepEqualOrFatal(t, result, expected)
+}
+
+func TestBasicGetNull(t *testing.T) {
+	client := getBasicOperations(t)
+	result, err := client.GetNull(context.Background())
+	if err != nil {
+		t.Fatalf("GetNull: %v", err)
+	}
+	expected := &complexgroup.BasicGetNullResponse{
+		StatusCode: http.StatusOK,
+		Basic:      &complexgroup.Basic{},
+	}
+	deepEqualOrFatal(t, result, expected)
+}
+
+func TestBasicGetNotProvided(t *testing.T) {
+	client := getBasicOperations(t)
+	result, err := client.GetNotProvided(context.Background())
+	if err != nil {
+		t.Fatalf("GetNotProvided: %v", err)
+	}
+	expected := &complexgroup.BasicGetNotProvidedResponse{
+		StatusCode: http.StatusOK,
+		Basic:      nil,
+	}
+	deepEqualOrFatal(t, result, expected)
+}

--- a/test/autorest/complexgroup/common.go
+++ b/test/autorest/complexgroup/common.go
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package complexgrouptest
+
+import (
+	"reflect"
+	"testing"
+)
+
+func deepEqualOrFatal(t *testing.T, result interface{}, expected interface{}) {
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("got %+v, want %+v", result, expected)
+	}
+}

--- a/test/autorest/complexgroup/primitive_test.go
+++ b/test/autorest/complexgroup/primitive_test.go
@@ -7,17 +7,8 @@ import (
 	"context"
 	"generatortests/autorest/generated/complexgroup"
 	"net/http"
-	"reflect"
 	"testing"
 )
-
-func getBasicOperations(t *testing.T) complexgroup.BasicOperations {
-	client, err := complexgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create complex client: %v", err)
-	}
-	return client.BasicOperations()
-}
 
 func getPrimitiveOperations(t *testing.T) complexgroup.PrimitiveOperations {
 	client, err := complexgroup.NewDefaultClient(nil)
@@ -25,106 +16,6 @@ func getPrimitiveOperations(t *testing.T) complexgroup.PrimitiveOperations {
 		t.Fatalf("failed to create complex client: %v", err)
 	}
 	return client.PrimitiveOperations()
-}
-
-func deepEqualOrFatal(t *testing.T, result interface{}, expected interface{}) {
-	if !reflect.DeepEqual(result, expected) {
-		t.Fatalf("got %+v, want %+v", result, expected)
-	}
-}
-
-func TestGetValid(t *testing.T) {
-	client := getBasicOperations(t)
-	result, err := client.GetValid(context.Background())
-	if err != nil {
-		t.Fatalf("GetValid: %v", err)
-	}
-	var v complexgroup.CMYKColors
-	colors := complexgroup.PossibleCMYKColorsValues()
-	for _, c := range colors {
-		if string(c) == "YELLOW" {
-			v = c
-			break
-		}
-	}
-	i, s := int32(2), "abc"
-	expected := &complexgroup.BasicGetValidResponse{
-		StatusCode: http.StatusOK,
-		Basic:      &complexgroup.Basic{ID: &i, Name: &s, Color: &v},
-	}
-	deepEqualOrFatal(t, result, expected)
-}
-
-func TestPutValid(t *testing.T) {
-	client := getBasicOperations(t)
-	var v complexgroup.CMYKColors
-	colors := complexgroup.PossibleCMYKColorsValues()
-	for _, c := range colors {
-		if string(c) == "Magenta" {
-			v = c
-			break
-		}
-	}
-	i, s := int32(2), "abc"
-	result, err := client.PutValid(context.Background(), complexgroup.Basic{ID: &i, Name: &s, Color: &v})
-	if err != nil {
-		t.Fatalf("PutValid: %v", err)
-	}
-	expected := &complexgroup.BasicPutValidResponse{
-		StatusCode: http.StatusOK,
-	}
-	deepEqualOrFatal(t, result, expected)
-}
-
-// TODO check this
-func TestGetInvalid(t *testing.T) {
-	client := getBasicOperations(t)
-	result, err := client.GetInvalid(context.Background())
-	if err == nil {
-		t.Fatalf("GetInvalid expected an error")
-	}
-	var expected *complexgroup.BasicGetInvalidResponse
-	expected = nil
-	deepEqualOrFatal(t, result, expected)
-}
-
-func TestGetEmpty(t *testing.T) {
-	client := getBasicOperations(t)
-	result, err := client.GetEmpty(context.Background())
-	if err != nil {
-		t.Fatalf("GetEmpty: %v", err)
-	}
-	expected := &complexgroup.BasicGetEmptyResponse{
-		StatusCode: http.StatusOK,
-		Basic:      &complexgroup.Basic{},
-	}
-	deepEqualOrFatal(t, result, expected)
-}
-
-func TestGetNull(t *testing.T) {
-	client := getBasicOperations(t)
-	result, err := client.GetNull(context.Background())
-	if err != nil {
-		t.Fatalf("GetNull: %v", err)
-	}
-	expected := &complexgroup.BasicGetNullResponse{
-		StatusCode: http.StatusOK,
-		Basic:      &complexgroup.Basic{},
-	}
-	deepEqualOrFatal(t, result, expected)
-}
-
-func TestGetNotProvided(t *testing.T) {
-	client := getBasicOperations(t)
-	result, err := client.GetNotProvided(context.Background())
-	if err != nil {
-		t.Fatalf("GetNotProvided: %v", err)
-	}
-	expected := &complexgroup.BasicGetNotProvidedResponse{
-		StatusCode: http.StatusOK,
-		Basic:      nil,
-	}
-	deepEqualOrFatal(t, result, expected)
 }
 
 func TestGetInt(t *testing.T) {

--- a/test/autorest/complexgroup/primitive_test.go
+++ b/test/autorest/complexgroup/primitive_test.go
@@ -18,7 +18,7 @@ func getPrimitiveOperations(t *testing.T) complexgroup.PrimitiveOperations {
 	return client.PrimitiveOperations()
 }
 
-func TestGetInt(t *testing.T) {
+func TestPrimitiveGetInt(t *testing.T) {
 	client := getPrimitiveOperations(t)
 	result, err := client.GetInt(context.Background())
 	if err != nil {
@@ -32,7 +32,7 @@ func TestGetInt(t *testing.T) {
 	deepEqualOrFatal(t, result, expected)
 }
 
-func TestPutInt(t *testing.T) {
+func TestPrimitivePutInt(t *testing.T) {
 	client := getPrimitiveOperations(t)
 	a, b := int32(-1), int32(2)
 	result, err := client.PutInt(context.Background(), complexgroup.IntWrapper{Field1: &a, Field2: &b})
@@ -45,7 +45,7 @@ func TestPutInt(t *testing.T) {
 	deepEqualOrFatal(t, result, expected)
 }
 
-func TestGetLong(t *testing.T) {
+func TestPrimitiveGetLong(t *testing.T) {
 	client := getPrimitiveOperations(t)
 	result, err := client.GetLong(context.Background())
 	if err != nil {
@@ -59,7 +59,7 @@ func TestGetLong(t *testing.T) {
 	deepEqualOrFatal(t, result, expected)
 }
 
-func TestPutLong(t *testing.T) {
+func TestPrimitivePutLong(t *testing.T) {
 	client := getPrimitiveOperations(t)
 	a, b := int64(1099511627775), int64(-999511627788)
 	result, err := client.PutLong(context.Background(), complexgroup.LongWrapper{Field1: &a, Field2: &b})
@@ -72,7 +72,7 @@ func TestPutLong(t *testing.T) {
 	deepEqualOrFatal(t, result, expected)
 }
 
-func TestGetFloat(t *testing.T) {
+func TestPrimitiveGetFloat(t *testing.T) {
 	client := getPrimitiveOperations(t)
 	result, err := client.GetFloat(context.Background())
 	if err != nil {
@@ -86,7 +86,7 @@ func TestGetFloat(t *testing.T) {
 	deepEqualOrFatal(t, result, expected)
 }
 
-func TestPutFloat(t *testing.T) {
+func TestPrimitivePutFloat(t *testing.T) {
 	client := getPrimitiveOperations(t)
 	a, b := float32(1.05), float32(-0.003)
 	result, err := client.PutFloat(context.Background(), complexgroup.FloatWrapper{Field1: &a, Field2: &b})
@@ -99,7 +99,7 @@ func TestPutFloat(t *testing.T) {
 	deepEqualOrFatal(t, result, expected)
 }
 
-func TestGetDouble(t *testing.T) {
+func TestPrimitiveGetDouble(t *testing.T) {
 	client := getPrimitiveOperations(t)
 	result, err := client.GetDouble(context.Background())
 	if err != nil {
@@ -113,7 +113,7 @@ func TestGetDouble(t *testing.T) {
 	deepEqualOrFatal(t, result, expected)
 }
 
-func TestPutDouble(t *testing.T) {
+func TestPrimitivePutDouble(t *testing.T) {
 	client := getPrimitiveOperations(t)
 	a, b := float64(3e-100), float64(-0.000000000000000000000000000000000000000000000000000000005)
 	result, err := client.PutDouble(context.Background(), complexgroup.DoubleWrapper{Field1: &a, Field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose: &b})
@@ -126,7 +126,7 @@ func TestPutDouble(t *testing.T) {
 	deepEqualOrFatal(t, result, expected)
 }
 
-func TestGetBool(t *testing.T) {
+func TestPrimitiveGetBool(t *testing.T) {
 	client := getPrimitiveOperations(t)
 	result, err := client.GetBool(context.Background())
 	if err != nil {
@@ -140,7 +140,7 @@ func TestGetBool(t *testing.T) {
 	deepEqualOrFatal(t, result, expected)
 }
 
-func TestPutBool(t *testing.T) {
+func TestPrimitivePutBool(t *testing.T) {
 	client := getPrimitiveOperations(t)
 	a, b := true, false
 	result, err := client.PutBool(context.Background(), complexgroup.BooleanWrapper{FieldTrue: &a, FieldFalse: &b})
@@ -153,7 +153,7 @@ func TestPutBool(t *testing.T) {
 	deepEqualOrFatal(t, result, expected)
 }
 
-func TestGetString(t *testing.T) {
+func TestPrimitiveGetString(t *testing.T) {
 	client := getPrimitiveOperations(t)
 	result, err := client.GetString(context.Background())
 	if err != nil {
@@ -168,7 +168,7 @@ func TestGetString(t *testing.T) {
 	deepEqualOrFatal(t, result, expected)
 }
 
-func TestPutString(t *testing.T) {
+func TestPrimitivePutString(t *testing.T) {
 	client := getPrimitiveOperations(t)
 	var c *string
 	a, b, c := "goodrequest", "", nil
@@ -182,7 +182,7 @@ func TestPutString(t *testing.T) {
 	deepEqualOrFatal(t, result, expected)
 }
 
-// func TestGetDate(t *testing.T) {
+// func TestPrimitiveGetDate(t *testing.T) {
 // 	client := getPrimitiveOperations(t)
 // 	result, err := client.GetDate(context.Background())
 // 	if err != nil {
@@ -203,7 +203,7 @@ func TestPutString(t *testing.T) {
 // 	deepEqualOrFatal(t, result, expected)
 // }
 
-// func TestPutDate(t *testing.T) {
+// func TestPrimitivePutDate(t *testing.T) {
 // 	client := getPrimitiveOperations(t)
 // 	a, err := time.Parse("2006-01-02", "0001-01-01")
 // 	if err != nil {


### PR DESCRIPTION
Separating complexgroup tests into different files based on operation groups. 
Updating test names to include group name to avoid conflicts between different groups. 