### PR TITLE
Group optional parameters into their own Options struct

### DIFF
--- a/src/generator/convenience/client.ts
+++ b/src/generator/convenience/client.ts
@@ -7,7 +7,7 @@ import { Session } from '@azure-tools/autorest-extension-base';
 import { camelCase } from '@azure-tools/codegen';
 import { CodeModel, Parameter } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';
-import { ContentPreamble, ImportManager, ParamInfo } from '../common/helpers';
+import { ContentPreamble, formatParamInfoTypeName, ImportManager, ParamInfo, sortParamInfoByRequired } from '../common/helpers';
 
 // generates content for client.go
 export async function generateClient(session: Session<CodeModel>): Promise<string> {
@@ -82,11 +82,13 @@ export async function generateClient(session: Session<CodeModel>): Promise<strin
   for (const group of values(session.model.operationGroups)) {
     const clientParams = ['Client: client'];
     const methodParams = new Array<string>();
+    // add global params to the operation group getter method
     if (group.language.go!.globals) {
       const globals = <Array<ParamInfo>>group.language.go!.globals;
+      globals.sort(sortParamInfoByRequired);
       globals.forEach((value: ParamInfo, index: Number, obj: ParamInfo[]) => {
         clientParams.push(`${value.name}: ${value.name}`);
-        methodParams.push(`${value.name} ${value.type}`);
+        methodParams.push(`${value.name} ${formatParamInfoTypeName(value)}`);
       })
     }
     text += `// ${group.language.go!.clientName} returns the ${group.language.go!.clientName} associated with this client.\n`;

--- a/src/generator/convenience/models.ts
+++ b/src/generator/convenience/models.ts
@@ -29,6 +29,13 @@ export async function generateModels(session: Session<CodeModel>): Promise<strin
   }
   for (const group of values(session.model.operationGroups)) {
     for (const op of values(group.operations)) {
+      if (op.request.language.go!.optionalParam) {
+        const entry: EntryType = {
+          name: op.request.language.go!.optionalParam.name,
+          desc: op.request.language.go!.optionalParam.description,
+        };
+        structs.push(entry);
+      }
       if (op.responses) {
         const entry: EntryType = {
           name: op.responses[0].language.go!.name,

--- a/src/generator/protocol/operations.ts
+++ b/src/generator/protocol/operations.ts
@@ -137,8 +137,8 @@ function formatParamValue(param: Parameter, imports: ImportManager): string {
     case SchemaType.DateTime:
     case SchemaType.Duration:
     case SchemaType.UnixTime:
-      if (param.required !== true) {
-        // remove the dereference (bit of a hack but this is the only case where it's necessary)
+      if (param.required !== true && paramName[0] === '*') {
+        // remove the dereference
         paramName = paramName.substr(1);
       }
       return `${paramName}.String()`;

--- a/src/generator/protocol/operations.ts
+++ b/src/generator/protocol/operations.ts
@@ -7,7 +7,7 @@ import { Session } from '@azure-tools/autorest-extension-base';
 import { comment, KnownMediaType, pascalCase } from '@azure-tools/codegen'
 import { ArraySchema, CodeModel, ConstantSchema, ImplementationLocation, Language, NumberSchema, Operation, Parameter, Protocols, SchemaResponse, SchemaType, SerializationStyle } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';
-import { ContentPreamble, generateParamsSig, generateParameterInfo, genereateReturnsInfo, ImportManager, MethodSig, ParamInfo, SortAscending } from '../common/helpers';
+import { ContentPreamble, generateParamsSig, generateParameterInfo, genereateReturnsInfo, ImportManager, MethodSig, ParamInfo, paramInfo, SortAscending } from '../common/helpers';
 import { OperationNaming } from '../../namer/namer';
 
 // represents the generated content for an operation group
@@ -96,6 +96,16 @@ function formatParamValue(param: Parameter, imports: ImportManager): string {
       separator = '\\t';
       break;
   }
+  let paramName = param.language.go!.name;
+  if (param.required !== true) {
+    if (param.implementation === ImplementationLocation.Method) {
+      // optional params at the method level will be in an options struct
+      paramName = `*options.${pascalCase(paramName)}`;
+    } else {
+      // optional globals are passed as just another parameter
+      paramName = `*${paramName}`;
+    }
+  }
   switch (param.schema.type) {
     case SchemaType.Array:
       const arraySchema = <ArraySchema>param.schema;
@@ -104,21 +114,21 @@ function formatParamValue(param: Parameter, imports: ImportManager): string {
         case SchemaType.SealedChoice:
         case SchemaType.String:
           imports.add('strings');
-          return `strings.Join(${param.language.go!.name}, "${separator}")`;
+          return `strings.Join(${paramName}, "${separator}")`;
         default:
           imports.add('fmt');
           imports.add('strings');
-          return `strings.Join(strings.Fields(strings.Trim(fmt.Sprint(${param.language.go!.name}), "[]")), "${separator}")`;
+          return `strings.Join(strings.Fields(strings.Trim(fmt.Sprint(${paramName}), "[]")), "${separator}")`;
       }
     case SchemaType.Boolean:
       imports.add('strconv');
-      return `strconv.FormatBool(${param.language.go!.name})`;
+      return `strconv.FormatBool(${paramName})`;
     case SchemaType.ByteArray:
       // ByteArray is a base-64 encoded value in string format
-      return `string(${param.language.go!.name})`;
+      return `string(${paramName})`;
     case SchemaType.Choice:
     case SchemaType.SealedChoice:
-      return `string(${param.language.go!.name})`;
+      return `string(${paramName})`;
     case SchemaType.Constant:
       const constSchema = <ConstantSchema>param.schema;
       // cannot use formatConstantValue() since all values are treated as strings
@@ -127,11 +137,15 @@ function formatParamValue(param: Parameter, imports: ImportManager): string {
     case SchemaType.DateTime:
     case SchemaType.Duration:
     case SchemaType.UnixTime:
-      return `${param.language.go!.name}.String()`;
+      if (param.required !== true) {
+        // remove the dereference (bit of a hack but this is the only case where it's necessary)
+        paramName = paramName.substr(1);
+      }
+      return `${paramName}.String()`;
     case SchemaType.Integer:
       imports.add('strconv');
       const intSchema = <NumberSchema>param.schema;
-      let intParam = param.language.go!.name;
+      let intParam = paramName;
       if (intSchema.precision === 32) {
         intParam = `int64(${intParam})`;
       }
@@ -139,13 +153,13 @@ function formatParamValue(param: Parameter, imports: ImportManager): string {
     case SchemaType.Number:
       imports.add('strconv');
       const numberSchema = <NumberSchema>param.schema;
-      let floatParam = param.language.go!.name;
+      let floatParam = paramName;
       if (numberSchema.precision === 32) {
         floatParam = `float64(${floatParam})`;
       }
       return `strconv.FormatFloat(${floatParam}, 'f', -1, ${numberSchema.precision})`;
     default:
-      return param.language.go!.name;
+      return paramName;
   }
 }
 
@@ -153,14 +167,14 @@ function createProtocolRequest(client: string, op: Operation, imports: ImportMan
   const info = <OperationNaming>op.language.go!;
   const name = info.protocolNaming.requestMethod;
   for (const param of values(op.request.parameters)) {
-    if (param.implementation !== ImplementationLocation.Method) {
+    if (param.implementation !== ImplementationLocation.Method || param.required !== true) {
       continue;
     }
     imports.addImportForSchemaType(param.schema);
   }
   // stick the method signature info into the code model so other generators can access it later
   const sig = <ProtocolSig>op.language.go!;
-  sig.protocolSigs.requestMethod.params = [{ name: 'u', type: 'url.URL', global: false }].concat(generateParameterInfo(op));
+  sig.protocolSigs.requestMethod.params = [new paramInfo('u', 'url.URL', false, true)].concat(generateParameterInfo(op));
   sig.protocolSigs.requestMethod.returns = ['*azcore.Request', 'error'];
   let text = `${comment(name, '// ')} creates the ${info.name} request.\n`;
   text += `func (${client}) ${name}(${generateParamsSig(sig.protocolSigs.requestMethod.params, true)}) (${sig.protocolSigs.requestMethod.returns.join(', ')}) {\n`;
@@ -178,7 +192,18 @@ function createProtocolRequest(client: string, op: Operation, imports: ImportMan
     // add query parameters
     text += '\tquery := u.Query()\n';
     for (const qp of values(op.request.parameters).where((each: Parameter) => { return each.protocol.http!.in === 'query'; })) {
-      text += `\tquery.Set("${qp.language.go!.name}", ${formatParamValue(qp, imports)})\n`;
+      if (qp.required === true) {
+        text += `\tquery.Set("${qp.language.go!.name}", ${formatParamValue(qp, imports)})\n`;
+      } else if (qp.implementation === ImplementationLocation.Client) {
+        // global optional param
+        text += `\tif ${qp.language.go!.name} != nil {\n`;
+        text += `\t\tquery.Set("${qp.language.go!.name}", ${formatParamValue(qp, imports)})\n`;
+        text += `\t}\n`;
+      } else {
+        text += `\tif options != nil && options.${pascalCase(qp.language.go!.name)} != nil {\n`;
+        text += `\t\tquery.Set("${qp.language.go!.name}", ${formatParamValue(qp, imports)})\n`;
+        text += `\t}\n`;
+      }
     }
     text += '\tu.RawQuery = query.Encode()\n';
   }
@@ -219,7 +244,7 @@ function createProtocolResponse(client: string, op: Operation): string {
   const name = info.protocolNaming.responseMethod;
   // stick the method signature info into the code model so other generators can access it later
   const sig = <ProtocolSig>op.language.go!;
-  sig.protocolSigs.responseMethod.params = [{ name: 'resp', type: '*azcore.Response', global: false }];
+  sig.protocolSigs.responseMethod.params = [new paramInfo('resp', '*azcore.Response', false, true)];
   sig.protocolSigs.responseMethod.returns = genereateReturnsInfo(op);
 
   let text = `${comment(name, '// ')} handles the ${info.name} response.\n`;

--- a/src/namer/namer.ts
+++ b/src/namer/namer.ts
@@ -5,7 +5,7 @@
 
 import { serialize, pascalCase, camelCase } from '@azure-tools/codegen'
 import { Host, startSession, Session } from '@azure-tools/autorest-extension-base'
-import { codeModelSchema, CodeModel, Language, ObjectSchema, SchemaType, Schema } from '@azure-tools/codemodel'
+import { codeModelSchema, CodeModel, Language, Parameter } from '@azure-tools/codemodel'
 import { length, visitor, clone, values } from '@azure-tools/linq'
 import { CommonAcronyms, ReservedWords } from './mappings'
 
@@ -89,9 +89,23 @@ async function process(session: Session<CodeModel>) {
     for (const op of values(group.operations)) {
       const details = <OperationNaming>op.language.go;
       details.name = getEscapedReservedName(capitalizeAcronyms(pascalCase(details.name)), 'Method');
+      // track any optional parameters
+      const optionalParams = new Array<Parameter>();
       for (const param of values(op.request.parameters)) {
         const paramDetails = <Language>param.language.go;
         paramDetails.name = getEscapedReservedName(camelCase(paramDetails.name), 'Parameter');
+        if (param.required !== true) {
+          optionalParams.push(param);
+        }
+      }
+      if (optionalParams.length > 0) {
+        // create a type named <OperationGroup><Operation>Options
+        const name = `${group.language.go!.name}${op.language.go!.name}Options`;
+        op.request.language.go!.optionalParam = {
+          name: name,
+          description: `${name} contains the optional parameters for the ${group.language.go!.name}.${op.language.go!.name} method.`,
+          params: optionalParams
+        };
       }
       details.protocolNaming = new protocolMethods(details.name);
       // fix up response type name and description

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -7,8 +7,7 @@ import { KnownMediaType, serialize } from '@azure-tools/codegen';
 import { Host, startSession, Session } from '@azure-tools/autorest-extension-base';
 import { ObjectSchema, ArraySchema, codeModelSchema, CodeModel, ImplementationLocation, Language, SchemaType, NumberSchema, Operation, SchemaResponse, Parameter, Property, Protocols, Response, Schema, DictionarySchema } from '@azure-tools/codemodel';
 import { length, values } from '@azure-tools/linq';
-import { ParamInfo, generateParameterInfo } from '../generator/common/helpers';
-import { stringify } from 'querystring';
+import { ParamInfo, paramInfo } from '../generator/common/helpers';
 
 // The transformer adds Go-specific information to the code model.
 export async function transform(host: Host) {
@@ -137,7 +136,7 @@ function processOperationRequests(session: Session<CodeModel>) {
             return false;
           });
           if (index === -1) {
-            globals.push({ name: param.language.go!.name, type: param.schema.language.go!.name, global: true });
+            globals.push(new paramInfo(param.language.go!.name, param.schema.language.go!.name, true, param.required === true));
           }
         }
       }

--- a/test/autorest/generated/urlgroup/client.go
+++ b/test/autorest/generated/urlgroup/client.go
@@ -77,6 +77,6 @@ func (client *Client) QueriesOperations() QueriesOperations {
 }
 
 // PathItemsOperations returns the PathItemsOperations associated with this client.
-func (client *Client) PathItemsOperations(globalStringPath string, globalStringQuery string) PathItemsOperations {
+func (client *Client) PathItemsOperations(globalStringPath string, globalStringQuery *string) PathItemsOperations {
 	return &pathItemsOperations{Client: client, globalStringPath: globalStringPath, globalStringQuery: globalStringQuery}
 }

--- a/test/autorest/generated/urlgroup/internal/urlgroup/models.go
+++ b/test/autorest/generated/urlgroup/internal/urlgroup/models.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"time"
 )
 
 type Error struct {
@@ -38,10 +39,27 @@ func (e Error) Error() string {
 	return msg
 }
 
+// PathItemsGetAllWithValuesOptions contains the optional parameters for the PathItems.GetAllWithValues method.
+type PathItemsGetAllWithValuesOptions struct {
+	// should contain value 'localStringQuery'
+	LocalStringQuery *string
+	// A string value 'pathItemStringQuery' that appears as a query parameter
+	PathItemStringQuery *string
+}
+
 // PathItemsGetAllWithValuesResponse contains the response from method PathItems.GetAllWithValues.
 type PathItemsGetAllWithValuesResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// PathItemsGetGlobalAndLocalQueryNullOptions contains the optional parameters for the PathItems.GetGlobalAndLocalQueryNull
+// method.
+type PathItemsGetGlobalAndLocalQueryNullOptions struct {
+	// should contain value 'localStringQuery'
+	LocalStringQuery *string
+	// A string value 'pathItemStringQuery' that appears as a query parameter
+	PathItemStringQuery *string
 }
 
 // PathItemsGetGlobalAndLocalQueryNullResponse contains the response from method PathItems.GetGlobalAndLocalQueryNull.
@@ -50,10 +68,27 @@ type PathItemsGetGlobalAndLocalQueryNullResponse struct {
 	RawResponse *http.Response
 }
 
+// PathItemsGetGlobalQueryNullOptions contains the optional parameters for the PathItems.GetGlobalQueryNull method.
+type PathItemsGetGlobalQueryNullOptions struct {
+	// should contain value 'localStringQuery'
+	LocalStringQuery *string
+	// A string value 'pathItemStringQuery' that appears as a query parameter
+	PathItemStringQuery *string
+}
+
 // PathItemsGetGlobalQueryNullResponse contains the response from method PathItems.GetGlobalQueryNull.
 type PathItemsGetGlobalQueryNullResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// PathItemsGetLocalPathItemQueryNullOptions contains the optional parameters for the PathItems.GetLocalPathItemQueryNull
+// method.
+type PathItemsGetLocalPathItemQueryNullOptions struct {
+	// should contain value 'localStringQuery'
+	LocalStringQuery *string
+	// A string value 'pathItemStringQuery' that appears as a query parameter
+	PathItemStringQuery *string
 }
 
 // PathItemsGetLocalPathItemQueryNullResponse contains the response from method PathItems.GetLocalPathItemQueryNull.
@@ -224,10 +259,22 @@ type PathsUnixTimeURLResponse struct {
 	RawResponse *http.Response
 }
 
+// QueriesArrayStringCsvEmptyOptions contains the optional parameters for the Queries.ArrayStringCsvEmpty method.
+type QueriesArrayStringCsvEmptyOptions struct {
+	// an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
+	ArrayQuery *[]string
+}
+
 // QueriesArrayStringCsvEmptyResponse contains the response from method Queries.ArrayStringCsvEmpty.
 type QueriesArrayStringCsvEmptyResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// QueriesArrayStringCsvNullOptions contains the optional parameters for the Queries.ArrayStringCsvNull method.
+type QueriesArrayStringCsvNullOptions struct {
+	// an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
+	ArrayQuery *[]string
 }
 
 // QueriesArrayStringCsvNullResponse contains the response from method Queries.ArrayStringCsvNull.
@@ -236,10 +283,22 @@ type QueriesArrayStringCsvNullResponse struct {
 	RawResponse *http.Response
 }
 
+// QueriesArrayStringCsvValidOptions contains the optional parameters for the Queries.ArrayStringCsvValid method.
+type QueriesArrayStringCsvValidOptions struct {
+	// an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
+	ArrayQuery *[]string
+}
+
 // QueriesArrayStringCsvValidResponse contains the response from method Queries.ArrayStringCsvValid.
 type QueriesArrayStringCsvValidResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// QueriesArrayStringPipesValidOptions contains the optional parameters for the Queries.ArrayStringPipesValid method.
+type QueriesArrayStringPipesValidOptions struct {
+	// an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array format
+	ArrayQuery *[]string
 }
 
 // QueriesArrayStringPipesValidResponse contains the response from method Queries.ArrayStringPipesValid.
@@ -248,10 +307,22 @@ type QueriesArrayStringPipesValidResponse struct {
 	RawResponse *http.Response
 }
 
+// QueriesArrayStringSsvValidOptions contains the optional parameters for the Queries.ArrayStringSsvValid method.
+type QueriesArrayStringSsvValidOptions struct {
+	// an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format
+	ArrayQuery *[]string
+}
+
 // QueriesArrayStringSsvValidResponse contains the response from method Queries.ArrayStringSsvValid.
 type QueriesArrayStringSsvValidResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// QueriesArrayStringTsvValidOptions contains the optional parameters for the Queries.ArrayStringTsvValid method.
+type QueriesArrayStringTsvValidOptions struct {
+	// an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array format
+	ArrayQuery *[]string
 }
 
 // QueriesArrayStringTsvValidResponse contains the response from method Queries.ArrayStringTsvValid.
@@ -266,10 +337,22 @@ type QueriesByteEmptyResponse struct {
 	RawResponse *http.Response
 }
 
+// QueriesByteMultiByteOptions contains the optional parameters for the Queries.ByteMultiByte method.
+type QueriesByteMultiByteOptions struct {
+	// '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+	ByteQuery *[]byte
+}
+
 // QueriesByteMultiByteResponse contains the response from method Queries.ByteMultiByte.
 type QueriesByteMultiByteResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// QueriesByteNullOptions contains the optional parameters for the Queries.ByteNull method.
+type QueriesByteNullOptions struct {
+	// '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+	ByteQuery *[]byte
 }
 
 // QueriesByteNullResponse contains the response from method Queries.ByteNull.
@@ -278,10 +361,22 @@ type QueriesByteNullResponse struct {
 	RawResponse *http.Response
 }
 
+// QueriesDateNullOptions contains the optional parameters for the Queries.DateNull method.
+type QueriesDateNullOptions struct {
+	// null as date (no query parameters in uri)
+	DateQuery *time.Time
+}
+
 // QueriesDateNullResponse contains the response from method Queries.DateNull.
 type QueriesDateNullResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// QueriesDateTimeNullOptions contains the optional parameters for the Queries.DateTimeNull method.
+type QueriesDateTimeNullOptions struct {
+	// null as date-time (no query parameters)
+	DateTimeQuery *time.Time
 }
 
 // QueriesDateTimeNullResponse contains the response from method Queries.DateTimeNull.
@@ -314,10 +409,22 @@ type QueriesDoubleDecimalPositiveResponse struct {
 	RawResponse *http.Response
 }
 
+// QueriesDoubleNullOptions contains the optional parameters for the Queries.DoubleNull method.
+type QueriesDoubleNullOptions struct {
+	// null numeric value
+	DoubleQuery *float64
+}
+
 // QueriesDoubleNullResponse contains the response from method Queries.DoubleNull.
 type QueriesDoubleNullResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// QueriesEnumNullOptions contains the optional parameters for the Queries.EnumNull method.
+type QueriesEnumNullOptions struct {
+	// 'green color' enum value
+	EnumQuery *UriColor
 }
 
 // QueriesEnumNullResponse contains the response from method Queries.EnumNull.
@@ -326,10 +433,22 @@ type QueriesEnumNullResponse struct {
 	RawResponse *http.Response
 }
 
+// QueriesEnumValidOptions contains the optional parameters for the Queries.EnumValid method.
+type QueriesEnumValidOptions struct {
+	// 'green color' enum value
+	EnumQuery *UriColor
+}
+
 // QueriesEnumValidResponse contains the response from method Queries.EnumValid.
 type QueriesEnumValidResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// QueriesFloatNullOptions contains the optional parameters for the Queries.FloatNull method.
+type QueriesFloatNullOptions struct {
+	// null numeric value
+	FloatQuery *float32
 }
 
 // QueriesFloatNullResponse contains the response from method Queries.FloatNull.
@@ -356,6 +475,12 @@ type QueriesGetBooleanFalseResponse struct {
 	RawResponse *http.Response
 }
 
+// QueriesGetBooleanNullOptions contains the optional parameters for the Queries.GetBooleanNull method.
+type QueriesGetBooleanNullOptions struct {
+	// null boolean value
+	BoolQuery *bool
+}
+
 // QueriesGetBooleanNullResponse contains the response from method Queries.GetBooleanNull.
 type QueriesGetBooleanNullResponse struct {
 	// RawResponse contains the underlying HTTP response.
@@ -374,6 +499,12 @@ type QueriesGetIntNegativeOneMillionResponse struct {
 	RawResponse *http.Response
 }
 
+// QueriesGetIntNullOptions contains the optional parameters for the Queries.GetIntNull method.
+type QueriesGetIntNullOptions struct {
+	// null integer value
+	IntQuery *int32
+}
+
 // QueriesGetIntNullResponse contains the response from method Queries.GetIntNull.
 type QueriesGetIntNullResponse struct {
 	// RawResponse contains the underlying HTTP response.
@@ -384,6 +515,12 @@ type QueriesGetIntNullResponse struct {
 type QueriesGetIntOneMillionResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// QueriesGetLongNullOptions contains the optional parameters for the Queries.GetLongNull method.
+type QueriesGetLongNullOptions struct {
+	// null 64 bit integer value
+	LongQuery *int64
 }
 
 // QueriesGetLongNullResponse contains the response from method Queries.GetLongNull.
@@ -408,6 +545,12 @@ type QueriesGetTenBillionResponse struct {
 type QueriesStringEmptyResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// QueriesStringNullOptions contains the optional parameters for the Queries.StringNull method.
+type QueriesStringNullOptions struct {
+	// null string value
+	StringQuery *string
 }
 
 // QueriesStringNullResponse contains the response from method Queries.StringNull.

--- a/test/autorest/generated/urlgroup/internal/urlgroup/pathitems.go
+++ b/test/autorest/generated/urlgroup/internal/urlgroup/pathitems.go
@@ -16,16 +16,22 @@ import (
 type PathItemsOperations struct{}
 
 // GetAllWithValuesCreateRequest creates the GetAllWithValues request.
-func (PathItemsOperations) GetAllWithValuesCreateRequest(u url.URL, pathItemStringPath string, pathItemStringQuery string, globalStringPath string, globalStringQuery string, localStringPath string, localStringQuery string) (*azcore.Request, error) {
+func (PathItemsOperations) GetAllWithValuesCreateRequest(u url.URL, pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetAllWithValuesOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("pathItemStringQuery", pathItemStringQuery)
-	query.Set("globalStringQuery", globalStringQuery)
-	query.Set("localStringQuery", localStringQuery)
+	if options != nil && options.PathItemStringQuery != nil {
+		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
+	}
+	if globalStringQuery != nil {
+		query.Set("globalStringQuery", *globalStringQuery)
+	}
+	if options != nil && options.LocalStringQuery != nil {
+		query.Set("localStringQuery", *options.LocalStringQuery)
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -39,16 +45,22 @@ func (PathItemsOperations) GetAllWithValuesHandleResponse(resp *azcore.Response)
 }
 
 // GetGlobalAndLocalQueryNullCreateRequest creates the GetGlobalAndLocalQueryNull request.
-func (PathItemsOperations) GetGlobalAndLocalQueryNullCreateRequest(u url.URL, pathItemStringPath string, pathItemStringQuery string, globalStringPath string, globalStringQuery string, localStringPath string, localStringQuery string) (*azcore.Request, error) {
+func (PathItemsOperations) GetGlobalAndLocalQueryNullCreateRequest(u url.URL, pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("pathItemStringQuery", pathItemStringQuery)
-	query.Set("globalStringQuery", globalStringQuery)
-	query.Set("localStringQuery", localStringQuery)
+	if options != nil && options.PathItemStringQuery != nil {
+		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
+	}
+	if globalStringQuery != nil {
+		query.Set("globalStringQuery", *globalStringQuery)
+	}
+	if options != nil && options.LocalStringQuery != nil {
+		query.Set("localStringQuery", *options.LocalStringQuery)
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -62,16 +74,22 @@ func (PathItemsOperations) GetGlobalAndLocalQueryNullHandleResponse(resp *azcore
 }
 
 // GetGlobalQueryNullCreateRequest creates the GetGlobalQueryNull request.
-func (PathItemsOperations) GetGlobalQueryNullCreateRequest(u url.URL, pathItemStringPath string, pathItemStringQuery string, globalStringPath string, globalStringQuery string, localStringPath string, localStringQuery string) (*azcore.Request, error) {
+func (PathItemsOperations) GetGlobalQueryNullCreateRequest(u url.URL, pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetGlobalQueryNullOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("pathItemStringQuery", pathItemStringQuery)
-	query.Set("globalStringQuery", globalStringQuery)
-	query.Set("localStringQuery", localStringQuery)
+	if options != nil && options.PathItemStringQuery != nil {
+		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
+	}
+	if globalStringQuery != nil {
+		query.Set("globalStringQuery", *globalStringQuery)
+	}
+	if options != nil && options.LocalStringQuery != nil {
+		query.Set("localStringQuery", *options.LocalStringQuery)
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -85,16 +103,22 @@ func (PathItemsOperations) GetGlobalQueryNullHandleResponse(resp *azcore.Respons
 }
 
 // GetLocalPathItemQueryNullCreateRequest creates the GetLocalPathItemQueryNull request.
-func (PathItemsOperations) GetLocalPathItemQueryNullCreateRequest(u url.URL, pathItemStringPath string, pathItemStringQuery string, globalStringPath string, globalStringQuery string, localStringPath string, localStringQuery string) (*azcore.Request, error) {
+func (PathItemsOperations) GetLocalPathItemQueryNullCreateRequest(u url.URL, pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetLocalPathItemQueryNullOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("pathItemStringQuery", pathItemStringQuery)
-	query.Set("globalStringQuery", globalStringQuery)
-	query.Set("localStringQuery", localStringQuery)
+	if options != nil && options.PathItemStringQuery != nil {
+		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
+	}
+	if globalStringQuery != nil {
+		query.Set("globalStringQuery", *globalStringQuery)
+	}
+	if options != nil && options.LocalStringQuery != nil {
+		query.Set("localStringQuery", *options.LocalStringQuery)
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }

--- a/test/autorest/generated/urlgroup/internal/urlgroup/queries.go
+++ b/test/autorest/generated/urlgroup/internal/urlgroup/queries.go
@@ -12,17 +12,18 @@ import (
 	"path"
 	"strconv"
 	"strings"
-	"time"
 )
 
 type QueriesOperations struct{}
 
 // ArrayStringCsvEmptyCreateRequest creates the ArrayStringCsvEmpty request.
-func (QueriesOperations) ArrayStringCsvEmptyCreateRequest(u url.URL, arrayQuery []string) (*azcore.Request, error) {
+func (QueriesOperations) ArrayStringCsvEmptyCreateRequest(u url.URL, options *QueriesArrayStringCsvEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/csv/string/empty"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("arrayQuery", strings.Join(arrayQuery, ","))
+	if options != nil && options.ArrayQuery != nil {
+		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, ","))
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -36,11 +37,13 @@ func (QueriesOperations) ArrayStringCsvEmptyHandleResponse(resp *azcore.Response
 }
 
 // ArrayStringCsvNullCreateRequest creates the ArrayStringCsvNull request.
-func (QueriesOperations) ArrayStringCsvNullCreateRequest(u url.URL, arrayQuery []string) (*azcore.Request, error) {
+func (QueriesOperations) ArrayStringCsvNullCreateRequest(u url.URL, options *QueriesArrayStringCsvNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/csv/string/null"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("arrayQuery", strings.Join(arrayQuery, ","))
+	if options != nil && options.ArrayQuery != nil {
+		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, ","))
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -54,11 +57,13 @@ func (QueriesOperations) ArrayStringCsvNullHandleResponse(resp *azcore.Response)
 }
 
 // ArrayStringCsvValidCreateRequest creates the ArrayStringCsvValid request.
-func (QueriesOperations) ArrayStringCsvValidCreateRequest(u url.URL, arrayQuery []string) (*azcore.Request, error) {
+func (QueriesOperations) ArrayStringCsvValidCreateRequest(u url.URL, options *QueriesArrayStringCsvValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/csv/string/valid"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("arrayQuery", strings.Join(arrayQuery, ","))
+	if options != nil && options.ArrayQuery != nil {
+		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, ","))
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -72,11 +77,13 @@ func (QueriesOperations) ArrayStringCsvValidHandleResponse(resp *azcore.Response
 }
 
 // ArrayStringPipesValidCreateRequest creates the ArrayStringPipesValid request.
-func (QueriesOperations) ArrayStringPipesValidCreateRequest(u url.URL, arrayQuery []string) (*azcore.Request, error) {
+func (QueriesOperations) ArrayStringPipesValidCreateRequest(u url.URL, options *QueriesArrayStringPipesValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/pipes/string/valid"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("arrayQuery", strings.Join(arrayQuery, "|"))
+	if options != nil && options.ArrayQuery != nil {
+		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, "|"))
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -90,11 +97,13 @@ func (QueriesOperations) ArrayStringPipesValidHandleResponse(resp *azcore.Respon
 }
 
 // ArrayStringSsvValidCreateRequest creates the ArrayStringSsvValid request.
-func (QueriesOperations) ArrayStringSsvValidCreateRequest(u url.URL, arrayQuery []string) (*azcore.Request, error) {
+func (QueriesOperations) ArrayStringSsvValidCreateRequest(u url.URL, options *QueriesArrayStringSsvValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/ssv/string/valid"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("arrayQuery", strings.Join(arrayQuery, " "))
+	if options != nil && options.ArrayQuery != nil {
+		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, " "))
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -108,11 +117,13 @@ func (QueriesOperations) ArrayStringSsvValidHandleResponse(resp *azcore.Response
 }
 
 // ArrayStringTsvValidCreateRequest creates the ArrayStringTsvValid request.
-func (QueriesOperations) ArrayStringTsvValidCreateRequest(u url.URL, arrayQuery []string) (*azcore.Request, error) {
+func (QueriesOperations) ArrayStringTsvValidCreateRequest(u url.URL, options *QueriesArrayStringTsvValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/tsv/string/valid"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("arrayQuery", strings.Join(arrayQuery, "\t"))
+	if options != nil && options.ArrayQuery != nil {
+		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, "\t"))
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -144,11 +155,13 @@ func (QueriesOperations) ByteEmptyHandleResponse(resp *azcore.Response) (*Querie
 }
 
 // ByteMultiByteCreateRequest creates the ByteMultiByte request.
-func (QueriesOperations) ByteMultiByteCreateRequest(u url.URL, byteQuery []byte) (*azcore.Request, error) {
+func (QueriesOperations) ByteMultiByteCreateRequest(u url.URL, options *QueriesByteMultiByteOptions) (*azcore.Request, error) {
 	urlPath := "/queries/byte/multibyte"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("byteQuery", string(byteQuery))
+	if options != nil && options.ByteQuery != nil {
+		query.Set("byteQuery", string(*options.ByteQuery))
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -162,11 +175,13 @@ func (QueriesOperations) ByteMultiByteHandleResponse(resp *azcore.Response) (*Qu
 }
 
 // ByteNullCreateRequest creates the ByteNull request.
-func (QueriesOperations) ByteNullCreateRequest(u url.URL, byteQuery []byte) (*azcore.Request, error) {
+func (QueriesOperations) ByteNullCreateRequest(u url.URL, options *QueriesByteNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/byte/null"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("byteQuery", string(byteQuery))
+	if options != nil && options.ByteQuery != nil {
+		query.Set("byteQuery", string(*options.ByteQuery))
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -180,11 +195,13 @@ func (QueriesOperations) ByteNullHandleResponse(resp *azcore.Response) (*Queries
 }
 
 // DateNullCreateRequest creates the DateNull request.
-func (QueriesOperations) DateNullCreateRequest(u url.URL, dateQuery time.Time) (*azcore.Request, error) {
+func (QueriesOperations) DateNullCreateRequest(u url.URL, options *QueriesDateNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/date/null"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("dateQuery", dateQuery.String())
+	if options != nil && options.DateQuery != nil {
+		query.Set("dateQuery", options.DateQuery.String())
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -198,11 +215,13 @@ func (QueriesOperations) DateNullHandleResponse(resp *azcore.Response) (*Queries
 }
 
 // DateTimeNullCreateRequest creates the DateTimeNull request.
-func (QueriesOperations) DateTimeNullCreateRequest(u url.URL, dateTimeQuery time.Time) (*azcore.Request, error) {
+func (QueriesOperations) DateTimeNullCreateRequest(u url.URL, options *QueriesDateTimeNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/datetime/null"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("dateTimeQuery", dateTimeQuery.String())
+	if options != nil && options.DateTimeQuery != nil {
+		query.Set("dateTimeQuery", options.DateTimeQuery.String())
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -288,11 +307,13 @@ func (QueriesOperations) DoubleDecimalPositiveHandleResponse(resp *azcore.Respon
 }
 
 // DoubleNullCreateRequest creates the DoubleNull request.
-func (QueriesOperations) DoubleNullCreateRequest(u url.URL, doubleQuery float64) (*azcore.Request, error) {
+func (QueriesOperations) DoubleNullCreateRequest(u url.URL, options *QueriesDoubleNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/double/null"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("doubleQuery", strconv.FormatFloat(doubleQuery, 'f', -1, 64))
+	if options != nil && options.DoubleQuery != nil {
+		query.Set("doubleQuery", strconv.FormatFloat(*options.DoubleQuery, 'f', -1, 64))
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -306,11 +327,13 @@ func (QueriesOperations) DoubleNullHandleResponse(resp *azcore.Response) (*Queri
 }
 
 // EnumNullCreateRequest creates the EnumNull request.
-func (QueriesOperations) EnumNullCreateRequest(u url.URL, enumQuery UriColor) (*azcore.Request, error) {
+func (QueriesOperations) EnumNullCreateRequest(u url.URL, options *QueriesEnumNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/enum/null"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("enumQuery", string(enumQuery))
+	if options != nil && options.EnumQuery != nil {
+		query.Set("enumQuery", string(*options.EnumQuery))
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -324,11 +347,13 @@ func (QueriesOperations) EnumNullHandleResponse(resp *azcore.Response) (*Queries
 }
 
 // EnumValidCreateRequest creates the EnumValid request.
-func (QueriesOperations) EnumValidCreateRequest(u url.URL, enumQuery UriColor) (*azcore.Request, error) {
+func (QueriesOperations) EnumValidCreateRequest(u url.URL, options *QueriesEnumValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/enum/green%20color"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("enumQuery", string(enumQuery))
+	if options != nil && options.EnumQuery != nil {
+		query.Set("enumQuery", string(*options.EnumQuery))
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -342,11 +367,13 @@ func (QueriesOperations) EnumValidHandleResponse(resp *azcore.Response) (*Querie
 }
 
 // FloatNullCreateRequest creates the FloatNull request.
-func (QueriesOperations) FloatNullCreateRequest(u url.URL, floatQuery float32) (*azcore.Request, error) {
+func (QueriesOperations) FloatNullCreateRequest(u url.URL, options *QueriesFloatNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/float/null"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("floatQuery", strconv.FormatFloat(float64(floatQuery), 'f', -1, 32))
+	if options != nil && options.FloatQuery != nil {
+		query.Set("floatQuery", strconv.FormatFloat(float64(*options.FloatQuery), 'f', -1, 32))
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -414,11 +441,13 @@ func (QueriesOperations) GetBooleanFalseHandleResponse(resp *azcore.Response) (*
 }
 
 // GetBooleanNullCreateRequest creates the GetBooleanNull request.
-func (QueriesOperations) GetBooleanNullCreateRequest(u url.URL, boolQuery bool) (*azcore.Request, error) {
+func (QueriesOperations) GetBooleanNullCreateRequest(u url.URL, options *QueriesGetBooleanNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/bool/null"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("boolQuery", strconv.FormatBool(boolQuery))
+	if options != nil && options.BoolQuery != nil {
+		query.Set("boolQuery", strconv.FormatBool(*options.BoolQuery))
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -468,11 +497,13 @@ func (QueriesOperations) GetIntNegativeOneMillionHandleResponse(resp *azcore.Res
 }
 
 // GetIntNullCreateRequest creates the GetIntNull request.
-func (QueriesOperations) GetIntNullCreateRequest(u url.URL, intQuery int32) (*azcore.Request, error) {
+func (QueriesOperations) GetIntNullCreateRequest(u url.URL, options *QueriesGetIntNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/int/null"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("intQuery", strconv.FormatInt(int64(intQuery), 10))
+	if options != nil && options.IntQuery != nil {
+		query.Set("intQuery", strconv.FormatInt(int64(*options.IntQuery), 10))
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -504,11 +535,13 @@ func (QueriesOperations) GetIntOneMillionHandleResponse(resp *azcore.Response) (
 }
 
 // GetLongNullCreateRequest creates the GetLongNull request.
-func (QueriesOperations) GetLongNullCreateRequest(u url.URL, longQuery int64) (*azcore.Request, error) {
+func (QueriesOperations) GetLongNullCreateRequest(u url.URL, options *QueriesGetLongNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/long/null"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("longQuery", strconv.FormatInt(longQuery, 10))
+	if options != nil && options.LongQuery != nil {
+		query.Set("longQuery", strconv.FormatInt(*options.LongQuery, 10))
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }
@@ -576,11 +609,13 @@ func (QueriesOperations) StringEmptyHandleResponse(resp *azcore.Response) (*Quer
 }
 
 // StringNullCreateRequest creates the StringNull request.
-func (QueriesOperations) StringNullCreateRequest(u url.URL, stringQuery string) (*azcore.Request, error) {
+func (QueriesOperations) StringNullCreateRequest(u url.URL, options *QueriesStringNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/string/null"
 	u.Path = path.Join(u.Path, urlPath)
 	query := u.Query()
-	query.Set("stringQuery", stringQuery)
+	if options != nil && options.StringQuery != nil {
+		query.Set("stringQuery", *options.StringQuery)
+	}
 	u.RawQuery = query.Encode()
 	return azcore.NewRequest(http.MethodGet, u), nil
 }

--- a/test/autorest/generated/urlgroup/models.go
+++ b/test/autorest/generated/urlgroup/models.go
@@ -9,14 +9,28 @@ import azinternal "generatortests/autorest/generated/urlgroup/internal/urlgroup"
 
 type Error = azinternal.Error
 
+// PathItemsGetAllWithValuesOptions contains the optional parameters for the PathItems.GetAllWithValues method.
+type PathItemsGetAllWithValuesOptions = azinternal.PathItemsGetAllWithValuesOptions
+
 // PathItemsGetAllWithValuesResponse contains the response from method PathItems.GetAllWithValues.
 type PathItemsGetAllWithValuesResponse = azinternal.PathItemsGetAllWithValuesResponse
+
+// PathItemsGetGlobalAndLocalQueryNullOptions contains the optional parameters for the PathItems.GetGlobalAndLocalQueryNull
+// method.
+type PathItemsGetGlobalAndLocalQueryNullOptions = azinternal.PathItemsGetGlobalAndLocalQueryNullOptions
 
 // PathItemsGetGlobalAndLocalQueryNullResponse contains the response from method PathItems.GetGlobalAndLocalQueryNull.
 type PathItemsGetGlobalAndLocalQueryNullResponse = azinternal.PathItemsGetGlobalAndLocalQueryNullResponse
 
+// PathItemsGetGlobalQueryNullOptions contains the optional parameters for the PathItems.GetGlobalQueryNull method.
+type PathItemsGetGlobalQueryNullOptions = azinternal.PathItemsGetGlobalQueryNullOptions
+
 // PathItemsGetGlobalQueryNullResponse contains the response from method PathItems.GetGlobalQueryNull.
 type PathItemsGetGlobalQueryNullResponse = azinternal.PathItemsGetGlobalQueryNullResponse
+
+// PathItemsGetLocalPathItemQueryNullOptions contains the optional parameters for the PathItems.GetLocalPathItemQueryNull
+// method.
+type PathItemsGetLocalPathItemQueryNullOptions = azinternal.PathItemsGetLocalPathItemQueryNullOptions
 
 // PathItemsGetLocalPathItemQueryNullResponse contains the response from method PathItems.GetLocalPathItemQueryNull.
 type PathItemsGetLocalPathItemQueryNullResponse = azinternal.PathItemsGetLocalPathItemQueryNullResponse
@@ -102,20 +116,38 @@ type PathsStringUnicodeResponse = azinternal.PathsStringUnicodeResponse
 // PathsUnixTimeURLResponse contains the response from method Paths.UnixTimeURL.
 type PathsUnixTimeURLResponse = azinternal.PathsUnixTimeURLResponse
 
+// QueriesArrayStringCsvEmptyOptions contains the optional parameters for the Queries.ArrayStringCsvEmpty method.
+type QueriesArrayStringCsvEmptyOptions = azinternal.QueriesArrayStringCsvEmptyOptions
+
 // QueriesArrayStringCsvEmptyResponse contains the response from method Queries.ArrayStringCsvEmpty.
 type QueriesArrayStringCsvEmptyResponse = azinternal.QueriesArrayStringCsvEmptyResponse
+
+// QueriesArrayStringCsvNullOptions contains the optional parameters for the Queries.ArrayStringCsvNull method.
+type QueriesArrayStringCsvNullOptions = azinternal.QueriesArrayStringCsvNullOptions
 
 // QueriesArrayStringCsvNullResponse contains the response from method Queries.ArrayStringCsvNull.
 type QueriesArrayStringCsvNullResponse = azinternal.QueriesArrayStringCsvNullResponse
 
+// QueriesArrayStringCsvValidOptions contains the optional parameters for the Queries.ArrayStringCsvValid method.
+type QueriesArrayStringCsvValidOptions = azinternal.QueriesArrayStringCsvValidOptions
+
 // QueriesArrayStringCsvValidResponse contains the response from method Queries.ArrayStringCsvValid.
 type QueriesArrayStringCsvValidResponse = azinternal.QueriesArrayStringCsvValidResponse
+
+// QueriesArrayStringPipesValidOptions contains the optional parameters for the Queries.ArrayStringPipesValid method.
+type QueriesArrayStringPipesValidOptions = azinternal.QueriesArrayStringPipesValidOptions
 
 // QueriesArrayStringPipesValidResponse contains the response from method Queries.ArrayStringPipesValid.
 type QueriesArrayStringPipesValidResponse = azinternal.QueriesArrayStringPipesValidResponse
 
+// QueriesArrayStringSsvValidOptions contains the optional parameters for the Queries.ArrayStringSsvValid method.
+type QueriesArrayStringSsvValidOptions = azinternal.QueriesArrayStringSsvValidOptions
+
 // QueriesArrayStringSsvValidResponse contains the response from method Queries.ArrayStringSsvValid.
 type QueriesArrayStringSsvValidResponse = azinternal.QueriesArrayStringSsvValidResponse
+
+// QueriesArrayStringTsvValidOptions contains the optional parameters for the Queries.ArrayStringTsvValid method.
+type QueriesArrayStringTsvValidOptions = azinternal.QueriesArrayStringTsvValidOptions
 
 // QueriesArrayStringTsvValidResponse contains the response from method Queries.ArrayStringTsvValid.
 type QueriesArrayStringTsvValidResponse = azinternal.QueriesArrayStringTsvValidResponse
@@ -123,14 +155,26 @@ type QueriesArrayStringTsvValidResponse = azinternal.QueriesArrayStringTsvValidR
 // QueriesByteEmptyResponse contains the response from method Queries.ByteEmpty.
 type QueriesByteEmptyResponse = azinternal.QueriesByteEmptyResponse
 
+// QueriesByteMultiByteOptions contains the optional parameters for the Queries.ByteMultiByte method.
+type QueriesByteMultiByteOptions = azinternal.QueriesByteMultiByteOptions
+
 // QueriesByteMultiByteResponse contains the response from method Queries.ByteMultiByte.
 type QueriesByteMultiByteResponse = azinternal.QueriesByteMultiByteResponse
+
+// QueriesByteNullOptions contains the optional parameters for the Queries.ByteNull method.
+type QueriesByteNullOptions = azinternal.QueriesByteNullOptions
 
 // QueriesByteNullResponse contains the response from method Queries.ByteNull.
 type QueriesByteNullResponse = azinternal.QueriesByteNullResponse
 
+// QueriesDateNullOptions contains the optional parameters for the Queries.DateNull method.
+type QueriesDateNullOptions = azinternal.QueriesDateNullOptions
+
 // QueriesDateNullResponse contains the response from method Queries.DateNull.
 type QueriesDateNullResponse = azinternal.QueriesDateNullResponse
+
+// QueriesDateTimeNullOptions contains the optional parameters for the Queries.DateTimeNull method.
+type QueriesDateTimeNullOptions = azinternal.QueriesDateTimeNullOptions
 
 // QueriesDateTimeNullResponse contains the response from method Queries.DateTimeNull.
 type QueriesDateTimeNullResponse = azinternal.QueriesDateTimeNullResponse
@@ -147,14 +191,26 @@ type QueriesDoubleDecimalNegativeResponse = azinternal.QueriesDoubleDecimalNegat
 // QueriesDoubleDecimalPositiveResponse contains the response from method Queries.DoubleDecimalPositive.
 type QueriesDoubleDecimalPositiveResponse = azinternal.QueriesDoubleDecimalPositiveResponse
 
+// QueriesDoubleNullOptions contains the optional parameters for the Queries.DoubleNull method.
+type QueriesDoubleNullOptions = azinternal.QueriesDoubleNullOptions
+
 // QueriesDoubleNullResponse contains the response from method Queries.DoubleNull.
 type QueriesDoubleNullResponse = azinternal.QueriesDoubleNullResponse
+
+// QueriesEnumNullOptions contains the optional parameters for the Queries.EnumNull method.
+type QueriesEnumNullOptions = azinternal.QueriesEnumNullOptions
 
 // QueriesEnumNullResponse contains the response from method Queries.EnumNull.
 type QueriesEnumNullResponse = azinternal.QueriesEnumNullResponse
 
+// QueriesEnumValidOptions contains the optional parameters for the Queries.EnumValid method.
+type QueriesEnumValidOptions = azinternal.QueriesEnumValidOptions
+
 // QueriesEnumValidResponse contains the response from method Queries.EnumValid.
 type QueriesEnumValidResponse = azinternal.QueriesEnumValidResponse
+
+// QueriesFloatNullOptions contains the optional parameters for the Queries.FloatNull method.
+type QueriesFloatNullOptions = azinternal.QueriesFloatNullOptions
 
 // QueriesFloatNullResponse contains the response from method Queries.FloatNull.
 type QueriesFloatNullResponse = azinternal.QueriesFloatNullResponse
@@ -168,6 +224,9 @@ type QueriesFloatScientificPositiveResponse = azinternal.QueriesFloatScientificP
 // QueriesGetBooleanFalseResponse contains the response from method Queries.GetBooleanFalse.
 type QueriesGetBooleanFalseResponse = azinternal.QueriesGetBooleanFalseResponse
 
+// QueriesGetBooleanNullOptions contains the optional parameters for the Queries.GetBooleanNull method.
+type QueriesGetBooleanNullOptions = azinternal.QueriesGetBooleanNullOptions
+
 // QueriesGetBooleanNullResponse contains the response from method Queries.GetBooleanNull.
 type QueriesGetBooleanNullResponse = azinternal.QueriesGetBooleanNullResponse
 
@@ -177,11 +236,17 @@ type QueriesGetBooleanTrueResponse = azinternal.QueriesGetBooleanTrueResponse
 // QueriesGetIntNegativeOneMillionResponse contains the response from method Queries.GetIntNegativeOneMillion.
 type QueriesGetIntNegativeOneMillionResponse = azinternal.QueriesGetIntNegativeOneMillionResponse
 
+// QueriesGetIntNullOptions contains the optional parameters for the Queries.GetIntNull method.
+type QueriesGetIntNullOptions = azinternal.QueriesGetIntNullOptions
+
 // QueriesGetIntNullResponse contains the response from method Queries.GetIntNull.
 type QueriesGetIntNullResponse = azinternal.QueriesGetIntNullResponse
 
 // QueriesGetIntOneMillionResponse contains the response from method Queries.GetIntOneMillion.
 type QueriesGetIntOneMillionResponse = azinternal.QueriesGetIntOneMillionResponse
+
+// QueriesGetLongNullOptions contains the optional parameters for the Queries.GetLongNull method.
+type QueriesGetLongNullOptions = azinternal.QueriesGetLongNullOptions
 
 // QueriesGetLongNullResponse contains the response from method Queries.GetLongNull.
 type QueriesGetLongNullResponse = azinternal.QueriesGetLongNullResponse
@@ -194,6 +259,9 @@ type QueriesGetTenBillionResponse = azinternal.QueriesGetTenBillionResponse
 
 // QueriesStringEmptyResponse contains the response from method Queries.StringEmpty.
 type QueriesStringEmptyResponse = azinternal.QueriesStringEmptyResponse
+
+// QueriesStringNullOptions contains the optional parameters for the Queries.StringNull method.
+type QueriesStringNullOptions = azinternal.QueriesStringNullOptions
 
 // QueriesStringNullResponse contains the response from method Queries.StringNull.
 type QueriesStringNullResponse = azinternal.QueriesStringNullResponse

--- a/test/autorest/generated/urlgroup/pathitems.go
+++ b/test/autorest/generated/urlgroup/pathitems.go
@@ -13,25 +13,25 @@ import (
 // PathItemsOperations contains the methods for the PathItems group.
 type PathItemsOperations interface {
 	// GetAllWithValues - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-	GetAllWithValues(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetAllWithValuesResponse, error)
+	GetAllWithValues(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetAllWithValuesOptions) (*PathItemsGetAllWithValuesResponse, error)
 	// GetGlobalAndLocalQueryNull - send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null
-	GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetGlobalAndLocalQueryNullResponse, error)
+	GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*PathItemsGetGlobalAndLocalQueryNullResponse, error)
 	// GetGlobalQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-	GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetGlobalQueryNullResponse, error)
+	GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalQueryNullOptions) (*PathItemsGetGlobalQueryNullResponse, error)
 	// GetLocalPathItemQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null
-	GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetLocalPathItemQueryNullResponse, error)
+	GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetLocalPathItemQueryNullOptions) (*PathItemsGetLocalPathItemQueryNullResponse, error)
 }
 
 type pathItemsOperations struct {
 	*Client
 	azinternal.PathItemsOperations
 	globalStringPath  string
-	globalStringQuery string
+	globalStringQuery *string
 }
 
 // GetAllWithValues - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-func (client *pathItemsOperations) GetAllWithValues(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetAllWithValuesResponse, error) {
-	req, err := client.GetAllWithValuesCreateRequest(*client.u, pathItemStringPath, pathItemStringQuery, client.globalStringPath, client.globalStringQuery, localStringPath, localStringQuery)
+func (client *pathItemsOperations) GetAllWithValues(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetAllWithValuesOptions) (*PathItemsGetAllWithValuesResponse, error) {
+	req, err := client.GetAllWithValuesCreateRequest(*client.u, pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +47,8 @@ func (client *pathItemsOperations) GetAllWithValues(ctx context.Context, pathIte
 }
 
 // GetGlobalAndLocalQueryNull - send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null
-func (client *pathItemsOperations) GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetGlobalAndLocalQueryNullResponse, error) {
-	req, err := client.GetGlobalAndLocalQueryNullCreateRequest(*client.u, pathItemStringPath, pathItemStringQuery, client.globalStringPath, client.globalStringQuery, localStringPath, localStringQuery)
+func (client *pathItemsOperations) GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*PathItemsGetGlobalAndLocalQueryNullResponse, error) {
+	req, err := client.GetGlobalAndLocalQueryNullCreateRequest(*client.u, pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
 	if err != nil {
 		return nil, err
 	}
@@ -64,8 +64,8 @@ func (client *pathItemsOperations) GetGlobalAndLocalQueryNull(ctx context.Contex
 }
 
 // GetGlobalQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-func (client *pathItemsOperations) GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetGlobalQueryNullResponse, error) {
-	req, err := client.GetGlobalQueryNullCreateRequest(*client.u, pathItemStringPath, pathItemStringQuery, client.globalStringPath, client.globalStringQuery, localStringPath, localStringQuery)
+func (client *pathItemsOperations) GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalQueryNullOptions) (*PathItemsGetGlobalQueryNullResponse, error) {
+	req, err := client.GetGlobalQueryNullCreateRequest(*client.u, pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
 	if err != nil {
 		return nil, err
 	}
@@ -81,8 +81,8 @@ func (client *pathItemsOperations) GetGlobalQueryNull(ctx context.Context, pathI
 }
 
 // GetLocalPathItemQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null
-func (client *pathItemsOperations) GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, pathItemStringQuery string, localStringPath string, localStringQuery string) (*PathItemsGetLocalPathItemQueryNullResponse, error) {
-	req, err := client.GetLocalPathItemQueryNullCreateRequest(*client.u, pathItemStringPath, pathItemStringQuery, client.globalStringPath, client.globalStringQuery, localStringPath, localStringQuery)
+func (client *pathItemsOperations) GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetLocalPathItemQueryNullOptions) (*PathItemsGetLocalPathItemQueryNullResponse, error) {
+	req, err := client.GetLocalPathItemQueryNullCreateRequest(*client.u, pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/urlgroup/queries.go
+++ b/test/autorest/generated/urlgroup/queries.go
@@ -8,33 +8,32 @@ package urlgroup
 import (
 	"context"
 	azinternal "generatortests/autorest/generated/urlgroup/internal/urlgroup"
-	"time"
 )
 
 // QueriesOperations contains the methods for the Queries group.
 type QueriesOperations interface {
 	// ArrayStringCsvEmpty - Get an empty array [] of string using the csv-array format
-	ArrayStringCsvEmpty(ctx context.Context, arrayQuery []string) (*QueriesArrayStringCsvEmptyResponse, error)
+	ArrayStringCsvEmpty(ctx context.Context, options *QueriesArrayStringCsvEmptyOptions) (*QueriesArrayStringCsvEmptyResponse, error)
 	// ArrayStringCsvNull - Get a null array of string using the csv-array format
-	ArrayStringCsvNull(ctx context.Context, arrayQuery []string) (*QueriesArrayStringCsvNullResponse, error)
+	ArrayStringCsvNull(ctx context.Context, options *QueriesArrayStringCsvNullOptions) (*QueriesArrayStringCsvNullResponse, error)
 	// ArrayStringCsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
-	ArrayStringCsvValid(ctx context.Context, arrayQuery []string) (*QueriesArrayStringCsvValidResponse, error)
+	ArrayStringCsvValid(ctx context.Context, options *QueriesArrayStringCsvValidOptions) (*QueriesArrayStringCsvValidResponse, error)
 	// ArrayStringPipesValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array format
-	ArrayStringPipesValid(ctx context.Context, arrayQuery []string) (*QueriesArrayStringPipesValidResponse, error)
+	ArrayStringPipesValid(ctx context.Context, options *QueriesArrayStringPipesValidOptions) (*QueriesArrayStringPipesValidResponse, error)
 	// ArrayStringSsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format
-	ArrayStringSsvValid(ctx context.Context, arrayQuery []string) (*QueriesArrayStringSsvValidResponse, error)
+	ArrayStringSsvValid(ctx context.Context, options *QueriesArrayStringSsvValidOptions) (*QueriesArrayStringSsvValidResponse, error)
 	// ArrayStringTsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array format
-	ArrayStringTsvValid(ctx context.Context, arrayQuery []string) (*QueriesArrayStringTsvValidResponse, error)
+	ArrayStringTsvValid(ctx context.Context, options *QueriesArrayStringTsvValidOptions) (*QueriesArrayStringTsvValidResponse, error)
 	// ByteEmpty - Get '' as byte array
 	ByteEmpty(ctx context.Context) (*QueriesByteEmptyResponse, error)
 	// ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-	ByteMultiByte(ctx context.Context, byteQuery []byte) (*QueriesByteMultiByteResponse, error)
+	ByteMultiByte(ctx context.Context, options *QueriesByteMultiByteOptions) (*QueriesByteMultiByteResponse, error)
 	// ByteNull - Get null as byte array (no query parameters in uri)
-	ByteNull(ctx context.Context, byteQuery []byte) (*QueriesByteNullResponse, error)
+	ByteNull(ctx context.Context, options *QueriesByteNullOptions) (*QueriesByteNullResponse, error)
 	// DateNull - Get null as date - this should result in no query parameters in uri
-	DateNull(ctx context.Context, dateQuery time.Time) (*QueriesDateNullResponse, error)
+	DateNull(ctx context.Context, options *QueriesDateNullOptions) (*QueriesDateNullResponse, error)
 	// DateTimeNull - Get null as date-time, should result in no query parameters in uri
-	DateTimeNull(ctx context.Context, dateTimeQuery time.Time) (*QueriesDateTimeNullResponse, error)
+	DateTimeNull(ctx context.Context, options *QueriesDateTimeNullOptions) (*QueriesDateTimeNullResponse, error)
 	// DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
 	DateTimeValid(ctx context.Context) (*QueriesDateTimeValidResponse, error)
 	// DateValid - Get '2012-01-01' as date
@@ -44,13 +43,13 @@ type QueriesOperations interface {
 	// DoubleDecimalPositive - Get '9999999.999' numeric value
 	DoubleDecimalPositive(ctx context.Context) (*QueriesDoubleDecimalPositiveResponse, error)
 	// DoubleNull - Get null numeric value (no query parameter)
-	DoubleNull(ctx context.Context, doubleQuery float64) (*QueriesDoubleNullResponse, error)
+	DoubleNull(ctx context.Context, options *QueriesDoubleNullOptions) (*QueriesDoubleNullResponse, error)
 	// EnumNull - Get null (no query parameter in url)
-	EnumNull(ctx context.Context, enumQuery UriColor) (*QueriesEnumNullResponse, error)
+	EnumNull(ctx context.Context, options *QueriesEnumNullOptions) (*QueriesEnumNullResponse, error)
 	// EnumValid - Get using uri with query parameter 'green color'
-	EnumValid(ctx context.Context, enumQuery UriColor) (*QueriesEnumValidResponse, error)
+	EnumValid(ctx context.Context, options *QueriesEnumValidOptions) (*QueriesEnumValidResponse, error)
 	// FloatNull - Get null numeric value (no query parameter)
-	FloatNull(ctx context.Context, floatQuery float32) (*QueriesFloatNullResponse, error)
+	FloatNull(ctx context.Context, options *QueriesFloatNullOptions) (*QueriesFloatNullResponse, error)
 	// FloatScientificNegative - Get '-1.034E-20' numeric value
 	FloatScientificNegative(ctx context.Context) (*QueriesFloatScientificNegativeResponse, error)
 	// FloatScientificPositive - Get '1.034E+20' numeric value
@@ -58,17 +57,17 @@ type QueriesOperations interface {
 	// GetBooleanFalse - Get false Boolean value on path
 	GetBooleanFalse(ctx context.Context) (*QueriesGetBooleanFalseResponse, error)
 	// GetBooleanNull - Get null Boolean value on query (query string should be absent)
-	GetBooleanNull(ctx context.Context, boolQuery bool) (*QueriesGetBooleanNullResponse, error)
+	GetBooleanNull(ctx context.Context, options *QueriesGetBooleanNullOptions) (*QueriesGetBooleanNullResponse, error)
 	// GetBooleanTrue - Get true Boolean value on path
 	GetBooleanTrue(ctx context.Context) (*QueriesGetBooleanTrueResponse, error)
 	// GetIntNegativeOneMillion - Get '-1000000' integer value
 	GetIntNegativeOneMillion(ctx context.Context) (*QueriesGetIntNegativeOneMillionResponse, error)
 	// GetIntNull - Get null integer value (no query parameter)
-	GetIntNull(ctx context.Context, intQuery int32) (*QueriesGetIntNullResponse, error)
+	GetIntNull(ctx context.Context, options *QueriesGetIntNullOptions) (*QueriesGetIntNullResponse, error)
 	// GetIntOneMillion - Get '1000000' integer value
 	GetIntOneMillion(ctx context.Context) (*QueriesGetIntOneMillionResponse, error)
 	// GetLongNull - Get 'null 64 bit integer value (no query param in uri)
-	GetLongNull(ctx context.Context, longQuery int64) (*QueriesGetLongNullResponse, error)
+	GetLongNull(ctx context.Context, options *QueriesGetLongNullOptions) (*QueriesGetLongNullResponse, error)
 	// GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
 	GetNegativeTenBillion(ctx context.Context) (*QueriesGetNegativeTenBillionResponse, error)
 	// GetTenBillion - Get '10000000000' 64 bit integer value
@@ -76,7 +75,7 @@ type QueriesOperations interface {
 	// StringEmpty - Get ''
 	StringEmpty(ctx context.Context) (*QueriesStringEmptyResponse, error)
 	// StringNull - Get null (no query parameter in url)
-	StringNull(ctx context.Context, stringQuery string) (*QueriesStringNullResponse, error)
+	StringNull(ctx context.Context, options *QueriesStringNullOptions) (*QueriesStringNullResponse, error)
 	// StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
 	StringURLEncoded(ctx context.Context) (*QueriesStringURLEncodedResponse, error)
 	// StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
@@ -89,8 +88,8 @@ type queriesOperations struct {
 }
 
 // ArrayStringCsvEmpty - Get an empty array [] of string using the csv-array format
-func (client *queriesOperations) ArrayStringCsvEmpty(ctx context.Context, arrayQuery []string) (*QueriesArrayStringCsvEmptyResponse, error) {
-	req, err := client.ArrayStringCsvEmptyCreateRequest(*client.u, arrayQuery)
+func (client *queriesOperations) ArrayStringCsvEmpty(ctx context.Context, options *QueriesArrayStringCsvEmptyOptions) (*QueriesArrayStringCsvEmptyResponse, error) {
+	req, err := client.ArrayStringCsvEmptyCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -106,8 +105,8 @@ func (client *queriesOperations) ArrayStringCsvEmpty(ctx context.Context, arrayQ
 }
 
 // ArrayStringCsvNull - Get a null array of string using the csv-array format
-func (client *queriesOperations) ArrayStringCsvNull(ctx context.Context, arrayQuery []string) (*QueriesArrayStringCsvNullResponse, error) {
-	req, err := client.ArrayStringCsvNullCreateRequest(*client.u, arrayQuery)
+func (client *queriesOperations) ArrayStringCsvNull(ctx context.Context, options *QueriesArrayStringCsvNullOptions) (*QueriesArrayStringCsvNullResponse, error) {
+	req, err := client.ArrayStringCsvNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -123,8 +122,8 @@ func (client *queriesOperations) ArrayStringCsvNull(ctx context.Context, arrayQu
 }
 
 // ArrayStringCsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
-func (client *queriesOperations) ArrayStringCsvValid(ctx context.Context, arrayQuery []string) (*QueriesArrayStringCsvValidResponse, error) {
-	req, err := client.ArrayStringCsvValidCreateRequest(*client.u, arrayQuery)
+func (client *queriesOperations) ArrayStringCsvValid(ctx context.Context, options *QueriesArrayStringCsvValidOptions) (*QueriesArrayStringCsvValidResponse, error) {
+	req, err := client.ArrayStringCsvValidCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -140,8 +139,8 @@ func (client *queriesOperations) ArrayStringCsvValid(ctx context.Context, arrayQ
 }
 
 // ArrayStringPipesValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array format
-func (client *queriesOperations) ArrayStringPipesValid(ctx context.Context, arrayQuery []string) (*QueriesArrayStringPipesValidResponse, error) {
-	req, err := client.ArrayStringPipesValidCreateRequest(*client.u, arrayQuery)
+func (client *queriesOperations) ArrayStringPipesValid(ctx context.Context, options *QueriesArrayStringPipesValidOptions) (*QueriesArrayStringPipesValidResponse, error) {
+	req, err := client.ArrayStringPipesValidCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -157,8 +156,8 @@ func (client *queriesOperations) ArrayStringPipesValid(ctx context.Context, arra
 }
 
 // ArrayStringSsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format
-func (client *queriesOperations) ArrayStringSsvValid(ctx context.Context, arrayQuery []string) (*QueriesArrayStringSsvValidResponse, error) {
-	req, err := client.ArrayStringSsvValidCreateRequest(*client.u, arrayQuery)
+func (client *queriesOperations) ArrayStringSsvValid(ctx context.Context, options *QueriesArrayStringSsvValidOptions) (*QueriesArrayStringSsvValidResponse, error) {
+	req, err := client.ArrayStringSsvValidCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -174,8 +173,8 @@ func (client *queriesOperations) ArrayStringSsvValid(ctx context.Context, arrayQ
 }
 
 // ArrayStringTsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array format
-func (client *queriesOperations) ArrayStringTsvValid(ctx context.Context, arrayQuery []string) (*QueriesArrayStringTsvValidResponse, error) {
-	req, err := client.ArrayStringTsvValidCreateRequest(*client.u, arrayQuery)
+func (client *queriesOperations) ArrayStringTsvValid(ctx context.Context, options *QueriesArrayStringTsvValidOptions) (*QueriesArrayStringTsvValidResponse, error) {
+	req, err := client.ArrayStringTsvValidCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -208,8 +207,8 @@ func (client *queriesOperations) ByteEmpty(ctx context.Context) (*QueriesByteEmp
 }
 
 // ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-func (client *queriesOperations) ByteMultiByte(ctx context.Context, byteQuery []byte) (*QueriesByteMultiByteResponse, error) {
-	req, err := client.ByteMultiByteCreateRequest(*client.u, byteQuery)
+func (client *queriesOperations) ByteMultiByte(ctx context.Context, options *QueriesByteMultiByteOptions) (*QueriesByteMultiByteResponse, error) {
+	req, err := client.ByteMultiByteCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -225,8 +224,8 @@ func (client *queriesOperations) ByteMultiByte(ctx context.Context, byteQuery []
 }
 
 // ByteNull - Get null as byte array (no query parameters in uri)
-func (client *queriesOperations) ByteNull(ctx context.Context, byteQuery []byte) (*QueriesByteNullResponse, error) {
-	req, err := client.ByteNullCreateRequest(*client.u, byteQuery)
+func (client *queriesOperations) ByteNull(ctx context.Context, options *QueriesByteNullOptions) (*QueriesByteNullResponse, error) {
+	req, err := client.ByteNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -242,8 +241,8 @@ func (client *queriesOperations) ByteNull(ctx context.Context, byteQuery []byte)
 }
 
 // DateNull - Get null as date - this should result in no query parameters in uri
-func (client *queriesOperations) DateNull(ctx context.Context, dateQuery time.Time) (*QueriesDateNullResponse, error) {
-	req, err := client.DateNullCreateRequest(*client.u, dateQuery)
+func (client *queriesOperations) DateNull(ctx context.Context, options *QueriesDateNullOptions) (*QueriesDateNullResponse, error) {
+	req, err := client.DateNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -259,8 +258,8 @@ func (client *queriesOperations) DateNull(ctx context.Context, dateQuery time.Ti
 }
 
 // DateTimeNull - Get null as date-time, should result in no query parameters in uri
-func (client *queriesOperations) DateTimeNull(ctx context.Context, dateTimeQuery time.Time) (*QueriesDateTimeNullResponse, error) {
-	req, err := client.DateTimeNullCreateRequest(*client.u, dateTimeQuery)
+func (client *queriesOperations) DateTimeNull(ctx context.Context, options *QueriesDateTimeNullOptions) (*QueriesDateTimeNullResponse, error) {
+	req, err := client.DateTimeNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -344,8 +343,8 @@ func (client *queriesOperations) DoubleDecimalPositive(ctx context.Context) (*Qu
 }
 
 // DoubleNull - Get null numeric value (no query parameter)
-func (client *queriesOperations) DoubleNull(ctx context.Context, doubleQuery float64) (*QueriesDoubleNullResponse, error) {
-	req, err := client.DoubleNullCreateRequest(*client.u, doubleQuery)
+func (client *queriesOperations) DoubleNull(ctx context.Context, options *QueriesDoubleNullOptions) (*QueriesDoubleNullResponse, error) {
+	req, err := client.DoubleNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -361,8 +360,8 @@ func (client *queriesOperations) DoubleNull(ctx context.Context, doubleQuery flo
 }
 
 // EnumNull - Get null (no query parameter in url)
-func (client *queriesOperations) EnumNull(ctx context.Context, enumQuery UriColor) (*QueriesEnumNullResponse, error) {
-	req, err := client.EnumNullCreateRequest(*client.u, enumQuery)
+func (client *queriesOperations) EnumNull(ctx context.Context, options *QueriesEnumNullOptions) (*QueriesEnumNullResponse, error) {
+	req, err := client.EnumNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -378,8 +377,8 @@ func (client *queriesOperations) EnumNull(ctx context.Context, enumQuery UriColo
 }
 
 // EnumValid - Get using uri with query parameter 'green color'
-func (client *queriesOperations) EnumValid(ctx context.Context, enumQuery UriColor) (*QueriesEnumValidResponse, error) {
-	req, err := client.EnumValidCreateRequest(*client.u, enumQuery)
+func (client *queriesOperations) EnumValid(ctx context.Context, options *QueriesEnumValidOptions) (*QueriesEnumValidResponse, error) {
+	req, err := client.EnumValidCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -395,8 +394,8 @@ func (client *queriesOperations) EnumValid(ctx context.Context, enumQuery UriCol
 }
 
 // FloatNull - Get null numeric value (no query parameter)
-func (client *queriesOperations) FloatNull(ctx context.Context, floatQuery float32) (*QueriesFloatNullResponse, error) {
-	req, err := client.FloatNullCreateRequest(*client.u, floatQuery)
+func (client *queriesOperations) FloatNull(ctx context.Context, options *QueriesFloatNullOptions) (*QueriesFloatNullResponse, error) {
+	req, err := client.FloatNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -463,8 +462,8 @@ func (client *queriesOperations) GetBooleanFalse(ctx context.Context) (*QueriesG
 }
 
 // GetBooleanNull - Get null Boolean value on query (query string should be absent)
-func (client *queriesOperations) GetBooleanNull(ctx context.Context, boolQuery bool) (*QueriesGetBooleanNullResponse, error) {
-	req, err := client.GetBooleanNullCreateRequest(*client.u, boolQuery)
+func (client *queriesOperations) GetBooleanNull(ctx context.Context, options *QueriesGetBooleanNullOptions) (*QueriesGetBooleanNullResponse, error) {
+	req, err := client.GetBooleanNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -514,8 +513,8 @@ func (client *queriesOperations) GetIntNegativeOneMillion(ctx context.Context) (
 }
 
 // GetIntNull - Get null integer value (no query parameter)
-func (client *queriesOperations) GetIntNull(ctx context.Context, intQuery int32) (*QueriesGetIntNullResponse, error) {
-	req, err := client.GetIntNullCreateRequest(*client.u, intQuery)
+func (client *queriesOperations) GetIntNull(ctx context.Context, options *QueriesGetIntNullOptions) (*QueriesGetIntNullResponse, error) {
+	req, err := client.GetIntNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -548,8 +547,8 @@ func (client *queriesOperations) GetIntOneMillion(ctx context.Context) (*Queries
 }
 
 // GetLongNull - Get 'null 64 bit integer value (no query param in uri)
-func (client *queriesOperations) GetLongNull(ctx context.Context, longQuery int64) (*QueriesGetLongNullResponse, error) {
-	req, err := client.GetLongNullCreateRequest(*client.u, longQuery)
+func (client *queriesOperations) GetLongNull(ctx context.Context, options *QueriesGetLongNullOptions) (*QueriesGetLongNullResponse, error) {
+	req, err := client.GetLongNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -616,8 +615,8 @@ func (client *queriesOperations) StringEmpty(ctx context.Context) (*QueriesStrin
 }
 
 // StringNull - Get null (no query parameter in url)
-func (client *queriesOperations) StringNull(ctx context.Context, stringQuery string) (*QueriesStringNullResponse, error) {
-	req, err := client.StringNullCreateRequest(*client.u, stringQuery)
+func (client *queriesOperations) StringNull(ctx context.Context, options *QueriesStringNullOptions) (*QueriesStringNullResponse, error) {
+	req, err := client.StringNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/urlgroup/pathitems_test.go
+++ b/test/autorest/urlgroup/pathitems_test.go
@@ -9,19 +9,25 @@ import (
 	"generatortests/helpers"
 	"net/http"
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getPathItemsClient(t *testing.T) urlgroup.PathItemsOperations {
+func getPathItemsClient(t *testing.T) *urlgroup.Client {
 	client, err := urlgroup.NewDefaultClient(nil)
 	if err != nil {
 		t.Fatalf("failed to create enum client: %v", err)
 	}
-	return client.PathItemsOperations("globalStringPath", "globalStringQuery")
+	return client
 }
 
 func TestGetAllWithValues(t *testing.T) {
 	client := getPathItemsClient(t)
-	result, err := client.GetAllWithValues(context.Background(), "pathItemStringPath", "pathItemStringQuery", "localStringPath", "localStringQuery")
+	grp := client.PathItemsOperations("globalStringPath", to.StringPtr("globalStringQuery"))
+	result, err := grp.GetAllWithValues(context.Background(), "pathItemStringPath", "localStringPath", &urlgroup.PathItemsGetAllWithValuesOptions{
+		LocalStringQuery:    to.StringPtr("localStringQuery"),
+		PathItemStringQuery: to.StringPtr("pathItemStringQuery"),
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,9 +35,11 @@ func TestGetAllWithValues(t *testing.T) {
 }
 
 func TestGetGlobalAndLocalQueryNull(t *testing.T) {
-	t.Skip("need optional string params")
 	client := getPathItemsClient(t)
-	result, err := client.GetGlobalAndLocalQueryNull(context.Background(), "pathItemStringPath", "pathItemStringQuery", "localStringPath", "")
+	grp := client.PathItemsOperations("globalStringPath", nil)
+	result, err := grp.GetGlobalAndLocalQueryNull(context.Background(), "pathItemStringPath", "localStringPath", &urlgroup.PathItemsGetGlobalAndLocalQueryNullOptions{
+		PathItemStringQuery: to.StringPtr("pathItemStringQuery"),
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,9 +47,12 @@ func TestGetGlobalAndLocalQueryNull(t *testing.T) {
 }
 
 func TestGetGlobalQueryNull(t *testing.T) {
-	t.Skip("need optional string params")
 	client := getPathItemsClient(t)
-	result, err := client.GetGlobalQueryNull(context.Background(), "pathItemStringPath", "pathItemStringQuery", "localStringPath", "localStringQuery")
+	grp := client.PathItemsOperations("globalStringPath", nil)
+	result, err := grp.GetGlobalQueryNull(context.Background(), "pathItemStringPath", "localStringPath", &urlgroup.PathItemsGetGlobalQueryNullOptions{
+		LocalStringQuery:    to.StringPtr("localStringQuery"),
+		PathItemStringQuery: to.StringPtr("pathItemStringQuery"),
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,9 +60,9 @@ func TestGetGlobalQueryNull(t *testing.T) {
 }
 
 func TestGetLocalPathItemQueryNull(t *testing.T) {
-	t.Skip("need optional string params")
 	client := getPathItemsClient(t)
-	result, err := client.GetLocalPathItemQueryNull(context.Background(), "pathItemStringPath", "", "localStringPath", "")
+	grp := client.PathItemsOperations("globalStringPath", to.StringPtr("globalStringQuery"))
+	result, err := grp.GetLocalPathItemQueryNull(context.Background(), "pathItemStringPath", "localStringPath", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/urlgroup/queries_test.go
+++ b/test/autorest/urlgroup/queries_test.go
@@ -22,8 +22,8 @@ func getQueriesClient(t *testing.T) urlgroup.QueriesOperations {
 
 func TestArrayStringCsvValid(t *testing.T) {
 	client := getQueriesClient(t)
-	result, err := client.ArrayStringCsvValid(context.Background(), []string{
-		"ArrayQuery1", "begin!*'();:@ &=+$,/?#[]end", "", "",
+	result, err := client.ArrayStringCsvValid(context.Background(), &urlgroup.QueriesArrayStringCsvValidOptions{
+		ArrayQuery: &[]string{"ArrayQuery1", "begin!*'();:@ &=+$,/?#[]end", "", ""},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -33,8 +33,8 @@ func TestArrayStringCsvValid(t *testing.T) {
 
 func TestArrayStringPipesValid(t *testing.T) {
 	client := getQueriesClient(t)
-	result, err := client.ArrayStringPipesValid(context.Background(), []string{
-		"ArrayQuery1", "begin!*'();:@ &=+$,/?#[]end", "", "",
+	result, err := client.ArrayStringPipesValid(context.Background(), &urlgroup.QueriesArrayStringPipesValidOptions{
+		ArrayQuery: &[]string{"ArrayQuery1", "begin!*'();:@ &=+$,/?#[]end", "", ""},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -42,10 +42,16 @@ func TestArrayStringPipesValid(t *testing.T) {
 	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
 }
 
+func toByteSlicePtr(v []byte) *[]byte {
+	return &v
+}
+
 func TestByteMultiByte(t *testing.T) {
 	client := getQueriesClient(t)
 	encoded := base64.StdEncoding.EncodeToString([]byte("啊齄丂狛狜隣郎隣兀﨩"))
-	result, err := client.ByteMultiByte(context.Background(), []byte(encoded))
+	result, err := client.ByteMultiByte(context.Background(), &urlgroup.QueriesByteMultiByteOptions{
+		ByteQuery: toByteSlicePtr([]byte(encoded)),
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +80,9 @@ func TestDoubleDecimalNegative(t *testing.T) {
 func TestEnumValid(t *testing.T) {
 	t.Skip("test fails, needs investigation")
 	client := getQueriesClient(t)
-	result, err := client.EnumValid(context.Background(), urlgroup.UriColorGreenColor)
+	result, err := client.EnumValid(context.Background(), &urlgroup.QueriesEnumValidOptions{
+		EnumQuery: urlgroup.UriColorGreenColor.ToPtr(),
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/go.mod
+++ b/test/go.mod
@@ -2,4 +2,7 @@ module generatortests
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.3.0
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.3.0
+	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.0
+)

--- a/test/go.sum
+++ b/test/go.sum
@@ -2,3 +2,5 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v0.3.0 h1:EcVbHX9mW2L7/91WD0nvwdcCi
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.3.0/go.mod h1:UKq2za3CMGx75vfPM9tPSuTBNODR4hX1qAeb+GRoDkc=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.1.0 h1:sgOdyT1ZAW3nErwCuvlGrkeP03pTtbRBW5MGCXWGZws=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.1.0/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=
+github.com/Azure/azure-sdk-for-go/sdk/to v0.1.0 h1:5PmE4x8xzfL3onRdC5adQPrJSMDhYT2h5DwPB1uR9tA=
+github.com/Azure/azure-sdk-for-go/sdk/to v0.1.0/go.mod h1:UL/d4lvWAzSJUuX+19uKdN0ktyjoOyQhgY+HWNgtIYI=


### PR DESCRIPTION
For operations with optional parameters (i.e. not marked as required:
true in the swagger) create a type <OperationGroup><Operation>Options
that contains all of the optional args.  This type will be passed by
pointer as the last method argument.