### PR TITLE
Add support for URL path parameters

### DIFF
--- a/src/generator/convenience/client.ts
+++ b/src/generator/convenience/client.ts
@@ -7,7 +7,7 @@ import { Session } from '@azure-tools/autorest-extension-base';
 import { camelCase } from '@azure-tools/codegen';
 import { CodeModel, Parameter } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';
-import { ContentPreamble, ImportManager } from '../common/helpers';
+import { ContentPreamble, ImportManager, ParamInfo } from '../common/helpers';
 
 // generates content for client.go
 export async function generateClient(session: Session<CodeModel>): Promise<string> {
@@ -44,9 +44,6 @@ export async function generateClient(session: Session<CodeModel>): Promise<strin
   text += 'type Client struct {\n';
   text += `\t${urlVar} *url.URL\n`;
   text += `\t${pipelineVar} azcore.Pipeline\n`;
-  for (const op of values(session.model.operationGroups)) {
-    text += `\t${camelCase(op.language.go!.clientName)} ${op.language.go!.clientName}\n`;
-  }
   text += '}\n\n';
 
   const endpoint = getDefaultEndpoint(session.model.globalParameters);
@@ -79,17 +76,22 @@ export async function generateClient(session: Session<CodeModel>): Promise<strin
   text += '\tif err != nil {\n';
   text += '\t\treturn nil, err\n';
   text += '\t}\n';
-  text += `\tc := &Client{${urlVar}: ${urlVar}, ${pipelineVar}: ${pipelineVar}}\n`;
-  for (const op of values(session.model.operationGroups)) {
-    text += `\tc.${camelCase(op.language.go!.clientName)} = &${camelCase(op.language.go!.clientName)}{Client: c}\n`;
-  }
-  text += '\treturn c, nil\n';
+  text += `\treturn &Client{${urlVar}: ${urlVar}, ${pipelineVar}: ${pipelineVar}}, nil\n`;
   text += '}\n\n';
 
-  for (const op of values(session.model.operationGroups)) {
-    text += `// ${op.language.go!.clientName} returns the ${op.language.go!.clientName} associated with this client.\n`;
-    text += `func (client *Client) ${op.language.go!.clientName}() ${op.language.go!.clientName} {\n`;
-    text += `\treturn client.${camelCase(op.language.go!.clientName)}\n`;
+  for (const group of values(session.model.operationGroups)) {
+    const clientParams = ['Client: client'];
+    const methodParams = new Array<string>();
+    if (group.language.go!.globals) {
+      const globals = <Array<ParamInfo>>group.language.go!.globals;
+      globals.forEach((value: ParamInfo, index: Number, obj: ParamInfo[]) => {
+        clientParams.push(`${value.name}: ${value.name}`);
+        methodParams.push(`${value.name} ${value.type}`);
+      })
+    }
+    text += `// ${group.language.go!.clientName} returns the ${group.language.go!.clientName} associated with this client.\n`;
+    text += `func (client *Client) ${group.language.go!.clientName}(${methodParams.join(', ')}) ${group.language.go!.clientName} {\n`;
+    text += `\treturn &${camelCase(group.language.go!.clientName)}{${clientParams.join(', ')}}\n`;
     text += '}\n\n';
   }
 

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -5,8 +5,10 @@
 
 import { KnownMediaType, serialize } from '@azure-tools/codegen';
 import { Host, startSession, Session } from '@azure-tools/autorest-extension-base';
-import { ObjectSchema, ArraySchema, codeModelSchema, CodeModel, Language, SchemaType, NumberSchema, Operation, SchemaResponse, Parameter, Property, Protocols, Response, Schema, DictionarySchema } from '@azure-tools/codemodel';
+import { ObjectSchema, ArraySchema, codeModelSchema, CodeModel, ImplementationLocation, Language, SchemaType, NumberSchema, Operation, SchemaResponse, Parameter, Property, Protocols, Response, Schema, DictionarySchema } from '@azure-tools/codemodel';
 import { length, values } from '@azure-tools/linq';
+import { ParamInfo, generateParameterInfo } from '../generator/common/helpers';
+import { stringify } from 'querystring';
 
 // The transformer adds Go-specific information to the code model.
 export async function transform(host: Host) {
@@ -116,7 +118,28 @@ function processOperationRequests(session: Session<CodeModel>) {
   for (const group of values(session.model.operationGroups)) {
     for (const op of values(group.operations)) {
       for (const param of values(op.request.parameters)) {
+        // skip the host param as we use our own url.URL instead
+        if (param.language.go!.name === 'host' || param.language.go!.name === '$host') {
+          continue;
+        }
         param.schema.language.go!.name = schemaTypeToGoType(param.schema);
+        if (param.implementation === ImplementationLocation.Client) {
+          // add global param info to the operation group
+          if (group.language.go!.globals === undefined) {
+            group.language.go!.globals = new Array<ParamInfo>();
+          }
+          const globals = <Array<ParamInfo>>group.language.go!.globals;
+          // check if this global param has already been added
+          const index = globals.findIndex((value: ParamInfo, index: Number, obj: ParamInfo[]) => {
+            if (value.name === param.language.go!.name) {
+              return true;
+            }
+            return false;
+          });
+          if (index === -1) {
+            globals.push({ name: param.language.go!.name, type: param.schema.language.go!.name, global: true });
+          }
+        }
       }
       // recursively add the marshalling format to the body param if applicable
       const marshallingFormat = getMarshallingFormat(op.request.protocol);

--- a/test/autorest/generated/urlgroup/client.go
+++ b/test/autorest/generated/urlgroup/client.go
@@ -31,11 +31,8 @@ func DefaultClientOptions() ClientOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u                   *url.URL
-	p                   azcore.Pipeline
-	pathsOperations     PathsOperations
-	queriesOperations   QueriesOperations
-	pathItemsOperations PathItemsOperations
+	u *url.URL
+	p azcore.Pipeline
 }
 
 // DefaultEndpoint is the default service endpoint.
@@ -66,24 +63,20 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if err != nil {
 		return nil, err
 	}
-	c := &Client{u: u, p: p}
-	c.pathsOperations = &pathsOperations{Client: c}
-	c.queriesOperations = &queriesOperations{Client: c}
-	c.pathItemsOperations = &pathItemsOperations{Client: c}
-	return c, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // PathsOperations returns the PathsOperations associated with this client.
 func (client *Client) PathsOperations() PathsOperations {
-	return client.pathsOperations
+	return &pathsOperations{Client: client}
 }
 
 // QueriesOperations returns the QueriesOperations associated with this client.
 func (client *Client) QueriesOperations() QueriesOperations {
-	return client.queriesOperations
+	return &queriesOperations{Client: client}
 }
 
 // PathItemsOperations returns the PathItemsOperations associated with this client.
-func (client *Client) PathItemsOperations() PathItemsOperations {
-	return client.pathItemsOperations
+func (client *Client) PathItemsOperations(globalStringPath string, globalStringQuery string) PathItemsOperations {
+	return &pathItemsOperations{Client: client, globalStringPath: globalStringPath, globalStringQuery: globalStringQuery}
 }

--- a/test/autorest/generated/urlgroup/internal/urlgroup/pathitems.go
+++ b/test/autorest/generated/urlgroup/internal/urlgroup/pathitems.go
@@ -6,18 +6,22 @@
 package urlgroup
 
 import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
 	"path"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"strings"
 )
 
 type PathItemsOperations struct{}
 
 // GetAllWithValuesCreateRequest creates the GetAllWithValues request.
-func (PathItemsOperations) GetAllWithValuesCreateRequest(u url.URL, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string, globalStringQuery string) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery")
+func (PathItemsOperations) GetAllWithValuesCreateRequest(u url.URL, pathItemStringPath string, pathItemStringQuery string, globalStringPath string, globalStringQuery string, localStringPath string, localStringQuery string) (*azcore.Request, error) {
+	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery"
+	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
+	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
+	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("pathItemStringQuery", pathItemStringQuery)
 	query.Set("globalStringQuery", globalStringQuery)
@@ -35,8 +39,12 @@ func (PathItemsOperations) GetAllWithValuesHandleResponse(resp *azcore.Response)
 }
 
 // GetGlobalAndLocalQueryNullCreateRequest creates the GetGlobalAndLocalQueryNull request.
-func (PathItemsOperations) GetGlobalAndLocalQueryNullCreateRequest(u url.URL, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string, globalStringQuery string) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null")
+func (PathItemsOperations) GetGlobalAndLocalQueryNullCreateRequest(u url.URL, pathItemStringPath string, pathItemStringQuery string, globalStringPath string, globalStringQuery string, localStringPath string, localStringQuery string) (*azcore.Request, error) {
+	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null"
+	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
+	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
+	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("pathItemStringQuery", pathItemStringQuery)
 	query.Set("globalStringQuery", globalStringQuery)
@@ -54,8 +62,12 @@ func (PathItemsOperations) GetGlobalAndLocalQueryNullHandleResponse(resp *azcore
 }
 
 // GetGlobalQueryNullCreateRequest creates the GetGlobalQueryNull request.
-func (PathItemsOperations) GetGlobalQueryNullCreateRequest(u url.URL, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string, globalStringQuery string) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery")
+func (PathItemsOperations) GetGlobalQueryNullCreateRequest(u url.URL, pathItemStringPath string, pathItemStringQuery string, globalStringPath string, globalStringQuery string, localStringPath string, localStringQuery string) (*azcore.Request, error) {
+	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery"
+	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
+	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
+	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("pathItemStringQuery", pathItemStringQuery)
 	query.Set("globalStringQuery", globalStringQuery)
@@ -73,8 +85,12 @@ func (PathItemsOperations) GetGlobalQueryNullHandleResponse(resp *azcore.Respons
 }
 
 // GetLocalPathItemQueryNullCreateRequest creates the GetLocalPathItemQueryNull request.
-func (PathItemsOperations) GetLocalPathItemQueryNullCreateRequest(u url.URL, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string, globalStringQuery string) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null")
+func (PathItemsOperations) GetLocalPathItemQueryNullCreateRequest(u url.URL, pathItemStringPath string, pathItemStringQuery string, globalStringPath string, globalStringQuery string, localStringPath string, localStringQuery string) (*azcore.Request, error) {
+	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null"
+	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
+	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
+	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("pathItemStringQuery", pathItemStringQuery)
 	query.Set("globalStringQuery", globalStringQuery)

--- a/test/autorest/generated/urlgroup/internal/urlgroup/paths.go
+++ b/test/autorest/generated/urlgroup/internal/urlgroup/paths.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"time"
 )
 
@@ -17,7 +18,9 @@ type PathsOperations struct{}
 
 // ArrayCsvInPathCreateRequest creates the ArrayCsvInPath request.
 func (PathsOperations) ArrayCsvInPathCreateRequest(u url.URL, arrayPath []string) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}")
+	urlPath := "/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{arrayPath}", url.PathEscape(strings.Join(arrayPath, ",")))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -31,7 +34,9 @@ func (PathsOperations) ArrayCsvInPathHandleResponse(resp *azcore.Response) (*Pat
 
 // Base64URLCreateRequest creates the Base64URL request.
 func (PathsOperations) Base64URLCreateRequest(u url.URL, base64UrlPath []byte) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/string/bG9yZW0/{base64UrlPath}")
+	urlPath := "/paths/string/bG9yZW0/{base64UrlPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{base64UrlPath}", url.PathEscape(string(base64UrlPath)))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -45,7 +50,9 @@ func (PathsOperations) Base64URLHandleResponse(resp *azcore.Response) (*PathsBas
 
 // ByteEmptyCreateRequest creates the ByteEmpty request.
 func (PathsOperations) ByteEmptyCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/byte/empty/{bytePath}")
+	urlPath := "/paths/byte/empty/{bytePath}"
+	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(""))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -59,7 +66,9 @@ func (PathsOperations) ByteEmptyHandleResponse(resp *azcore.Response) (*PathsByt
 
 // ByteMultiByteCreateRequest creates the ByteMultiByte request.
 func (PathsOperations) ByteMultiByteCreateRequest(u url.URL, bytePath []byte) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/byte/multibyte/{bytePath}")
+	urlPath := "/paths/byte/multibyte/{bytePath}"
+	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(string(bytePath)))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -73,7 +82,9 @@ func (PathsOperations) ByteMultiByteHandleResponse(resp *azcore.Response) (*Path
 
 // ByteNullCreateRequest creates the ByteNull request.
 func (PathsOperations) ByteNullCreateRequest(u url.URL, bytePath []byte) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/byte/null/{bytePath}")
+	urlPath := "/paths/byte/null/{bytePath}"
+	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(string(bytePath)))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -87,7 +98,9 @@ func (PathsOperations) ByteNullHandleResponse(resp *azcore.Response) (*PathsByte
 
 // DateNullCreateRequest creates the DateNull request.
 func (PathsOperations) DateNullCreateRequest(u url.URL, datePath time.Time) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/date/null/{datePath}")
+	urlPath := "/paths/date/null/{datePath}"
+	urlPath = strings.ReplaceAll(urlPath, "{datePath}", url.PathEscape(datePath.String()))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -101,7 +114,9 @@ func (PathsOperations) DateNullHandleResponse(resp *azcore.Response) (*PathsDate
 
 // DateTimeNullCreateRequest creates the DateTimeNull request.
 func (PathsOperations) DateTimeNullCreateRequest(u url.URL, dateTimePath time.Time) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/datetime/null/{dateTimePath}")
+	urlPath := "/paths/datetime/null/{dateTimePath}"
+	urlPath = strings.ReplaceAll(urlPath, "{dateTimePath}", url.PathEscape(dateTimePath.String()))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -115,7 +130,9 @@ func (PathsOperations) DateTimeNullHandleResponse(resp *azcore.Response) (*Paths
 
 // DateTimeValidCreateRequest creates the DateTimeValid request.
 func (PathsOperations) DateTimeValidCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}")
+	urlPath := "/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}"
+	urlPath = strings.ReplaceAll(urlPath, "{dateTimePath}", url.PathEscape("2012-01-01T01:01:01Z"))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -129,7 +146,9 @@ func (PathsOperations) DateTimeValidHandleResponse(resp *azcore.Response) (*Path
 
 // DateValidCreateRequest creates the DateValid request.
 func (PathsOperations) DateValidCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/date/2012-01-01/{datePath}")
+	urlPath := "/paths/date/2012-01-01/{datePath}"
+	urlPath = strings.ReplaceAll(urlPath, "{datePath}", url.PathEscape("2012-01-01"))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -143,7 +162,9 @@ func (PathsOperations) DateValidHandleResponse(resp *azcore.Response) (*PathsDat
 
 // DoubleDecimalNegativeCreateRequest creates the DoubleDecimalNegative request.
 func (PathsOperations) DoubleDecimalNegativeCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/double/-9999999.999/{doublePath}")
+	urlPath := "/paths/double/-9999999.999/{doublePath}"
+	urlPath = strings.ReplaceAll(urlPath, "{doublePath}", url.PathEscape("-9999999.999"))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -157,7 +178,9 @@ func (PathsOperations) DoubleDecimalNegativeHandleResponse(resp *azcore.Response
 
 // DoubleDecimalPositiveCreateRequest creates the DoubleDecimalPositive request.
 func (PathsOperations) DoubleDecimalPositiveCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/double/9999999.999/{doublePath}")
+	urlPath := "/paths/double/9999999.999/{doublePath}"
+	urlPath = strings.ReplaceAll(urlPath, "{doublePath}", url.PathEscape("9999999.999"))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -171,7 +194,9 @@ func (PathsOperations) DoubleDecimalPositiveHandleResponse(resp *azcore.Response
 
 // EnumNullCreateRequest creates the EnumNull request.
 func (PathsOperations) EnumNullCreateRequest(u url.URL, enumPath UriColor) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/string/null/{enumPath}")
+	urlPath := "/paths/string/null/{enumPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{enumPath}", url.PathEscape(string(enumPath)))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -185,7 +210,9 @@ func (PathsOperations) EnumNullHandleResponse(resp *azcore.Response) (*PathsEnum
 
 // EnumValidCreateRequest creates the EnumValid request.
 func (PathsOperations) EnumValidCreateRequest(u url.URL, enumPath UriColor) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/enum/green%20color/{enumPath}")
+	urlPath := "/paths/enum/green%20color/{enumPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{enumPath}", url.PathEscape(string(enumPath)))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -199,7 +226,9 @@ func (PathsOperations) EnumValidHandleResponse(resp *azcore.Response) (*PathsEnu
 
 // FloatScientificNegativeCreateRequest creates the FloatScientificNegative request.
 func (PathsOperations) FloatScientificNegativeCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/float/-1.034E-20/{floatPath}")
+	urlPath := "/paths/float/-1.034E-20/{floatPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{floatPath}", url.PathEscape("-1.034e-20"))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -213,7 +242,9 @@ func (PathsOperations) FloatScientificNegativeHandleResponse(resp *azcore.Respon
 
 // FloatScientificPositiveCreateRequest creates the FloatScientificPositive request.
 func (PathsOperations) FloatScientificPositiveCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/float/1.034E+20/{floatPath}")
+	urlPath := "/paths/float/1.034E+20/{floatPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{floatPath}", url.PathEscape("103400000000000000000"))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -227,7 +258,9 @@ func (PathsOperations) FloatScientificPositiveHandleResponse(resp *azcore.Respon
 
 // GetBooleanFalseCreateRequest creates the GetBooleanFalse request.
 func (PathsOperations) GetBooleanFalseCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/bool/false/{boolPath}")
+	urlPath := "/paths/bool/false/{boolPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{boolPath}", url.PathEscape("false"))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -241,7 +274,9 @@ func (PathsOperations) GetBooleanFalseHandleResponse(resp *azcore.Response) (*Pa
 
 // GetBooleanTrueCreateRequest creates the GetBooleanTrue request.
 func (PathsOperations) GetBooleanTrueCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/bool/true/{boolPath}")
+	urlPath := "/paths/bool/true/{boolPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{boolPath}", url.PathEscape("true"))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -255,7 +290,9 @@ func (PathsOperations) GetBooleanTrueHandleResponse(resp *azcore.Response) (*Pat
 
 // GetIntNegativeOneMillionCreateRequest creates the GetIntNegativeOneMillion request.
 func (PathsOperations) GetIntNegativeOneMillionCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/int/-1000000/{intPath}")
+	urlPath := "/paths/int/-1000000/{intPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{intPath}", url.PathEscape("-1000000"))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -269,7 +306,9 @@ func (PathsOperations) GetIntNegativeOneMillionHandleResponse(resp *azcore.Respo
 
 // GetIntOneMillionCreateRequest creates the GetIntOneMillion request.
 func (PathsOperations) GetIntOneMillionCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/int/1000000/{intPath}")
+	urlPath := "/paths/int/1000000/{intPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{intPath}", url.PathEscape("1000000"))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -283,7 +322,9 @@ func (PathsOperations) GetIntOneMillionHandleResponse(resp *azcore.Response) (*P
 
 // GetNegativeTenBillionCreateRequest creates the GetNegativeTenBillion request.
 func (PathsOperations) GetNegativeTenBillionCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/long/-10000000000/{longPath}")
+	urlPath := "/paths/long/-10000000000/{longPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{longPath}", url.PathEscape("-10000000000"))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -297,7 +338,9 @@ func (PathsOperations) GetNegativeTenBillionHandleResponse(resp *azcore.Response
 
 // GetTenBillionCreateRequest creates the GetTenBillion request.
 func (PathsOperations) GetTenBillionCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/long/10000000000/{longPath}")
+	urlPath := "/paths/long/10000000000/{longPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{longPath}", url.PathEscape("10000000000"))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -311,7 +354,9 @@ func (PathsOperations) GetTenBillionHandleResponse(resp *azcore.Response) (*Path
 
 // StringEmptyCreateRequest creates the StringEmpty request.
 func (PathsOperations) StringEmptyCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/string/empty/{stringPath}")
+	urlPath := "/paths/string/empty/{stringPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape(""))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -325,7 +370,9 @@ func (PathsOperations) StringEmptyHandleResponse(resp *azcore.Response) (*PathsS
 
 // StringNullCreateRequest creates the StringNull request.
 func (PathsOperations) StringNullCreateRequest(u url.URL, stringPath string) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/string/null/{stringPath}")
+	urlPath := "/paths/string/null/{stringPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape(stringPath))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -339,7 +386,9 @@ func (PathsOperations) StringNullHandleResponse(resp *azcore.Response) (*PathsSt
 
 // StringURLEncodedCreateRequest creates the StringURLEncoded request.
 func (PathsOperations) StringURLEncodedCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}")
+	urlPath := "/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape("begin!*'();:@ &=+$,/?#[]end"))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -353,7 +402,9 @@ func (PathsOperations) StringURLEncodedHandleResponse(resp *azcore.Response) (*P
 
 // StringURLNonEncodedCreateRequest creates the StringURLNonEncoded request.
 func (PathsOperations) StringURLNonEncodedCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/string/begin!*'();:@&=+$,end/{stringPath}")
+	urlPath := "/paths/string/begin!*'();:@&=+$,end/{stringPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape("begin!*'();:@&=+$,end"))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -367,7 +418,9 @@ func (PathsOperations) StringURLNonEncodedHandleResponse(resp *azcore.Response) 
 
 // StringUnicodeCreateRequest creates the StringUnicode request.
 func (PathsOperations) StringUnicodeCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/string/unicode/{stringPath}")
+	urlPath := "/paths/string/unicode/{stringPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape("啊齄丂狛狜隣郎隣兀﨩"))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 
@@ -381,7 +434,9 @@ func (PathsOperations) StringUnicodeHandleResponse(resp *azcore.Response) (*Path
 
 // UnixTimeURLCreateRequest creates the UnixTimeURL request.
 func (PathsOperations) UnixTimeURLCreateRequest(u url.URL, unixTimeUrlPath time.Time) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/paths/int/1460505600/{unixTimeUrlPath}")
+	urlPath := "/paths/int/1460505600/{unixTimeUrlPath}"
+	urlPath = strings.ReplaceAll(urlPath, "{unixTimeUrlPath}", url.PathEscape(unixTimeUrlPath.String()))
+	u.Path = path.Join(u.Path, urlPath)
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
 

--- a/test/autorest/generated/urlgroup/internal/urlgroup/queries.go
+++ b/test/autorest/generated/urlgroup/internal/urlgroup/queries.go
@@ -19,7 +19,8 @@ type QueriesOperations struct{}
 
 // ArrayStringCsvEmptyCreateRequest creates the ArrayStringCsvEmpty request.
 func (QueriesOperations) ArrayStringCsvEmptyCreateRequest(u url.URL, arrayQuery []string) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/array/csv/string/empty")
+	urlPath := "/queries/array/csv/string/empty"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("arrayQuery", strings.Join(arrayQuery, ","))
 	u.RawQuery = query.Encode()
@@ -36,7 +37,8 @@ func (QueriesOperations) ArrayStringCsvEmptyHandleResponse(resp *azcore.Response
 
 // ArrayStringCsvNullCreateRequest creates the ArrayStringCsvNull request.
 func (QueriesOperations) ArrayStringCsvNullCreateRequest(u url.URL, arrayQuery []string) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/array/csv/string/null")
+	urlPath := "/queries/array/csv/string/null"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("arrayQuery", strings.Join(arrayQuery, ","))
 	u.RawQuery = query.Encode()
@@ -53,7 +55,8 @@ func (QueriesOperations) ArrayStringCsvNullHandleResponse(resp *azcore.Response)
 
 // ArrayStringCsvValidCreateRequest creates the ArrayStringCsvValid request.
 func (QueriesOperations) ArrayStringCsvValidCreateRequest(u url.URL, arrayQuery []string) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/array/csv/string/valid")
+	urlPath := "/queries/array/csv/string/valid"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("arrayQuery", strings.Join(arrayQuery, ","))
 	u.RawQuery = query.Encode()
@@ -70,7 +73,8 @@ func (QueriesOperations) ArrayStringCsvValidHandleResponse(resp *azcore.Response
 
 // ArrayStringPipesValidCreateRequest creates the ArrayStringPipesValid request.
 func (QueriesOperations) ArrayStringPipesValidCreateRequest(u url.URL, arrayQuery []string) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/array/pipes/string/valid")
+	urlPath := "/queries/array/pipes/string/valid"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("arrayQuery", strings.Join(arrayQuery, "|"))
 	u.RawQuery = query.Encode()
@@ -87,7 +91,8 @@ func (QueriesOperations) ArrayStringPipesValidHandleResponse(resp *azcore.Respon
 
 // ArrayStringSsvValidCreateRequest creates the ArrayStringSsvValid request.
 func (QueriesOperations) ArrayStringSsvValidCreateRequest(u url.URL, arrayQuery []string) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/array/ssv/string/valid")
+	urlPath := "/queries/array/ssv/string/valid"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("arrayQuery", strings.Join(arrayQuery, " "))
 	u.RawQuery = query.Encode()
@@ -104,7 +109,8 @@ func (QueriesOperations) ArrayStringSsvValidHandleResponse(resp *azcore.Response
 
 // ArrayStringTsvValidCreateRequest creates the ArrayStringTsvValid request.
 func (QueriesOperations) ArrayStringTsvValidCreateRequest(u url.URL, arrayQuery []string) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/array/tsv/string/valid")
+	urlPath := "/queries/array/tsv/string/valid"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("arrayQuery", strings.Join(arrayQuery, "\t"))
 	u.RawQuery = query.Encode()
@@ -121,7 +127,8 @@ func (QueriesOperations) ArrayStringTsvValidHandleResponse(resp *azcore.Response
 
 // ByteEmptyCreateRequest creates the ByteEmpty request.
 func (QueriesOperations) ByteEmptyCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/byte/empty")
+	urlPath := "/queries/byte/empty"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("byteQuery", "")
 	u.RawQuery = query.Encode()
@@ -138,7 +145,8 @@ func (QueriesOperations) ByteEmptyHandleResponse(resp *azcore.Response) (*Querie
 
 // ByteMultiByteCreateRequest creates the ByteMultiByte request.
 func (QueriesOperations) ByteMultiByteCreateRequest(u url.URL, byteQuery []byte) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/byte/multibyte")
+	urlPath := "/queries/byte/multibyte"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("byteQuery", string(byteQuery))
 	u.RawQuery = query.Encode()
@@ -155,7 +163,8 @@ func (QueriesOperations) ByteMultiByteHandleResponse(resp *azcore.Response) (*Qu
 
 // ByteNullCreateRequest creates the ByteNull request.
 func (QueriesOperations) ByteNullCreateRequest(u url.URL, byteQuery []byte) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/byte/null")
+	urlPath := "/queries/byte/null"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("byteQuery", string(byteQuery))
 	u.RawQuery = query.Encode()
@@ -172,7 +181,8 @@ func (QueriesOperations) ByteNullHandleResponse(resp *azcore.Response) (*Queries
 
 // DateNullCreateRequest creates the DateNull request.
 func (QueriesOperations) DateNullCreateRequest(u url.URL, dateQuery time.Time) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/date/null")
+	urlPath := "/queries/date/null"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("dateQuery", dateQuery.String())
 	u.RawQuery = query.Encode()
@@ -189,7 +199,8 @@ func (QueriesOperations) DateNullHandleResponse(resp *azcore.Response) (*Queries
 
 // DateTimeNullCreateRequest creates the DateTimeNull request.
 func (QueriesOperations) DateTimeNullCreateRequest(u url.URL, dateTimeQuery time.Time) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/datetime/null")
+	urlPath := "/queries/datetime/null"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("dateTimeQuery", dateTimeQuery.String())
 	u.RawQuery = query.Encode()
@@ -206,7 +217,8 @@ func (QueriesOperations) DateTimeNullHandleResponse(resp *azcore.Response) (*Que
 
 // DateTimeValidCreateRequest creates the DateTimeValid request.
 func (QueriesOperations) DateTimeValidCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/datetime/2012-01-01T01%3A01%3A01Z")
+	urlPath := "/queries/datetime/2012-01-01T01%3A01%3A01Z"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("dateTimeQuery", "2012-01-01T01:01:01Z")
 	u.RawQuery = query.Encode()
@@ -223,7 +235,8 @@ func (QueriesOperations) DateTimeValidHandleResponse(resp *azcore.Response) (*Qu
 
 // DateValidCreateRequest creates the DateValid request.
 func (QueriesOperations) DateValidCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/date/2012-01-01")
+	urlPath := "/queries/date/2012-01-01"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("dateQuery", "2012-01-01")
 	u.RawQuery = query.Encode()
@@ -240,7 +253,8 @@ func (QueriesOperations) DateValidHandleResponse(resp *azcore.Response) (*Querie
 
 // DoubleDecimalNegativeCreateRequest creates the DoubleDecimalNegative request.
 func (QueriesOperations) DoubleDecimalNegativeCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/double/-9999999.999")
+	urlPath := "/queries/double/-9999999.999"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("doubleQuery", "-9999999.999")
 	u.RawQuery = query.Encode()
@@ -257,7 +271,8 @@ func (QueriesOperations) DoubleDecimalNegativeHandleResponse(resp *azcore.Respon
 
 // DoubleDecimalPositiveCreateRequest creates the DoubleDecimalPositive request.
 func (QueriesOperations) DoubleDecimalPositiveCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/double/9999999.999")
+	urlPath := "/queries/double/9999999.999"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("doubleQuery", "9999999.999")
 	u.RawQuery = query.Encode()
@@ -274,7 +289,8 @@ func (QueriesOperations) DoubleDecimalPositiveHandleResponse(resp *azcore.Respon
 
 // DoubleNullCreateRequest creates the DoubleNull request.
 func (QueriesOperations) DoubleNullCreateRequest(u url.URL, doubleQuery float64) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/double/null")
+	urlPath := "/queries/double/null"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("doubleQuery", strconv.FormatFloat(doubleQuery, 'f', -1, 64))
 	u.RawQuery = query.Encode()
@@ -291,7 +307,8 @@ func (QueriesOperations) DoubleNullHandleResponse(resp *azcore.Response) (*Queri
 
 // EnumNullCreateRequest creates the EnumNull request.
 func (QueriesOperations) EnumNullCreateRequest(u url.URL, enumQuery UriColor) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/enum/null")
+	urlPath := "/queries/enum/null"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("enumQuery", string(enumQuery))
 	u.RawQuery = query.Encode()
@@ -308,7 +325,8 @@ func (QueriesOperations) EnumNullHandleResponse(resp *azcore.Response) (*Queries
 
 // EnumValidCreateRequest creates the EnumValid request.
 func (QueriesOperations) EnumValidCreateRequest(u url.URL, enumQuery UriColor) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/enum/green%20color")
+	urlPath := "/queries/enum/green%20color"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("enumQuery", string(enumQuery))
 	u.RawQuery = query.Encode()
@@ -325,7 +343,8 @@ func (QueriesOperations) EnumValidHandleResponse(resp *azcore.Response) (*Querie
 
 // FloatNullCreateRequest creates the FloatNull request.
 func (QueriesOperations) FloatNullCreateRequest(u url.URL, floatQuery float32) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/float/null")
+	urlPath := "/queries/float/null"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("floatQuery", strconv.FormatFloat(float64(floatQuery), 'f', -1, 32))
 	u.RawQuery = query.Encode()
@@ -342,7 +361,8 @@ func (QueriesOperations) FloatNullHandleResponse(resp *azcore.Response) (*Querie
 
 // FloatScientificNegativeCreateRequest creates the FloatScientificNegative request.
 func (QueriesOperations) FloatScientificNegativeCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/float/-1.034E-20")
+	urlPath := "/queries/float/-1.034E-20"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("floatQuery", "-1.034e-20")
 	u.RawQuery = query.Encode()
@@ -359,7 +379,8 @@ func (QueriesOperations) FloatScientificNegativeHandleResponse(resp *azcore.Resp
 
 // FloatScientificPositiveCreateRequest creates the FloatScientificPositive request.
 func (QueriesOperations) FloatScientificPositiveCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/float/1.034E+20")
+	urlPath := "/queries/float/1.034E+20"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("floatQuery", "103400000000000000000")
 	u.RawQuery = query.Encode()
@@ -376,7 +397,8 @@ func (QueriesOperations) FloatScientificPositiveHandleResponse(resp *azcore.Resp
 
 // GetBooleanFalseCreateRequest creates the GetBooleanFalse request.
 func (QueriesOperations) GetBooleanFalseCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/bool/false")
+	urlPath := "/queries/bool/false"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("boolQuery", "false")
 	u.RawQuery = query.Encode()
@@ -393,7 +415,8 @@ func (QueriesOperations) GetBooleanFalseHandleResponse(resp *azcore.Response) (*
 
 // GetBooleanNullCreateRequest creates the GetBooleanNull request.
 func (QueriesOperations) GetBooleanNullCreateRequest(u url.URL, boolQuery bool) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/bool/null")
+	urlPath := "/queries/bool/null"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("boolQuery", strconv.FormatBool(boolQuery))
 	u.RawQuery = query.Encode()
@@ -410,7 +433,8 @@ func (QueriesOperations) GetBooleanNullHandleResponse(resp *azcore.Response) (*Q
 
 // GetBooleanTrueCreateRequest creates the GetBooleanTrue request.
 func (QueriesOperations) GetBooleanTrueCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/bool/true")
+	urlPath := "/queries/bool/true"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("boolQuery", "true")
 	u.RawQuery = query.Encode()
@@ -427,7 +451,8 @@ func (QueriesOperations) GetBooleanTrueHandleResponse(resp *azcore.Response) (*Q
 
 // GetIntNegativeOneMillionCreateRequest creates the GetIntNegativeOneMillion request.
 func (QueriesOperations) GetIntNegativeOneMillionCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/int/-1000000")
+	urlPath := "/queries/int/-1000000"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("intQuery", "-1000000")
 	u.RawQuery = query.Encode()
@@ -444,7 +469,8 @@ func (QueriesOperations) GetIntNegativeOneMillionHandleResponse(resp *azcore.Res
 
 // GetIntNullCreateRequest creates the GetIntNull request.
 func (QueriesOperations) GetIntNullCreateRequest(u url.URL, intQuery int32) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/int/null")
+	urlPath := "/queries/int/null"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("intQuery", strconv.FormatInt(int64(intQuery), 10))
 	u.RawQuery = query.Encode()
@@ -461,7 +487,8 @@ func (QueriesOperations) GetIntNullHandleResponse(resp *azcore.Response) (*Queri
 
 // GetIntOneMillionCreateRequest creates the GetIntOneMillion request.
 func (QueriesOperations) GetIntOneMillionCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/int/1000000")
+	urlPath := "/queries/int/1000000"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("intQuery", "1000000")
 	u.RawQuery = query.Encode()
@@ -478,7 +505,8 @@ func (QueriesOperations) GetIntOneMillionHandleResponse(resp *azcore.Response) (
 
 // GetLongNullCreateRequest creates the GetLongNull request.
 func (QueriesOperations) GetLongNullCreateRequest(u url.URL, longQuery int64) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/long/null")
+	urlPath := "/queries/long/null"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("longQuery", strconv.FormatInt(longQuery, 10))
 	u.RawQuery = query.Encode()
@@ -495,7 +523,8 @@ func (QueriesOperations) GetLongNullHandleResponse(resp *azcore.Response) (*Quer
 
 // GetNegativeTenBillionCreateRequest creates the GetNegativeTenBillion request.
 func (QueriesOperations) GetNegativeTenBillionCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/long/-10000000000")
+	urlPath := "/queries/long/-10000000000"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("longQuery", "-10000000000")
 	u.RawQuery = query.Encode()
@@ -512,7 +541,8 @@ func (QueriesOperations) GetNegativeTenBillionHandleResponse(resp *azcore.Respon
 
 // GetTenBillionCreateRequest creates the GetTenBillion request.
 func (QueriesOperations) GetTenBillionCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/long/10000000000")
+	urlPath := "/queries/long/10000000000"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("longQuery", "10000000000")
 	u.RawQuery = query.Encode()
@@ -529,7 +559,8 @@ func (QueriesOperations) GetTenBillionHandleResponse(resp *azcore.Response) (*Qu
 
 // StringEmptyCreateRequest creates the StringEmpty request.
 func (QueriesOperations) StringEmptyCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/string/empty")
+	urlPath := "/queries/string/empty"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("stringQuery", "")
 	u.RawQuery = query.Encode()
@@ -546,7 +577,8 @@ func (QueriesOperations) StringEmptyHandleResponse(resp *azcore.Response) (*Quer
 
 // StringNullCreateRequest creates the StringNull request.
 func (QueriesOperations) StringNullCreateRequest(u url.URL, stringQuery string) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/string/null")
+	urlPath := "/queries/string/null"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("stringQuery", stringQuery)
 	u.RawQuery = query.Encode()
@@ -563,7 +595,8 @@ func (QueriesOperations) StringNullHandleResponse(resp *azcore.Response) (*Queri
 
 // StringURLEncodedCreateRequest creates the StringURLEncoded request.
 func (QueriesOperations) StringURLEncodedCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend")
+	urlPath := "/queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("stringQuery", "begin!*'();:@ &=+$,/?#[]end")
 	u.RawQuery = query.Encode()
@@ -580,7 +613,8 @@ func (QueriesOperations) StringURLEncodedHandleResponse(resp *azcore.Response) (
 
 // StringUnicodeCreateRequest creates the StringUnicode request.
 func (QueriesOperations) StringUnicodeCreateRequest(u url.URL) (*azcore.Request, error) {
-	u.Path = path.Join(u.Path, "/queries/string/unicode/")
+	urlPath := "/queries/string/unicode/"
+	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
 	query.Set("stringQuery", "啊齄丂狛狜隣郎隣兀﨩")
 	u.RawQuery = query.Encode()

--- a/test/autorest/generated/urlgroup/pathitems.go
+++ b/test/autorest/generated/urlgroup/pathitems.go
@@ -13,23 +13,25 @@ import (
 // PathItemsOperations contains the methods for the PathItems group.
 type PathItemsOperations interface {
 	// GetAllWithValues - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-	GetAllWithValues(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string, globalStringQuery string) (*PathItemsGetAllWithValuesResponse, error)
+	GetAllWithValues(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetAllWithValuesResponse, error)
 	// GetGlobalAndLocalQueryNull - send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null
-	GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string, globalStringQuery string) (*PathItemsGetGlobalAndLocalQueryNullResponse, error)
+	GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetGlobalAndLocalQueryNullResponse, error)
 	// GetGlobalQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-	GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string, globalStringQuery string) (*PathItemsGetGlobalQueryNullResponse, error)
+	GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetGlobalQueryNullResponse, error)
 	// GetLocalPathItemQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null
-	GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string, globalStringQuery string) (*PathItemsGetLocalPathItemQueryNullResponse, error)
+	GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetLocalPathItemQueryNullResponse, error)
 }
 
 type pathItemsOperations struct {
 	*Client
 	azinternal.PathItemsOperations
+	globalStringPath  string
+	globalStringQuery string
 }
 
 // GetAllWithValues - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-func (client *pathItemsOperations) GetAllWithValues(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string, globalStringQuery string) (*PathItemsGetAllWithValuesResponse, error) {
-	req, err := client.GetAllWithValuesCreateRequest(*client.u, pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery, globalStringQuery)
+func (client *pathItemsOperations) GetAllWithValues(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetAllWithValuesResponse, error) {
+	req, err := client.GetAllWithValuesCreateRequest(*client.u, pathItemStringPath, pathItemStringQuery, client.globalStringPath, client.globalStringQuery, localStringPath, localStringQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +47,8 @@ func (client *pathItemsOperations) GetAllWithValues(ctx context.Context, pathIte
 }
 
 // GetGlobalAndLocalQueryNull - send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null
-func (client *pathItemsOperations) GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string, globalStringQuery string) (*PathItemsGetGlobalAndLocalQueryNullResponse, error) {
-	req, err := client.GetGlobalAndLocalQueryNullCreateRequest(*client.u, pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery, globalStringQuery)
+func (client *pathItemsOperations) GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetGlobalAndLocalQueryNullResponse, error) {
+	req, err := client.GetGlobalAndLocalQueryNullCreateRequest(*client.u, pathItemStringPath, pathItemStringQuery, client.globalStringPath, client.globalStringQuery, localStringPath, localStringQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -62,8 +64,8 @@ func (client *pathItemsOperations) GetGlobalAndLocalQueryNull(ctx context.Contex
 }
 
 // GetGlobalQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-func (client *pathItemsOperations) GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string, globalStringQuery string) (*PathItemsGetGlobalQueryNullResponse, error) {
-	req, err := client.GetGlobalQueryNullCreateRequest(*client.u, pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery, globalStringQuery)
+func (client *pathItemsOperations) GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetGlobalQueryNullResponse, error) {
+	req, err := client.GetGlobalQueryNullCreateRequest(*client.u, pathItemStringPath, pathItemStringQuery, client.globalStringPath, client.globalStringQuery, localStringPath, localStringQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +81,8 @@ func (client *pathItemsOperations) GetGlobalQueryNull(ctx context.Context, pathI
 }
 
 // GetLocalPathItemQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null
-func (client *pathItemsOperations) GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string, globalStringQuery string) (*PathItemsGetLocalPathItemQueryNullResponse, error) {
-	req, err := client.GetLocalPathItemQueryNullCreateRequest(*client.u, pathItemStringPath, pathItemStringQuery, localStringPath, localStringQuery, globalStringQuery)
+func (client *pathItemsOperations) GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetLocalPathItemQueryNullResponse, error) {
+	req, err := client.GetLocalPathItemQueryNullCreateRequest(*client.u, pathItemStringPath, pathItemStringQuery, client.globalStringPath, client.globalStringQuery, localStringPath, localStringQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/urlgroup/pathitems_test.go
+++ b/test/autorest/urlgroup/pathitems_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package urlgrouptest
+
+import (
+	"context"
+	"generatortests/autorest/generated/urlgroup"
+	"generatortests/helpers"
+	"net/http"
+	"testing"
+)
+
+func getPathItemsClient(t *testing.T) urlgroup.PathItemsOperations {
+	client, err := urlgroup.NewDefaultClient(nil)
+	if err != nil {
+		t.Fatalf("failed to create enum client: %v", err)
+	}
+	return client.PathItemsOperations("globalStringPath", "globalStringQuery")
+}
+
+func TestGetAllWithValues(t *testing.T) {
+	client := getPathItemsClient(t)
+	result, err := client.GetAllWithValues(context.Background(), "pathItemStringPath", "pathItemStringQuery", "localStringPath", "localStringQuery")
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+}
+
+func TestGetGlobalAndLocalQueryNull(t *testing.T) {
+	t.Skip("need optional string params")
+	client := getPathItemsClient(t)
+	result, err := client.GetGlobalAndLocalQueryNull(context.Background(), "pathItemStringPath", "pathItemStringQuery", "localStringPath", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+}
+
+func TestGetGlobalQueryNull(t *testing.T) {
+	t.Skip("need optional string params")
+	client := getPathItemsClient(t)
+	result, err := client.GetGlobalQueryNull(context.Background(), "pathItemStringPath", "pathItemStringQuery", "localStringPath", "localStringQuery")
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+}
+
+func TestGetLocalPathItemQueryNull(t *testing.T) {
+	t.Skip("need optional string params")
+	client := getPathItemsClient(t)
+	result, err := client.GetLocalPathItemQueryNull(context.Background(), "pathItemStringPath", "", "localStringPath", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+}


### PR DESCRIPTION
Replace all URL path parameters with their URL-encoded values.
Include client (i.e. global) parameters in protocol function sigs.
Add client parameters to operation group method getters.