### PR TITLE
Add Send to the list of reserved method names

### DIFF
--- a/src/CodeNamerGo.cs
+++ b/src/CodeNamerGo.cs
@@ -239,7 +239,10 @@ namespace AutoRest.Go
                     "unsafe",
 
                     // Other reserved names and packages (defined by the base libraries this code uses)
-                    "autorest", "client", "date", "err", "req", "resp", "result", "sender", "to", "validation", "m", "v", "k", "objectMap"
+                    "autorest", "client", "date", "err", "req", "resp", "result", "sender", "to", "validation", "m", "v", "k", "objectMap",
+
+                    // reserved method names
+                    "Send"
 
                 });
         }


### PR DESCRIPTION
Recent changes to the autorest.Client type added a method named Send.
Add it to the list of reserved method names.