### PR TITLE
Separating stringgroup tests and adding enum tests

### DIFF
--- a/test/autorest/generated/stringgroup/internal/stringgroup/enum.go
+++ b/test/autorest/generated/stringgroup/internal/stringgroup/enum.go
@@ -56,7 +56,7 @@ func (EnumOperations) GetReferencedConstantHandleResponse(resp *azcore.Response)
 		return nil, newError(resp)
 	}
 	result := EnumGetReferencedConstantResponse{StatusCode: resp.StatusCode}
-	return &result, resp.UnmarshalAsJSON(&result.Value)
+	return &result, resp.UnmarshalAsJSON(&result.RefColorConstant)
 }
 
 // PutNotExpandableCreateRequest creates the PutNotExpandable request.

--- a/test/autorest/generated/stringgroup/internal/stringgroup/models.go
+++ b/test/autorest/generated/stringgroup/internal/stringgroup/models.go
@@ -5,7 +5,10 @@
 
 package stringgroup
 
-import "github.com/Azure/azure-sdk-for-go/sdk/azcore"
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
 
 type Colors string
 
@@ -28,9 +31,9 @@ type EnumGetNotExpandableResponse struct {
 
 // EnumGetReferencedConstantResponse contains the response from method Enum.GetReferencedConstant.
 type EnumGetReferencedConstantResponse struct {
+	RefColorConstant *RefColorConstant
 	// StatusCode contains the HTTP status code.
 	StatusCode int
-	Value *RefColorConstant
 }
 
 // EnumGetReferencedResponse contains the response from method Enum.GetReferenced.
@@ -59,8 +62,8 @@ type EnumPutReferencedResponse struct {
 }
 
 type Error struct {
-	Message *string
-	Status *int32
+	Message *string `json:"message,omitempty"`
+	Status *int32 `json:"status,omitempty"`
 }
 
 func newError(resp *azcore.Response) error {
@@ -72,14 +75,24 @@ func newError(resp *azcore.Response) error {
 }
 
 func (e Error) Error() string {
-	return "TODO"
+	msg := ""
+	if e.Message != nil {
+		msg += fmt.Sprintf("Message: %v\n", *e.Message)
+	}
+	if e.Status != nil {
+		msg += fmt.Sprintf("Status: %v\n", *e.Status)
+	}
+	if msg == "" {
+		msg = "missing error info"
+	}
+	return msg
 }
 
 type RefColorConstant struct {
 	// Referenced Color Constant Description.
-	ColorConstant *string
+	ColorConstant *string `json:"ColorConstant,omitempty"`
 	// Sample string.
-	Field1 *string
+	Field1 *string `json:"field1,omitempty"`
 }
 
 // StringGetBase64EncodedResponse contains the response from method String.GetBase64Encoded.

--- a/test/autorest/stringgroup/common.go
+++ b/test/autorest/stringgroup/common.go
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package stringgrouptest
+
+import (
+	"reflect"
+	"testing"
+)
+
+func deepEqualOrFatal(t *testing.T, result interface{}, expected interface{}) {
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("got %+v, want %+v", result, expected)
+	}
+}

--- a/test/autorest/stringgroup/enum_test.go
+++ b/test/autorest/stringgroup/enum_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package stringgrouptest
+
+import (
+	"context"
+	"generatortests/autorest/generated/stringgroup"
+	"net/http"
+	"testing"
+)
+
+func getEnumClient(t *testing.T) stringgroup.EnumOperations {
+	client, err := stringgroup.NewDefaultClient(nil)
+	if err != nil {
+		t.Fatalf("failed to create enum client: %v", err)
+	}
+	return client.EnumOperations()
+}
+
+func TestEnumGetNotExpandable(t *testing.T) {
+	client := getEnumClient(t)
+	result, err := client.GetNotExpandable(context.Background())
+	if err != nil {
+		t.Fatalf("GetNotExpandable: %v", err)
+	}
+	color := stringgroup.ColorsRedColor
+	expected := &stringgroup.EnumGetNotExpandableResponse{
+		StatusCode: http.StatusOK,
+		Value:      &color,
+	}
+	deepEqualOrFatal(t, result, expected)
+}
+
+func TestEnumGetReferenced(t *testing.T) {
+	client := getEnumClient(t)
+	result, err := client.GetReferenced(context.Background())
+	if err != nil {
+		t.Fatalf("GetReferenced: %v", err)
+	}
+	color := stringgroup.ColorsRedColor
+	expected := &stringgroup.EnumGetReferencedResponse{
+		StatusCode: http.StatusOK,
+		Value:      &color,
+	}
+	deepEqualOrFatal(t, result, expected)
+}
+
+func TestEnumGetReferencedConstant(t *testing.T) {
+	client := getEnumClient(t)
+	result, err := client.GetReferencedConstant(context.Background())
+	if err != nil {
+		t.Fatalf("GetReferencedConstant: %v", err)
+	}
+	val := "Sample String"
+	expected := &stringgroup.EnumGetReferencedConstantResponse{
+		StatusCode:       http.StatusOK,
+		RefColorConstant: &stringgroup.RefColorConstant{Field1: &val},
+	}
+	deepEqualOrFatal(t, result, expected)
+}
+
+func TestEnumPutNotExpandable(t *testing.T) {
+	client := getEnumClient(t)
+	result, err := client.PutNotExpandable(context.Background(), stringgroup.ColorsRedColor)
+	if err != nil {
+		t.Fatalf("PutNotExpandable: %v", err)
+	}
+	expected := &stringgroup.EnumPutNotExpandableResponse{
+		StatusCode: http.StatusOK,
+	}
+	deepEqualOrFatal(t, result, expected)
+}
+
+func TestEnumPutReferenced(t *testing.T) {
+	client := getEnumClient(t)
+	result, err := client.PutReferenced(context.Background(), stringgroup.ColorsRedColor)
+	if err != nil {
+		t.Fatalf("PutReferenced: %v", err)
+	}
+	expected := &stringgroup.EnumPutReferencedResponse{
+		StatusCode: http.StatusOK,
+	}
+	deepEqualOrFatal(t, result, expected)
+}
+
+func TestEnumPutReferencedConstant(t *testing.T) {
+	client := getEnumClient(t)
+	val := string(stringgroup.ColorsGreenColor)
+	result, err := client.PutReferencedConstant(context.Background(), stringgroup.RefColorConstant{ColorConstant: &val})
+	if err != nil {
+		t.Fatalf("PutReferencedConstant: %v", err)
+	}
+	expected := &stringgroup.EnumPutReferencedConstantResponse{
+		StatusCode: http.StatusOK,
+	}
+	deepEqualOrFatal(t, result, expected)
+}

--- a/test/autorest/stringgroup/string_test.go
+++ b/test/autorest/stringgroup/string_test.go
@@ -7,17 +7,8 @@ import (
 	"context"
 	"generatortests/autorest/generated/stringgroup"
 	"net/http"
-	"reflect"
 	"testing"
 )
-
-func getEnumClient(t *testing.T) stringgroup.EnumOperations {
-	client, err := stringgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create string client: %v", err)
-	}
-	return client.EnumOperations()
-}
 
 func getStringClient(t *testing.T) stringgroup.StringOperations {
 	client, err := stringgroup.NewDefaultClient(nil)
@@ -25,12 +16,6 @@ func getStringClient(t *testing.T) stringgroup.StringOperations {
 		t.Fatalf("failed to create string client: %v", err)
 	}
 	return client.StringOperations()
-}
-
-func deepEqualOrFatal(t *testing.T, result interface{}, expected interface{}) {
-	if !reflect.DeepEqual(result, expected) {
-		t.Fatalf("got %+v, want %+v", result, expected)
-	}
 }
 
 func TestStringGetMBCS(t *testing.T) {


### PR DESCRIPTION
Adding enum tests to stringgroup and separating test files for string client vs enum client. 

Adding auto-generated enum.go and models.go files for stringgroup