### PR TITLE
Add marshallingFormat during transformation

### DIFF
--- a/src/generator/protocol/models.ts
+++ b/src/generator/protocol/models.ts
@@ -74,7 +74,7 @@ class StructDef {
         // for constants we use the underlying type name
         typeName = (<ConstantSchema>prop.schema).valueType.language.go!.name;
       }
-      let tag = ` \`json:"${prop.serializedName},omitempty"\``;
+      let tag = ` \`${prop.schema.language.go!.marshallingFormat}:"${prop.serializedName},omitempty"\``;
       if (this.Language.responseType) {
         // tags aren't required for response types
         tag = '';
@@ -85,7 +85,7 @@ class StructDef {
     if (this.Language.errorType) {
       text += `func new${this.Language.name}(resp *azcore.Response) error {\n`;
       text += `\terr := ${this.Language.name}{}\n`;
-      text += `\tif err := resp.UnmarshalAsJSON(&err); err != nil {\n`;
+      text += `\tif err := resp.UnmarshalAs${(<string>this.Language.marshallingFormat).toUpperCase()}(&err); err != nil {\n`;
       text += `\t\treturn err\n`;
       text += `\t}\n`;
       text += '\treturn err\n';

--- a/src/generator/protocol/operations.ts
+++ b/src/generator/protocol/operations.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Session } from '@azure-tools/autorest-extension-base';
-import { comment, pascalCase } from '@azure-tools/codegen'
+import { comment, KnownMediaType, pascalCase } from '@azure-tools/codegen'
 import { CodeModel, ConstantSchema, ImplementationLocation, Language, Operation, Parameter, Protocols, SchemaResponse, SchemaType } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';
 import { ContentPreamble, generateParamsSig, generateParameterInfo, genereateReturnsInfo, ImportManager, MethodSig, ParamInfo, SortAscending } from '../common/helpers';
@@ -149,11 +149,17 @@ function createProtocolResponse(client: string, op: Operation): string {
   return text;
 }
 
-function getMediaType(protocol: Protocols): 'JSON' | 'none' {
-  if (protocol.http!.knownMediaType === undefined) {
-    return 'none';
+// returns the media type used by the protocol
+function getMediaType(protocol: Protocols): 'JSON' | 'XML' | 'none' {
+  // TODO: binary, forms etc
+  switch (protocol.http!.knownMediaType) {
+    case KnownMediaType.Json:
+      return 'JSON';
+    case KnownMediaType.Xml:
+      return 'XML';
+    default:
+      return 'none';
   }
-  return 'JSON';
 }
 
 function formatConstantValue(schema: ConstantSchema) {


### PR DESCRIPTION
During transformation, request body and response types are recursively
walked to add marshallingFormat to their schemas and any applicable
child schemas as well as parents/children for discriminated types.
Removed hard-coded 'json' in property tags, using the value in the
marshallingFormat field.