### PR TITLE
Merge response types

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start-wiremock": "node -e \"p = child_process.spawn( 'node' ,['./src/node_modules/wiremock/jdeploy-bundle/jdeploy.js','--root-dir', '../../testserverv2', '--port', '3000'],{ detatched: true,   stdio: 'ignore'} ) ; setTimeout( () => { p.unref(); process.exit()},1000 )  \""
   },
   "dependencies": {
-    "@autorest/autorest": "^3.0.6173"
+    "@autorest/autorest": "^3.0.6173",
+    "autorest": "^3.0.6187"
   }
 }

--- a/rushScripts/regeneration.js
+++ b/rushScripts/regeneration.js
@@ -53,28 +53,30 @@ function autorestCallback(namespace, inputFile) {
             console.log('autorest stdout: ' + stdout);
         }
         if (stderr !== '') {
-            console.error('autorest stderr: ' + stderr);
+            console.error('\x1b[91m%s\x1b[0m', 'autorest stderr: ' + stderr);
         }
         // print any output resulting from executing the autorest command
         if (error !== null) {
-            console.error('autorest exec error: ' + error);
+            console.error('\x1b[91m%s\x1b[0m', 'autorest exec error: ' + error);
         }
-        // format the output
+        // format the output on success
         // print any output or error from go fmt
-        let formatDir = './test/autorest/generated/' + namespace + '/...';
-        exec('go fmt ' + formatDir,
-        function (error, stdout, stderr) {
-            console.log('formatting ' + formatDir);
-            if (stdout !== '') {
-                console.log('fmt stdout: ' + stdout);
-            }
-            if (stderr !== '') {
-                console.error('fmt stderr: ' + stderr);
-            }
-            // print any output resulting from a failure to execute go fmt
-            if (error !== null) {
-                console.error('fmt exec error: ' + error);
-            }
-        });
+        if (stderr === '' && error === null) {
+            let formatDir = './test/autorest/generated/' + namespace + '/...';
+            exec('go fmt ' + formatDir,
+            function (error, stdout, stderr) {
+                console.log('formatting ' + formatDir);
+                if (stdout !== '') {
+                    console.log('fmt stdout: ' + stdout);
+                }
+                if (stderr !== '') {
+                    console.error('\x1b[91m%s\x1b[0m', 'fmt stderr: ' + stderr);
+                }
+                // print any output resulting from a failure to execute go fmt
+                if (error !== null) {
+                    console.error('\x1b[91m%s\x1b[0m', 'fmt exec error: ' + error);
+                }
+            });
+        }
     };
 }

--- a/test/autorest/booleangroup/booleangroup_test.go
+++ b/test/autorest/booleangroup/booleangroup_test.go
@@ -69,7 +69,7 @@ func TestPutTrue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutTrue: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestPutFalse(t *testing.T) {
@@ -78,5 +78,5 @@ func TestPutFalse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutFalse: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }

--- a/test/autorest/bytegroup/bytegroup_test.go
+++ b/test/autorest/bytegroup/bytegroup_test.go
@@ -67,5 +67,5 @@ func TestPutNonASCII(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutNonASCII: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }

--- a/test/autorest/custombaseurlgroup/custombaseurlgroup_test.go
+++ b/test/autorest/custombaseurlgroup/custombaseurlgroup_test.go
@@ -25,5 +25,5 @@ func TestGetEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }

--- a/test/autorest/datetimegroup/datetimegroup_test.go
+++ b/test/autorest/datetimegroup/datetimegroup_test.go
@@ -195,7 +195,7 @@ func TestPutLocalNegativeOffsetMaxDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestPutLocalNegativeOffsetMinDateTime(t *testing.T) {
@@ -208,7 +208,7 @@ func TestPutLocalNegativeOffsetMinDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestPutLocalPositiveOffsetMaxDateTime(t *testing.T) {
@@ -221,7 +221,7 @@ func TestPutLocalPositiveOffsetMaxDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestPutLocalPositiveOffsetMinDateTime(t *testing.T) {
@@ -234,7 +234,7 @@ func TestPutLocalPositiveOffsetMinDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestPutUTCMaxDateTime(t *testing.T) {
@@ -247,7 +247,7 @@ func TestPutUTCMaxDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestPutUTCMaxDateTime7Digits(t *testing.T) {
@@ -260,7 +260,7 @@ func TestPutUTCMaxDateTime7Digits(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestPutUTCMinDateTime(t *testing.T) {
@@ -273,5 +273,5 @@ func TestPutUTCMinDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }

--- a/test/autorest/datetimerfc1123group/datetimerfc1123group_test.go
+++ b/test/autorest/datetimerfc1123group/datetimerfc1123group_test.go
@@ -107,7 +107,7 @@ func TestPutUTCMaxDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 // PutUTCMinDateTime - Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT
@@ -121,5 +121,5 @@ func TestPutUTCMinDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }

--- a/test/autorest/filegroup/filegroup_test.go
+++ b/test/autorest/filegroup/filegroup_test.go
@@ -26,14 +26,14 @@ func TestGetEmptyFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
-	if result.RawResponse.Body == nil {
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
+	if result.Body == nil {
 		t.Fatal("unexpected nil response body")
 	}
-	if result.RawResponse.ContentLength != 0 {
-		t.Fatalf("expected zero ContentLength, got %d", result.RawResponse.ContentLength)
+	if result.ContentLength != 0 {
+		t.Fatalf("expected zero ContentLength, got %d", result.ContentLength)
 	}
-	result.RawResponse.Body.Close()
+	result.Body.Close()
 }
 
 func TestGetFile(t *testing.T) {
@@ -42,15 +42,15 @@ func TestGetFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
-	if result.RawResponse.Body == nil {
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
+	if result.Body == nil {
 		t.Fatal("unexpected nil response body")
 	}
-	b, err := ioutil.ReadAll(result.RawResponse.Body)
+	b, err := ioutil.ReadAll(result.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	result.RawResponse.Body.Close()
+	result.Body.Close()
 	if l := len(b); l != 8725 {
 		t.Fatalf("unexpected byte count: want 8725, got %d", l)
 	}
@@ -62,15 +62,15 @@ func TestGetFileLarge(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
-	if result.RawResponse.Body == nil {
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
+	if result.Body == nil {
 		t.Fatal("unexpected nil response body")
 	}
-	b, err := ioutil.ReadAll(result.RawResponse.Body)
+	b, err := ioutil.ReadAll(result.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	result.RawResponse.Body.Close()
+	result.Body.Close()
 	const size = 3000 * 1024 * 1024
 	if l := len(b); l != size {
 		t.Fatalf("unexpected byte count: want %d, got %d", size, l)

--- a/test/autorest/generated/booleangroup/bool.go
+++ b/test/autorest/generated/booleangroup/bool.go
@@ -16,17 +16,17 @@ import (
 // BoolOperations contains the methods for the Bool group.
 type BoolOperations interface {
 	// GetFalse - Get false Boolean value
-	GetFalse(ctx context.Context) (*BoolGetFalseResponse, error)
+	GetFalse(ctx context.Context) (*BoolResponse, error)
 	// GetInvalid - Get invalid Boolean value
-	GetInvalid(ctx context.Context) (*BoolGetInvalidResponse, error)
+	GetInvalid(ctx context.Context) (*BoolResponse, error)
 	// GetNull - Get null Boolean value
-	GetNull(ctx context.Context) (*BoolGetNullResponse, error)
+	GetNull(ctx context.Context) (*BoolResponse, error)
 	// GetTrue - Get true Boolean value
-	GetTrue(ctx context.Context) (*BoolGetTrueResponse, error)
+	GetTrue(ctx context.Context) (*BoolResponse, error)
 	// PutFalse - Set Boolean value false
-	PutFalse(ctx context.Context) (*BoolPutFalseResponse, error)
+	PutFalse(ctx context.Context) (*http.Response, error)
 	// PutTrue - Set Boolean value true
-	PutTrue(ctx context.Context) (*BoolPutTrueResponse, error)
+	PutTrue(ctx context.Context) (*http.Response, error)
 }
 
 // boolOperations implements the BoolOperations interface.
@@ -35,7 +35,7 @@ type boolOperations struct {
 }
 
 // GetFalse - Get false Boolean value
-func (client *boolOperations) GetFalse(ctx context.Context) (*BoolGetFalseResponse, error) {
+func (client *boolOperations) GetFalse(ctx context.Context) (*BoolResponse, error) {
 	req, err := client.getFalseCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -60,16 +60,16 @@ func (client *boolOperations) getFalseCreateRequest(u url.URL) (*azcore.Request,
 }
 
 // getFalseHandleResponse handles the GetFalse response.
-func (client *boolOperations) getFalseHandleResponse(resp *azcore.Response) (*BoolGetFalseResponse, error) {
+func (client *boolOperations) getFalseHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := BoolGetFalseResponse{RawResponse: resp.Response}
+	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetInvalid - Get invalid Boolean value
-func (client *boolOperations) GetInvalid(ctx context.Context) (*BoolGetInvalidResponse, error) {
+func (client *boolOperations) GetInvalid(ctx context.Context) (*BoolResponse, error) {
 	req, err := client.getInvalidCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -94,16 +94,16 @@ func (client *boolOperations) getInvalidCreateRequest(u url.URL) (*azcore.Reques
 }
 
 // getInvalidHandleResponse handles the GetInvalid response.
-func (client *boolOperations) getInvalidHandleResponse(resp *azcore.Response) (*BoolGetInvalidResponse, error) {
+func (client *boolOperations) getInvalidHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := BoolGetInvalidResponse{RawResponse: resp.Response}
+	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNull - Get null Boolean value
-func (client *boolOperations) GetNull(ctx context.Context) (*BoolGetNullResponse, error) {
+func (client *boolOperations) GetNull(ctx context.Context) (*BoolResponse, error) {
 	req, err := client.getNullCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -128,16 +128,16 @@ func (client *boolOperations) getNullCreateRequest(u url.URL) (*azcore.Request, 
 }
 
 // getNullHandleResponse handles the GetNull response.
-func (client *boolOperations) getNullHandleResponse(resp *azcore.Response) (*BoolGetNullResponse, error) {
+func (client *boolOperations) getNullHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := BoolGetNullResponse{RawResponse: resp.Response}
+	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetTrue - Get true Boolean value
-func (client *boolOperations) GetTrue(ctx context.Context) (*BoolGetTrueResponse, error) {
+func (client *boolOperations) GetTrue(ctx context.Context) (*BoolResponse, error) {
 	req, err := client.getTrueCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -162,16 +162,16 @@ func (client *boolOperations) getTrueCreateRequest(u url.URL) (*azcore.Request, 
 }
 
 // getTrueHandleResponse handles the GetTrue response.
-func (client *boolOperations) getTrueHandleResponse(resp *azcore.Response) (*BoolGetTrueResponse, error) {
+func (client *boolOperations) getTrueHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := BoolGetTrueResponse{RawResponse: resp.Response}
+	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // PutFalse - Set Boolean value false
-func (client *boolOperations) PutFalse(ctx context.Context) (*BoolPutFalseResponse, error) {
+func (client *boolOperations) PutFalse(ctx context.Context) (*http.Response, error) {
 	req, err := client.putFalseCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -200,15 +200,15 @@ func (client *boolOperations) putFalseCreateRequest(u url.URL) (*azcore.Request,
 }
 
 // putFalseHandleResponse handles the PutFalse response.
-func (client *boolOperations) putFalseHandleResponse(resp *azcore.Response) (*BoolPutFalseResponse, error) {
+func (client *boolOperations) putFalseHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &BoolPutFalseResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutTrue - Set Boolean value true
-func (client *boolOperations) PutTrue(ctx context.Context) (*BoolPutTrueResponse, error) {
+func (client *boolOperations) PutTrue(ctx context.Context) (*http.Response, error) {
 	req, err := client.putTrueCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -237,9 +237,9 @@ func (client *boolOperations) putTrueCreateRequest(u url.URL) (*azcore.Request, 
 }
 
 // putTrueHandleResponse handles the PutTrue response.
-func (client *boolOperations) putTrueHandleResponse(resp *azcore.Response) (*BoolPutTrueResponse, error) {
+func (client *boolOperations) putTrueHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &BoolPutTrueResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }

--- a/test/autorest/generated/booleangroup/models.go
+++ b/test/autorest/generated/booleangroup/models.go
@@ -11,48 +11,13 @@ import (
 	"net/http"
 )
 
-// BoolGetFalseResponse contains the response from method Bool.GetFalse.
-type BoolGetFalseResponse struct {
+// BoolResponse is the response envelope for operations that return a bool type.
+type BoolResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// simple boolean
 	Value *bool
-}
-
-// BoolGetInvalidResponse contains the response from method Bool.GetInvalid.
-type BoolGetInvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *bool
-}
-
-// BoolGetNullResponse contains the response from method Bool.GetNull.
-type BoolGetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *bool
-}
-
-// BoolGetTrueResponse contains the response from method Bool.GetTrue.
-type BoolGetTrueResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
-	// simple boolean
-	Value *bool
-}
-
-// BoolPutFalseResponse contains the response from method Bool.PutFalse.
-type BoolPutFalseResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// BoolPutTrueResponse contains the response from method Bool.PutTrue.
-type BoolPutTrueResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 type Error struct {

--- a/test/autorest/generated/bytegroup/byte.go
+++ b/test/autorest/generated/bytegroup/byte.go
@@ -16,15 +16,15 @@ import (
 // ByteOperations contains the methods for the Byte group.
 type ByteOperations interface {
 	// GetEmpty - Get empty byte value ''
-	GetEmpty(ctx context.Context) (*ByteGetEmptyResponse, error)
+	GetEmpty(ctx context.Context) (*ByteArrayResponse, error)
 	// GetInvalid - Get invalid byte value ':::SWAGGER::::'
-	GetInvalid(ctx context.Context) (*ByteGetInvalidResponse, error)
+	GetInvalid(ctx context.Context) (*ByteArrayResponse, error)
 	// GetNonASCII - Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
-	GetNonASCII(ctx context.Context) (*ByteGetNonASCIIResponse, error)
+	GetNonASCII(ctx context.Context) (*ByteArrayResponse, error)
 	// GetNull - Get null byte value
-	GetNull(ctx context.Context) (*ByteGetNullResponse, error)
+	GetNull(ctx context.Context) (*ByteArrayResponse, error)
 	// PutNonASCII - Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
-	PutNonASCII(ctx context.Context, byteBody []byte) (*BytePutNonASCIIResponse, error)
+	PutNonASCII(ctx context.Context, byteBody []byte) (*http.Response, error)
 }
 
 // byteOperations implements the ByteOperations interface.
@@ -33,7 +33,7 @@ type byteOperations struct {
 }
 
 // GetEmpty - Get empty byte value ''
-func (client *byteOperations) GetEmpty(ctx context.Context) (*ByteGetEmptyResponse, error) {
+func (client *byteOperations) GetEmpty(ctx context.Context) (*ByteArrayResponse, error) {
 	req, err := client.getEmptyCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -58,16 +58,16 @@ func (client *byteOperations) getEmptyCreateRequest(u url.URL) (*azcore.Request,
 }
 
 // getEmptyHandleResponse handles the GetEmpty response.
-func (client *byteOperations) getEmptyHandleResponse(resp *azcore.Response) (*ByteGetEmptyResponse, error) {
+func (client *byteOperations) getEmptyHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := ByteGetEmptyResponse{RawResponse: resp.Response}
+	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetInvalid - Get invalid byte value ':::SWAGGER::::'
-func (client *byteOperations) GetInvalid(ctx context.Context) (*ByteGetInvalidResponse, error) {
+func (client *byteOperations) GetInvalid(ctx context.Context) (*ByteArrayResponse, error) {
 	req, err := client.getInvalidCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -92,16 +92,16 @@ func (client *byteOperations) getInvalidCreateRequest(u url.URL) (*azcore.Reques
 }
 
 // getInvalidHandleResponse handles the GetInvalid response.
-func (client *byteOperations) getInvalidHandleResponse(resp *azcore.Response) (*ByteGetInvalidResponse, error) {
+func (client *byteOperations) getInvalidHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := ByteGetInvalidResponse{RawResponse: resp.Response}
+	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNonASCII - Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
-func (client *byteOperations) GetNonASCII(ctx context.Context) (*ByteGetNonASCIIResponse, error) {
+func (client *byteOperations) GetNonASCII(ctx context.Context) (*ByteArrayResponse, error) {
 	req, err := client.getNonAsciiCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -126,16 +126,16 @@ func (client *byteOperations) getNonAsciiCreateRequest(u url.URL) (*azcore.Reque
 }
 
 // getNonAsciiHandleResponse handles the GetNonASCII response.
-func (client *byteOperations) getNonAsciiHandleResponse(resp *azcore.Response) (*ByteGetNonASCIIResponse, error) {
+func (client *byteOperations) getNonAsciiHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := ByteGetNonASCIIResponse{RawResponse: resp.Response}
+	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNull - Get null byte value
-func (client *byteOperations) GetNull(ctx context.Context) (*ByteGetNullResponse, error) {
+func (client *byteOperations) GetNull(ctx context.Context) (*ByteArrayResponse, error) {
 	req, err := client.getNullCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -160,16 +160,16 @@ func (client *byteOperations) getNullCreateRequest(u url.URL) (*azcore.Request, 
 }
 
 // getNullHandleResponse handles the GetNull response.
-func (client *byteOperations) getNullHandleResponse(resp *azcore.Response) (*ByteGetNullResponse, error) {
+func (client *byteOperations) getNullHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := ByteGetNullResponse{RawResponse: resp.Response}
+	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // PutNonASCII - Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
-func (client *byteOperations) PutNonASCII(ctx context.Context, byteBody []byte) (*BytePutNonASCIIResponse, error) {
+func (client *byteOperations) PutNonASCII(ctx context.Context, byteBody []byte) (*http.Response, error) {
 	req, err := client.putNonAsciiCreateRequest(*client.u, byteBody)
 	if err != nil {
 		return nil, err
@@ -198,9 +198,9 @@ func (client *byteOperations) putNonAsciiCreateRequest(u url.URL, byteBody []byt
 }
 
 // putNonAsciiHandleResponse handles the PutNonASCII response.
-func (client *byteOperations) putNonAsciiHandleResponse(resp *azcore.Response) (*BytePutNonASCIIResponse, error) {
+func (client *byteOperations) putNonAsciiHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &BytePutNonASCIIResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }

--- a/test/autorest/generated/bytegroup/models.go
+++ b/test/autorest/generated/bytegroup/models.go
@@ -11,46 +11,13 @@ import (
 	"net/http"
 )
 
-// ByteGetEmptyResponse contains the response from method Byte.GetEmpty.
-type ByteGetEmptyResponse struct {
+// ByteArrayResponse is the response envelope for operations that return a []byte type.
+type ByteArrayResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// The null byte value
 	Value *[]byte
-}
-
-// ByteGetInvalidResponse contains the response from method Byte.GetInvalid.
-type ByteGetInvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
-	// The null byte value
-	Value *[]byte
-}
-
-// ByteGetNonASCIIResponse contains the response from method Byte.GetNonASCII.
-type ByteGetNonASCIIResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
-	// The null byte value
-	Value *[]byte
-}
-
-// ByteGetNullResponse contains the response from method Byte.GetNull.
-type ByteGetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
-	// The null byte value
-	Value *[]byte
-}
-
-// BytePutNonASCIIResponse contains the response from method Byte.PutNonASCII.
-type BytePutNonASCIIResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 type Error struct {

--- a/test/autorest/generated/complexmodelgroup/models.go
+++ b/test/autorest/generated/complexmodelgroup/models.go
@@ -21,6 +21,14 @@ type CatalogArrayOfDictionary struct {
 	ProductArrayOfDictionary *[]map[string]*Product `json:"productArrayOfDictionary,omitempty"`
 }
 
+// CatalogArrayResponse is the response envelope for operations that return a CatalogArray type.
+type CatalogArrayResponse struct {
+	CatalogArray *CatalogArray
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+}
+
 type CatalogDictionary struct {
 	// Dictionary of products
 	ProductDictionary *map[string]*Product `json:"productDictionary,omitempty"`
@@ -31,8 +39,8 @@ type CatalogDictionaryOfArray struct {
 	ProductDictionaryOfArray *map[string]*[]Product `json:"productDictionaryOfArray,omitempty"`
 }
 
-// CreateResponse contains the response from method Operations.Create.
-type CreateResponse struct {
+// CatalogDictionaryResponse is the response envelope for operations that return a CatalogDictionary type.
+type CatalogDictionaryResponse struct {
 	CatalogDictionary *CatalogDictionary
 
 	// RawResponse contains the underlying HTTP response.
@@ -66,14 +74,6 @@ func (e Error) Error() string {
 	return msg
 }
 
-// ListResponse contains the response from method Operations.List.
-type ListResponse struct {
-	CatalogArray *CatalogArray
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // The product documentation.
 type Product struct {
 	// Capacity of product. For example, 4 people.
@@ -91,12 +91,4 @@ type Product struct {
 	// Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco
 	// will have a different product_id than uberX in Los Angeles.
 	ProductID *string `json:"product_id,omitempty"`
-}
-
-// UpdateResponse contains the response from method Operations.Update.
-type UpdateResponse struct {
-	CatalogArray *CatalogArray
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/autorest/generated/complexmodelgroup/operations.go
+++ b/test/autorest/generated/complexmodelgroup/operations.go
@@ -17,11 +17,11 @@ import (
 // Operations contains the methods for the Operations group.
 type Operations interface {
 	// Create - Resets products.
-	Create(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*CreateResponse, error)
+	Create(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*CatalogDictionaryResponse, error)
 	// List - The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.
-	List(ctx context.Context, resourceGroupName string) (*ListResponse, error)
+	List(ctx context.Context, resourceGroupName string) (*CatalogArrayResponse, error)
 	// Update - Resets products.
-	Update(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*UpdateResponse, error)
+	Update(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*CatalogArrayResponse, error)
 }
 
 // operations implements the Operations interface.
@@ -30,7 +30,7 @@ type operations struct {
 }
 
 // Create - Resets products.
-func (client *operations) Create(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*CreateResponse, error) {
+func (client *operations) Create(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*CatalogDictionaryResponse, error) {
 	req, err := client.createCreateRequest(*client.u, subscriptionId, resourceGroupName, bodyParameter)
 	if err != nil {
 		return nil, err
@@ -64,16 +64,16 @@ func (client *operations) createCreateRequest(u url.URL, subscriptionId string, 
 }
 
 // createHandleResponse handles the Create response.
-func (client *operations) createHandleResponse(resp *azcore.Response) (*CreateResponse, error) {
+func (client *operations) createHandleResponse(resp *azcore.Response) (*CatalogDictionaryResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := CreateResponse{RawResponse: resp.Response}
+	result := CatalogDictionaryResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.CatalogDictionary)
 }
 
 // List - The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.
-func (client *operations) List(ctx context.Context, resourceGroupName string) (*ListResponse, error) {
+func (client *operations) List(ctx context.Context, resourceGroupName string) (*CatalogArrayResponse, error) {
 	req, err := client.listCreateRequest(*client.u, resourceGroupName)
 	if err != nil {
 		return nil, err
@@ -103,16 +103,16 @@ func (client *operations) listCreateRequest(u url.URL, resourceGroupName string)
 }
 
 // listHandleResponse handles the List response.
-func (client *operations) listHandleResponse(resp *azcore.Response) (*ListResponse, error) {
+func (client *operations) listHandleResponse(resp *azcore.Response) (*CatalogArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := ListResponse{RawResponse: resp.Response}
+	result := CatalogArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.CatalogArray)
 }
 
 // Update - Resets products.
-func (client *operations) Update(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*UpdateResponse, error) {
+func (client *operations) Update(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*CatalogArrayResponse, error) {
 	req, err := client.updateCreateRequest(*client.u, subscriptionId, resourceGroupName, bodyParameter)
 	if err != nil {
 		return nil, err
@@ -146,10 +146,10 @@ func (client *operations) updateCreateRequest(u url.URL, subscriptionId string, 
 }
 
 // updateHandleResponse handles the Update response.
-func (client *operations) updateHandleResponse(resp *azcore.Response) (*UpdateResponse, error) {
+func (client *operations) updateHandleResponse(resp *azcore.Response) (*CatalogArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := UpdateResponse{RawResponse: resp.Response}
+	result := CatalogArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.CatalogArray)
 }

--- a/test/autorest/generated/custombaseurlgroup/models.go
+++ b/test/autorest/generated/custombaseurlgroup/models.go
@@ -8,7 +8,6 @@ package custombaseurlgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/http"
 )
 
 type Error struct {
@@ -36,10 +35,4 @@ func (e Error) Error() string {
 		msg = "missing error info"
 	}
 	return msg
-}
-
-// PathsGetEmptyResponse contains the response from method Paths.GetEmpty.
-type PathsGetEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/autorest/generated/custombaseurlgroup/paths.go
+++ b/test/autorest/generated/custombaseurlgroup/paths.go
@@ -16,7 +16,7 @@ import (
 // PathsOperations contains the methods for the Paths group.
 type PathsOperations interface {
 	// GetEmpty - Get a 200 to test a valid base uri
-	GetEmpty(ctx context.Context, accountName string) (*PathsGetEmptyResponse, error)
+	GetEmpty(ctx context.Context, accountName string) (*http.Response, error)
 }
 
 // pathsOperations implements the PathsOperations interface.
@@ -25,7 +25,7 @@ type pathsOperations struct {
 }
 
 // GetEmpty - Get a 200 to test a valid base uri
-func (client *pathsOperations) GetEmpty(ctx context.Context, accountName string) (*PathsGetEmptyResponse, error) {
+func (client *pathsOperations) GetEmpty(ctx context.Context, accountName string) (*http.Response, error) {
 	req, err := client.getEmptyCreateRequest(*client.u, accountName)
 	if err != nil {
 		return nil, err
@@ -50,9 +50,9 @@ func (client *pathsOperations) getEmptyCreateRequest(u url.URL, accountName stri
 }
 
 // getEmptyHandleResponse handles the GetEmpty response.
-func (client *pathsOperations) getEmptyHandleResponse(resp *azcore.Response) (*PathsGetEmptyResponse, error) {
+func (client *pathsOperations) getEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsGetEmptyResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }

--- a/test/autorest/generated/datetimegroup/datetime.go
+++ b/test/autorest/generated/datetimegroup/datetime.go
@@ -17,47 +17,47 @@ import (
 // DatetimeOperations contains the methods for the Datetime group.
 type DatetimeOperations interface {
 	// GetInvalid - Get invalid datetime value
-	GetInvalid(ctx context.Context) (*DatetimeGetInvalidResponse, error)
+	GetInvalid(ctx context.Context) (*TimeResponse, error)
 	// GetLocalNegativeOffsetLowercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00
-	GetLocalNegativeOffsetLowercaseMaxDateTime(ctx context.Context) (*DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeResponse, error)
+	GetLocalNegativeOffsetLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
 	// GetLocalNegativeOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00-14:00
-	GetLocalNegativeOffsetMinDateTime(ctx context.Context) (*DatetimeGetLocalNegativeOffsetMinDateTimeResponse, error)
+	GetLocalNegativeOffsetMinDateTime(ctx context.Context) (*TimeResponse, error)
 	// GetLocalNegativeOffsetUppercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00
-	GetLocalNegativeOffsetUppercaseMaxDateTime(ctx context.Context) (*DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeResponse, error)
+	GetLocalNegativeOffsetUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
 	// GetLocalPositiveOffsetLowercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00
-	GetLocalPositiveOffsetLowercaseMaxDateTime(ctx context.Context) (*DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeResponse, error)
+	GetLocalPositiveOffsetLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
 	// GetLocalPositiveOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00+14:00
-	GetLocalPositiveOffsetMinDateTime(ctx context.Context) (*DatetimeGetLocalPositiveOffsetMinDateTimeResponse, error)
+	GetLocalPositiveOffsetMinDateTime(ctx context.Context) (*TimeResponse, error)
 	// GetLocalPositiveOffsetUppercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00
-	GetLocalPositiveOffsetUppercaseMaxDateTime(ctx context.Context) (*DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeResponse, error)
+	GetLocalPositiveOffsetUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
 	// GetNull - Get null datetime value
-	GetNull(ctx context.Context) (*DatetimeGetNullResponse, error)
+	GetNull(ctx context.Context) (*TimeResponse, error)
 	// GetOverflow - Get overflow datetime value
-	GetOverflow(ctx context.Context) (*DatetimeGetOverflowResponse, error)
+	GetOverflow(ctx context.Context) (*TimeResponse, error)
 	// GetUTCLowercaseMaxDateTime - Get max datetime value 9999-12-31t23:59:59.999z
-	GetUTCLowercaseMaxDateTime(ctx context.Context) (*DatetimeGetUTCLowercaseMaxDateTimeResponse, error)
+	GetUTCLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
 	// GetUTCMinDateTime - Get min datetime value 0001-01-01T00:00:00Z
-	GetUTCMinDateTime(ctx context.Context) (*DatetimeGetUTCMinDateTimeResponse, error)
+	GetUTCMinDateTime(ctx context.Context) (*TimeResponse, error)
 	// GetUTCUppercaseMaxDateTime - Get max datetime value 9999-12-31T23:59:59.999Z
-	GetUTCUppercaseMaxDateTime(ctx context.Context) (*DatetimeGetUTCUppercaseMaxDateTimeResponse, error)
+	GetUTCUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
 	// GetUTCUppercaseMaxDateTime7Digits - Get max datetime value 9999-12-31T23:59:59.9999999Z
-	GetUTCUppercaseMaxDateTime7Digits(ctx context.Context) (*DatetimeGetUTCUppercaseMaxDateTime7DigitsResponse, error)
+	GetUTCUppercaseMaxDateTime7Digits(ctx context.Context) (*TimeResponse, error)
 	// GetUnderflow - Get underflow datetime value
-	GetUnderflow(ctx context.Context) (*DatetimeGetUnderflowResponse, error)
+	GetUnderflow(ctx context.Context) (*TimeResponse, error)
 	// PutLocalNegativeOffsetMaxDateTime - Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00
-	PutLocalNegativeOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time) (*DatetimePutLocalNegativeOffsetMaxDateTimeResponse, error)
+	PutLocalNegativeOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
 	// PutLocalNegativeOffsetMinDateTime - Put min datetime value 0001-01-01T00:00:00-14:00
-	PutLocalNegativeOffsetMinDateTime(ctx context.Context, datetimeBody time.Time) (*DatetimePutLocalNegativeOffsetMinDateTimeResponse, error)
+	PutLocalNegativeOffsetMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
 	// PutLocalPositiveOffsetMaxDateTime - Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00
-	PutLocalPositiveOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time) (*DatetimePutLocalPositiveOffsetMaxDateTimeResponse, error)
+	PutLocalPositiveOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
 	// PutLocalPositiveOffsetMinDateTime - Put min datetime value 0001-01-01T00:00:00+14:00
-	PutLocalPositiveOffsetMinDateTime(ctx context.Context, datetimeBody time.Time) (*DatetimePutLocalPositiveOffsetMinDateTimeResponse, error)
+	PutLocalPositiveOffsetMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
 	// PutUTCMaxDateTime - Put max datetime value 9999-12-31T23:59:59.999Z
-	PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time) (*DatetimePutUTCMaxDateTimeResponse, error)
+	PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
 	// PutUTCMaxDateTime7Digits - Put max datetime value 9999-12-31T23:59:59.9999999Z
-	PutUTCMaxDateTime7Digits(ctx context.Context, datetimeBody time.Time) (*DatetimePutUTCMaxDateTime7DigitsResponse, error)
+	PutUTCMaxDateTime7Digits(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
 	// PutUTCMinDateTime - Put min datetime value 0001-01-01T00:00:00Z
-	PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time) (*DatetimePutUTCMinDateTimeResponse, error)
+	PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
 }
 
 // datetimeOperations implements the DatetimeOperations interface.
@@ -66,7 +66,7 @@ type datetimeOperations struct {
 }
 
 // GetInvalid - Get invalid datetime value
-func (client *datetimeOperations) GetInvalid(ctx context.Context) (*DatetimeGetInvalidResponse, error) {
+func (client *datetimeOperations) GetInvalid(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getInvalidCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -91,19 +91,19 @@ func (client *datetimeOperations) getInvalidCreateRequest(u url.URL) (*azcore.Re
 }
 
 // getInvalidHandleResponse handles the GetInvalid response.
-func (client *datetimeOperations) getInvalidHandleResponse(resp *azcore.Response) (*DatetimeGetInvalidResponse, error) {
+func (client *datetimeOperations) getInvalidHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
-	result := DatetimeGetInvalidResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetLocalNegativeOffsetLowercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00
-func (client *datetimeOperations) GetLocalNegativeOffsetLowercaseMaxDateTime(ctx context.Context) (*DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeResponse, error) {
+func (client *datetimeOperations) GetLocalNegativeOffsetLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -128,19 +128,19 @@ func (client *datetimeOperations) getLocalNegativeOffsetLowercaseMaxDateTimeCrea
 }
 
 // getLocalNegativeOffsetLowercaseMaxDateTimeHandleResponse handles the GetLocalNegativeOffsetLowercaseMaxDateTime response.
-func (client *datetimeOperations) getLocalNegativeOffsetLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeResponse, error) {
+func (client *datetimeOperations) getLocalNegativeOffsetLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
-	result := DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetLocalNegativeOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00-14:00
-func (client *datetimeOperations) GetLocalNegativeOffsetMinDateTime(ctx context.Context) (*DatetimeGetLocalNegativeOffsetMinDateTimeResponse, error) {
+func (client *datetimeOperations) GetLocalNegativeOffsetMinDateTime(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getLocalNegativeOffsetMinDateTimeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -165,19 +165,19 @@ func (client *datetimeOperations) getLocalNegativeOffsetMinDateTimeCreateRequest
 }
 
 // getLocalNegativeOffsetMinDateTimeHandleResponse handles the GetLocalNegativeOffsetMinDateTime response.
-func (client *datetimeOperations) getLocalNegativeOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*DatetimeGetLocalNegativeOffsetMinDateTimeResponse, error) {
+func (client *datetimeOperations) getLocalNegativeOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
-	result := DatetimeGetLocalNegativeOffsetMinDateTimeResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetLocalNegativeOffsetUppercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00
-func (client *datetimeOperations) GetLocalNegativeOffsetUppercaseMaxDateTime(ctx context.Context) (*DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeResponse, error) {
+func (client *datetimeOperations) GetLocalNegativeOffsetUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -202,19 +202,19 @@ func (client *datetimeOperations) getLocalNegativeOffsetUppercaseMaxDateTimeCrea
 }
 
 // getLocalNegativeOffsetUppercaseMaxDateTimeHandleResponse handles the GetLocalNegativeOffsetUppercaseMaxDateTime response.
-func (client *datetimeOperations) getLocalNegativeOffsetUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeResponse, error) {
+func (client *datetimeOperations) getLocalNegativeOffsetUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
-	result := DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetLocalPositiveOffsetLowercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00
-func (client *datetimeOperations) GetLocalPositiveOffsetLowercaseMaxDateTime(ctx context.Context) (*DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeResponse, error) {
+func (client *datetimeOperations) GetLocalPositiveOffsetLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -239,19 +239,19 @@ func (client *datetimeOperations) getLocalPositiveOffsetLowercaseMaxDateTimeCrea
 }
 
 // getLocalPositiveOffsetLowercaseMaxDateTimeHandleResponse handles the GetLocalPositiveOffsetLowercaseMaxDateTime response.
-func (client *datetimeOperations) getLocalPositiveOffsetLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeResponse, error) {
+func (client *datetimeOperations) getLocalPositiveOffsetLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
-	result := DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetLocalPositiveOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00+14:00
-func (client *datetimeOperations) GetLocalPositiveOffsetMinDateTime(ctx context.Context) (*DatetimeGetLocalPositiveOffsetMinDateTimeResponse, error) {
+func (client *datetimeOperations) GetLocalPositiveOffsetMinDateTime(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getLocalPositiveOffsetMinDateTimeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -276,19 +276,19 @@ func (client *datetimeOperations) getLocalPositiveOffsetMinDateTimeCreateRequest
 }
 
 // getLocalPositiveOffsetMinDateTimeHandleResponse handles the GetLocalPositiveOffsetMinDateTime response.
-func (client *datetimeOperations) getLocalPositiveOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*DatetimeGetLocalPositiveOffsetMinDateTimeResponse, error) {
+func (client *datetimeOperations) getLocalPositiveOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
-	result := DatetimeGetLocalPositiveOffsetMinDateTimeResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetLocalPositiveOffsetUppercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00
-func (client *datetimeOperations) GetLocalPositiveOffsetUppercaseMaxDateTime(ctx context.Context) (*DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeResponse, error) {
+func (client *datetimeOperations) GetLocalPositiveOffsetUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -313,19 +313,19 @@ func (client *datetimeOperations) getLocalPositiveOffsetUppercaseMaxDateTimeCrea
 }
 
 // getLocalPositiveOffsetUppercaseMaxDateTimeHandleResponse handles the GetLocalPositiveOffsetUppercaseMaxDateTime response.
-func (client *datetimeOperations) getLocalPositiveOffsetUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeResponse, error) {
+func (client *datetimeOperations) getLocalPositiveOffsetUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
-	result := DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetNull - Get null datetime value
-func (client *datetimeOperations) GetNull(ctx context.Context) (*DatetimeGetNullResponse, error) {
+func (client *datetimeOperations) GetNull(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getNullCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -350,19 +350,19 @@ func (client *datetimeOperations) getNullCreateRequest(u url.URL) (*azcore.Reque
 }
 
 // getNullHandleResponse handles the GetNull response.
-func (client *datetimeOperations) getNullHandleResponse(resp *azcore.Response) (*DatetimeGetNullResponse, error) {
+func (client *datetimeOperations) getNullHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
-	result := DatetimeGetNullResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetOverflow - Get overflow datetime value
-func (client *datetimeOperations) GetOverflow(ctx context.Context) (*DatetimeGetOverflowResponse, error) {
+func (client *datetimeOperations) GetOverflow(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getOverflowCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -387,19 +387,19 @@ func (client *datetimeOperations) getOverflowCreateRequest(u url.URL) (*azcore.R
 }
 
 // getOverflowHandleResponse handles the GetOverflow response.
-func (client *datetimeOperations) getOverflowHandleResponse(resp *azcore.Response) (*DatetimeGetOverflowResponse, error) {
+func (client *datetimeOperations) getOverflowHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
-	result := DatetimeGetOverflowResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetUTCLowercaseMaxDateTime - Get max datetime value 9999-12-31t23:59:59.999z
-func (client *datetimeOperations) GetUTCLowercaseMaxDateTime(ctx context.Context) (*DatetimeGetUTCLowercaseMaxDateTimeResponse, error) {
+func (client *datetimeOperations) GetUTCLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getUtcLowercaseMaxDateTimeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -424,19 +424,19 @@ func (client *datetimeOperations) getUtcLowercaseMaxDateTimeCreateRequest(u url.
 }
 
 // getUtcLowercaseMaxDateTimeHandleResponse handles the GetUTCLowercaseMaxDateTime response.
-func (client *datetimeOperations) getUtcLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*DatetimeGetUTCLowercaseMaxDateTimeResponse, error) {
+func (client *datetimeOperations) getUtcLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
-	result := DatetimeGetUTCLowercaseMaxDateTimeResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetUTCMinDateTime - Get min datetime value 0001-01-01T00:00:00Z
-func (client *datetimeOperations) GetUTCMinDateTime(ctx context.Context) (*DatetimeGetUTCMinDateTimeResponse, error) {
+func (client *datetimeOperations) GetUTCMinDateTime(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getUtcMinDateTimeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -461,19 +461,19 @@ func (client *datetimeOperations) getUtcMinDateTimeCreateRequest(u url.URL) (*az
 }
 
 // getUtcMinDateTimeHandleResponse handles the GetUTCMinDateTime response.
-func (client *datetimeOperations) getUtcMinDateTimeHandleResponse(resp *azcore.Response) (*DatetimeGetUTCMinDateTimeResponse, error) {
+func (client *datetimeOperations) getUtcMinDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
-	result := DatetimeGetUTCMinDateTimeResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetUTCUppercaseMaxDateTime - Get max datetime value 9999-12-31T23:59:59.999Z
-func (client *datetimeOperations) GetUTCUppercaseMaxDateTime(ctx context.Context) (*DatetimeGetUTCUppercaseMaxDateTimeResponse, error) {
+func (client *datetimeOperations) GetUTCUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getUtcUppercaseMaxDateTimeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -498,19 +498,19 @@ func (client *datetimeOperations) getUtcUppercaseMaxDateTimeCreateRequest(u url.
 }
 
 // getUtcUppercaseMaxDateTimeHandleResponse handles the GetUTCUppercaseMaxDateTime response.
-func (client *datetimeOperations) getUtcUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*DatetimeGetUTCUppercaseMaxDateTimeResponse, error) {
+func (client *datetimeOperations) getUtcUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
-	result := DatetimeGetUTCUppercaseMaxDateTimeResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetUTCUppercaseMaxDateTime7Digits - Get max datetime value 9999-12-31T23:59:59.9999999Z
-func (client *datetimeOperations) GetUTCUppercaseMaxDateTime7Digits(ctx context.Context) (*DatetimeGetUTCUppercaseMaxDateTime7DigitsResponse, error) {
+func (client *datetimeOperations) GetUTCUppercaseMaxDateTime7Digits(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getUtcUppercaseMaxDateTime7DigitsCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -535,19 +535,19 @@ func (client *datetimeOperations) getUtcUppercaseMaxDateTime7DigitsCreateRequest
 }
 
 // getUtcUppercaseMaxDateTime7DigitsHandleResponse handles the GetUTCUppercaseMaxDateTime7Digits response.
-func (client *datetimeOperations) getUtcUppercaseMaxDateTime7DigitsHandleResponse(resp *azcore.Response) (*DatetimeGetUTCUppercaseMaxDateTime7DigitsResponse, error) {
+func (client *datetimeOperations) getUtcUppercaseMaxDateTime7DigitsHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
-	result := DatetimeGetUTCUppercaseMaxDateTime7DigitsResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetUnderflow - Get underflow datetime value
-func (client *datetimeOperations) GetUnderflow(ctx context.Context) (*DatetimeGetUnderflowResponse, error) {
+func (client *datetimeOperations) GetUnderflow(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getUnderflowCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -572,19 +572,19 @@ func (client *datetimeOperations) getUnderflowCreateRequest(u url.URL) (*azcore.
 }
 
 // getUnderflowHandleResponse handles the GetUnderflow response.
-func (client *datetimeOperations) getUnderflowHandleResponse(resp *azcore.Response) (*DatetimeGetUnderflowResponse, error) {
+func (client *datetimeOperations) getUnderflowHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
-	result := DatetimeGetUnderflowResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // PutLocalNegativeOffsetMaxDateTime - Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00
-func (client *datetimeOperations) PutLocalNegativeOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time) (*DatetimePutLocalNegativeOffsetMaxDateTimeResponse, error) {
+func (client *datetimeOperations) PutLocalNegativeOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
 	req, err := client.putLocalNegativeOffsetMaxDateTimeCreateRequest(*client.u, datetimeBody)
 	if err != nil {
 		return nil, err
@@ -613,15 +613,15 @@ func (client *datetimeOperations) putLocalNegativeOffsetMaxDateTimeCreateRequest
 }
 
 // putLocalNegativeOffsetMaxDateTimeHandleResponse handles the PutLocalNegativeOffsetMaxDateTime response.
-func (client *datetimeOperations) putLocalNegativeOffsetMaxDateTimeHandleResponse(resp *azcore.Response) (*DatetimePutLocalNegativeOffsetMaxDateTimeResponse, error) {
+func (client *datetimeOperations) putLocalNegativeOffsetMaxDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &DatetimePutLocalNegativeOffsetMaxDateTimeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutLocalNegativeOffsetMinDateTime - Put min datetime value 0001-01-01T00:00:00-14:00
-func (client *datetimeOperations) PutLocalNegativeOffsetMinDateTime(ctx context.Context, datetimeBody time.Time) (*DatetimePutLocalNegativeOffsetMinDateTimeResponse, error) {
+func (client *datetimeOperations) PutLocalNegativeOffsetMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
 	req, err := client.putLocalNegativeOffsetMinDateTimeCreateRequest(*client.u, datetimeBody)
 	if err != nil {
 		return nil, err
@@ -650,15 +650,15 @@ func (client *datetimeOperations) putLocalNegativeOffsetMinDateTimeCreateRequest
 }
 
 // putLocalNegativeOffsetMinDateTimeHandleResponse handles the PutLocalNegativeOffsetMinDateTime response.
-func (client *datetimeOperations) putLocalNegativeOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*DatetimePutLocalNegativeOffsetMinDateTimeResponse, error) {
+func (client *datetimeOperations) putLocalNegativeOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &DatetimePutLocalNegativeOffsetMinDateTimeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutLocalPositiveOffsetMaxDateTime - Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00
-func (client *datetimeOperations) PutLocalPositiveOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time) (*DatetimePutLocalPositiveOffsetMaxDateTimeResponse, error) {
+func (client *datetimeOperations) PutLocalPositiveOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
 	req, err := client.putLocalPositiveOffsetMaxDateTimeCreateRequest(*client.u, datetimeBody)
 	if err != nil {
 		return nil, err
@@ -687,15 +687,15 @@ func (client *datetimeOperations) putLocalPositiveOffsetMaxDateTimeCreateRequest
 }
 
 // putLocalPositiveOffsetMaxDateTimeHandleResponse handles the PutLocalPositiveOffsetMaxDateTime response.
-func (client *datetimeOperations) putLocalPositiveOffsetMaxDateTimeHandleResponse(resp *azcore.Response) (*DatetimePutLocalPositiveOffsetMaxDateTimeResponse, error) {
+func (client *datetimeOperations) putLocalPositiveOffsetMaxDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &DatetimePutLocalPositiveOffsetMaxDateTimeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutLocalPositiveOffsetMinDateTime - Put min datetime value 0001-01-01T00:00:00+14:00
-func (client *datetimeOperations) PutLocalPositiveOffsetMinDateTime(ctx context.Context, datetimeBody time.Time) (*DatetimePutLocalPositiveOffsetMinDateTimeResponse, error) {
+func (client *datetimeOperations) PutLocalPositiveOffsetMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
 	req, err := client.putLocalPositiveOffsetMinDateTimeCreateRequest(*client.u, datetimeBody)
 	if err != nil {
 		return nil, err
@@ -724,15 +724,15 @@ func (client *datetimeOperations) putLocalPositiveOffsetMinDateTimeCreateRequest
 }
 
 // putLocalPositiveOffsetMinDateTimeHandleResponse handles the PutLocalPositiveOffsetMinDateTime response.
-func (client *datetimeOperations) putLocalPositiveOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*DatetimePutLocalPositiveOffsetMinDateTimeResponse, error) {
+func (client *datetimeOperations) putLocalPositiveOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &DatetimePutLocalPositiveOffsetMinDateTimeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutUTCMaxDateTime - Put max datetime value 9999-12-31T23:59:59.999Z
-func (client *datetimeOperations) PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time) (*DatetimePutUTCMaxDateTimeResponse, error) {
+func (client *datetimeOperations) PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
 	req, err := client.putUtcMaxDateTimeCreateRequest(*client.u, datetimeBody)
 	if err != nil {
 		return nil, err
@@ -761,15 +761,15 @@ func (client *datetimeOperations) putUtcMaxDateTimeCreateRequest(u url.URL, date
 }
 
 // putUtcMaxDateTimeHandleResponse handles the PutUTCMaxDateTime response.
-func (client *datetimeOperations) putUtcMaxDateTimeHandleResponse(resp *azcore.Response) (*DatetimePutUTCMaxDateTimeResponse, error) {
+func (client *datetimeOperations) putUtcMaxDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &DatetimePutUTCMaxDateTimeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutUTCMaxDateTime7Digits - Put max datetime value 9999-12-31T23:59:59.9999999Z
-func (client *datetimeOperations) PutUTCMaxDateTime7Digits(ctx context.Context, datetimeBody time.Time) (*DatetimePutUTCMaxDateTime7DigitsResponse, error) {
+func (client *datetimeOperations) PutUTCMaxDateTime7Digits(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
 	req, err := client.putUtcMaxDateTime7DigitsCreateRequest(*client.u, datetimeBody)
 	if err != nil {
 		return nil, err
@@ -798,15 +798,15 @@ func (client *datetimeOperations) putUtcMaxDateTime7DigitsCreateRequest(u url.UR
 }
 
 // putUtcMaxDateTime7DigitsHandleResponse handles the PutUTCMaxDateTime7Digits response.
-func (client *datetimeOperations) putUtcMaxDateTime7DigitsHandleResponse(resp *azcore.Response) (*DatetimePutUTCMaxDateTime7DigitsResponse, error) {
+func (client *datetimeOperations) putUtcMaxDateTime7DigitsHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &DatetimePutUTCMaxDateTime7DigitsResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutUTCMinDateTime - Put min datetime value 0001-01-01T00:00:00Z
-func (client *datetimeOperations) PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time) (*DatetimePutUTCMinDateTimeResponse, error) {
+func (client *datetimeOperations) PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
 	req, err := client.putUtcMinDateTimeCreateRequest(*client.u, datetimeBody)
 	if err != nil {
 		return nil, err
@@ -835,9 +835,9 @@ func (client *datetimeOperations) putUtcMinDateTimeCreateRequest(u url.URL, date
 }
 
 // putUtcMinDateTimeHandleResponse handles the PutUTCMinDateTime response.
-func (client *datetimeOperations) putUtcMinDateTimeHandleResponse(resp *azcore.Response) (*DatetimePutUTCMinDateTimeResponse, error) {
+func (client *datetimeOperations) putUtcMinDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &DatetimePutUTCMinDateTimeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }

--- a/test/autorest/generated/datetimegroup/models.go
+++ b/test/autorest/generated/datetimegroup/models.go
@@ -12,146 +12,6 @@ import (
 	"time"
 )
 
-// DatetimeGetInvalidResponse contains the response from method Datetime.GetInvalid.
-type DatetimeGetInvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeResponse contains the response from method Datetime.GetLocalNegativeOffsetLowercaseMaxDateTime.
-type DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// DatetimeGetLocalNegativeOffsetMinDateTimeResponse contains the response from method Datetime.GetLocalNegativeOffsetMinDateTime.
-type DatetimeGetLocalNegativeOffsetMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeResponse contains the response from method Datetime.GetLocalNegativeOffsetUppercaseMaxDateTime.
-type DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeResponse contains the response from method Datetime.GetLocalPositiveOffsetLowercaseMaxDateTime.
-type DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// DatetimeGetLocalPositiveOffsetMinDateTimeResponse contains the response from method Datetime.GetLocalPositiveOffsetMinDateTime.
-type DatetimeGetLocalPositiveOffsetMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeResponse contains the response from method Datetime.GetLocalPositiveOffsetUppercaseMaxDateTime.
-type DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// DatetimeGetNullResponse contains the response from method Datetime.GetNull.
-type DatetimeGetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// DatetimeGetOverflowResponse contains the response from method Datetime.GetOverflow.
-type DatetimeGetOverflowResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// DatetimeGetUTCLowercaseMaxDateTimeResponse contains the response from method Datetime.GetUTCLowercaseMaxDateTime.
-type DatetimeGetUTCLowercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// DatetimeGetUTCMinDateTimeResponse contains the response from method Datetime.GetUTCMinDateTime.
-type DatetimeGetUTCMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// DatetimeGetUTCUppercaseMaxDateTime7DigitsResponse contains the response from method Datetime.GetUTCUppercaseMaxDateTime7Digits.
-type DatetimeGetUTCUppercaseMaxDateTime7DigitsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// DatetimeGetUTCUppercaseMaxDateTimeResponse contains the response from method Datetime.GetUTCUppercaseMaxDateTime.
-type DatetimeGetUTCUppercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// DatetimeGetUnderflowResponse contains the response from method Datetime.GetUnderflow.
-type DatetimeGetUnderflowResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// DatetimePutLocalNegativeOffsetMaxDateTimeResponse contains the response from method Datetime.PutLocalNegativeOffsetMaxDateTime.
-type DatetimePutLocalNegativeOffsetMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// DatetimePutLocalNegativeOffsetMinDateTimeResponse contains the response from method Datetime.PutLocalNegativeOffsetMinDateTime.
-type DatetimePutLocalNegativeOffsetMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// DatetimePutLocalPositiveOffsetMaxDateTimeResponse contains the response from method Datetime.PutLocalPositiveOffsetMaxDateTime.
-type DatetimePutLocalPositiveOffsetMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// DatetimePutLocalPositiveOffsetMinDateTimeResponse contains the response from method Datetime.PutLocalPositiveOffsetMinDateTime.
-type DatetimePutLocalPositiveOffsetMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// DatetimePutUTCMaxDateTime7DigitsResponse contains the response from method Datetime.PutUTCMaxDateTime7Digits.
-type DatetimePutUTCMaxDateTime7DigitsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// DatetimePutUTCMaxDateTimeResponse contains the response from method Datetime.PutUTCMaxDateTime.
-type DatetimePutUTCMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// DatetimePutUTCMinDateTimeResponse contains the response from method Datetime.PutUTCMinDateTime.
-type DatetimePutUTCMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
@@ -177,4 +37,11 @@ func (e Error) Error() string {
 		msg = "missing error info"
 	}
 	return msg
+}
+
+// TimeResponse is the response envelope for operations that return a time.Time type.
+type TimeResponse struct {
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+	Value       *time.Time
 }

--- a/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
+++ b/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
@@ -17,23 +17,23 @@ import (
 // Datetimerfc1123Operations contains the methods for the Datetimerfc1123 group.
 type Datetimerfc1123Operations interface {
 	// GetInvalid - Get invalid datetime value
-	GetInvalid(ctx context.Context) (*Datetimerfc1123GetInvalidResponse, error)
+	GetInvalid(ctx context.Context) (*TimeResponse, error)
 	// GetNull - Get null datetime value
-	GetNull(ctx context.Context) (*Datetimerfc1123GetNullResponse, error)
+	GetNull(ctx context.Context) (*TimeResponse, error)
 	// GetOverflow - Get overflow datetime value
-	GetOverflow(ctx context.Context) (*Datetimerfc1123GetOverflowResponse, error)
+	GetOverflow(ctx context.Context) (*TimeResponse, error)
 	// GetUTCLowercaseMaxDateTime - Get max datetime value fri, 31 dec 9999 23:59:59 gmt
-	GetUTCLowercaseMaxDateTime(ctx context.Context) (*Datetimerfc1123GetUTCLowercaseMaxDateTimeResponse, error)
+	GetUTCLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
 	// GetUTCMinDateTime - Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT
-	GetUTCMinDateTime(ctx context.Context) (*Datetimerfc1123GetUTCMinDateTimeResponse, error)
+	GetUTCMinDateTime(ctx context.Context) (*TimeResponse, error)
 	// GetUTCUppercaseMaxDateTime - Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT
-	GetUTCUppercaseMaxDateTime(ctx context.Context) (*Datetimerfc1123GetUTCUppercaseMaxDateTimeResponse, error)
+	GetUTCUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
 	// GetUnderflow - Get underflow datetime value
-	GetUnderflow(ctx context.Context) (*Datetimerfc1123GetUnderflowResponse, error)
+	GetUnderflow(ctx context.Context) (*TimeResponse, error)
 	// PutUTCMaxDateTime - Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT
-	PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time) (*Datetimerfc1123PutUTCMaxDateTimeResponse, error)
+	PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
 	// PutUTCMinDateTime - Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT
-	PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time) (*Datetimerfc1123PutUTCMinDateTimeResponse, error)
+	PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
 }
 
 // datetimerfc1123Operations implements the Datetimerfc1123Operations interface.
@@ -42,7 +42,7 @@ type datetimerfc1123Operations struct {
 }
 
 // GetInvalid - Get invalid datetime value
-func (client *datetimerfc1123Operations) GetInvalid(ctx context.Context) (*Datetimerfc1123GetInvalidResponse, error) {
+func (client *datetimerfc1123Operations) GetInvalid(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getInvalidCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -67,19 +67,19 @@ func (client *datetimerfc1123Operations) getInvalidCreateRequest(u url.URL) (*az
 }
 
 // getInvalidHandleResponse handles the GetInvalid response.
-func (client *datetimerfc1123Operations) getInvalidHandleResponse(resp *azcore.Response) (*Datetimerfc1123GetInvalidResponse, error) {
+func (client *datetimerfc1123Operations) getInvalidHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
-	result := Datetimerfc1123GetInvalidResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetNull - Get null datetime value
-func (client *datetimerfc1123Operations) GetNull(ctx context.Context) (*Datetimerfc1123GetNullResponse, error) {
+func (client *datetimerfc1123Operations) GetNull(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getNullCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -104,19 +104,19 @@ func (client *datetimerfc1123Operations) getNullCreateRequest(u url.URL) (*azcor
 }
 
 // getNullHandleResponse handles the GetNull response.
-func (client *datetimerfc1123Operations) getNullHandleResponse(resp *azcore.Response) (*Datetimerfc1123GetNullResponse, error) {
+func (client *datetimerfc1123Operations) getNullHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
-	result := Datetimerfc1123GetNullResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetOverflow - Get overflow datetime value
-func (client *datetimerfc1123Operations) GetOverflow(ctx context.Context) (*Datetimerfc1123GetOverflowResponse, error) {
+func (client *datetimerfc1123Operations) GetOverflow(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getOverflowCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -141,19 +141,19 @@ func (client *datetimerfc1123Operations) getOverflowCreateRequest(u url.URL) (*a
 }
 
 // getOverflowHandleResponse handles the GetOverflow response.
-func (client *datetimerfc1123Operations) getOverflowHandleResponse(resp *azcore.Response) (*Datetimerfc1123GetOverflowResponse, error) {
+func (client *datetimerfc1123Operations) getOverflowHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
-	result := Datetimerfc1123GetOverflowResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetUTCLowercaseMaxDateTime - Get max datetime value fri, 31 dec 9999 23:59:59 gmt
-func (client *datetimerfc1123Operations) GetUTCLowercaseMaxDateTime(ctx context.Context) (*Datetimerfc1123GetUTCLowercaseMaxDateTimeResponse, error) {
+func (client *datetimerfc1123Operations) GetUTCLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getUtcLowercaseMaxDateTimeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -178,19 +178,19 @@ func (client *datetimerfc1123Operations) getUtcLowercaseMaxDateTimeCreateRequest
 }
 
 // getUtcLowercaseMaxDateTimeHandleResponse handles the GetUTCLowercaseMaxDateTime response.
-func (client *datetimerfc1123Operations) getUtcLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*Datetimerfc1123GetUTCLowercaseMaxDateTimeResponse, error) {
+func (client *datetimerfc1123Operations) getUtcLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
-	result := Datetimerfc1123GetUTCLowercaseMaxDateTimeResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetUTCMinDateTime - Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT
-func (client *datetimerfc1123Operations) GetUTCMinDateTime(ctx context.Context) (*Datetimerfc1123GetUTCMinDateTimeResponse, error) {
+func (client *datetimerfc1123Operations) GetUTCMinDateTime(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getUtcMinDateTimeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -215,19 +215,19 @@ func (client *datetimerfc1123Operations) getUtcMinDateTimeCreateRequest(u url.UR
 }
 
 // getUtcMinDateTimeHandleResponse handles the GetUTCMinDateTime response.
-func (client *datetimerfc1123Operations) getUtcMinDateTimeHandleResponse(resp *azcore.Response) (*Datetimerfc1123GetUTCMinDateTimeResponse, error) {
+func (client *datetimerfc1123Operations) getUtcMinDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
-	result := Datetimerfc1123GetUTCMinDateTimeResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetUTCUppercaseMaxDateTime - Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT
-func (client *datetimerfc1123Operations) GetUTCUppercaseMaxDateTime(ctx context.Context) (*Datetimerfc1123GetUTCUppercaseMaxDateTimeResponse, error) {
+func (client *datetimerfc1123Operations) GetUTCUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getUtcUppercaseMaxDateTimeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -252,19 +252,19 @@ func (client *datetimerfc1123Operations) getUtcUppercaseMaxDateTimeCreateRequest
 }
 
 // getUtcUppercaseMaxDateTimeHandleResponse handles the GetUTCUppercaseMaxDateTime response.
-func (client *datetimerfc1123Operations) getUtcUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*Datetimerfc1123GetUTCUppercaseMaxDateTimeResponse, error) {
+func (client *datetimerfc1123Operations) getUtcUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
-	result := Datetimerfc1123GetUTCUppercaseMaxDateTimeResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // GetUnderflow - Get underflow datetime value
-func (client *datetimerfc1123Operations) GetUnderflow(ctx context.Context) (*Datetimerfc1123GetUnderflowResponse, error) {
+func (client *datetimerfc1123Operations) GetUnderflow(ctx context.Context) (*TimeResponse, error) {
 	req, err := client.getUnderflowCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -289,19 +289,19 @@ func (client *datetimerfc1123Operations) getUnderflowCreateRequest(u url.URL) (*
 }
 
 // getUnderflowHandleResponse handles the GetUnderflow response.
-func (client *datetimerfc1123Operations) getUnderflowHandleResponse(resp *azcore.Response) (*Datetimerfc1123GetUnderflowResponse, error) {
+func (client *datetimerfc1123Operations) getUnderflowHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := TimeResponse{RawResponse: resp.Response}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
-	result := Datetimerfc1123GetUnderflowResponse{RawResponse: resp.Response}
 	result.Value = (*time.Time)(aux)
 	return &result, err
 }
 
 // PutUTCMaxDateTime - Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT
-func (client *datetimerfc1123Operations) PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time) (*Datetimerfc1123PutUTCMaxDateTimeResponse, error) {
+func (client *datetimerfc1123Operations) PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
 	req, err := client.putUtcMaxDateTimeCreateRequest(*client.u, datetimeBody)
 	if err != nil {
 		return nil, err
@@ -331,15 +331,15 @@ func (client *datetimerfc1123Operations) putUtcMaxDateTimeCreateRequest(u url.UR
 }
 
 // putUtcMaxDateTimeHandleResponse handles the PutUTCMaxDateTime response.
-func (client *datetimerfc1123Operations) putUtcMaxDateTimeHandleResponse(resp *azcore.Response) (*Datetimerfc1123PutUTCMaxDateTimeResponse, error) {
+func (client *datetimerfc1123Operations) putUtcMaxDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &Datetimerfc1123PutUTCMaxDateTimeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutUTCMinDateTime - Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT
-func (client *datetimerfc1123Operations) PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time) (*Datetimerfc1123PutUTCMinDateTimeResponse, error) {
+func (client *datetimerfc1123Operations) PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
 	req, err := client.putUtcMinDateTimeCreateRequest(*client.u, datetimeBody)
 	if err != nil {
 		return nil, err
@@ -369,9 +369,9 @@ func (client *datetimerfc1123Operations) putUtcMinDateTimeCreateRequest(u url.UR
 }
 
 // putUtcMinDateTimeHandleResponse handles the PutUTCMinDateTime response.
-func (client *datetimerfc1123Operations) putUtcMinDateTimeHandleResponse(resp *azcore.Response) (*Datetimerfc1123PutUTCMinDateTimeResponse, error) {
+func (client *datetimerfc1123Operations) putUtcMinDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &Datetimerfc1123PutUTCMinDateTimeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }

--- a/test/autorest/generated/datetimerfc1123group/models.go
+++ b/test/autorest/generated/datetimerfc1123group/models.go
@@ -12,67 +12,6 @@ import (
 	"time"
 )
 
-// Datetimerfc1123GetInvalidResponse contains the response from method Datetimerfc1123.GetInvalid.
-type Datetimerfc1123GetInvalidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// Datetimerfc1123GetNullResponse contains the response from method Datetimerfc1123.GetNull.
-type Datetimerfc1123GetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// Datetimerfc1123GetOverflowResponse contains the response from method Datetimerfc1123.GetOverflow.
-type Datetimerfc1123GetOverflowResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// Datetimerfc1123GetUTCLowercaseMaxDateTimeResponse contains the response from method Datetimerfc1123.GetUTCLowercaseMaxDateTime.
-type Datetimerfc1123GetUTCLowercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// Datetimerfc1123GetUTCMinDateTimeResponse contains the response from method Datetimerfc1123.GetUTCMinDateTime.
-type Datetimerfc1123GetUTCMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// Datetimerfc1123GetUTCUppercaseMaxDateTimeResponse contains the response from method Datetimerfc1123.GetUTCUppercaseMaxDateTime.
-type Datetimerfc1123GetUTCUppercaseMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// Datetimerfc1123GetUnderflowResponse contains the response from method Datetimerfc1123.GetUnderflow.
-type Datetimerfc1123GetUnderflowResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *time.Time
-}
-
-// Datetimerfc1123PutUTCMaxDateTimeResponse contains the response from method Datetimerfc1123.PutUTCMaxDateTime.
-type Datetimerfc1123PutUTCMaxDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// Datetimerfc1123PutUTCMinDateTimeResponse contains the response from method Datetimerfc1123.PutUTCMinDateTime.
-type Datetimerfc1123PutUTCMinDateTimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
@@ -98,4 +37,11 @@ func (e Error) Error() string {
 		msg = "missing error info"
 	}
 	return msg
+}
+
+// TimeResponse is the response envelope for operations that return a time.Time type.
+type TimeResponse struct {
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+	Value       *time.Time
 }

--- a/test/autorest/generated/filegroup/files.go
+++ b/test/autorest/generated/filegroup/files.go
@@ -16,11 +16,11 @@ import (
 // FilesOperations contains the methods for the Files group.
 type FilesOperations interface {
 	// GetEmptyFile - Get empty file
-	GetEmptyFile(ctx context.Context) (*FilesGetEmptyFileResponse, error)
+	GetEmptyFile(ctx context.Context) (*http.Response, error)
 	// GetFile - Get file
-	GetFile(ctx context.Context) (*FilesGetFileResponse, error)
+	GetFile(ctx context.Context) (*http.Response, error)
 	// GetFileLarge - Get a large file
-	GetFileLarge(ctx context.Context) (*FilesGetFileLargeResponse, error)
+	GetFileLarge(ctx context.Context) (*http.Response, error)
 }
 
 // filesOperations implements the FilesOperations interface.
@@ -29,7 +29,7 @@ type filesOperations struct {
 }
 
 // GetEmptyFile - Get empty file
-func (client *filesOperations) GetEmptyFile(ctx context.Context) (*FilesGetEmptyFileResponse, error) {
+func (client *filesOperations) GetEmptyFile(ctx context.Context) (*http.Response, error) {
 	req, err := client.getEmptyFileCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -55,15 +55,15 @@ func (client *filesOperations) getEmptyFileCreateRequest(u url.URL) (*azcore.Req
 }
 
 // getEmptyFileHandleResponse handles the GetEmptyFile response.
-func (client *filesOperations) getEmptyFileHandleResponse(resp *azcore.Response) (*FilesGetEmptyFileResponse, error) {
+func (client *filesOperations) getEmptyFileHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &FilesGetEmptyFileResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetFile - Get file
-func (client *filesOperations) GetFile(ctx context.Context) (*FilesGetFileResponse, error) {
+func (client *filesOperations) GetFile(ctx context.Context) (*http.Response, error) {
 	req, err := client.getFileCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -89,15 +89,15 @@ func (client *filesOperations) getFileCreateRequest(u url.URL) (*azcore.Request,
 }
 
 // getFileHandleResponse handles the GetFile response.
-func (client *filesOperations) getFileHandleResponse(resp *azcore.Response) (*FilesGetFileResponse, error) {
+func (client *filesOperations) getFileHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &FilesGetFileResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetFileLarge - Get a large file
-func (client *filesOperations) GetFileLarge(ctx context.Context) (*FilesGetFileLargeResponse, error) {
+func (client *filesOperations) GetFileLarge(ctx context.Context) (*http.Response, error) {
 	req, err := client.getFileLargeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -123,9 +123,9 @@ func (client *filesOperations) getFileLargeCreateRequest(u url.URL) (*azcore.Req
 }
 
 // getFileLargeHandleResponse handles the GetFileLarge response.
-func (client *filesOperations) getFileLargeHandleResponse(resp *azcore.Response) (*FilesGetFileLargeResponse, error) {
+func (client *filesOperations) getFileLargeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &FilesGetFileLargeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }

--- a/test/autorest/generated/filegroup/models.go
+++ b/test/autorest/generated/filegroup/models.go
@@ -8,7 +8,6 @@ package filegroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/http"
 )
 
 type Error struct {
@@ -36,22 +35,4 @@ func (e Error) Error() string {
 		msg = "missing error info"
 	}
 	return msg
-}
-
-// FilesGetEmptyFileResponse contains the response from method Files.GetEmptyFile.
-type FilesGetEmptyFileResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// FilesGetFileLargeResponse contains the response from method Files.GetFileLarge.
-type FilesGetFileLargeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// FilesGetFileResponse contains the response from method Files.GetFile.
-type FilesGetFileResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/autorest/generated/headergroup/header.go
+++ b/test/autorest/generated/headergroup/header.go
@@ -19,35 +19,35 @@ import (
 // HeaderOperations contains the methods for the Header group.
 type HeaderOperations interface {
 	// CustomRequestID - Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
-	CustomRequestID(ctx context.Context) (*HeaderCustomRequestIDResponse, error)
+	CustomRequestID(ctx context.Context) (*http.Response, error)
 	// ParamBool - Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false
-	ParamBool(ctx context.Context, scenario string, value bool) (*HeaderParamBoolResponse, error)
+	ParamBool(ctx context.Context, scenario string, value bool) (*http.Response, error)
 	// ParamByte - Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩"
-	ParamByte(ctx context.Context, scenario string, value []byte) (*HeaderParamByteResponse, error)
+	ParamByte(ctx context.Context, scenario string, value []byte) (*http.Response, error)
 	// ParamDate - Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01"
-	ParamDate(ctx context.Context, scenario string, value time.Time) (*HeaderParamDateResponse, error)
+	ParamDate(ctx context.Context, scenario string, value time.Time) (*http.Response, error)
 	// ParamDatetime - Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z"
-	ParamDatetime(ctx context.Context, scenario string, value time.Time) (*HeaderParamDatetimeResponse, error)
+	ParamDatetime(ctx context.Context, scenario string, value time.Time) (*http.Response, error)
 	// ParamDatetimeRFC1123 - Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT"
-	ParamDatetimeRFC1123(ctx context.Context, scenario string, options *HeaderParamDatetimeRFC1123Options) (*HeaderParamDatetimeRFC1123Response, error)
+	ParamDatetimeRFC1123(ctx context.Context, scenario string, options *HeaderParamDatetimeRFC1123Options) (*http.Response, error)
 	// ParamDouble - Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0
-	ParamDouble(ctx context.Context, scenario string, value float64) (*HeaderParamDoubleResponse, error)
+	ParamDouble(ctx context.Context, scenario string, value float64) (*http.Response, error)
 	// ParamDuration - Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S"
-	ParamDuration(ctx context.Context, scenario string, value time.Duration) (*HeaderParamDurationResponse, error)
+	ParamDuration(ctx context.Context, scenario string, value time.Duration) (*http.Response, error)
 	// ParamEnum - Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null
-	ParamEnum(ctx context.Context, scenario string, options *HeaderParamEnumOptions) (*HeaderParamEnumResponse, error)
+	ParamEnum(ctx context.Context, scenario string, options *HeaderParamEnumOptions) (*http.Response, error)
 	// ParamExistingKey - Send a post request with header value "User-Agent": "overwrite"
-	ParamExistingKey(ctx context.Context, userAgent string) (*HeaderParamExistingKeyResponse, error)
+	ParamExistingKey(ctx context.Context, userAgent string) (*http.Response, error)
 	// ParamFloat - Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0
-	ParamFloat(ctx context.Context, scenario string, value float32) (*HeaderParamFloatResponse, error)
+	ParamFloat(ctx context.Context, scenario string, value float32) (*http.Response, error)
 	// ParamInteger - Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2
-	ParamInteger(ctx context.Context, scenario string, value int32) (*HeaderParamIntegerResponse, error)
+	ParamInteger(ctx context.Context, scenario string, value int32) (*http.Response, error)
 	// ParamLong - Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2
-	ParamLong(ctx context.Context, scenario string, value int64) (*HeaderParamLongResponse, error)
+	ParamLong(ctx context.Context, scenario string, value int64) (*http.Response, error)
 	// ParamProtectedKey - Send a post request with header value "Content-Type": "text/html"
-	ParamProtectedKey(ctx context.Context, contentType string) (*HeaderParamProtectedKeyResponse, error)
+	ParamProtectedKey(ctx context.Context, contentType string) (*http.Response, error)
 	// ParamString - Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": ""
-	ParamString(ctx context.Context, scenario string, options *HeaderParamStringOptions) (*HeaderParamStringResponse, error)
+	ParamString(ctx context.Context, scenario string, options *HeaderParamStringOptions) (*http.Response, error)
 	// ResponseBool - Get a response with header value "value": true or false
 	ResponseBool(ctx context.Context, scenario string) (*HeaderResponseBoolResponse, error)
 	// ResponseByte - Get a response with header values "啊齄丂狛狜隣郎隣兀﨩"
@@ -84,7 +84,7 @@ type headerOperations struct {
 }
 
 // CustomRequestID - Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
-func (client *headerOperations) CustomRequestID(ctx context.Context) (*HeaderCustomRequestIDResponse, error) {
+func (client *headerOperations) CustomRequestID(ctx context.Context) (*http.Response, error) {
 	req, err := client.customRequestIdCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -109,15 +109,15 @@ func (client *headerOperations) customRequestIdCreateRequest(u url.URL) (*azcore
 }
 
 // customRequestIdHandleResponse handles the CustomRequestID response.
-func (client *headerOperations) customRequestIdHandleResponse(resp *azcore.Response) (*HeaderCustomRequestIDResponse, error) {
+func (client *headerOperations) customRequestIdHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &HeaderCustomRequestIDResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ParamBool - Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false
-func (client *headerOperations) ParamBool(ctx context.Context, scenario string, value bool) (*HeaderParamBoolResponse, error) {
+func (client *headerOperations) ParamBool(ctx context.Context, scenario string, value bool) (*http.Response, error) {
 	req, err := client.paramBoolCreateRequest(*client.u, scenario, value)
 	if err != nil {
 		return nil, err
@@ -144,15 +144,15 @@ func (client *headerOperations) paramBoolCreateRequest(u url.URL, scenario strin
 }
 
 // paramBoolHandleResponse handles the ParamBool response.
-func (client *headerOperations) paramBoolHandleResponse(resp *azcore.Response) (*HeaderParamBoolResponse, error) {
+func (client *headerOperations) paramBoolHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &HeaderParamBoolResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ParamByte - Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩"
-func (client *headerOperations) ParamByte(ctx context.Context, scenario string, value []byte) (*HeaderParamByteResponse, error) {
+func (client *headerOperations) ParamByte(ctx context.Context, scenario string, value []byte) (*http.Response, error) {
 	req, err := client.paramByteCreateRequest(*client.u, scenario, value)
 	if err != nil {
 		return nil, err
@@ -179,15 +179,15 @@ func (client *headerOperations) paramByteCreateRequest(u url.URL, scenario strin
 }
 
 // paramByteHandleResponse handles the ParamByte response.
-func (client *headerOperations) paramByteHandleResponse(resp *azcore.Response) (*HeaderParamByteResponse, error) {
+func (client *headerOperations) paramByteHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &HeaderParamByteResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ParamDate - Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01"
-func (client *headerOperations) ParamDate(ctx context.Context, scenario string, value time.Time) (*HeaderParamDateResponse, error) {
+func (client *headerOperations) ParamDate(ctx context.Context, scenario string, value time.Time) (*http.Response, error) {
 	req, err := client.paramDateCreateRequest(*client.u, scenario, value)
 	if err != nil {
 		return nil, err
@@ -214,15 +214,15 @@ func (client *headerOperations) paramDateCreateRequest(u url.URL, scenario strin
 }
 
 // paramDateHandleResponse handles the ParamDate response.
-func (client *headerOperations) paramDateHandleResponse(resp *azcore.Response) (*HeaderParamDateResponse, error) {
+func (client *headerOperations) paramDateHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &HeaderParamDateResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ParamDatetime - Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z"
-func (client *headerOperations) ParamDatetime(ctx context.Context, scenario string, value time.Time) (*HeaderParamDatetimeResponse, error) {
+func (client *headerOperations) ParamDatetime(ctx context.Context, scenario string, value time.Time) (*http.Response, error) {
 	req, err := client.paramDatetimeCreateRequest(*client.u, scenario, value)
 	if err != nil {
 		return nil, err
@@ -249,15 +249,15 @@ func (client *headerOperations) paramDatetimeCreateRequest(u url.URL, scenario s
 }
 
 // paramDatetimeHandleResponse handles the ParamDatetime response.
-func (client *headerOperations) paramDatetimeHandleResponse(resp *azcore.Response) (*HeaderParamDatetimeResponse, error) {
+func (client *headerOperations) paramDatetimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &HeaderParamDatetimeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ParamDatetimeRFC1123 - Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT"
-func (client *headerOperations) ParamDatetimeRFC1123(ctx context.Context, scenario string, options *HeaderParamDatetimeRFC1123Options) (*HeaderParamDatetimeRFC1123Response, error) {
+func (client *headerOperations) ParamDatetimeRFC1123(ctx context.Context, scenario string, options *HeaderParamDatetimeRFC1123Options) (*http.Response, error) {
 	req, err := client.paramDatetimeRfc1123CreateRequest(*client.u, scenario, options)
 	if err != nil {
 		return nil, err
@@ -286,15 +286,15 @@ func (client *headerOperations) paramDatetimeRfc1123CreateRequest(u url.URL, sce
 }
 
 // paramDatetimeRfc1123HandleResponse handles the ParamDatetimeRFC1123 response.
-func (client *headerOperations) paramDatetimeRfc1123HandleResponse(resp *azcore.Response) (*HeaderParamDatetimeRFC1123Response, error) {
+func (client *headerOperations) paramDatetimeRfc1123HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &HeaderParamDatetimeRFC1123Response{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ParamDouble - Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0
-func (client *headerOperations) ParamDouble(ctx context.Context, scenario string, value float64) (*HeaderParamDoubleResponse, error) {
+func (client *headerOperations) ParamDouble(ctx context.Context, scenario string, value float64) (*http.Response, error) {
 	req, err := client.paramDoubleCreateRequest(*client.u, scenario, value)
 	if err != nil {
 		return nil, err
@@ -321,15 +321,15 @@ func (client *headerOperations) paramDoubleCreateRequest(u url.URL, scenario str
 }
 
 // paramDoubleHandleResponse handles the ParamDouble response.
-func (client *headerOperations) paramDoubleHandleResponse(resp *azcore.Response) (*HeaderParamDoubleResponse, error) {
+func (client *headerOperations) paramDoubleHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &HeaderParamDoubleResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ParamDuration - Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S"
-func (client *headerOperations) ParamDuration(ctx context.Context, scenario string, value time.Duration) (*HeaderParamDurationResponse, error) {
+func (client *headerOperations) ParamDuration(ctx context.Context, scenario string, value time.Duration) (*http.Response, error) {
 	req, err := client.paramDurationCreateRequest(*client.u, scenario, value)
 	if err != nil {
 		return nil, err
@@ -356,15 +356,15 @@ func (client *headerOperations) paramDurationCreateRequest(u url.URL, scenario s
 }
 
 // paramDurationHandleResponse handles the ParamDuration response.
-func (client *headerOperations) paramDurationHandleResponse(resp *azcore.Response) (*HeaderParamDurationResponse, error) {
+func (client *headerOperations) paramDurationHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &HeaderParamDurationResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ParamEnum - Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null
-func (client *headerOperations) ParamEnum(ctx context.Context, scenario string, options *HeaderParamEnumOptions) (*HeaderParamEnumResponse, error) {
+func (client *headerOperations) ParamEnum(ctx context.Context, scenario string, options *HeaderParamEnumOptions) (*http.Response, error) {
 	req, err := client.paramEnumCreateRequest(*client.u, scenario, options)
 	if err != nil {
 		return nil, err
@@ -393,15 +393,15 @@ func (client *headerOperations) paramEnumCreateRequest(u url.URL, scenario strin
 }
 
 // paramEnumHandleResponse handles the ParamEnum response.
-func (client *headerOperations) paramEnumHandleResponse(resp *azcore.Response) (*HeaderParamEnumResponse, error) {
+func (client *headerOperations) paramEnumHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &HeaderParamEnumResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ParamExistingKey - Send a post request with header value "User-Agent": "overwrite"
-func (client *headerOperations) ParamExistingKey(ctx context.Context, userAgent string) (*HeaderParamExistingKeyResponse, error) {
+func (client *headerOperations) ParamExistingKey(ctx context.Context, userAgent string) (*http.Response, error) {
 	req, err := client.paramExistingKeyCreateRequest(*client.u, userAgent)
 	if err != nil {
 		return nil, err
@@ -427,15 +427,15 @@ func (client *headerOperations) paramExistingKeyCreateRequest(u url.URL, userAge
 }
 
 // paramExistingKeyHandleResponse handles the ParamExistingKey response.
-func (client *headerOperations) paramExistingKeyHandleResponse(resp *azcore.Response) (*HeaderParamExistingKeyResponse, error) {
+func (client *headerOperations) paramExistingKeyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &HeaderParamExistingKeyResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ParamFloat - Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0
-func (client *headerOperations) ParamFloat(ctx context.Context, scenario string, value float32) (*HeaderParamFloatResponse, error) {
+func (client *headerOperations) ParamFloat(ctx context.Context, scenario string, value float32) (*http.Response, error) {
 	req, err := client.paramFloatCreateRequest(*client.u, scenario, value)
 	if err != nil {
 		return nil, err
@@ -462,15 +462,15 @@ func (client *headerOperations) paramFloatCreateRequest(u url.URL, scenario stri
 }
 
 // paramFloatHandleResponse handles the ParamFloat response.
-func (client *headerOperations) paramFloatHandleResponse(resp *azcore.Response) (*HeaderParamFloatResponse, error) {
+func (client *headerOperations) paramFloatHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &HeaderParamFloatResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ParamInteger - Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2
-func (client *headerOperations) ParamInteger(ctx context.Context, scenario string, value int32) (*HeaderParamIntegerResponse, error) {
+func (client *headerOperations) ParamInteger(ctx context.Context, scenario string, value int32) (*http.Response, error) {
 	req, err := client.paramIntegerCreateRequest(*client.u, scenario, value)
 	if err != nil {
 		return nil, err
@@ -497,15 +497,15 @@ func (client *headerOperations) paramIntegerCreateRequest(u url.URL, scenario st
 }
 
 // paramIntegerHandleResponse handles the ParamInteger response.
-func (client *headerOperations) paramIntegerHandleResponse(resp *azcore.Response) (*HeaderParamIntegerResponse, error) {
+func (client *headerOperations) paramIntegerHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &HeaderParamIntegerResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ParamLong - Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2
-func (client *headerOperations) ParamLong(ctx context.Context, scenario string, value int64) (*HeaderParamLongResponse, error) {
+func (client *headerOperations) ParamLong(ctx context.Context, scenario string, value int64) (*http.Response, error) {
 	req, err := client.paramLongCreateRequest(*client.u, scenario, value)
 	if err != nil {
 		return nil, err
@@ -532,15 +532,15 @@ func (client *headerOperations) paramLongCreateRequest(u url.URL, scenario strin
 }
 
 // paramLongHandleResponse handles the ParamLong response.
-func (client *headerOperations) paramLongHandleResponse(resp *azcore.Response) (*HeaderParamLongResponse, error) {
+func (client *headerOperations) paramLongHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &HeaderParamLongResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ParamProtectedKey - Send a post request with header value "Content-Type": "text/html"
-func (client *headerOperations) ParamProtectedKey(ctx context.Context, contentType string) (*HeaderParamProtectedKeyResponse, error) {
+func (client *headerOperations) ParamProtectedKey(ctx context.Context, contentType string) (*http.Response, error) {
 	req, err := client.paramProtectedKeyCreateRequest(*client.u, contentType)
 	if err != nil {
 		return nil, err
@@ -566,15 +566,15 @@ func (client *headerOperations) paramProtectedKeyCreateRequest(u url.URL, conten
 }
 
 // paramProtectedKeyHandleResponse handles the ParamProtectedKey response.
-func (client *headerOperations) paramProtectedKeyHandleResponse(resp *azcore.Response) (*HeaderParamProtectedKeyResponse, error) {
+func (client *headerOperations) paramProtectedKeyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &HeaderParamProtectedKeyResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ParamString - Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": ""
-func (client *headerOperations) ParamString(ctx context.Context, scenario string, options *HeaderParamStringOptions) (*HeaderParamStringResponse, error) {
+func (client *headerOperations) ParamString(ctx context.Context, scenario string, options *HeaderParamStringOptions) (*http.Response, error) {
 	req, err := client.paramStringCreateRequest(*client.u, scenario, options)
 	if err != nil {
 		return nil, err
@@ -603,11 +603,11 @@ func (client *headerOperations) paramStringCreateRequest(u url.URL, scenario str
 }
 
 // paramStringHandleResponse handles the ParamString response.
-func (client *headerOperations) paramStringHandleResponse(resp *azcore.Response) (*HeaderParamStringResponse, error) {
+func (client *headerOperations) paramStringHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &HeaderParamStringResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ResponseBool - Get a response with header value "value": true or false
@@ -641,11 +641,13 @@ func (client *headerOperations) responseBoolHandleResponse(resp *azcore.Response
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := HeaderResponseBoolResponse{RawResponse: resp.Response}
 	value, err := strconv.ParseBool(resp.Header.Get("value"))
 	if err != nil {
 		return nil, err
 	}
-	return &HeaderResponseBoolResponse{RawResponse: resp.Response, Value: &value}, nil
+	result.Value = &value
+	return &result, nil
 }
 
 // ResponseByte - Get a response with header values "啊齄丂狛狜隣郎隣兀﨩"
@@ -679,11 +681,13 @@ func (client *headerOperations) responseByteHandleResponse(resp *azcore.Response
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := HeaderResponseByteResponse{RawResponse: resp.Response}
 	value, err := base64.StdEncoding.DecodeString(resp.Header.Get("value"))
 	if err != nil {
 		return nil, err
 	}
-	return &HeaderResponseByteResponse{RawResponse: resp.Response, Value: &value}, nil
+	result.Value = &value
+	return &result, nil
 }
 
 // ResponseDate - Get a response with header values "2010-01-01" or "0001-01-01"
@@ -717,11 +721,13 @@ func (client *headerOperations) responseDateHandleResponse(resp *azcore.Response
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := HeaderResponseDateResponse{RawResponse: resp.Response}
 	value, err := time.Parse("2006-01-02", resp.Header.Get("value"))
 	if err != nil {
 		return nil, err
 	}
-	return &HeaderResponseDateResponse{RawResponse: resp.Response, Value: &value}, nil
+	result.Value = &value
+	return &result, nil
 }
 
 // ResponseDatetime - Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
@@ -755,11 +761,13 @@ func (client *headerOperations) responseDatetimeHandleResponse(resp *azcore.Resp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := HeaderResponseDatetimeResponse{RawResponse: resp.Response}
 	value, err := time.Parse(time.RFC3339, resp.Header.Get("value"))
 	if err != nil {
 		return nil, err
 	}
-	return &HeaderResponseDatetimeResponse{RawResponse: resp.Response, Value: &value}, nil
+	result.Value = &value
+	return &result, nil
 }
 
 // ResponseDatetimeRFC1123 - Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
@@ -793,11 +801,13 @@ func (client *headerOperations) responseDatetimeRfc1123HandleResponse(resp *azco
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := HeaderResponseDatetimeRFC1123Response{RawResponse: resp.Response}
 	value, err := time.Parse(time.RFC1123, resp.Header.Get("value"))
 	if err != nil {
 		return nil, err
 	}
-	return &HeaderResponseDatetimeRFC1123Response{RawResponse: resp.Response, Value: &value}, nil
+	result.Value = &value
+	return &result, nil
 }
 
 // ResponseDouble - Get a response with header value "value": 7e120 or -3.0
@@ -831,11 +841,13 @@ func (client *headerOperations) responseDoubleHandleResponse(resp *azcore.Respon
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := HeaderResponseDoubleResponse{RawResponse: resp.Response}
 	value, err := strconv.ParseFloat(resp.Header.Get("value"), 64)
 	if err != nil {
 		return nil, err
 	}
-	return &HeaderResponseDoubleResponse{RawResponse: resp.Response, Value: &value}, nil
+	result.Value = &value
+	return &result, nil
 }
 
 // ResponseDuration - Get a response with header values "P123DT22H14M12.011S"
@@ -869,11 +881,13 @@ func (client *headerOperations) responseDurationHandleResponse(resp *azcore.Resp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := HeaderResponseDurationResponse{RawResponse: resp.Response}
 	value, err := time.ParseDuration(resp.Header.Get("value"))
 	if err != nil {
 		return nil, err
 	}
-	return &HeaderResponseDurationResponse{RawResponse: resp.Response, Value: &value}, nil
+	result.Value = &value
+	return &result, nil
 }
 
 // ResponseEnum - Get a response with header values "GREY" or null
@@ -907,8 +921,10 @@ func (client *headerOperations) responseEnumHandleResponse(resp *azcore.Response
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := HeaderResponseEnumResponse{RawResponse: resp.Response}
 	value := GreyscaleColors(resp.Header.Get("value"))
-	return &HeaderResponseEnumResponse{RawResponse: resp.Response, Value: &value}, nil
+	result.Value = &value
+	return &result, nil
 }
 
 // ResponseExistingKey - Get a response with header value "User-Agent": "overwrite"
@@ -941,8 +957,10 @@ func (client *headerOperations) responseExistingKeyHandleResponse(resp *azcore.R
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := HeaderResponseExistingKeyResponse{RawResponse: resp.Response}
 	userAgent := resp.Header.Get("User-Agent")
-	return &HeaderResponseExistingKeyResponse{RawResponse: resp.Response, UserAgent: &userAgent}, nil
+	result.UserAgent = &userAgent
+	return &result, nil
 }
 
 // ResponseFloat - Get a response with header value "value": 0.07 or -3.0
@@ -976,12 +994,14 @@ func (client *headerOperations) responseFloatHandleResponse(resp *azcore.Respons
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := HeaderResponseFloatResponse{RawResponse: resp.Response}
 	value32, err := strconv.ParseFloat(resp.Header.Get("value"), 32)
 	value := float32(value32)
 	if err != nil {
 		return nil, err
 	}
-	return &HeaderResponseFloatResponse{RawResponse: resp.Response, Value: &value}, nil
+	result.Value = &value
+	return &result, nil
 }
 
 // ResponseInteger - Get a response with header value "value": 1 or -2
@@ -1015,12 +1035,14 @@ func (client *headerOperations) responseIntegerHandleResponse(resp *azcore.Respo
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := HeaderResponseIntegerResponse{RawResponse: resp.Response}
 	value32, err := strconv.ParseInt(resp.Header.Get("value"), 10, 32)
 	value := int32(value32)
 	if err != nil {
 		return nil, err
 	}
-	return &HeaderResponseIntegerResponse{RawResponse: resp.Response, Value: &value}, nil
+	result.Value = &value
+	return &result, nil
 }
 
 // ResponseLong - Get a response with header value "value": 105 or -2
@@ -1054,11 +1076,13 @@ func (client *headerOperations) responseLongHandleResponse(resp *azcore.Response
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := HeaderResponseLongResponse{RawResponse: resp.Response}
 	value, err := strconv.ParseInt(resp.Header.Get("value"), 10, 64)
 	if err != nil {
 		return nil, err
 	}
-	return &HeaderResponseLongResponse{RawResponse: resp.Response, Value: &value}, nil
+	result.Value = &value
+	return &result, nil
 }
 
 // ResponseProtectedKey - Get a response with header value "Content-Type": "text/html"
@@ -1091,8 +1115,10 @@ func (client *headerOperations) responseProtectedKeyHandleResponse(resp *azcore.
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := HeaderResponseProtectedKeyResponse{RawResponse: resp.Response}
 	contentType := resp.Header.Get("Content-Type")
-	return &HeaderResponseProtectedKeyResponse{RawResponse: resp.Response, ContentType: &contentType}, nil
+	result.ContentType = &contentType
+	return &result, nil
 }
 
 // ResponseString - Get a response with header values "The quick brown fox jumps over the lazy dog" or null or ""
@@ -1126,6 +1152,8 @@ func (client *headerOperations) responseStringHandleResponse(resp *azcore.Respon
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
+	result := HeaderResponseStringResponse{RawResponse: resp.Response}
 	value := resp.Header.Get("value")
-	return &HeaderResponseStringResponse{RawResponse: resp.Response, Value: &value}, nil
+	result.Value = &value
+	return &result, nil
 }

--- a/test/autorest/generated/headergroup/models.go
+++ b/test/autorest/generated/headergroup/models.go
@@ -39,58 +39,10 @@ func (e Error) Error() string {
 	return msg
 }
 
-// HeaderCustomRequestIDResponse contains the response from method Header.CustomRequestID.
-type HeaderCustomRequestIDResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HeaderParamBoolResponse contains the response from method Header.ParamBool.
-type HeaderParamBoolResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HeaderParamByteResponse contains the response from method Header.ParamByte.
-type HeaderParamByteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HeaderParamDateResponse contains the response from method Header.ParamDate.
-type HeaderParamDateResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // HeaderParamDatetimeRFC1123Options contains the optional parameters for the Header.ParamDatetimeRFC1123 method.
 type HeaderParamDatetimeRFC1123Options struct {
 	// Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
 	Value *time.Time
-}
-
-// HeaderParamDatetimeRFC1123Response contains the response from method Header.ParamDatetimeRFC1123.
-type HeaderParamDatetimeRFC1123Response struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HeaderParamDatetimeResponse contains the response from method Header.ParamDatetime.
-type HeaderParamDatetimeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HeaderParamDoubleResponse contains the response from method Header.ParamDouble.
-type HeaderParamDoubleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HeaderParamDurationResponse contains the response from method Header.ParamDuration.
-type HeaderParamDurationResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // HeaderParamEnumOptions contains the optional parameters for the Header.ParamEnum method.
@@ -99,52 +51,10 @@ type HeaderParamEnumOptions struct {
 	Value *GreyscaleColors
 }
 
-// HeaderParamEnumResponse contains the response from method Header.ParamEnum.
-type HeaderParamEnumResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HeaderParamExistingKeyResponse contains the response from method Header.ParamExistingKey.
-type HeaderParamExistingKeyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HeaderParamFloatResponse contains the response from method Header.ParamFloat.
-type HeaderParamFloatResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HeaderParamIntegerResponse contains the response from method Header.ParamInteger.
-type HeaderParamIntegerResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HeaderParamLongResponse contains the response from method Header.ParamLong.
-type HeaderParamLongResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HeaderParamProtectedKeyResponse contains the response from method Header.ParamProtectedKey.
-type HeaderParamProtectedKeyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // HeaderParamStringOptions contains the optional parameters for the Header.ParamString method.
 type HeaderParamStringOptions struct {
 	// Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
 	Value *string
-}
-
-// HeaderParamStringResponse contains the response from method Header.ParamString.
-type HeaderParamStringResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // HeaderResponseBoolResponse contains the response from method Header.ResponseBool.
@@ -152,7 +62,7 @@ type HeaderResponseBoolResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
-	// Value contains the information returned from the Value header response.
+	// Value contains the information returned from the value header response.
 	Value *bool
 }
 
@@ -161,7 +71,7 @@ type HeaderResponseByteResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
-	// Value contains the information returned from the Value header response.
+	// Value contains the information returned from the value header response.
 	Value *[]byte
 }
 
@@ -170,7 +80,7 @@ type HeaderResponseDateResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
-	// Value contains the information returned from the Value header response.
+	// Value contains the information returned from the value header response.
 	Value *time.Time
 }
 
@@ -179,7 +89,7 @@ type HeaderResponseDatetimeRFC1123Response struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
-	// Value contains the information returned from the Value header response.
+	// Value contains the information returned from the value header response.
 	Value *time.Time
 }
 
@@ -188,7 +98,7 @@ type HeaderResponseDatetimeResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
-	// Value contains the information returned from the Value header response.
+	// Value contains the information returned from the value header response.
 	Value *time.Time
 }
 
@@ -197,7 +107,7 @@ type HeaderResponseDoubleResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
-	// Value contains the information returned from the Value header response.
+	// Value contains the information returned from the value header response.
 	Value *float64
 }
 
@@ -206,7 +116,7 @@ type HeaderResponseDurationResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
-	// Value contains the information returned from the Value header response.
+	// Value contains the information returned from the value header response.
 	Value *time.Duration
 }
 
@@ -215,7 +125,7 @@ type HeaderResponseEnumResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
-	// Value contains the information returned from the Value header response.
+	// Value contains the information returned from the value header response.
 	Value *GreyscaleColors
 }
 
@@ -224,7 +134,7 @@ type HeaderResponseExistingKeyResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
-	// UserAgent contains the information returned from the UserAgent header response.
+	// UserAgent contains the information returned from the User-Agent header response.
 	UserAgent *string
 }
 
@@ -233,7 +143,7 @@ type HeaderResponseFloatResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
-	// Value contains the information returned from the Value header response.
+	// Value contains the information returned from the value header response.
 	Value *float32
 }
 
@@ -242,7 +152,7 @@ type HeaderResponseIntegerResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
-	// Value contains the information returned from the Value header response.
+	// Value contains the information returned from the value header response.
 	Value *int32
 }
 
@@ -251,13 +161,13 @@ type HeaderResponseLongResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
-	// Value contains the information returned from the Value header response.
+	// Value contains the information returned from the value header response.
 	Value *int64
 }
 
 // HeaderResponseProtectedKeyResponse contains the response from method Header.ResponseProtectedKey.
 type HeaderResponseProtectedKeyResponse struct {
-	// ContentType contains the information returned from the ContentType header response.
+	// ContentType contains the information returned from the Content-Type header response.
 	ContentType *string
 
 	// RawResponse contains the underlying HTTP response.
@@ -269,6 +179,6 @@ type HeaderResponseStringResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
-	// Value contains the information returned from the Value header response.
+	// Value contains the information returned from the value header response.
 	Value *string
 }

--- a/test/autorest/generated/morecustombaseurigroup/models.go
+++ b/test/autorest/generated/morecustombaseurigroup/models.go
@@ -8,7 +8,6 @@ package morecustombaseurigroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/http"
 )
 
 type Error struct {
@@ -42,10 +41,4 @@ func (e Error) Error() string {
 type PathsGetEmptyOptions struct {
 	// The key version. Default value 'v1'.
 	KeyVersion *string
-}
-
-// PathsGetEmptyResponse contains the response from method Paths.GetEmpty.
-type PathsGetEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/autorest/generated/morecustombaseurigroup/paths.go
+++ b/test/autorest/generated/morecustombaseurigroup/paths.go
@@ -17,7 +17,7 @@ import (
 // PathsOperations contains the methods for the Paths group.
 type PathsOperations interface {
 	// GetEmpty - Get a 200 to test a valid base uri
-	GetEmpty(ctx context.Context, vault string, secret string, keyName string, options *PathsGetEmptyOptions) (*PathsGetEmptyResponse, error)
+	GetEmpty(ctx context.Context, vault string, secret string, keyName string, options *PathsGetEmptyOptions) (*http.Response, error)
 }
 
 // pathsOperations implements the PathsOperations interface.
@@ -28,7 +28,7 @@ type pathsOperations struct {
 }
 
 // GetEmpty - Get a 200 to test a valid base uri
-func (client *pathsOperations) GetEmpty(ctx context.Context, vault string, secret string, keyName string, options *PathsGetEmptyOptions) (*PathsGetEmptyResponse, error) {
+func (client *pathsOperations) GetEmpty(ctx context.Context, vault string, secret string, keyName string, options *PathsGetEmptyOptions) (*http.Response, error) {
 	req, err := client.getEmptyCreateRequest(*client.u, vault, secret, client.dnsSuffix, keyName, client.subscriptionID, options)
 	if err != nil {
 		return nil, err
@@ -60,9 +60,9 @@ func (client *pathsOperations) getEmptyCreateRequest(u url.URL, vault string, se
 }
 
 // getEmptyHandleResponse handles the GetEmpty response.
-func (client *pathsOperations) getEmptyHandleResponse(resp *azcore.Response) (*PathsGetEmptyResponse, error) {
+func (client *pathsOperations) getEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsGetEmptyResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }

--- a/test/autorest/generated/numbergroup/models.go
+++ b/test/autorest/generated/numbergroup/models.go
@@ -38,160 +38,16 @@ func (e Error) Error() string {
 	return msg
 }
 
-// NumberGetBigDecimalNegativeDecimalResponse contains the response from method Number.GetBigDecimalNegativeDecimal.
-type NumberGetBigDecimalNegativeDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
-}
-
-// NumberGetBigDecimalPositiveDecimalResponse contains the response from method Number.GetBigDecimalPositiveDecimal.
-type NumberGetBigDecimalPositiveDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
-}
-
-// NumberGetBigDecimalResponse contains the response from method Number.GetBigDecimal.
-type NumberGetBigDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
-}
-
-// NumberGetBigDoubleNegativeDecimalResponse contains the response from method Number.GetBigDoubleNegativeDecimal.
-type NumberGetBigDoubleNegativeDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
-}
-
-// NumberGetBigDoublePositiveDecimalResponse contains the response from method Number.GetBigDoublePositiveDecimal.
-type NumberGetBigDoublePositiveDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
-}
-
-// NumberGetBigDoubleResponse contains the response from method Number.GetBigDouble.
-type NumberGetBigDoubleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
-}
-
-// NumberGetBigFloatResponse contains the response from method Number.GetBigFloat.
-type NumberGetBigFloatResponse struct {
+// Float32Response is the response envelope for operations that return a float32 type.
+type Float32Response struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 	Value       *float32
 }
 
-// NumberGetInvalidDecimalResponse contains the response from method Number.GetInvalidDecimal.
-type NumberGetInvalidDecimalResponse struct {
+// Float64Response is the response envelope for operations that return a float64 type.
+type Float64Response struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 	Value       *float64
-}
-
-// NumberGetInvalidDoubleResponse contains the response from method Number.GetInvalidDouble.
-type NumberGetInvalidDoubleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
-}
-
-// NumberGetInvalidFloatResponse contains the response from method Number.GetInvalidFloat.
-type NumberGetInvalidFloatResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float32
-}
-
-// NumberGetNullResponse contains the response from method Number.GetNull.
-type NumberGetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float32
-}
-
-// NumberGetSmallDecimalResponse contains the response from method Number.GetSmallDecimal.
-type NumberGetSmallDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
-}
-
-// NumberGetSmallDoubleResponse contains the response from method Number.GetSmallDouble.
-type NumberGetSmallDoubleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
-}
-
-// NumberGetSmallFloatResponse contains the response from method Number.GetSmallFloat.
-type NumberGetSmallFloatResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *float64
-}
-
-// NumberPutBigDecimalNegativeDecimalResponse contains the response from method Number.PutBigDecimalNegativeDecimal.
-type NumberPutBigDecimalNegativeDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// NumberPutBigDecimalPositiveDecimalResponse contains the response from method Number.PutBigDecimalPositiveDecimal.
-type NumberPutBigDecimalPositiveDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// NumberPutBigDecimalResponse contains the response from method Number.PutBigDecimal.
-type NumberPutBigDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// NumberPutBigDoubleNegativeDecimalResponse contains the response from method Number.PutBigDoubleNegativeDecimal.
-type NumberPutBigDoubleNegativeDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// NumberPutBigDoublePositiveDecimalResponse contains the response from method Number.PutBigDoublePositiveDecimal.
-type NumberPutBigDoublePositiveDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// NumberPutBigDoubleResponse contains the response from method Number.PutBigDouble.
-type NumberPutBigDoubleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// NumberPutBigFloatResponse contains the response from method Number.PutBigFloat.
-type NumberPutBigFloatResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// NumberPutSmallDecimalResponse contains the response from method Number.PutSmallDecimal.
-type NumberPutSmallDecimalResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// NumberPutSmallDoubleResponse contains the response from method Number.PutSmallDouble.
-type NumberPutSmallDoubleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// NumberPutSmallFloatResponse contains the response from method Number.PutSmallFloat.
-type NumberPutSmallFloatResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/autorest/generated/numbergroup/number.go
+++ b/test/autorest/generated/numbergroup/number.go
@@ -16,53 +16,53 @@ import (
 // NumberOperations contains the methods for the Number group.
 type NumberOperations interface {
 	// GetBigDecimal - Get big decimal value 2.5976931e+101
-	GetBigDecimal(ctx context.Context) (*NumberGetBigDecimalResponse, error)
+	GetBigDecimal(ctx context.Context) (*Float64Response, error)
 	// GetBigDecimalNegativeDecimal - Get big decimal value -99999999.99
-	GetBigDecimalNegativeDecimal(ctx context.Context) (*NumberGetBigDecimalNegativeDecimalResponse, error)
+	GetBigDecimalNegativeDecimal(ctx context.Context) (*Float64Response, error)
 	// GetBigDecimalPositiveDecimal - Get big decimal value 99999999.99
-	GetBigDecimalPositiveDecimal(ctx context.Context) (*NumberGetBigDecimalPositiveDecimalResponse, error)
+	GetBigDecimalPositiveDecimal(ctx context.Context) (*Float64Response, error)
 	// GetBigDouble - Get big double value 2.5976931e+101
-	GetBigDouble(ctx context.Context) (*NumberGetBigDoubleResponse, error)
+	GetBigDouble(ctx context.Context) (*Float64Response, error)
 	// GetBigDoubleNegativeDecimal - Get big double value -99999999.99
-	GetBigDoubleNegativeDecimal(ctx context.Context) (*NumberGetBigDoubleNegativeDecimalResponse, error)
+	GetBigDoubleNegativeDecimal(ctx context.Context) (*Float64Response, error)
 	// GetBigDoublePositiveDecimal - Get big double value 99999999.99
-	GetBigDoublePositiveDecimal(ctx context.Context) (*NumberGetBigDoublePositiveDecimalResponse, error)
+	GetBigDoublePositiveDecimal(ctx context.Context) (*Float64Response, error)
 	// GetBigFloat - Get big float value 3.402823e+20
-	GetBigFloat(ctx context.Context) (*NumberGetBigFloatResponse, error)
+	GetBigFloat(ctx context.Context) (*Float32Response, error)
 	// GetInvalidDecimal - Get invalid decimal Number value
-	GetInvalidDecimal(ctx context.Context) (*NumberGetInvalidDecimalResponse, error)
+	GetInvalidDecimal(ctx context.Context) (*Float64Response, error)
 	// GetInvalidDouble - Get invalid double Number value
-	GetInvalidDouble(ctx context.Context) (*NumberGetInvalidDoubleResponse, error)
+	GetInvalidDouble(ctx context.Context) (*Float64Response, error)
 	// GetInvalidFloat - Get invalid float Number value
-	GetInvalidFloat(ctx context.Context) (*NumberGetInvalidFloatResponse, error)
+	GetInvalidFloat(ctx context.Context) (*Float32Response, error)
 	// GetNull - Get null Number value
-	GetNull(ctx context.Context) (*NumberGetNullResponse, error)
+	GetNull(ctx context.Context) (*Float32Response, error)
 	// GetSmallDecimal - Get small decimal value 2.5976931e-101
-	GetSmallDecimal(ctx context.Context) (*NumberGetSmallDecimalResponse, error)
+	GetSmallDecimal(ctx context.Context) (*Float64Response, error)
 	// GetSmallDouble - Get big double value 2.5976931e-101
-	GetSmallDouble(ctx context.Context) (*NumberGetSmallDoubleResponse, error)
+	GetSmallDouble(ctx context.Context) (*Float64Response, error)
 	// GetSmallFloat - Get big double value 3.402823e-20
-	GetSmallFloat(ctx context.Context) (*NumberGetSmallFloatResponse, error)
+	GetSmallFloat(ctx context.Context) (*Float64Response, error)
 	// PutBigDecimal - Put big decimal value 2.5976931e+101
-	PutBigDecimal(ctx context.Context, numberBody float64) (*NumberPutBigDecimalResponse, error)
+	PutBigDecimal(ctx context.Context, numberBody float64) (*http.Response, error)
 	// PutBigDecimalNegativeDecimal - Put big decimal value -99999999.99
-	PutBigDecimalNegativeDecimal(ctx context.Context) (*NumberPutBigDecimalNegativeDecimalResponse, error)
+	PutBigDecimalNegativeDecimal(ctx context.Context) (*http.Response, error)
 	// PutBigDecimalPositiveDecimal - Put big decimal value 99999999.99
-	PutBigDecimalPositiveDecimal(ctx context.Context) (*NumberPutBigDecimalPositiveDecimalResponse, error)
+	PutBigDecimalPositiveDecimal(ctx context.Context) (*http.Response, error)
 	// PutBigDouble - Put big double value 2.5976931e+101
-	PutBigDouble(ctx context.Context, numberBody float64) (*NumberPutBigDoubleResponse, error)
+	PutBigDouble(ctx context.Context, numberBody float64) (*http.Response, error)
 	// PutBigDoubleNegativeDecimal - Put big double value -99999999.99
-	PutBigDoubleNegativeDecimal(ctx context.Context) (*NumberPutBigDoubleNegativeDecimalResponse, error)
+	PutBigDoubleNegativeDecimal(ctx context.Context) (*http.Response, error)
 	// PutBigDoublePositiveDecimal - Put big double value 99999999.99
-	PutBigDoublePositiveDecimal(ctx context.Context) (*NumberPutBigDoublePositiveDecimalResponse, error)
+	PutBigDoublePositiveDecimal(ctx context.Context) (*http.Response, error)
 	// PutBigFloat - Put big float value 3.402823e+20
-	PutBigFloat(ctx context.Context, numberBody float32) (*NumberPutBigFloatResponse, error)
+	PutBigFloat(ctx context.Context, numberBody float32) (*http.Response, error)
 	// PutSmallDecimal - Put small decimal value 2.5976931e-101
-	PutSmallDecimal(ctx context.Context, numberBody float64) (*NumberPutSmallDecimalResponse, error)
+	PutSmallDecimal(ctx context.Context, numberBody float64) (*http.Response, error)
 	// PutSmallDouble - Put small double value 2.5976931e-101
-	PutSmallDouble(ctx context.Context, numberBody float64) (*NumberPutSmallDoubleResponse, error)
+	PutSmallDouble(ctx context.Context, numberBody float64) (*http.Response, error)
 	// PutSmallFloat - Put small float value 3.402823e-20
-	PutSmallFloat(ctx context.Context, numberBody float32) (*NumberPutSmallFloatResponse, error)
+	PutSmallFloat(ctx context.Context, numberBody float32) (*http.Response, error)
 }
 
 // numberOperations implements the NumberOperations interface.
@@ -71,7 +71,7 @@ type numberOperations struct {
 }
 
 // GetBigDecimal - Get big decimal value 2.5976931e+101
-func (client *numberOperations) GetBigDecimal(ctx context.Context) (*NumberGetBigDecimalResponse, error) {
+func (client *numberOperations) GetBigDecimal(ctx context.Context) (*Float64Response, error) {
 	req, err := client.getBigDecimalCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -96,16 +96,16 @@ func (client *numberOperations) getBigDecimalCreateRequest(u url.URL) (*azcore.R
 }
 
 // getBigDecimalHandleResponse handles the GetBigDecimal response.
-func (client *numberOperations) getBigDecimalHandleResponse(resp *azcore.Response) (*NumberGetBigDecimalResponse, error) {
+func (client *numberOperations) getBigDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := NumberGetBigDecimalResponse{RawResponse: resp.Response}
+	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBigDecimalNegativeDecimal - Get big decimal value -99999999.99
-func (client *numberOperations) GetBigDecimalNegativeDecimal(ctx context.Context) (*NumberGetBigDecimalNegativeDecimalResponse, error) {
+func (client *numberOperations) GetBigDecimalNegativeDecimal(ctx context.Context) (*Float64Response, error) {
 	req, err := client.getBigDecimalNegativeDecimalCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -130,16 +130,16 @@ func (client *numberOperations) getBigDecimalNegativeDecimalCreateRequest(u url.
 }
 
 // getBigDecimalNegativeDecimalHandleResponse handles the GetBigDecimalNegativeDecimal response.
-func (client *numberOperations) getBigDecimalNegativeDecimalHandleResponse(resp *azcore.Response) (*NumberGetBigDecimalNegativeDecimalResponse, error) {
+func (client *numberOperations) getBigDecimalNegativeDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := NumberGetBigDecimalNegativeDecimalResponse{RawResponse: resp.Response}
+	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBigDecimalPositiveDecimal - Get big decimal value 99999999.99
-func (client *numberOperations) GetBigDecimalPositiveDecimal(ctx context.Context) (*NumberGetBigDecimalPositiveDecimalResponse, error) {
+func (client *numberOperations) GetBigDecimalPositiveDecimal(ctx context.Context) (*Float64Response, error) {
 	req, err := client.getBigDecimalPositiveDecimalCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -164,16 +164,16 @@ func (client *numberOperations) getBigDecimalPositiveDecimalCreateRequest(u url.
 }
 
 // getBigDecimalPositiveDecimalHandleResponse handles the GetBigDecimalPositiveDecimal response.
-func (client *numberOperations) getBigDecimalPositiveDecimalHandleResponse(resp *azcore.Response) (*NumberGetBigDecimalPositiveDecimalResponse, error) {
+func (client *numberOperations) getBigDecimalPositiveDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := NumberGetBigDecimalPositiveDecimalResponse{RawResponse: resp.Response}
+	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBigDouble - Get big double value 2.5976931e+101
-func (client *numberOperations) GetBigDouble(ctx context.Context) (*NumberGetBigDoubleResponse, error) {
+func (client *numberOperations) GetBigDouble(ctx context.Context) (*Float64Response, error) {
 	req, err := client.getBigDoubleCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -198,16 +198,16 @@ func (client *numberOperations) getBigDoubleCreateRequest(u url.URL) (*azcore.Re
 }
 
 // getBigDoubleHandleResponse handles the GetBigDouble response.
-func (client *numberOperations) getBigDoubleHandleResponse(resp *azcore.Response) (*NumberGetBigDoubleResponse, error) {
+func (client *numberOperations) getBigDoubleHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := NumberGetBigDoubleResponse{RawResponse: resp.Response}
+	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBigDoubleNegativeDecimal - Get big double value -99999999.99
-func (client *numberOperations) GetBigDoubleNegativeDecimal(ctx context.Context) (*NumberGetBigDoubleNegativeDecimalResponse, error) {
+func (client *numberOperations) GetBigDoubleNegativeDecimal(ctx context.Context) (*Float64Response, error) {
 	req, err := client.getBigDoubleNegativeDecimalCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -232,16 +232,16 @@ func (client *numberOperations) getBigDoubleNegativeDecimalCreateRequest(u url.U
 }
 
 // getBigDoubleNegativeDecimalHandleResponse handles the GetBigDoubleNegativeDecimal response.
-func (client *numberOperations) getBigDoubleNegativeDecimalHandleResponse(resp *azcore.Response) (*NumberGetBigDoubleNegativeDecimalResponse, error) {
+func (client *numberOperations) getBigDoubleNegativeDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := NumberGetBigDoubleNegativeDecimalResponse{RawResponse: resp.Response}
+	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBigDoublePositiveDecimal - Get big double value 99999999.99
-func (client *numberOperations) GetBigDoublePositiveDecimal(ctx context.Context) (*NumberGetBigDoublePositiveDecimalResponse, error) {
+func (client *numberOperations) GetBigDoublePositiveDecimal(ctx context.Context) (*Float64Response, error) {
 	req, err := client.getBigDoublePositiveDecimalCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -266,16 +266,16 @@ func (client *numberOperations) getBigDoublePositiveDecimalCreateRequest(u url.U
 }
 
 // getBigDoublePositiveDecimalHandleResponse handles the GetBigDoublePositiveDecimal response.
-func (client *numberOperations) getBigDoublePositiveDecimalHandleResponse(resp *azcore.Response) (*NumberGetBigDoublePositiveDecimalResponse, error) {
+func (client *numberOperations) getBigDoublePositiveDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := NumberGetBigDoublePositiveDecimalResponse{RawResponse: resp.Response}
+	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBigFloat - Get big float value 3.402823e+20
-func (client *numberOperations) GetBigFloat(ctx context.Context) (*NumberGetBigFloatResponse, error) {
+func (client *numberOperations) GetBigFloat(ctx context.Context) (*Float32Response, error) {
 	req, err := client.getBigFloatCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -300,16 +300,16 @@ func (client *numberOperations) getBigFloatCreateRequest(u url.URL) (*azcore.Req
 }
 
 // getBigFloatHandleResponse handles the GetBigFloat response.
-func (client *numberOperations) getBigFloatHandleResponse(resp *azcore.Response) (*NumberGetBigFloatResponse, error) {
+func (client *numberOperations) getBigFloatHandleResponse(resp *azcore.Response) (*Float32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := NumberGetBigFloatResponse{RawResponse: resp.Response}
+	result := Float32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetInvalidDecimal - Get invalid decimal Number value
-func (client *numberOperations) GetInvalidDecimal(ctx context.Context) (*NumberGetInvalidDecimalResponse, error) {
+func (client *numberOperations) GetInvalidDecimal(ctx context.Context) (*Float64Response, error) {
 	req, err := client.getInvalidDecimalCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -334,16 +334,16 @@ func (client *numberOperations) getInvalidDecimalCreateRequest(u url.URL) (*azco
 }
 
 // getInvalidDecimalHandleResponse handles the GetInvalidDecimal response.
-func (client *numberOperations) getInvalidDecimalHandleResponse(resp *azcore.Response) (*NumberGetInvalidDecimalResponse, error) {
+func (client *numberOperations) getInvalidDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := NumberGetInvalidDecimalResponse{RawResponse: resp.Response}
+	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetInvalidDouble - Get invalid double Number value
-func (client *numberOperations) GetInvalidDouble(ctx context.Context) (*NumberGetInvalidDoubleResponse, error) {
+func (client *numberOperations) GetInvalidDouble(ctx context.Context) (*Float64Response, error) {
 	req, err := client.getInvalidDoubleCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -368,16 +368,16 @@ func (client *numberOperations) getInvalidDoubleCreateRequest(u url.URL) (*azcor
 }
 
 // getInvalidDoubleHandleResponse handles the GetInvalidDouble response.
-func (client *numberOperations) getInvalidDoubleHandleResponse(resp *azcore.Response) (*NumberGetInvalidDoubleResponse, error) {
+func (client *numberOperations) getInvalidDoubleHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := NumberGetInvalidDoubleResponse{RawResponse: resp.Response}
+	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetInvalidFloat - Get invalid float Number value
-func (client *numberOperations) GetInvalidFloat(ctx context.Context) (*NumberGetInvalidFloatResponse, error) {
+func (client *numberOperations) GetInvalidFloat(ctx context.Context) (*Float32Response, error) {
 	req, err := client.getInvalidFloatCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -402,16 +402,16 @@ func (client *numberOperations) getInvalidFloatCreateRequest(u url.URL) (*azcore
 }
 
 // getInvalidFloatHandleResponse handles the GetInvalidFloat response.
-func (client *numberOperations) getInvalidFloatHandleResponse(resp *azcore.Response) (*NumberGetInvalidFloatResponse, error) {
+func (client *numberOperations) getInvalidFloatHandleResponse(resp *azcore.Response) (*Float32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := NumberGetInvalidFloatResponse{RawResponse: resp.Response}
+	result := Float32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNull - Get null Number value
-func (client *numberOperations) GetNull(ctx context.Context) (*NumberGetNullResponse, error) {
+func (client *numberOperations) GetNull(ctx context.Context) (*Float32Response, error) {
 	req, err := client.getNullCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -436,16 +436,16 @@ func (client *numberOperations) getNullCreateRequest(u url.URL) (*azcore.Request
 }
 
 // getNullHandleResponse handles the GetNull response.
-func (client *numberOperations) getNullHandleResponse(resp *azcore.Response) (*NumberGetNullResponse, error) {
+func (client *numberOperations) getNullHandleResponse(resp *azcore.Response) (*Float32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := NumberGetNullResponse{RawResponse: resp.Response}
+	result := Float32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetSmallDecimal - Get small decimal value 2.5976931e-101
-func (client *numberOperations) GetSmallDecimal(ctx context.Context) (*NumberGetSmallDecimalResponse, error) {
+func (client *numberOperations) GetSmallDecimal(ctx context.Context) (*Float64Response, error) {
 	req, err := client.getSmallDecimalCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -470,16 +470,16 @@ func (client *numberOperations) getSmallDecimalCreateRequest(u url.URL) (*azcore
 }
 
 // getSmallDecimalHandleResponse handles the GetSmallDecimal response.
-func (client *numberOperations) getSmallDecimalHandleResponse(resp *azcore.Response) (*NumberGetSmallDecimalResponse, error) {
+func (client *numberOperations) getSmallDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := NumberGetSmallDecimalResponse{RawResponse: resp.Response}
+	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetSmallDouble - Get big double value 2.5976931e-101
-func (client *numberOperations) GetSmallDouble(ctx context.Context) (*NumberGetSmallDoubleResponse, error) {
+func (client *numberOperations) GetSmallDouble(ctx context.Context) (*Float64Response, error) {
 	req, err := client.getSmallDoubleCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -504,16 +504,16 @@ func (client *numberOperations) getSmallDoubleCreateRequest(u url.URL) (*azcore.
 }
 
 // getSmallDoubleHandleResponse handles the GetSmallDouble response.
-func (client *numberOperations) getSmallDoubleHandleResponse(resp *azcore.Response) (*NumberGetSmallDoubleResponse, error) {
+func (client *numberOperations) getSmallDoubleHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := NumberGetSmallDoubleResponse{RawResponse: resp.Response}
+	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetSmallFloat - Get big double value 3.402823e-20
-func (client *numberOperations) GetSmallFloat(ctx context.Context) (*NumberGetSmallFloatResponse, error) {
+func (client *numberOperations) GetSmallFloat(ctx context.Context) (*Float64Response, error) {
 	req, err := client.getSmallFloatCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -538,16 +538,16 @@ func (client *numberOperations) getSmallFloatCreateRequest(u url.URL) (*azcore.R
 }
 
 // getSmallFloatHandleResponse handles the GetSmallFloat response.
-func (client *numberOperations) getSmallFloatHandleResponse(resp *azcore.Response) (*NumberGetSmallFloatResponse, error) {
+func (client *numberOperations) getSmallFloatHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := NumberGetSmallFloatResponse{RawResponse: resp.Response}
+	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // PutBigDecimal - Put big decimal value 2.5976931e+101
-func (client *numberOperations) PutBigDecimal(ctx context.Context, numberBody float64) (*NumberPutBigDecimalResponse, error) {
+func (client *numberOperations) PutBigDecimal(ctx context.Context, numberBody float64) (*http.Response, error) {
 	req, err := client.putBigDecimalCreateRequest(*client.u, numberBody)
 	if err != nil {
 		return nil, err
@@ -576,15 +576,15 @@ func (client *numberOperations) putBigDecimalCreateRequest(u url.URL, numberBody
 }
 
 // putBigDecimalHandleResponse handles the PutBigDecimal response.
-func (client *numberOperations) putBigDecimalHandleResponse(resp *azcore.Response) (*NumberPutBigDecimalResponse, error) {
+func (client *numberOperations) putBigDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &NumberPutBigDecimalResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutBigDecimalNegativeDecimal - Put big decimal value -99999999.99
-func (client *numberOperations) PutBigDecimalNegativeDecimal(ctx context.Context) (*NumberPutBigDecimalNegativeDecimalResponse, error) {
+func (client *numberOperations) PutBigDecimalNegativeDecimal(ctx context.Context) (*http.Response, error) {
 	req, err := client.putBigDecimalNegativeDecimalCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -613,15 +613,15 @@ func (client *numberOperations) putBigDecimalNegativeDecimalCreateRequest(u url.
 }
 
 // putBigDecimalNegativeDecimalHandleResponse handles the PutBigDecimalNegativeDecimal response.
-func (client *numberOperations) putBigDecimalNegativeDecimalHandleResponse(resp *azcore.Response) (*NumberPutBigDecimalNegativeDecimalResponse, error) {
+func (client *numberOperations) putBigDecimalNegativeDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &NumberPutBigDecimalNegativeDecimalResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutBigDecimalPositiveDecimal - Put big decimal value 99999999.99
-func (client *numberOperations) PutBigDecimalPositiveDecimal(ctx context.Context) (*NumberPutBigDecimalPositiveDecimalResponse, error) {
+func (client *numberOperations) PutBigDecimalPositiveDecimal(ctx context.Context) (*http.Response, error) {
 	req, err := client.putBigDecimalPositiveDecimalCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -650,15 +650,15 @@ func (client *numberOperations) putBigDecimalPositiveDecimalCreateRequest(u url.
 }
 
 // putBigDecimalPositiveDecimalHandleResponse handles the PutBigDecimalPositiveDecimal response.
-func (client *numberOperations) putBigDecimalPositiveDecimalHandleResponse(resp *azcore.Response) (*NumberPutBigDecimalPositiveDecimalResponse, error) {
+func (client *numberOperations) putBigDecimalPositiveDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &NumberPutBigDecimalPositiveDecimalResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutBigDouble - Put big double value 2.5976931e+101
-func (client *numberOperations) PutBigDouble(ctx context.Context, numberBody float64) (*NumberPutBigDoubleResponse, error) {
+func (client *numberOperations) PutBigDouble(ctx context.Context, numberBody float64) (*http.Response, error) {
 	req, err := client.putBigDoubleCreateRequest(*client.u, numberBody)
 	if err != nil {
 		return nil, err
@@ -687,15 +687,15 @@ func (client *numberOperations) putBigDoubleCreateRequest(u url.URL, numberBody 
 }
 
 // putBigDoubleHandleResponse handles the PutBigDouble response.
-func (client *numberOperations) putBigDoubleHandleResponse(resp *azcore.Response) (*NumberPutBigDoubleResponse, error) {
+func (client *numberOperations) putBigDoubleHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &NumberPutBigDoubleResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutBigDoubleNegativeDecimal - Put big double value -99999999.99
-func (client *numberOperations) PutBigDoubleNegativeDecimal(ctx context.Context) (*NumberPutBigDoubleNegativeDecimalResponse, error) {
+func (client *numberOperations) PutBigDoubleNegativeDecimal(ctx context.Context) (*http.Response, error) {
 	req, err := client.putBigDoubleNegativeDecimalCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -724,15 +724,15 @@ func (client *numberOperations) putBigDoubleNegativeDecimalCreateRequest(u url.U
 }
 
 // putBigDoubleNegativeDecimalHandleResponse handles the PutBigDoubleNegativeDecimal response.
-func (client *numberOperations) putBigDoubleNegativeDecimalHandleResponse(resp *azcore.Response) (*NumberPutBigDoubleNegativeDecimalResponse, error) {
+func (client *numberOperations) putBigDoubleNegativeDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &NumberPutBigDoubleNegativeDecimalResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutBigDoublePositiveDecimal - Put big double value 99999999.99
-func (client *numberOperations) PutBigDoublePositiveDecimal(ctx context.Context) (*NumberPutBigDoublePositiveDecimalResponse, error) {
+func (client *numberOperations) PutBigDoublePositiveDecimal(ctx context.Context) (*http.Response, error) {
 	req, err := client.putBigDoublePositiveDecimalCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -761,15 +761,15 @@ func (client *numberOperations) putBigDoublePositiveDecimalCreateRequest(u url.U
 }
 
 // putBigDoublePositiveDecimalHandleResponse handles the PutBigDoublePositiveDecimal response.
-func (client *numberOperations) putBigDoublePositiveDecimalHandleResponse(resp *azcore.Response) (*NumberPutBigDoublePositiveDecimalResponse, error) {
+func (client *numberOperations) putBigDoublePositiveDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &NumberPutBigDoublePositiveDecimalResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutBigFloat - Put big float value 3.402823e+20
-func (client *numberOperations) PutBigFloat(ctx context.Context, numberBody float32) (*NumberPutBigFloatResponse, error) {
+func (client *numberOperations) PutBigFloat(ctx context.Context, numberBody float32) (*http.Response, error) {
 	req, err := client.putBigFloatCreateRequest(*client.u, numberBody)
 	if err != nil {
 		return nil, err
@@ -798,15 +798,15 @@ func (client *numberOperations) putBigFloatCreateRequest(u url.URL, numberBody f
 }
 
 // putBigFloatHandleResponse handles the PutBigFloat response.
-func (client *numberOperations) putBigFloatHandleResponse(resp *azcore.Response) (*NumberPutBigFloatResponse, error) {
+func (client *numberOperations) putBigFloatHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &NumberPutBigFloatResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutSmallDecimal - Put small decimal value 2.5976931e-101
-func (client *numberOperations) PutSmallDecimal(ctx context.Context, numberBody float64) (*NumberPutSmallDecimalResponse, error) {
+func (client *numberOperations) PutSmallDecimal(ctx context.Context, numberBody float64) (*http.Response, error) {
 	req, err := client.putSmallDecimalCreateRequest(*client.u, numberBody)
 	if err != nil {
 		return nil, err
@@ -835,15 +835,15 @@ func (client *numberOperations) putSmallDecimalCreateRequest(u url.URL, numberBo
 }
 
 // putSmallDecimalHandleResponse handles the PutSmallDecimal response.
-func (client *numberOperations) putSmallDecimalHandleResponse(resp *azcore.Response) (*NumberPutSmallDecimalResponse, error) {
+func (client *numberOperations) putSmallDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &NumberPutSmallDecimalResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutSmallDouble - Put small double value 2.5976931e-101
-func (client *numberOperations) PutSmallDouble(ctx context.Context, numberBody float64) (*NumberPutSmallDoubleResponse, error) {
+func (client *numberOperations) PutSmallDouble(ctx context.Context, numberBody float64) (*http.Response, error) {
 	req, err := client.putSmallDoubleCreateRequest(*client.u, numberBody)
 	if err != nil {
 		return nil, err
@@ -872,15 +872,15 @@ func (client *numberOperations) putSmallDoubleCreateRequest(u url.URL, numberBod
 }
 
 // putSmallDoubleHandleResponse handles the PutSmallDouble response.
-func (client *numberOperations) putSmallDoubleHandleResponse(resp *azcore.Response) (*NumberPutSmallDoubleResponse, error) {
+func (client *numberOperations) putSmallDoubleHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &NumberPutSmallDoubleResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutSmallFloat - Put small float value 3.402823e-20
-func (client *numberOperations) PutSmallFloat(ctx context.Context, numberBody float32) (*NumberPutSmallFloatResponse, error) {
+func (client *numberOperations) PutSmallFloat(ctx context.Context, numberBody float32) (*http.Response, error) {
 	req, err := client.putSmallFloatCreateRequest(*client.u, numberBody)
 	if err != nil {
 		return nil, err
@@ -909,9 +909,9 @@ func (client *numberOperations) putSmallFloatCreateRequest(u url.URL, numberBody
 }
 
 // putSmallFloatHandleResponse handles the PutSmallFloat response.
-func (client *numberOperations) putSmallFloatHandleResponse(resp *azcore.Response) (*NumberPutSmallFloatResponse, error) {
+func (client *numberOperations) putSmallFloatHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &NumberPutSmallFloatResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }

--- a/test/autorest/generated/stringgroup/enum.go
+++ b/test/autorest/generated/stringgroup/enum.go
@@ -16,17 +16,17 @@ import (
 // EnumOperations contains the methods for the Enum group.
 type EnumOperations interface {
 	// GetNotExpandable - Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
-	GetNotExpandable(ctx context.Context) (*EnumGetNotExpandableResponse, error)
+	GetNotExpandable(ctx context.Context) (*ColorsResponse, error)
 	// GetReferenced - Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
-	GetReferenced(ctx context.Context) (*EnumGetReferencedResponse, error)
+	GetReferenced(ctx context.Context) (*ColorsResponse, error)
 	// GetReferencedConstant - Get value 'green-color' from the constant.
-	GetReferencedConstant(ctx context.Context) (*EnumGetReferencedConstantResponse, error)
+	GetReferencedConstant(ctx context.Context) (*RefColorConstantResponse, error)
 	// PutNotExpandable - Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
-	PutNotExpandable(ctx context.Context, stringBody Colors) (*EnumPutNotExpandableResponse, error)
+	PutNotExpandable(ctx context.Context, stringBody Colors) (*http.Response, error)
 	// PutReferenced - Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
-	PutReferenced(ctx context.Context, enumStringBody Colors) (*EnumPutReferencedResponse, error)
+	PutReferenced(ctx context.Context, enumStringBody Colors) (*http.Response, error)
 	// PutReferencedConstant - Sends value 'green-color' from a constant
-	PutReferencedConstant(ctx context.Context, enumStringBody RefColorConstant) (*EnumPutReferencedConstantResponse, error)
+	PutReferencedConstant(ctx context.Context, enumStringBody RefColorConstant) (*http.Response, error)
 }
 
 // enumOperations implements the EnumOperations interface.
@@ -35,7 +35,7 @@ type enumOperations struct {
 }
 
 // GetNotExpandable - Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
-func (client *enumOperations) GetNotExpandable(ctx context.Context) (*EnumGetNotExpandableResponse, error) {
+func (client *enumOperations) GetNotExpandable(ctx context.Context) (*ColorsResponse, error) {
 	req, err := client.getNotExpandableCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -60,16 +60,16 @@ func (client *enumOperations) getNotExpandableCreateRequest(u url.URL) (*azcore.
 }
 
 // getNotExpandableHandleResponse handles the GetNotExpandable response.
-func (client *enumOperations) getNotExpandableHandleResponse(resp *azcore.Response) (*EnumGetNotExpandableResponse, error) {
+func (client *enumOperations) getNotExpandableHandleResponse(resp *azcore.Response) (*ColorsResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := EnumGetNotExpandableResponse{RawResponse: resp.Response}
+	result := ColorsResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetReferenced - Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
-func (client *enumOperations) GetReferenced(ctx context.Context) (*EnumGetReferencedResponse, error) {
+func (client *enumOperations) GetReferenced(ctx context.Context) (*ColorsResponse, error) {
 	req, err := client.getReferencedCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -94,16 +94,16 @@ func (client *enumOperations) getReferencedCreateRequest(u url.URL) (*azcore.Req
 }
 
 // getReferencedHandleResponse handles the GetReferenced response.
-func (client *enumOperations) getReferencedHandleResponse(resp *azcore.Response) (*EnumGetReferencedResponse, error) {
+func (client *enumOperations) getReferencedHandleResponse(resp *azcore.Response) (*ColorsResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := EnumGetReferencedResponse{RawResponse: resp.Response}
+	result := ColorsResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetReferencedConstant - Get value 'green-color' from the constant.
-func (client *enumOperations) GetReferencedConstant(ctx context.Context) (*EnumGetReferencedConstantResponse, error) {
+func (client *enumOperations) GetReferencedConstant(ctx context.Context) (*RefColorConstantResponse, error) {
 	req, err := client.getReferencedConstantCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -128,16 +128,16 @@ func (client *enumOperations) getReferencedConstantCreateRequest(u url.URL) (*az
 }
 
 // getReferencedConstantHandleResponse handles the GetReferencedConstant response.
-func (client *enumOperations) getReferencedConstantHandleResponse(resp *azcore.Response) (*EnumGetReferencedConstantResponse, error) {
+func (client *enumOperations) getReferencedConstantHandleResponse(resp *azcore.Response) (*RefColorConstantResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := EnumGetReferencedConstantResponse{RawResponse: resp.Response}
+	result := RefColorConstantResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.RefColorConstant)
 }
 
 // PutNotExpandable - Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
-func (client *enumOperations) PutNotExpandable(ctx context.Context, stringBody Colors) (*EnumPutNotExpandableResponse, error) {
+func (client *enumOperations) PutNotExpandable(ctx context.Context, stringBody Colors) (*http.Response, error) {
 	req, err := client.putNotExpandableCreateRequest(*client.u, stringBody)
 	if err != nil {
 		return nil, err
@@ -166,15 +166,15 @@ func (client *enumOperations) putNotExpandableCreateRequest(u url.URL, stringBod
 }
 
 // putNotExpandableHandleResponse handles the PutNotExpandable response.
-func (client *enumOperations) putNotExpandableHandleResponse(resp *azcore.Response) (*EnumPutNotExpandableResponse, error) {
+func (client *enumOperations) putNotExpandableHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &EnumPutNotExpandableResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutReferenced - Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
-func (client *enumOperations) PutReferenced(ctx context.Context, enumStringBody Colors) (*EnumPutReferencedResponse, error) {
+func (client *enumOperations) PutReferenced(ctx context.Context, enumStringBody Colors) (*http.Response, error) {
 	req, err := client.putReferencedCreateRequest(*client.u, enumStringBody)
 	if err != nil {
 		return nil, err
@@ -203,15 +203,15 @@ func (client *enumOperations) putReferencedCreateRequest(u url.URL, enumStringBo
 }
 
 // putReferencedHandleResponse handles the PutReferenced response.
-func (client *enumOperations) putReferencedHandleResponse(resp *azcore.Response) (*EnumPutReferencedResponse, error) {
+func (client *enumOperations) putReferencedHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &EnumPutReferencedResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutReferencedConstant - Sends value 'green-color' from a constant
-func (client *enumOperations) PutReferencedConstant(ctx context.Context, enumStringBody RefColorConstant) (*EnumPutReferencedConstantResponse, error) {
+func (client *enumOperations) PutReferencedConstant(ctx context.Context, enumStringBody RefColorConstant) (*http.Response, error) {
 	req, err := client.putReferencedConstantCreateRequest(*client.u, enumStringBody)
 	if err != nil {
 		return nil, err
@@ -240,9 +240,9 @@ func (client *enumOperations) putReferencedConstantCreateRequest(u url.URL, enum
 }
 
 // putReferencedConstantHandleResponse handles the PutReferencedConstant response.
-func (client *enumOperations) putReferencedConstantHandleResponse(resp *azcore.Response) (*EnumPutReferencedConstantResponse, error) {
+func (client *enumOperations) putReferencedConstantHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &EnumPutReferencedConstantResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }

--- a/test/autorest/generated/stringgroup/models.go
+++ b/test/autorest/generated/stringgroup/models.go
@@ -11,43 +11,18 @@ import (
 	"net/http"
 )
 
-// EnumGetNotExpandableResponse contains the response from method Enum.GetNotExpandable.
-type EnumGetNotExpandableResponse struct {
+// ByteArrayResponse is the response envelope for operations that return a []byte type.
+type ByteArrayResponse struct {
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+	Value       *[]byte
+}
+
+// ColorsResponse is the response envelope for operations that return a Colors type.
+type ColorsResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 	Value       *Colors
-}
-
-// EnumGetReferencedConstantResponse contains the response from method Enum.GetReferencedConstant.
-type EnumGetReferencedConstantResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse      *http.Response
-	RefColorConstant *RefColorConstant
-}
-
-// EnumGetReferencedResponse contains the response from method Enum.GetReferenced.
-type EnumGetReferencedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *Colors
-}
-
-// EnumPutNotExpandableResponse contains the response from method Enum.PutNotExpandable.
-type EnumPutNotExpandableResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// EnumPutReferencedConstantResponse contains the response from method Enum.PutReferencedConstant.
-type EnumPutReferencedConstantResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// EnumPutReferencedResponse contains the response from method Enum.PutReferenced.
-type EnumPutReferencedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 type Error struct {
@@ -85,96 +60,18 @@ type RefColorConstant struct {
 	Field1 *string `json:"field1,omitempty"`
 }
 
-// StringGetBase64EncodedResponse contains the response from method String.GetBase64Encoded.
-type StringGetBase64EncodedResponse struct {
+// RefColorConstantResponse is the response envelope for operations that return a RefColorConstant type.
+type RefColorConstantResponse struct {
 	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *[]byte
+	RawResponse      *http.Response
+	RefColorConstant *RefColorConstant
 }
 
-// StringGetBase64URLEncodedResponse contains the response from method String.GetBase64URLEncoded.
-type StringGetBase64URLEncodedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *[]byte
-}
-
-// StringGetEmptyResponse contains the response from method String.GetEmpty.
-type StringGetEmptyResponse struct {
+// StringResponse is the response envelope for operations that return a string type.
+type StringResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// simple string
 	Value *string
-}
-
-// StringGetMBCSResponse contains the response from method String.GetMBCS.
-type StringGetMBCSResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
-	// simple string
-	Value *string
-}
-
-// StringGetNotProvidedResponse contains the response from method String.GetNotProvided.
-type StringGetNotProvidedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *string
-}
-
-// StringGetNullBase64URLEncodedResponse contains the response from method String.GetNullBase64URLEncoded.
-type StringGetNullBase64URLEncodedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-	Value       *[]byte
-}
-
-// StringGetNullResponse contains the response from method String.GetNull.
-type StringGetNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
-	// simple string
-	Value *string
-}
-
-// StringGetWhitespaceResponse contains the response from method String.GetWhitespace.
-type StringGetWhitespaceResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
-	// simple string
-	Value *string
-}
-
-// StringPutBase64URLEncodedResponse contains the response from method String.PutBase64URLEncoded.
-type StringPutBase64URLEncodedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// StringPutEmptyResponse contains the response from method String.PutEmpty.
-type StringPutEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// StringPutMBCSResponse contains the response from method String.PutMBCS.
-type StringPutMBCSResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// StringPutNullResponse contains the response from method String.PutNull.
-type StringPutNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// StringPutWhitespaceResponse contains the response from method String.PutWhitespace.
-type StringPutWhitespaceResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/autorest/generated/stringgroup/string.go
+++ b/test/autorest/generated/stringgroup/string.go
@@ -16,31 +16,31 @@ import (
 // StringOperations contains the methods for the String group.
 type StringOperations interface {
 	// GetBase64Encoded - Get value that is base64 encoded
-	GetBase64Encoded(ctx context.Context) (*StringGetBase64EncodedResponse, error)
+	GetBase64Encoded(ctx context.Context) (*ByteArrayResponse, error)
 	// GetBase64URLEncoded - Get value that is base64url encoded
-	GetBase64URLEncoded(ctx context.Context) (*StringGetBase64URLEncodedResponse, error)
+	GetBase64URLEncoded(ctx context.Context) (*ByteArrayResponse, error)
 	// GetEmpty - Get empty string value value ''
-	GetEmpty(ctx context.Context) (*StringGetEmptyResponse, error)
+	GetEmpty(ctx context.Context) (*StringResponse, error)
 	// GetMBCS - Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
-	GetMBCS(ctx context.Context) (*StringGetMBCSResponse, error)
+	GetMBCS(ctx context.Context) (*StringResponse, error)
 	// GetNotProvided - Get String value when no string value is sent in response payload
-	GetNotProvided(ctx context.Context) (*StringGetNotProvidedResponse, error)
+	GetNotProvided(ctx context.Context) (*StringResponse, error)
 	// GetNull - Get null string value value
-	GetNull(ctx context.Context) (*StringGetNullResponse, error)
+	GetNull(ctx context.Context) (*StringResponse, error)
 	// GetNullBase64URLEncoded - Get null value that is expected to be base64url encoded
-	GetNullBase64URLEncoded(ctx context.Context) (*StringGetNullBase64URLEncodedResponse, error)
+	GetNullBase64URLEncoded(ctx context.Context) (*ByteArrayResponse, error)
 	// GetWhitespace - Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
-	GetWhitespace(ctx context.Context) (*StringGetWhitespaceResponse, error)
+	GetWhitespace(ctx context.Context) (*StringResponse, error)
 	// PutBase64URLEncoded - Put value that is base64url encoded
-	PutBase64URLEncoded(ctx context.Context, stringBody []byte) (*StringPutBase64URLEncodedResponse, error)
+	PutBase64URLEncoded(ctx context.Context, stringBody []byte) (*http.Response, error)
 	// PutEmpty - Set string value empty ''
-	PutEmpty(ctx context.Context) (*StringPutEmptyResponse, error)
+	PutEmpty(ctx context.Context) (*http.Response, error)
 	// PutMBCS - Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
-	PutMBCS(ctx context.Context) (*StringPutMBCSResponse, error)
+	PutMBCS(ctx context.Context) (*http.Response, error)
 	// PutNull - Set string value null
-	PutNull(ctx context.Context) (*StringPutNullResponse, error)
+	PutNull(ctx context.Context) (*http.Response, error)
 	// PutWhitespace - Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
-	PutWhitespace(ctx context.Context) (*StringPutWhitespaceResponse, error)
+	PutWhitespace(ctx context.Context) (*http.Response, error)
 }
 
 // stringOperations implements the StringOperations interface.
@@ -49,7 +49,7 @@ type stringOperations struct {
 }
 
 // GetBase64Encoded - Get value that is base64 encoded
-func (client *stringOperations) GetBase64Encoded(ctx context.Context) (*StringGetBase64EncodedResponse, error) {
+func (client *stringOperations) GetBase64Encoded(ctx context.Context) (*ByteArrayResponse, error) {
 	req, err := client.getBase64EncodedCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -74,16 +74,16 @@ func (client *stringOperations) getBase64EncodedCreateRequest(u url.URL) (*azcor
 }
 
 // getBase64EncodedHandleResponse handles the GetBase64Encoded response.
-func (client *stringOperations) getBase64EncodedHandleResponse(resp *azcore.Response) (*StringGetBase64EncodedResponse, error) {
+func (client *stringOperations) getBase64EncodedHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := StringGetBase64EncodedResponse{RawResponse: resp.Response}
+	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBase64URLEncoded - Get value that is base64url encoded
-func (client *stringOperations) GetBase64URLEncoded(ctx context.Context) (*StringGetBase64URLEncodedResponse, error) {
+func (client *stringOperations) GetBase64URLEncoded(ctx context.Context) (*ByteArrayResponse, error) {
 	req, err := client.getBase64UrlEncodedCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -108,16 +108,16 @@ func (client *stringOperations) getBase64UrlEncodedCreateRequest(u url.URL) (*az
 }
 
 // getBase64UrlEncodedHandleResponse handles the GetBase64URLEncoded response.
-func (client *stringOperations) getBase64UrlEncodedHandleResponse(resp *azcore.Response) (*StringGetBase64URLEncodedResponse, error) {
+func (client *stringOperations) getBase64UrlEncodedHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := StringGetBase64URLEncodedResponse{RawResponse: resp.Response}
+	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetEmpty - Get empty string value value ''
-func (client *stringOperations) GetEmpty(ctx context.Context) (*StringGetEmptyResponse, error) {
+func (client *stringOperations) GetEmpty(ctx context.Context) (*StringResponse, error) {
 	req, err := client.getEmptyCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -142,16 +142,16 @@ func (client *stringOperations) getEmptyCreateRequest(u url.URL) (*azcore.Reques
 }
 
 // getEmptyHandleResponse handles the GetEmpty response.
-func (client *stringOperations) getEmptyHandleResponse(resp *azcore.Response) (*StringGetEmptyResponse, error) {
+func (client *stringOperations) getEmptyHandleResponse(resp *azcore.Response) (*StringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := StringGetEmptyResponse{RawResponse: resp.Response}
+	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetMBCS - Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
-func (client *stringOperations) GetMBCS(ctx context.Context) (*StringGetMBCSResponse, error) {
+func (client *stringOperations) GetMBCS(ctx context.Context) (*StringResponse, error) {
 	req, err := client.getMbcsCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -176,16 +176,16 @@ func (client *stringOperations) getMbcsCreateRequest(u url.URL) (*azcore.Request
 }
 
 // getMbcsHandleResponse handles the GetMBCS response.
-func (client *stringOperations) getMbcsHandleResponse(resp *azcore.Response) (*StringGetMBCSResponse, error) {
+func (client *stringOperations) getMbcsHandleResponse(resp *azcore.Response) (*StringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := StringGetMBCSResponse{RawResponse: resp.Response}
+	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNotProvided - Get String value when no string value is sent in response payload
-func (client *stringOperations) GetNotProvided(ctx context.Context) (*StringGetNotProvidedResponse, error) {
+func (client *stringOperations) GetNotProvided(ctx context.Context) (*StringResponse, error) {
 	req, err := client.getNotProvidedCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -210,16 +210,16 @@ func (client *stringOperations) getNotProvidedCreateRequest(u url.URL) (*azcore.
 }
 
 // getNotProvidedHandleResponse handles the GetNotProvided response.
-func (client *stringOperations) getNotProvidedHandleResponse(resp *azcore.Response) (*StringGetNotProvidedResponse, error) {
+func (client *stringOperations) getNotProvidedHandleResponse(resp *azcore.Response) (*StringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := StringGetNotProvidedResponse{RawResponse: resp.Response}
+	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNull - Get null string value value
-func (client *stringOperations) GetNull(ctx context.Context) (*StringGetNullResponse, error) {
+func (client *stringOperations) GetNull(ctx context.Context) (*StringResponse, error) {
 	req, err := client.getNullCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -244,16 +244,16 @@ func (client *stringOperations) getNullCreateRequest(u url.URL) (*azcore.Request
 }
 
 // getNullHandleResponse handles the GetNull response.
-func (client *stringOperations) getNullHandleResponse(resp *azcore.Response) (*StringGetNullResponse, error) {
+func (client *stringOperations) getNullHandleResponse(resp *azcore.Response) (*StringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := StringGetNullResponse{RawResponse: resp.Response}
+	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNullBase64URLEncoded - Get null value that is expected to be base64url encoded
-func (client *stringOperations) GetNullBase64URLEncoded(ctx context.Context) (*StringGetNullBase64URLEncodedResponse, error) {
+func (client *stringOperations) GetNullBase64URLEncoded(ctx context.Context) (*ByteArrayResponse, error) {
 	req, err := client.getNullBase64UrlEncodedCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -278,16 +278,16 @@ func (client *stringOperations) getNullBase64UrlEncodedCreateRequest(u url.URL) 
 }
 
 // getNullBase64UrlEncodedHandleResponse handles the GetNullBase64URLEncoded response.
-func (client *stringOperations) getNullBase64UrlEncodedHandleResponse(resp *azcore.Response) (*StringGetNullBase64URLEncodedResponse, error) {
+func (client *stringOperations) getNullBase64UrlEncodedHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := StringGetNullBase64URLEncodedResponse{RawResponse: resp.Response}
+	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetWhitespace - Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
-func (client *stringOperations) GetWhitespace(ctx context.Context) (*StringGetWhitespaceResponse, error) {
+func (client *stringOperations) GetWhitespace(ctx context.Context) (*StringResponse, error) {
 	req, err := client.getWhitespaceCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -312,16 +312,16 @@ func (client *stringOperations) getWhitespaceCreateRequest(u url.URL) (*azcore.R
 }
 
 // getWhitespaceHandleResponse handles the GetWhitespace response.
-func (client *stringOperations) getWhitespaceHandleResponse(resp *azcore.Response) (*StringGetWhitespaceResponse, error) {
+func (client *stringOperations) getWhitespaceHandleResponse(resp *azcore.Response) (*StringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := StringGetWhitespaceResponse{RawResponse: resp.Response}
+	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // PutBase64URLEncoded - Put value that is base64url encoded
-func (client *stringOperations) PutBase64URLEncoded(ctx context.Context, stringBody []byte) (*StringPutBase64URLEncodedResponse, error) {
+func (client *stringOperations) PutBase64URLEncoded(ctx context.Context, stringBody []byte) (*http.Response, error) {
 	req, err := client.putBase64UrlEncodedCreateRequest(*client.u, stringBody)
 	if err != nil {
 		return nil, err
@@ -350,15 +350,15 @@ func (client *stringOperations) putBase64UrlEncodedCreateRequest(u url.URL, stri
 }
 
 // putBase64UrlEncodedHandleResponse handles the PutBase64URLEncoded response.
-func (client *stringOperations) putBase64UrlEncodedHandleResponse(resp *azcore.Response) (*StringPutBase64URLEncodedResponse, error) {
+func (client *stringOperations) putBase64UrlEncodedHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &StringPutBase64URLEncodedResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutEmpty - Set string value empty ''
-func (client *stringOperations) PutEmpty(ctx context.Context) (*StringPutEmptyResponse, error) {
+func (client *stringOperations) PutEmpty(ctx context.Context) (*http.Response, error) {
 	req, err := client.putEmptyCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -387,15 +387,15 @@ func (client *stringOperations) putEmptyCreateRequest(u url.URL) (*azcore.Reques
 }
 
 // putEmptyHandleResponse handles the PutEmpty response.
-func (client *stringOperations) putEmptyHandleResponse(resp *azcore.Response) (*StringPutEmptyResponse, error) {
+func (client *stringOperations) putEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &StringPutEmptyResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutMBCS - Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
-func (client *stringOperations) PutMBCS(ctx context.Context) (*StringPutMBCSResponse, error) {
+func (client *stringOperations) PutMBCS(ctx context.Context) (*http.Response, error) {
 	req, err := client.putMbcsCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -424,15 +424,15 @@ func (client *stringOperations) putMbcsCreateRequest(u url.URL) (*azcore.Request
 }
 
 // putMbcsHandleResponse handles the PutMBCS response.
-func (client *stringOperations) putMbcsHandleResponse(resp *azcore.Response) (*StringPutMBCSResponse, error) {
+func (client *stringOperations) putMbcsHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &StringPutMBCSResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutNull - Set string value null
-func (client *stringOperations) PutNull(ctx context.Context) (*StringPutNullResponse, error) {
+func (client *stringOperations) PutNull(ctx context.Context) (*http.Response, error) {
 	req, err := client.putNullCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -461,15 +461,15 @@ func (client *stringOperations) putNullCreateRequest(u url.URL) (*azcore.Request
 }
 
 // putNullHandleResponse handles the PutNull response.
-func (client *stringOperations) putNullHandleResponse(resp *azcore.Response) (*StringPutNullResponse, error) {
+func (client *stringOperations) putNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &StringPutNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutWhitespace - Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
-func (client *stringOperations) PutWhitespace(ctx context.Context) (*StringPutWhitespaceResponse, error) {
+func (client *stringOperations) PutWhitespace(ctx context.Context) (*http.Response, error) {
 	req, err := client.putWhitespaceCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -498,9 +498,9 @@ func (client *stringOperations) putWhitespaceCreateRequest(u url.URL) (*azcore.R
 }
 
 // putWhitespaceHandleResponse handles the PutWhitespace response.
-func (client *stringOperations) putWhitespaceHandleResponse(resp *azcore.Response) (*StringPutWhitespaceResponse, error) {
+func (client *stringOperations) putWhitespaceHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &StringPutWhitespaceResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }

--- a/test/autorest/generated/urlgroup/models.go
+++ b/test/autorest/generated/urlgroup/models.go
@@ -8,7 +8,6 @@ package urlgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/http"
 	"time"
 )
 
@@ -47,12 +46,6 @@ type PathItemsGetAllWithValuesOptions struct {
 	PathItemStringQuery *string
 }
 
-// PathItemsGetAllWithValuesResponse contains the response from method PathItems.GetAllWithValues.
-type PathItemsGetAllWithValuesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // PathItemsGetGlobalAndLocalQueryNullOptions contains the optional parameters for the PathItems.GetGlobalAndLocalQueryNull
 // method.
 type PathItemsGetGlobalAndLocalQueryNullOptions struct {
@@ -62,24 +55,12 @@ type PathItemsGetGlobalAndLocalQueryNullOptions struct {
 	PathItemStringQuery *string
 }
 
-// PathItemsGetGlobalAndLocalQueryNullResponse contains the response from method PathItems.GetGlobalAndLocalQueryNull.
-type PathItemsGetGlobalAndLocalQueryNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // PathItemsGetGlobalQueryNullOptions contains the optional parameters for the PathItems.GetGlobalQueryNull method.
 type PathItemsGetGlobalQueryNullOptions struct {
 	// should contain value 'localStringQuery'
 	LocalStringQuery *string
 	// A string value 'pathItemStringQuery' that appears as a query parameter
 	PathItemStringQuery *string
-}
-
-// PathItemsGetGlobalQueryNullResponse contains the response from method PathItems.GetGlobalQueryNull.
-type PathItemsGetGlobalQueryNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // PathItemsGetLocalPathItemQueryNullOptions contains the optional parameters for the PathItems.GetLocalPathItemQueryNull
@@ -91,184 +72,10 @@ type PathItemsGetLocalPathItemQueryNullOptions struct {
 	PathItemStringQuery *string
 }
 
-// PathItemsGetLocalPathItemQueryNullResponse contains the response from method PathItems.GetLocalPathItemQueryNull.
-type PathItemsGetLocalPathItemQueryNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsArrayCSVInPathResponse contains the response from method Paths.ArrayCSVInPath.
-type PathsArrayCSVInPathResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsBase64URLResponse contains the response from method Paths.Base64URL.
-type PathsBase64URLResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsByteEmptyResponse contains the response from method Paths.ByteEmpty.
-type PathsByteEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsByteMultiByteResponse contains the response from method Paths.ByteMultiByte.
-type PathsByteMultiByteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsByteNullResponse contains the response from method Paths.ByteNull.
-type PathsByteNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsDateNullResponse contains the response from method Paths.DateNull.
-type PathsDateNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsDateTimeNullResponse contains the response from method Paths.DateTimeNull.
-type PathsDateTimeNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsDateTimeValidResponse contains the response from method Paths.DateTimeValid.
-type PathsDateTimeValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsDateValidResponse contains the response from method Paths.DateValid.
-type PathsDateValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsDoubleDecimalNegativeResponse contains the response from method Paths.DoubleDecimalNegative.
-type PathsDoubleDecimalNegativeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsDoubleDecimalPositiveResponse contains the response from method Paths.DoubleDecimalPositive.
-type PathsDoubleDecimalPositiveResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsEnumNullResponse contains the response from method Paths.EnumNull.
-type PathsEnumNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsEnumValidResponse contains the response from method Paths.EnumValid.
-type PathsEnumValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsFloatScientificNegativeResponse contains the response from method Paths.FloatScientificNegative.
-type PathsFloatScientificNegativeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsFloatScientificPositiveResponse contains the response from method Paths.FloatScientificPositive.
-type PathsFloatScientificPositiveResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsGetBooleanFalseResponse contains the response from method Paths.GetBooleanFalse.
-type PathsGetBooleanFalseResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsGetBooleanTrueResponse contains the response from method Paths.GetBooleanTrue.
-type PathsGetBooleanTrueResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsGetIntNegativeOneMillionResponse contains the response from method Paths.GetIntNegativeOneMillion.
-type PathsGetIntNegativeOneMillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsGetIntOneMillionResponse contains the response from method Paths.GetIntOneMillion.
-type PathsGetIntOneMillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsGetNegativeTenBillionResponse contains the response from method Paths.GetNegativeTenBillion.
-type PathsGetNegativeTenBillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsGetTenBillionResponse contains the response from method Paths.GetTenBillion.
-type PathsGetTenBillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsStringEmptyResponse contains the response from method Paths.StringEmpty.
-type PathsStringEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsStringNullResponse contains the response from method Paths.StringNull.
-type PathsStringNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsStringURLEncodedResponse contains the response from method Paths.StringURLEncoded.
-type PathsStringURLEncodedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsStringURLNonEncodedResponse contains the response from method Paths.StringURLNonEncoded.
-type PathsStringURLNonEncodedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsStringUnicodeResponse contains the response from method Paths.StringUnicode.
-type PathsStringUnicodeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// PathsUnixTimeURLResponse contains the response from method Paths.UnixTimeURL.
-type PathsUnixTimeURLResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // QueriesArrayStringCSVEmptyOptions contains the optional parameters for the Queries.ArrayStringCSVEmpty method.
 type QueriesArrayStringCSVEmptyOptions struct {
 	// an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
 	ArrayQuery *[]string
-}
-
-// QueriesArrayStringCSVEmptyResponse contains the response from method Queries.ArrayStringCSVEmpty.
-type QueriesArrayStringCSVEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // QueriesArrayStringCSVNullOptions contains the optional parameters for the Queries.ArrayStringCSVNull method.
@@ -277,22 +84,10 @@ type QueriesArrayStringCSVNullOptions struct {
 	ArrayQuery *[]string
 }
 
-// QueriesArrayStringCSVNullResponse contains the response from method Queries.ArrayStringCSVNull.
-type QueriesArrayStringCSVNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // QueriesArrayStringCSVValidOptions contains the optional parameters for the Queries.ArrayStringCSVValid method.
 type QueriesArrayStringCSVValidOptions struct {
 	// an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
 	ArrayQuery *[]string
-}
-
-// QueriesArrayStringCSVValidResponse contains the response from method Queries.ArrayStringCSVValid.
-type QueriesArrayStringCSVValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // QueriesArrayStringPipesValidOptions contains the optional parameters for the Queries.ArrayStringPipesValid method.
@@ -301,22 +96,10 @@ type QueriesArrayStringPipesValidOptions struct {
 	ArrayQuery *[]string
 }
 
-// QueriesArrayStringPipesValidResponse contains the response from method Queries.ArrayStringPipesValid.
-type QueriesArrayStringPipesValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // QueriesArrayStringSsvValidOptions contains the optional parameters for the Queries.ArrayStringSsvValid method.
 type QueriesArrayStringSsvValidOptions struct {
 	// an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format
 	ArrayQuery *[]string
-}
-
-// QueriesArrayStringSsvValidResponse contains the response from method Queries.ArrayStringSsvValid.
-type QueriesArrayStringSsvValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // QueriesArrayStringTsvValidOptions contains the optional parameters for the Queries.ArrayStringTsvValid method.
@@ -325,28 +108,10 @@ type QueriesArrayStringTsvValidOptions struct {
 	ArrayQuery *[]string
 }
 
-// QueriesArrayStringTsvValidResponse contains the response from method Queries.ArrayStringTsvValid.
-type QueriesArrayStringTsvValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesByteEmptyResponse contains the response from method Queries.ByteEmpty.
-type QueriesByteEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // QueriesByteMultiByteOptions contains the optional parameters for the Queries.ByteMultiByte method.
 type QueriesByteMultiByteOptions struct {
 	// '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
 	ByteQuery *[]byte
-}
-
-// QueriesByteMultiByteResponse contains the response from method Queries.ByteMultiByte.
-type QueriesByteMultiByteResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // QueriesByteNullOptions contains the optional parameters for the Queries.ByteNull method.
@@ -355,22 +120,10 @@ type QueriesByteNullOptions struct {
 	ByteQuery *[]byte
 }
 
-// QueriesByteNullResponse contains the response from method Queries.ByteNull.
-type QueriesByteNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // QueriesDateNullOptions contains the optional parameters for the Queries.DateNull method.
 type QueriesDateNullOptions struct {
 	// null as date (no query parameters in uri)
 	DateQuery *time.Time
-}
-
-// QueriesDateNullResponse contains the response from method Queries.DateNull.
-type QueriesDateNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // QueriesDateTimeNullOptions contains the optional parameters for the Queries.DateTimeNull method.
@@ -379,46 +132,10 @@ type QueriesDateTimeNullOptions struct {
 	DateTimeQuery *time.Time
 }
 
-// QueriesDateTimeNullResponse contains the response from method Queries.DateTimeNull.
-type QueriesDateTimeNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesDateTimeValidResponse contains the response from method Queries.DateTimeValid.
-type QueriesDateTimeValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesDateValidResponse contains the response from method Queries.DateValid.
-type QueriesDateValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesDoubleDecimalNegativeResponse contains the response from method Queries.DoubleDecimalNegative.
-type QueriesDoubleDecimalNegativeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesDoubleDecimalPositiveResponse contains the response from method Queries.DoubleDecimalPositive.
-type QueriesDoubleDecimalPositiveResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // QueriesDoubleNullOptions contains the optional parameters for the Queries.DoubleNull method.
 type QueriesDoubleNullOptions struct {
 	// null numeric value
 	DoubleQuery *float64
-}
-
-// QueriesDoubleNullResponse contains the response from method Queries.DoubleNull.
-type QueriesDoubleNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // QueriesEnumNullOptions contains the optional parameters for the Queries.EnumNull method.
@@ -427,22 +144,10 @@ type QueriesEnumNullOptions struct {
 	EnumQuery *UriColor
 }
 
-// QueriesEnumNullResponse contains the response from method Queries.EnumNull.
-type QueriesEnumNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // QueriesEnumValidOptions contains the optional parameters for the Queries.EnumValid method.
 type QueriesEnumValidOptions struct {
 	// 'green color' enum value
 	EnumQuery *UriColor
-}
-
-// QueriesEnumValidResponse contains the response from method Queries.EnumValid.
-type QueriesEnumValidResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // QueriesFloatNullOptions contains the optional parameters for the Queries.FloatNull method.
@@ -451,52 +156,10 @@ type QueriesFloatNullOptions struct {
 	FloatQuery *float32
 }
 
-// QueriesFloatNullResponse contains the response from method Queries.FloatNull.
-type QueriesFloatNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesFloatScientificNegativeResponse contains the response from method Queries.FloatScientificNegative.
-type QueriesFloatScientificNegativeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesFloatScientificPositiveResponse contains the response from method Queries.FloatScientificPositive.
-type QueriesFloatScientificPositiveResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesGetBooleanFalseResponse contains the response from method Queries.GetBooleanFalse.
-type QueriesGetBooleanFalseResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // QueriesGetBooleanNullOptions contains the optional parameters for the Queries.GetBooleanNull method.
 type QueriesGetBooleanNullOptions struct {
 	// null boolean value
 	BoolQuery *bool
-}
-
-// QueriesGetBooleanNullResponse contains the response from method Queries.GetBooleanNull.
-type QueriesGetBooleanNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesGetBooleanTrueResponse contains the response from method Queries.GetBooleanTrue.
-type QueriesGetBooleanTrueResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesGetIntNegativeOneMillionResponse contains the response from method Queries.GetIntNegativeOneMillion.
-type QueriesGetIntNegativeOneMillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }
 
 // QueriesGetIntNullOptions contains the optional parameters for the Queries.GetIntNull method.
@@ -505,68 +168,14 @@ type QueriesGetIntNullOptions struct {
 	IntQuery *int32
 }
 
-// QueriesGetIntNullResponse contains the response from method Queries.GetIntNull.
-type QueriesGetIntNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesGetIntOneMillionResponse contains the response from method Queries.GetIntOneMillion.
-type QueriesGetIntOneMillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // QueriesGetLongNullOptions contains the optional parameters for the Queries.GetLongNull method.
 type QueriesGetLongNullOptions struct {
 	// null 64 bit integer value
 	LongQuery *int64
 }
 
-// QueriesGetLongNullResponse contains the response from method Queries.GetLongNull.
-type QueriesGetLongNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesGetNegativeTenBillionResponse contains the response from method Queries.GetNegativeTenBillion.
-type QueriesGetNegativeTenBillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesGetTenBillionResponse contains the response from method Queries.GetTenBillion.
-type QueriesGetTenBillionResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesStringEmptyResponse contains the response from method Queries.StringEmpty.
-type QueriesStringEmptyResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // QueriesStringNullOptions contains the optional parameters for the Queries.StringNull method.
 type QueriesStringNullOptions struct {
 	// null string value
 	StringQuery *string
-}
-
-// QueriesStringNullResponse contains the response from method Queries.StringNull.
-type QueriesStringNullResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesStringURLEncodedResponse contains the response from method Queries.StringURLEncoded.
-type QueriesStringURLEncodedResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// QueriesStringUnicodeResponse contains the response from method Queries.StringUnicode.
-type QueriesStringUnicodeResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
 }

--- a/test/autorest/generated/urlgroup/pathitems.go
+++ b/test/autorest/generated/urlgroup/pathitems.go
@@ -17,13 +17,13 @@ import (
 // PathItemsOperations contains the methods for the PathItems group.
 type PathItemsOperations interface {
 	// GetAllWithValues - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-	GetAllWithValues(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetAllWithValuesOptions) (*PathItemsGetAllWithValuesResponse, error)
+	GetAllWithValues(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetAllWithValuesOptions) (*http.Response, error)
 	// GetGlobalAndLocalQueryNull - send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null
-	GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*PathItemsGetGlobalAndLocalQueryNullResponse, error)
+	GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*http.Response, error)
 	// GetGlobalQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-	GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalQueryNullOptions) (*PathItemsGetGlobalQueryNullResponse, error)
+	GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalQueryNullOptions) (*http.Response, error)
 	// GetLocalPathItemQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null
-	GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetLocalPathItemQueryNullOptions) (*PathItemsGetLocalPathItemQueryNullResponse, error)
+	GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetLocalPathItemQueryNullOptions) (*http.Response, error)
 }
 
 // pathItemsOperations implements the PathItemsOperations interface.
@@ -34,7 +34,7 @@ type pathItemsOperations struct {
 }
 
 // GetAllWithValues - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-func (client *pathItemsOperations) GetAllWithValues(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetAllWithValuesOptions) (*PathItemsGetAllWithValuesResponse, error) {
+func (client *pathItemsOperations) GetAllWithValues(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetAllWithValuesOptions) (*http.Response, error) {
 	req, err := client.getAllWithValuesCreateRequest(*client.u, pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
 	if err != nil {
 		return nil, err
@@ -73,15 +73,15 @@ func (client *pathItemsOperations) getAllWithValuesCreateRequest(u url.URL, path
 }
 
 // getAllWithValuesHandleResponse handles the GetAllWithValues response.
-func (client *pathItemsOperations) getAllWithValuesHandleResponse(resp *azcore.Response) (*PathItemsGetAllWithValuesResponse, error) {
+func (client *pathItemsOperations) getAllWithValuesHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathItemsGetAllWithValuesResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetGlobalAndLocalQueryNull - send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null
-func (client *pathItemsOperations) GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*PathItemsGetGlobalAndLocalQueryNullResponse, error) {
+func (client *pathItemsOperations) GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*http.Response, error) {
 	req, err := client.getGlobalAndLocalQueryNullCreateRequest(*client.u, pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
 	if err != nil {
 		return nil, err
@@ -120,15 +120,15 @@ func (client *pathItemsOperations) getGlobalAndLocalQueryNullCreateRequest(u url
 }
 
 // getGlobalAndLocalQueryNullHandleResponse handles the GetGlobalAndLocalQueryNull response.
-func (client *pathItemsOperations) getGlobalAndLocalQueryNullHandleResponse(resp *azcore.Response) (*PathItemsGetGlobalAndLocalQueryNullResponse, error) {
+func (client *pathItemsOperations) getGlobalAndLocalQueryNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathItemsGetGlobalAndLocalQueryNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetGlobalQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-func (client *pathItemsOperations) GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalQueryNullOptions) (*PathItemsGetGlobalQueryNullResponse, error) {
+func (client *pathItemsOperations) GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalQueryNullOptions) (*http.Response, error) {
 	req, err := client.getGlobalQueryNullCreateRequest(*client.u, pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
 	if err != nil {
 		return nil, err
@@ -167,15 +167,15 @@ func (client *pathItemsOperations) getGlobalQueryNullCreateRequest(u url.URL, pa
 }
 
 // getGlobalQueryNullHandleResponse handles the GetGlobalQueryNull response.
-func (client *pathItemsOperations) getGlobalQueryNullHandleResponse(resp *azcore.Response) (*PathItemsGetGlobalQueryNullResponse, error) {
+func (client *pathItemsOperations) getGlobalQueryNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathItemsGetGlobalQueryNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetLocalPathItemQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null
-func (client *pathItemsOperations) GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetLocalPathItemQueryNullOptions) (*PathItemsGetLocalPathItemQueryNullResponse, error) {
+func (client *pathItemsOperations) GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetLocalPathItemQueryNullOptions) (*http.Response, error) {
 	req, err := client.getLocalPathItemQueryNullCreateRequest(*client.u, pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
 	if err != nil {
 		return nil, err
@@ -214,9 +214,9 @@ func (client *pathItemsOperations) getLocalPathItemQueryNullCreateRequest(u url.
 }
 
 // getLocalPathItemQueryNullHandleResponse handles the GetLocalPathItemQueryNull response.
-func (client *pathItemsOperations) getLocalPathItemQueryNullHandleResponse(resp *azcore.Response) (*PathItemsGetLocalPathItemQueryNullResponse, error) {
+func (client *pathItemsOperations) getLocalPathItemQueryNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathItemsGetLocalPathItemQueryNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }

--- a/test/autorest/generated/urlgroup/paths.go
+++ b/test/autorest/generated/urlgroup/paths.go
@@ -19,59 +19,59 @@ import (
 // PathsOperations contains the methods for the Paths group.
 type PathsOperations interface {
 	// ArrayCSVInPath - Get an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
-	ArrayCSVInPath(ctx context.Context, arrayPath []string) (*PathsArrayCSVInPathResponse, error)
+	ArrayCSVInPath(ctx context.Context, arrayPath []string) (*http.Response, error)
 	// Base64URL - Get 'lorem' encoded value as 'bG9yZW0' (base64url)
-	Base64URL(ctx context.Context, base64UrlPath []byte) (*PathsBase64URLResponse, error)
+	Base64URL(ctx context.Context, base64UrlPath []byte) (*http.Response, error)
 	// ByteEmpty - Get '' as byte array
-	ByteEmpty(ctx context.Context) (*PathsByteEmptyResponse, error)
+	ByteEmpty(ctx context.Context) (*http.Response, error)
 	// ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-	ByteMultiByte(ctx context.Context, bytePath []byte) (*PathsByteMultiByteResponse, error)
+	ByteMultiByte(ctx context.Context, bytePath []byte) (*http.Response, error)
 	// ByteNull - Get null as byte array (should throw)
-	ByteNull(ctx context.Context, bytePath []byte) (*PathsByteNullResponse, error)
+	ByteNull(ctx context.Context, bytePath []byte) (*http.Response, error)
 	// DateNull - Get null as date - this should throw or be unusable on the client side, depending on date representation
-	DateNull(ctx context.Context, datePath time.Time) (*PathsDateNullResponse, error)
+	DateNull(ctx context.Context, datePath time.Time) (*http.Response, error)
 	// DateTimeNull - Get null as date-time, should be disallowed or throw depending on representation of date-time
-	DateTimeNull(ctx context.Context, dateTimePath time.Time) (*PathsDateTimeNullResponse, error)
+	DateTimeNull(ctx context.Context, dateTimePath time.Time) (*http.Response, error)
 	// DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
-	DateTimeValid(ctx context.Context) (*PathsDateTimeValidResponse, error)
+	DateTimeValid(ctx context.Context) (*http.Response, error)
 	// DateValid - Get '2012-01-01' as date
-	DateValid(ctx context.Context) (*PathsDateValidResponse, error)
+	DateValid(ctx context.Context) (*http.Response, error)
 	// DoubleDecimalNegative - Get '-9999999.999' numeric value
-	DoubleDecimalNegative(ctx context.Context) (*PathsDoubleDecimalNegativeResponse, error)
+	DoubleDecimalNegative(ctx context.Context) (*http.Response, error)
 	// DoubleDecimalPositive - Get '9999999.999' numeric value
-	DoubleDecimalPositive(ctx context.Context) (*PathsDoubleDecimalPositiveResponse, error)
+	DoubleDecimalPositive(ctx context.Context) (*http.Response, error)
 	// EnumNull - Get null (should throw on the client before the request is sent on wire)
-	EnumNull(ctx context.Context, enumPath UriColor) (*PathsEnumNullResponse, error)
+	EnumNull(ctx context.Context, enumPath UriColor) (*http.Response, error)
 	// EnumValid - Get using uri with 'green color' in path parameter
-	EnumValid(ctx context.Context, enumPath UriColor) (*PathsEnumValidResponse, error)
+	EnumValid(ctx context.Context, enumPath UriColor) (*http.Response, error)
 	// FloatScientificNegative - Get '-1.034E-20' numeric value
-	FloatScientificNegative(ctx context.Context) (*PathsFloatScientificNegativeResponse, error)
+	FloatScientificNegative(ctx context.Context) (*http.Response, error)
 	// FloatScientificPositive - Get '1.034E+20' numeric value
-	FloatScientificPositive(ctx context.Context) (*PathsFloatScientificPositiveResponse, error)
+	FloatScientificPositive(ctx context.Context) (*http.Response, error)
 	// GetBooleanFalse - Get false Boolean value on path
-	GetBooleanFalse(ctx context.Context) (*PathsGetBooleanFalseResponse, error)
+	GetBooleanFalse(ctx context.Context) (*http.Response, error)
 	// GetBooleanTrue - Get true Boolean value on path
-	GetBooleanTrue(ctx context.Context) (*PathsGetBooleanTrueResponse, error)
+	GetBooleanTrue(ctx context.Context) (*http.Response, error)
 	// GetIntNegativeOneMillion - Get '-1000000' integer value
-	GetIntNegativeOneMillion(ctx context.Context) (*PathsGetIntNegativeOneMillionResponse, error)
+	GetIntNegativeOneMillion(ctx context.Context) (*http.Response, error)
 	// GetIntOneMillion - Get '1000000' integer value
-	GetIntOneMillion(ctx context.Context) (*PathsGetIntOneMillionResponse, error)
+	GetIntOneMillion(ctx context.Context) (*http.Response, error)
 	// GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
-	GetNegativeTenBillion(ctx context.Context) (*PathsGetNegativeTenBillionResponse, error)
+	GetNegativeTenBillion(ctx context.Context) (*http.Response, error)
 	// GetTenBillion - Get '10000000000' 64 bit integer value
-	GetTenBillion(ctx context.Context) (*PathsGetTenBillionResponse, error)
+	GetTenBillion(ctx context.Context) (*http.Response, error)
 	// StringEmpty - Get ''
-	StringEmpty(ctx context.Context) (*PathsStringEmptyResponse, error)
+	StringEmpty(ctx context.Context) (*http.Response, error)
 	// StringNull - Get null (should throw)
-	StringNull(ctx context.Context, stringPath string) (*PathsStringNullResponse, error)
+	StringNull(ctx context.Context, stringPath string) (*http.Response, error)
 	// StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
-	StringURLEncoded(ctx context.Context) (*PathsStringURLEncodedResponse, error)
+	StringURLEncoded(ctx context.Context) (*http.Response, error)
 	// StringURLNonEncoded - Get 'begin!*'();:@&=+$,end
-	StringURLNonEncoded(ctx context.Context) (*PathsStringURLNonEncodedResponse, error)
+	StringURLNonEncoded(ctx context.Context) (*http.Response, error)
 	// StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
-	StringUnicode(ctx context.Context) (*PathsStringUnicodeResponse, error)
+	StringUnicode(ctx context.Context) (*http.Response, error)
 	// UnixTimeURL - Get the date 2016-04-13 encoded value as '1460505600' (Unix time)
-	UnixTimeURL(ctx context.Context, unixTimeUrlPath time.Time) (*PathsUnixTimeURLResponse, error)
+	UnixTimeURL(ctx context.Context, unixTimeUrlPath time.Time) (*http.Response, error)
 }
 
 // pathsOperations implements the PathsOperations interface.
@@ -80,7 +80,7 @@ type pathsOperations struct {
 }
 
 // ArrayCSVInPath - Get an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
-func (client *pathsOperations) ArrayCSVInPath(ctx context.Context, arrayPath []string) (*PathsArrayCSVInPathResponse, error) {
+func (client *pathsOperations) ArrayCSVInPath(ctx context.Context, arrayPath []string) (*http.Response, error) {
 	req, err := client.arrayCsvInPathCreateRequest(*client.u, arrayPath)
 	if err != nil {
 		return nil, err
@@ -106,15 +106,15 @@ func (client *pathsOperations) arrayCsvInPathCreateRequest(u url.URL, arrayPath 
 }
 
 // arrayCsvInPathHandleResponse handles the ArrayCSVInPath response.
-func (client *pathsOperations) arrayCsvInPathHandleResponse(resp *azcore.Response) (*PathsArrayCSVInPathResponse, error) {
+func (client *pathsOperations) arrayCsvInPathHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsArrayCSVInPathResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // Base64URL - Get 'lorem' encoded value as 'bG9yZW0' (base64url)
-func (client *pathsOperations) Base64URL(ctx context.Context, base64UrlPath []byte) (*PathsBase64URLResponse, error) {
+func (client *pathsOperations) Base64URL(ctx context.Context, base64UrlPath []byte) (*http.Response, error) {
 	req, err := client.base64UrlCreateRequest(*client.u, base64UrlPath)
 	if err != nil {
 		return nil, err
@@ -140,15 +140,15 @@ func (client *pathsOperations) base64UrlCreateRequest(u url.URL, base64UrlPath [
 }
 
 // base64UrlHandleResponse handles the Base64URL response.
-func (client *pathsOperations) base64UrlHandleResponse(resp *azcore.Response) (*PathsBase64URLResponse, error) {
+func (client *pathsOperations) base64UrlHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsBase64URLResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ByteEmpty - Get '' as byte array
-func (client *pathsOperations) ByteEmpty(ctx context.Context) (*PathsByteEmptyResponse, error) {
+func (client *pathsOperations) ByteEmpty(ctx context.Context) (*http.Response, error) {
 	req, err := client.byteEmptyCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -174,15 +174,15 @@ func (client *pathsOperations) byteEmptyCreateRequest(u url.URL) (*azcore.Reques
 }
 
 // byteEmptyHandleResponse handles the ByteEmpty response.
-func (client *pathsOperations) byteEmptyHandleResponse(resp *azcore.Response) (*PathsByteEmptyResponse, error) {
+func (client *pathsOperations) byteEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsByteEmptyResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-func (client *pathsOperations) ByteMultiByte(ctx context.Context, bytePath []byte) (*PathsByteMultiByteResponse, error) {
+func (client *pathsOperations) ByteMultiByte(ctx context.Context, bytePath []byte) (*http.Response, error) {
 	req, err := client.byteMultiByteCreateRequest(*client.u, bytePath)
 	if err != nil {
 		return nil, err
@@ -208,15 +208,15 @@ func (client *pathsOperations) byteMultiByteCreateRequest(u url.URL, bytePath []
 }
 
 // byteMultiByteHandleResponse handles the ByteMultiByte response.
-func (client *pathsOperations) byteMultiByteHandleResponse(resp *azcore.Response) (*PathsByteMultiByteResponse, error) {
+func (client *pathsOperations) byteMultiByteHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsByteMultiByteResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ByteNull - Get null as byte array (should throw)
-func (client *pathsOperations) ByteNull(ctx context.Context, bytePath []byte) (*PathsByteNullResponse, error) {
+func (client *pathsOperations) ByteNull(ctx context.Context, bytePath []byte) (*http.Response, error) {
 	req, err := client.byteNullCreateRequest(*client.u, bytePath)
 	if err != nil {
 		return nil, err
@@ -242,15 +242,15 @@ func (client *pathsOperations) byteNullCreateRequest(u url.URL, bytePath []byte)
 }
 
 // byteNullHandleResponse handles the ByteNull response.
-func (client *pathsOperations) byteNullHandleResponse(resp *azcore.Response) (*PathsByteNullResponse, error) {
+func (client *pathsOperations) byteNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusBadRequest) {
 		return nil, newError(resp)
 	}
-	return &PathsByteNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // DateNull - Get null as date - this should throw or be unusable on the client side, depending on date representation
-func (client *pathsOperations) DateNull(ctx context.Context, datePath time.Time) (*PathsDateNullResponse, error) {
+func (client *pathsOperations) DateNull(ctx context.Context, datePath time.Time) (*http.Response, error) {
 	req, err := client.dateNullCreateRequest(*client.u, datePath)
 	if err != nil {
 		return nil, err
@@ -276,15 +276,15 @@ func (client *pathsOperations) dateNullCreateRequest(u url.URL, datePath time.Ti
 }
 
 // dateNullHandleResponse handles the DateNull response.
-func (client *pathsOperations) dateNullHandleResponse(resp *azcore.Response) (*PathsDateNullResponse, error) {
+func (client *pathsOperations) dateNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusBadRequest) {
 		return nil, newError(resp)
 	}
-	return &PathsDateNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // DateTimeNull - Get null as date-time, should be disallowed or throw depending on representation of date-time
-func (client *pathsOperations) DateTimeNull(ctx context.Context, dateTimePath time.Time) (*PathsDateTimeNullResponse, error) {
+func (client *pathsOperations) DateTimeNull(ctx context.Context, dateTimePath time.Time) (*http.Response, error) {
 	req, err := client.dateTimeNullCreateRequest(*client.u, dateTimePath)
 	if err != nil {
 		return nil, err
@@ -310,15 +310,15 @@ func (client *pathsOperations) dateTimeNullCreateRequest(u url.URL, dateTimePath
 }
 
 // dateTimeNullHandleResponse handles the DateTimeNull response.
-func (client *pathsOperations) dateTimeNullHandleResponse(resp *azcore.Response) (*PathsDateTimeNullResponse, error) {
+func (client *pathsOperations) dateTimeNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusBadRequest) {
 		return nil, newError(resp)
 	}
-	return &PathsDateTimeNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
-func (client *pathsOperations) DateTimeValid(ctx context.Context) (*PathsDateTimeValidResponse, error) {
+func (client *pathsOperations) DateTimeValid(ctx context.Context) (*http.Response, error) {
 	req, err := client.dateTimeValidCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -344,15 +344,15 @@ func (client *pathsOperations) dateTimeValidCreateRequest(u url.URL) (*azcore.Re
 }
 
 // dateTimeValidHandleResponse handles the DateTimeValid response.
-func (client *pathsOperations) dateTimeValidHandleResponse(resp *azcore.Response) (*PathsDateTimeValidResponse, error) {
+func (client *pathsOperations) dateTimeValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsDateTimeValidResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // DateValid - Get '2012-01-01' as date
-func (client *pathsOperations) DateValid(ctx context.Context) (*PathsDateValidResponse, error) {
+func (client *pathsOperations) DateValid(ctx context.Context) (*http.Response, error) {
 	req, err := client.dateValidCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -378,15 +378,15 @@ func (client *pathsOperations) dateValidCreateRequest(u url.URL) (*azcore.Reques
 }
 
 // dateValidHandleResponse handles the DateValid response.
-func (client *pathsOperations) dateValidHandleResponse(resp *azcore.Response) (*PathsDateValidResponse, error) {
+func (client *pathsOperations) dateValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsDateValidResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // DoubleDecimalNegative - Get '-9999999.999' numeric value
-func (client *pathsOperations) DoubleDecimalNegative(ctx context.Context) (*PathsDoubleDecimalNegativeResponse, error) {
+func (client *pathsOperations) DoubleDecimalNegative(ctx context.Context) (*http.Response, error) {
 	req, err := client.doubleDecimalNegativeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -412,15 +412,15 @@ func (client *pathsOperations) doubleDecimalNegativeCreateRequest(u url.URL) (*a
 }
 
 // doubleDecimalNegativeHandleResponse handles the DoubleDecimalNegative response.
-func (client *pathsOperations) doubleDecimalNegativeHandleResponse(resp *azcore.Response) (*PathsDoubleDecimalNegativeResponse, error) {
+func (client *pathsOperations) doubleDecimalNegativeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsDoubleDecimalNegativeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // DoubleDecimalPositive - Get '9999999.999' numeric value
-func (client *pathsOperations) DoubleDecimalPositive(ctx context.Context) (*PathsDoubleDecimalPositiveResponse, error) {
+func (client *pathsOperations) DoubleDecimalPositive(ctx context.Context) (*http.Response, error) {
 	req, err := client.doubleDecimalPositiveCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -446,15 +446,15 @@ func (client *pathsOperations) doubleDecimalPositiveCreateRequest(u url.URL) (*a
 }
 
 // doubleDecimalPositiveHandleResponse handles the DoubleDecimalPositive response.
-func (client *pathsOperations) doubleDecimalPositiveHandleResponse(resp *azcore.Response) (*PathsDoubleDecimalPositiveResponse, error) {
+func (client *pathsOperations) doubleDecimalPositiveHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsDoubleDecimalPositiveResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // EnumNull - Get null (should throw on the client before the request is sent on wire)
-func (client *pathsOperations) EnumNull(ctx context.Context, enumPath UriColor) (*PathsEnumNullResponse, error) {
+func (client *pathsOperations) EnumNull(ctx context.Context, enumPath UriColor) (*http.Response, error) {
 	req, err := client.enumNullCreateRequest(*client.u, enumPath)
 	if err != nil {
 		return nil, err
@@ -480,15 +480,15 @@ func (client *pathsOperations) enumNullCreateRequest(u url.URL, enumPath UriColo
 }
 
 // enumNullHandleResponse handles the EnumNull response.
-func (client *pathsOperations) enumNullHandleResponse(resp *azcore.Response) (*PathsEnumNullResponse, error) {
+func (client *pathsOperations) enumNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusBadRequest) {
 		return nil, newError(resp)
 	}
-	return &PathsEnumNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // EnumValid - Get using uri with 'green color' in path parameter
-func (client *pathsOperations) EnumValid(ctx context.Context, enumPath UriColor) (*PathsEnumValidResponse, error) {
+func (client *pathsOperations) EnumValid(ctx context.Context, enumPath UriColor) (*http.Response, error) {
 	req, err := client.enumValidCreateRequest(*client.u, enumPath)
 	if err != nil {
 		return nil, err
@@ -514,15 +514,15 @@ func (client *pathsOperations) enumValidCreateRequest(u url.URL, enumPath UriCol
 }
 
 // enumValidHandleResponse handles the EnumValid response.
-func (client *pathsOperations) enumValidHandleResponse(resp *azcore.Response) (*PathsEnumValidResponse, error) {
+func (client *pathsOperations) enumValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsEnumValidResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // FloatScientificNegative - Get '-1.034E-20' numeric value
-func (client *pathsOperations) FloatScientificNegative(ctx context.Context) (*PathsFloatScientificNegativeResponse, error) {
+func (client *pathsOperations) FloatScientificNegative(ctx context.Context) (*http.Response, error) {
 	req, err := client.floatScientificNegativeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -548,15 +548,15 @@ func (client *pathsOperations) floatScientificNegativeCreateRequest(u url.URL) (
 }
 
 // floatScientificNegativeHandleResponse handles the FloatScientificNegative response.
-func (client *pathsOperations) floatScientificNegativeHandleResponse(resp *azcore.Response) (*PathsFloatScientificNegativeResponse, error) {
+func (client *pathsOperations) floatScientificNegativeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsFloatScientificNegativeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // FloatScientificPositive - Get '1.034E+20' numeric value
-func (client *pathsOperations) FloatScientificPositive(ctx context.Context) (*PathsFloatScientificPositiveResponse, error) {
+func (client *pathsOperations) FloatScientificPositive(ctx context.Context) (*http.Response, error) {
 	req, err := client.floatScientificPositiveCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -582,15 +582,15 @@ func (client *pathsOperations) floatScientificPositiveCreateRequest(u url.URL) (
 }
 
 // floatScientificPositiveHandleResponse handles the FloatScientificPositive response.
-func (client *pathsOperations) floatScientificPositiveHandleResponse(resp *azcore.Response) (*PathsFloatScientificPositiveResponse, error) {
+func (client *pathsOperations) floatScientificPositiveHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsFloatScientificPositiveResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetBooleanFalse - Get false Boolean value on path
-func (client *pathsOperations) GetBooleanFalse(ctx context.Context) (*PathsGetBooleanFalseResponse, error) {
+func (client *pathsOperations) GetBooleanFalse(ctx context.Context) (*http.Response, error) {
 	req, err := client.getBooleanFalseCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -616,15 +616,15 @@ func (client *pathsOperations) getBooleanFalseCreateRequest(u url.URL) (*azcore.
 }
 
 // getBooleanFalseHandleResponse handles the GetBooleanFalse response.
-func (client *pathsOperations) getBooleanFalseHandleResponse(resp *azcore.Response) (*PathsGetBooleanFalseResponse, error) {
+func (client *pathsOperations) getBooleanFalseHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsGetBooleanFalseResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetBooleanTrue - Get true Boolean value on path
-func (client *pathsOperations) GetBooleanTrue(ctx context.Context) (*PathsGetBooleanTrueResponse, error) {
+func (client *pathsOperations) GetBooleanTrue(ctx context.Context) (*http.Response, error) {
 	req, err := client.getBooleanTrueCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -650,15 +650,15 @@ func (client *pathsOperations) getBooleanTrueCreateRequest(u url.URL) (*azcore.R
 }
 
 // getBooleanTrueHandleResponse handles the GetBooleanTrue response.
-func (client *pathsOperations) getBooleanTrueHandleResponse(resp *azcore.Response) (*PathsGetBooleanTrueResponse, error) {
+func (client *pathsOperations) getBooleanTrueHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsGetBooleanTrueResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetIntNegativeOneMillion - Get '-1000000' integer value
-func (client *pathsOperations) GetIntNegativeOneMillion(ctx context.Context) (*PathsGetIntNegativeOneMillionResponse, error) {
+func (client *pathsOperations) GetIntNegativeOneMillion(ctx context.Context) (*http.Response, error) {
 	req, err := client.getIntNegativeOneMillionCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -684,15 +684,15 @@ func (client *pathsOperations) getIntNegativeOneMillionCreateRequest(u url.URL) 
 }
 
 // getIntNegativeOneMillionHandleResponse handles the GetIntNegativeOneMillion response.
-func (client *pathsOperations) getIntNegativeOneMillionHandleResponse(resp *azcore.Response) (*PathsGetIntNegativeOneMillionResponse, error) {
+func (client *pathsOperations) getIntNegativeOneMillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsGetIntNegativeOneMillionResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetIntOneMillion - Get '1000000' integer value
-func (client *pathsOperations) GetIntOneMillion(ctx context.Context) (*PathsGetIntOneMillionResponse, error) {
+func (client *pathsOperations) GetIntOneMillion(ctx context.Context) (*http.Response, error) {
 	req, err := client.getIntOneMillionCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -718,15 +718,15 @@ func (client *pathsOperations) getIntOneMillionCreateRequest(u url.URL) (*azcore
 }
 
 // getIntOneMillionHandleResponse handles the GetIntOneMillion response.
-func (client *pathsOperations) getIntOneMillionHandleResponse(resp *azcore.Response) (*PathsGetIntOneMillionResponse, error) {
+func (client *pathsOperations) getIntOneMillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsGetIntOneMillionResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
-func (client *pathsOperations) GetNegativeTenBillion(ctx context.Context) (*PathsGetNegativeTenBillionResponse, error) {
+func (client *pathsOperations) GetNegativeTenBillion(ctx context.Context) (*http.Response, error) {
 	req, err := client.getNegativeTenBillionCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -752,15 +752,15 @@ func (client *pathsOperations) getNegativeTenBillionCreateRequest(u url.URL) (*a
 }
 
 // getNegativeTenBillionHandleResponse handles the GetNegativeTenBillion response.
-func (client *pathsOperations) getNegativeTenBillionHandleResponse(resp *azcore.Response) (*PathsGetNegativeTenBillionResponse, error) {
+func (client *pathsOperations) getNegativeTenBillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsGetNegativeTenBillionResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetTenBillion - Get '10000000000' 64 bit integer value
-func (client *pathsOperations) GetTenBillion(ctx context.Context) (*PathsGetTenBillionResponse, error) {
+func (client *pathsOperations) GetTenBillion(ctx context.Context) (*http.Response, error) {
 	req, err := client.getTenBillionCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -786,15 +786,15 @@ func (client *pathsOperations) getTenBillionCreateRequest(u url.URL) (*azcore.Re
 }
 
 // getTenBillionHandleResponse handles the GetTenBillion response.
-func (client *pathsOperations) getTenBillionHandleResponse(resp *azcore.Response) (*PathsGetTenBillionResponse, error) {
+func (client *pathsOperations) getTenBillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsGetTenBillionResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // StringEmpty - Get ''
-func (client *pathsOperations) StringEmpty(ctx context.Context) (*PathsStringEmptyResponse, error) {
+func (client *pathsOperations) StringEmpty(ctx context.Context) (*http.Response, error) {
 	req, err := client.stringEmptyCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -820,15 +820,15 @@ func (client *pathsOperations) stringEmptyCreateRequest(u url.URL) (*azcore.Requ
 }
 
 // stringEmptyHandleResponse handles the StringEmpty response.
-func (client *pathsOperations) stringEmptyHandleResponse(resp *azcore.Response) (*PathsStringEmptyResponse, error) {
+func (client *pathsOperations) stringEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsStringEmptyResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // StringNull - Get null (should throw)
-func (client *pathsOperations) StringNull(ctx context.Context, stringPath string) (*PathsStringNullResponse, error) {
+func (client *pathsOperations) StringNull(ctx context.Context, stringPath string) (*http.Response, error) {
 	req, err := client.stringNullCreateRequest(*client.u, stringPath)
 	if err != nil {
 		return nil, err
@@ -854,15 +854,15 @@ func (client *pathsOperations) stringNullCreateRequest(u url.URL, stringPath str
 }
 
 // stringNullHandleResponse handles the StringNull response.
-func (client *pathsOperations) stringNullHandleResponse(resp *azcore.Response) (*PathsStringNullResponse, error) {
+func (client *pathsOperations) stringNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusBadRequest) {
 		return nil, newError(resp)
 	}
-	return &PathsStringNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
-func (client *pathsOperations) StringURLEncoded(ctx context.Context) (*PathsStringURLEncodedResponse, error) {
+func (client *pathsOperations) StringURLEncoded(ctx context.Context) (*http.Response, error) {
 	req, err := client.stringUrlEncodedCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -888,15 +888,15 @@ func (client *pathsOperations) stringUrlEncodedCreateRequest(u url.URL) (*azcore
 }
 
 // stringUrlEncodedHandleResponse handles the StringURLEncoded response.
-func (client *pathsOperations) stringUrlEncodedHandleResponse(resp *azcore.Response) (*PathsStringURLEncodedResponse, error) {
+func (client *pathsOperations) stringUrlEncodedHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsStringURLEncodedResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // StringURLNonEncoded - Get 'begin!*'();:@&=+$,end
-func (client *pathsOperations) StringURLNonEncoded(ctx context.Context) (*PathsStringURLNonEncodedResponse, error) {
+func (client *pathsOperations) StringURLNonEncoded(ctx context.Context) (*http.Response, error) {
 	req, err := client.stringUrlNonEncodedCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -922,15 +922,15 @@ func (client *pathsOperations) stringUrlNonEncodedCreateRequest(u url.URL) (*azc
 }
 
 // stringUrlNonEncodedHandleResponse handles the StringURLNonEncoded response.
-func (client *pathsOperations) stringUrlNonEncodedHandleResponse(resp *azcore.Response) (*PathsStringURLNonEncodedResponse, error) {
+func (client *pathsOperations) stringUrlNonEncodedHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsStringURLNonEncodedResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
-func (client *pathsOperations) StringUnicode(ctx context.Context) (*PathsStringUnicodeResponse, error) {
+func (client *pathsOperations) StringUnicode(ctx context.Context) (*http.Response, error) {
 	req, err := client.stringUnicodeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -956,15 +956,15 @@ func (client *pathsOperations) stringUnicodeCreateRequest(u url.URL) (*azcore.Re
 }
 
 // stringUnicodeHandleResponse handles the StringUnicode response.
-func (client *pathsOperations) stringUnicodeHandleResponse(resp *azcore.Response) (*PathsStringUnicodeResponse, error) {
+func (client *pathsOperations) stringUnicodeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsStringUnicodeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // UnixTimeURL - Get the date 2016-04-13 encoded value as '1460505600' (Unix time)
-func (client *pathsOperations) UnixTimeURL(ctx context.Context, unixTimeUrlPath time.Time) (*PathsUnixTimeURLResponse, error) {
+func (client *pathsOperations) UnixTimeURL(ctx context.Context, unixTimeUrlPath time.Time) (*http.Response, error) {
 	req, err := client.unixTimeUrlCreateRequest(*client.u, unixTimeUrlPath)
 	if err != nil {
 		return nil, err
@@ -990,9 +990,9 @@ func (client *pathsOperations) unixTimeUrlCreateRequest(u url.URL, unixTimeUrlPa
 }
 
 // unixTimeUrlHandleResponse handles the UnixTimeURL response.
-func (client *pathsOperations) unixTimeUrlHandleResponse(resp *azcore.Response) (*PathsUnixTimeURLResponse, error) {
+func (client *pathsOperations) unixTimeUrlHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &PathsUnixTimeURLResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }

--- a/test/autorest/generated/urlgroup/queries.go
+++ b/test/autorest/generated/urlgroup/queries.go
@@ -20,73 +20,73 @@ import (
 // QueriesOperations contains the methods for the Queries group.
 type QueriesOperations interface {
 	// ArrayStringCSVEmpty - Get an empty array [] of string using the csv-array format
-	ArrayStringCSVEmpty(ctx context.Context, options *QueriesArrayStringCSVEmptyOptions) (*QueriesArrayStringCSVEmptyResponse, error)
+	ArrayStringCSVEmpty(ctx context.Context, options *QueriesArrayStringCSVEmptyOptions) (*http.Response, error)
 	// ArrayStringCSVNull - Get a null array of string using the csv-array format
-	ArrayStringCSVNull(ctx context.Context, options *QueriesArrayStringCSVNullOptions) (*QueriesArrayStringCSVNullResponse, error)
+	ArrayStringCSVNull(ctx context.Context, options *QueriesArrayStringCSVNullOptions) (*http.Response, error)
 	// ArrayStringCSVValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
-	ArrayStringCSVValid(ctx context.Context, options *QueriesArrayStringCSVValidOptions) (*QueriesArrayStringCSVValidResponse, error)
+	ArrayStringCSVValid(ctx context.Context, options *QueriesArrayStringCSVValidOptions) (*http.Response, error)
 	// ArrayStringPipesValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array format
-	ArrayStringPipesValid(ctx context.Context, options *QueriesArrayStringPipesValidOptions) (*QueriesArrayStringPipesValidResponse, error)
+	ArrayStringPipesValid(ctx context.Context, options *QueriesArrayStringPipesValidOptions) (*http.Response, error)
 	// ArrayStringSsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format
-	ArrayStringSsvValid(ctx context.Context, options *QueriesArrayStringSsvValidOptions) (*QueriesArrayStringSsvValidResponse, error)
+	ArrayStringSsvValid(ctx context.Context, options *QueriesArrayStringSsvValidOptions) (*http.Response, error)
 	// ArrayStringTsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array format
-	ArrayStringTsvValid(ctx context.Context, options *QueriesArrayStringTsvValidOptions) (*QueriesArrayStringTsvValidResponse, error)
+	ArrayStringTsvValid(ctx context.Context, options *QueriesArrayStringTsvValidOptions) (*http.Response, error)
 	// ByteEmpty - Get '' as byte array
-	ByteEmpty(ctx context.Context) (*QueriesByteEmptyResponse, error)
+	ByteEmpty(ctx context.Context) (*http.Response, error)
 	// ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-	ByteMultiByte(ctx context.Context, options *QueriesByteMultiByteOptions) (*QueriesByteMultiByteResponse, error)
+	ByteMultiByte(ctx context.Context, options *QueriesByteMultiByteOptions) (*http.Response, error)
 	// ByteNull - Get null as byte array (no query parameters in uri)
-	ByteNull(ctx context.Context, options *QueriesByteNullOptions) (*QueriesByteNullResponse, error)
+	ByteNull(ctx context.Context, options *QueriesByteNullOptions) (*http.Response, error)
 	// DateNull - Get null as date - this should result in no query parameters in uri
-	DateNull(ctx context.Context, options *QueriesDateNullOptions) (*QueriesDateNullResponse, error)
+	DateNull(ctx context.Context, options *QueriesDateNullOptions) (*http.Response, error)
 	// DateTimeNull - Get null as date-time, should result in no query parameters in uri
-	DateTimeNull(ctx context.Context, options *QueriesDateTimeNullOptions) (*QueriesDateTimeNullResponse, error)
+	DateTimeNull(ctx context.Context, options *QueriesDateTimeNullOptions) (*http.Response, error)
 	// DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
-	DateTimeValid(ctx context.Context) (*QueriesDateTimeValidResponse, error)
+	DateTimeValid(ctx context.Context) (*http.Response, error)
 	// DateValid - Get '2012-01-01' as date
-	DateValid(ctx context.Context) (*QueriesDateValidResponse, error)
+	DateValid(ctx context.Context) (*http.Response, error)
 	// DoubleDecimalNegative - Get '-9999999.999' numeric value
-	DoubleDecimalNegative(ctx context.Context) (*QueriesDoubleDecimalNegativeResponse, error)
+	DoubleDecimalNegative(ctx context.Context) (*http.Response, error)
 	// DoubleDecimalPositive - Get '9999999.999' numeric value
-	DoubleDecimalPositive(ctx context.Context) (*QueriesDoubleDecimalPositiveResponse, error)
+	DoubleDecimalPositive(ctx context.Context) (*http.Response, error)
 	// DoubleNull - Get null numeric value (no query parameter)
-	DoubleNull(ctx context.Context, options *QueriesDoubleNullOptions) (*QueriesDoubleNullResponse, error)
+	DoubleNull(ctx context.Context, options *QueriesDoubleNullOptions) (*http.Response, error)
 	// EnumNull - Get null (no query parameter in url)
-	EnumNull(ctx context.Context, options *QueriesEnumNullOptions) (*QueriesEnumNullResponse, error)
+	EnumNull(ctx context.Context, options *QueriesEnumNullOptions) (*http.Response, error)
 	// EnumValid - Get using uri with query parameter 'green color'
-	EnumValid(ctx context.Context, options *QueriesEnumValidOptions) (*QueriesEnumValidResponse, error)
+	EnumValid(ctx context.Context, options *QueriesEnumValidOptions) (*http.Response, error)
 	// FloatNull - Get null numeric value (no query parameter)
-	FloatNull(ctx context.Context, options *QueriesFloatNullOptions) (*QueriesFloatNullResponse, error)
+	FloatNull(ctx context.Context, options *QueriesFloatNullOptions) (*http.Response, error)
 	// FloatScientificNegative - Get '-1.034E-20' numeric value
-	FloatScientificNegative(ctx context.Context) (*QueriesFloatScientificNegativeResponse, error)
+	FloatScientificNegative(ctx context.Context) (*http.Response, error)
 	// FloatScientificPositive - Get '1.034E+20' numeric value
-	FloatScientificPositive(ctx context.Context) (*QueriesFloatScientificPositiveResponse, error)
+	FloatScientificPositive(ctx context.Context) (*http.Response, error)
 	// GetBooleanFalse - Get false Boolean value on path
-	GetBooleanFalse(ctx context.Context) (*QueriesGetBooleanFalseResponse, error)
+	GetBooleanFalse(ctx context.Context) (*http.Response, error)
 	// GetBooleanNull - Get null Boolean value on query (query string should be absent)
-	GetBooleanNull(ctx context.Context, options *QueriesGetBooleanNullOptions) (*QueriesGetBooleanNullResponse, error)
+	GetBooleanNull(ctx context.Context, options *QueriesGetBooleanNullOptions) (*http.Response, error)
 	// GetBooleanTrue - Get true Boolean value on path
-	GetBooleanTrue(ctx context.Context) (*QueriesGetBooleanTrueResponse, error)
+	GetBooleanTrue(ctx context.Context) (*http.Response, error)
 	// GetIntNegativeOneMillion - Get '-1000000' integer value
-	GetIntNegativeOneMillion(ctx context.Context) (*QueriesGetIntNegativeOneMillionResponse, error)
+	GetIntNegativeOneMillion(ctx context.Context) (*http.Response, error)
 	// GetIntNull - Get null integer value (no query parameter)
-	GetIntNull(ctx context.Context, options *QueriesGetIntNullOptions) (*QueriesGetIntNullResponse, error)
+	GetIntNull(ctx context.Context, options *QueriesGetIntNullOptions) (*http.Response, error)
 	// GetIntOneMillion - Get '1000000' integer value
-	GetIntOneMillion(ctx context.Context) (*QueriesGetIntOneMillionResponse, error)
+	GetIntOneMillion(ctx context.Context) (*http.Response, error)
 	// GetLongNull - Get 'null 64 bit integer value (no query param in uri)
-	GetLongNull(ctx context.Context, options *QueriesGetLongNullOptions) (*QueriesGetLongNullResponse, error)
+	GetLongNull(ctx context.Context, options *QueriesGetLongNullOptions) (*http.Response, error)
 	// GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
-	GetNegativeTenBillion(ctx context.Context) (*QueriesGetNegativeTenBillionResponse, error)
+	GetNegativeTenBillion(ctx context.Context) (*http.Response, error)
 	// GetTenBillion - Get '10000000000' 64 bit integer value
-	GetTenBillion(ctx context.Context) (*QueriesGetTenBillionResponse, error)
+	GetTenBillion(ctx context.Context) (*http.Response, error)
 	// StringEmpty - Get ''
-	StringEmpty(ctx context.Context) (*QueriesStringEmptyResponse, error)
+	StringEmpty(ctx context.Context) (*http.Response, error)
 	// StringNull - Get null (no query parameter in url)
-	StringNull(ctx context.Context, options *QueriesStringNullOptions) (*QueriesStringNullResponse, error)
+	StringNull(ctx context.Context, options *QueriesStringNullOptions) (*http.Response, error)
 	// StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
-	StringURLEncoded(ctx context.Context) (*QueriesStringURLEncodedResponse, error)
+	StringURLEncoded(ctx context.Context) (*http.Response, error)
 	// StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
-	StringUnicode(ctx context.Context) (*QueriesStringUnicodeResponse, error)
+	StringUnicode(ctx context.Context) (*http.Response, error)
 }
 
 // queriesOperations implements the QueriesOperations interface.
@@ -95,7 +95,7 @@ type queriesOperations struct {
 }
 
 // ArrayStringCSVEmpty - Get an empty array [] of string using the csv-array format
-func (client *queriesOperations) ArrayStringCSVEmpty(ctx context.Context, options *QueriesArrayStringCSVEmptyOptions) (*QueriesArrayStringCSVEmptyResponse, error) {
+func (client *queriesOperations) ArrayStringCSVEmpty(ctx context.Context, options *QueriesArrayStringCSVEmptyOptions) (*http.Response, error) {
 	req, err := client.arrayStringCsvEmptyCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -125,15 +125,15 @@ func (client *queriesOperations) arrayStringCsvEmptyCreateRequest(u url.URL, opt
 }
 
 // arrayStringCsvEmptyHandleResponse handles the ArrayStringCSVEmpty response.
-func (client *queriesOperations) arrayStringCsvEmptyHandleResponse(resp *azcore.Response) (*QueriesArrayStringCSVEmptyResponse, error) {
+func (client *queriesOperations) arrayStringCsvEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesArrayStringCSVEmptyResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ArrayStringCSVNull - Get a null array of string using the csv-array format
-func (client *queriesOperations) ArrayStringCSVNull(ctx context.Context, options *QueriesArrayStringCSVNullOptions) (*QueriesArrayStringCSVNullResponse, error) {
+func (client *queriesOperations) ArrayStringCSVNull(ctx context.Context, options *QueriesArrayStringCSVNullOptions) (*http.Response, error) {
 	req, err := client.arrayStringCsvNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -163,15 +163,15 @@ func (client *queriesOperations) arrayStringCsvNullCreateRequest(u url.URL, opti
 }
 
 // arrayStringCsvNullHandleResponse handles the ArrayStringCSVNull response.
-func (client *queriesOperations) arrayStringCsvNullHandleResponse(resp *azcore.Response) (*QueriesArrayStringCSVNullResponse, error) {
+func (client *queriesOperations) arrayStringCsvNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesArrayStringCSVNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ArrayStringCSVValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
-func (client *queriesOperations) ArrayStringCSVValid(ctx context.Context, options *QueriesArrayStringCSVValidOptions) (*QueriesArrayStringCSVValidResponse, error) {
+func (client *queriesOperations) ArrayStringCSVValid(ctx context.Context, options *QueriesArrayStringCSVValidOptions) (*http.Response, error) {
 	req, err := client.arrayStringCsvValidCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -201,15 +201,15 @@ func (client *queriesOperations) arrayStringCsvValidCreateRequest(u url.URL, opt
 }
 
 // arrayStringCsvValidHandleResponse handles the ArrayStringCSVValid response.
-func (client *queriesOperations) arrayStringCsvValidHandleResponse(resp *azcore.Response) (*QueriesArrayStringCSVValidResponse, error) {
+func (client *queriesOperations) arrayStringCsvValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesArrayStringCSVValidResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ArrayStringPipesValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array format
-func (client *queriesOperations) ArrayStringPipesValid(ctx context.Context, options *QueriesArrayStringPipesValidOptions) (*QueriesArrayStringPipesValidResponse, error) {
+func (client *queriesOperations) ArrayStringPipesValid(ctx context.Context, options *QueriesArrayStringPipesValidOptions) (*http.Response, error) {
 	req, err := client.arrayStringPipesValidCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -239,15 +239,15 @@ func (client *queriesOperations) arrayStringPipesValidCreateRequest(u url.URL, o
 }
 
 // arrayStringPipesValidHandleResponse handles the ArrayStringPipesValid response.
-func (client *queriesOperations) arrayStringPipesValidHandleResponse(resp *azcore.Response) (*QueriesArrayStringPipesValidResponse, error) {
+func (client *queriesOperations) arrayStringPipesValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesArrayStringPipesValidResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ArrayStringSsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format
-func (client *queriesOperations) ArrayStringSsvValid(ctx context.Context, options *QueriesArrayStringSsvValidOptions) (*QueriesArrayStringSsvValidResponse, error) {
+func (client *queriesOperations) ArrayStringSsvValid(ctx context.Context, options *QueriesArrayStringSsvValidOptions) (*http.Response, error) {
 	req, err := client.arrayStringSsvValidCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -277,15 +277,15 @@ func (client *queriesOperations) arrayStringSsvValidCreateRequest(u url.URL, opt
 }
 
 // arrayStringSsvValidHandleResponse handles the ArrayStringSsvValid response.
-func (client *queriesOperations) arrayStringSsvValidHandleResponse(resp *azcore.Response) (*QueriesArrayStringSsvValidResponse, error) {
+func (client *queriesOperations) arrayStringSsvValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesArrayStringSsvValidResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ArrayStringTsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array format
-func (client *queriesOperations) ArrayStringTsvValid(ctx context.Context, options *QueriesArrayStringTsvValidOptions) (*QueriesArrayStringTsvValidResponse, error) {
+func (client *queriesOperations) ArrayStringTsvValid(ctx context.Context, options *QueriesArrayStringTsvValidOptions) (*http.Response, error) {
 	req, err := client.arrayStringTsvValidCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -315,15 +315,15 @@ func (client *queriesOperations) arrayStringTsvValidCreateRequest(u url.URL, opt
 }
 
 // arrayStringTsvValidHandleResponse handles the ArrayStringTsvValid response.
-func (client *queriesOperations) arrayStringTsvValidHandleResponse(resp *azcore.Response) (*QueriesArrayStringTsvValidResponse, error) {
+func (client *queriesOperations) arrayStringTsvValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesArrayStringTsvValidResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ByteEmpty - Get '' as byte array
-func (client *queriesOperations) ByteEmpty(ctx context.Context) (*QueriesByteEmptyResponse, error) {
+func (client *queriesOperations) ByteEmpty(ctx context.Context) (*http.Response, error) {
 	req, err := client.byteEmptyCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -351,15 +351,15 @@ func (client *queriesOperations) byteEmptyCreateRequest(u url.URL) (*azcore.Requ
 }
 
 // byteEmptyHandleResponse handles the ByteEmpty response.
-func (client *queriesOperations) byteEmptyHandleResponse(resp *azcore.Response) (*QueriesByteEmptyResponse, error) {
+func (client *queriesOperations) byteEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesByteEmptyResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-func (client *queriesOperations) ByteMultiByte(ctx context.Context, options *QueriesByteMultiByteOptions) (*QueriesByteMultiByteResponse, error) {
+func (client *queriesOperations) ByteMultiByte(ctx context.Context, options *QueriesByteMultiByteOptions) (*http.Response, error) {
 	req, err := client.byteMultiByteCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -389,15 +389,15 @@ func (client *queriesOperations) byteMultiByteCreateRequest(u url.URL, options *
 }
 
 // byteMultiByteHandleResponse handles the ByteMultiByte response.
-func (client *queriesOperations) byteMultiByteHandleResponse(resp *azcore.Response) (*QueriesByteMultiByteResponse, error) {
+func (client *queriesOperations) byteMultiByteHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesByteMultiByteResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // ByteNull - Get null as byte array (no query parameters in uri)
-func (client *queriesOperations) ByteNull(ctx context.Context, options *QueriesByteNullOptions) (*QueriesByteNullResponse, error) {
+func (client *queriesOperations) ByteNull(ctx context.Context, options *QueriesByteNullOptions) (*http.Response, error) {
 	req, err := client.byteNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -427,15 +427,15 @@ func (client *queriesOperations) byteNullCreateRequest(u url.URL, options *Queri
 }
 
 // byteNullHandleResponse handles the ByteNull response.
-func (client *queriesOperations) byteNullHandleResponse(resp *azcore.Response) (*QueriesByteNullResponse, error) {
+func (client *queriesOperations) byteNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesByteNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // DateNull - Get null as date - this should result in no query parameters in uri
-func (client *queriesOperations) DateNull(ctx context.Context, options *QueriesDateNullOptions) (*QueriesDateNullResponse, error) {
+func (client *queriesOperations) DateNull(ctx context.Context, options *QueriesDateNullOptions) (*http.Response, error) {
 	req, err := client.dateNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -465,15 +465,15 @@ func (client *queriesOperations) dateNullCreateRequest(u url.URL, options *Queri
 }
 
 // dateNullHandleResponse handles the DateNull response.
-func (client *queriesOperations) dateNullHandleResponse(resp *azcore.Response) (*QueriesDateNullResponse, error) {
+func (client *queriesOperations) dateNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesDateNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // DateTimeNull - Get null as date-time, should result in no query parameters in uri
-func (client *queriesOperations) DateTimeNull(ctx context.Context, options *QueriesDateTimeNullOptions) (*QueriesDateTimeNullResponse, error) {
+func (client *queriesOperations) DateTimeNull(ctx context.Context, options *QueriesDateTimeNullOptions) (*http.Response, error) {
 	req, err := client.dateTimeNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -503,15 +503,15 @@ func (client *queriesOperations) dateTimeNullCreateRequest(u url.URL, options *Q
 }
 
 // dateTimeNullHandleResponse handles the DateTimeNull response.
-func (client *queriesOperations) dateTimeNullHandleResponse(resp *azcore.Response) (*QueriesDateTimeNullResponse, error) {
+func (client *queriesOperations) dateTimeNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesDateTimeNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
-func (client *queriesOperations) DateTimeValid(ctx context.Context) (*QueriesDateTimeValidResponse, error) {
+func (client *queriesOperations) DateTimeValid(ctx context.Context) (*http.Response, error) {
 	req, err := client.dateTimeValidCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -539,15 +539,15 @@ func (client *queriesOperations) dateTimeValidCreateRequest(u url.URL) (*azcore.
 }
 
 // dateTimeValidHandleResponse handles the DateTimeValid response.
-func (client *queriesOperations) dateTimeValidHandleResponse(resp *azcore.Response) (*QueriesDateTimeValidResponse, error) {
+func (client *queriesOperations) dateTimeValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesDateTimeValidResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // DateValid - Get '2012-01-01' as date
-func (client *queriesOperations) DateValid(ctx context.Context) (*QueriesDateValidResponse, error) {
+func (client *queriesOperations) DateValid(ctx context.Context) (*http.Response, error) {
 	req, err := client.dateValidCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -575,15 +575,15 @@ func (client *queriesOperations) dateValidCreateRequest(u url.URL) (*azcore.Requ
 }
 
 // dateValidHandleResponse handles the DateValid response.
-func (client *queriesOperations) dateValidHandleResponse(resp *azcore.Response) (*QueriesDateValidResponse, error) {
+func (client *queriesOperations) dateValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesDateValidResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // DoubleDecimalNegative - Get '-9999999.999' numeric value
-func (client *queriesOperations) DoubleDecimalNegative(ctx context.Context) (*QueriesDoubleDecimalNegativeResponse, error) {
+func (client *queriesOperations) DoubleDecimalNegative(ctx context.Context) (*http.Response, error) {
 	req, err := client.doubleDecimalNegativeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -611,15 +611,15 @@ func (client *queriesOperations) doubleDecimalNegativeCreateRequest(u url.URL) (
 }
 
 // doubleDecimalNegativeHandleResponse handles the DoubleDecimalNegative response.
-func (client *queriesOperations) doubleDecimalNegativeHandleResponse(resp *azcore.Response) (*QueriesDoubleDecimalNegativeResponse, error) {
+func (client *queriesOperations) doubleDecimalNegativeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesDoubleDecimalNegativeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // DoubleDecimalPositive - Get '9999999.999' numeric value
-func (client *queriesOperations) DoubleDecimalPositive(ctx context.Context) (*QueriesDoubleDecimalPositiveResponse, error) {
+func (client *queriesOperations) DoubleDecimalPositive(ctx context.Context) (*http.Response, error) {
 	req, err := client.doubleDecimalPositiveCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -647,15 +647,15 @@ func (client *queriesOperations) doubleDecimalPositiveCreateRequest(u url.URL) (
 }
 
 // doubleDecimalPositiveHandleResponse handles the DoubleDecimalPositive response.
-func (client *queriesOperations) doubleDecimalPositiveHandleResponse(resp *azcore.Response) (*QueriesDoubleDecimalPositiveResponse, error) {
+func (client *queriesOperations) doubleDecimalPositiveHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesDoubleDecimalPositiveResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // DoubleNull - Get null numeric value (no query parameter)
-func (client *queriesOperations) DoubleNull(ctx context.Context, options *QueriesDoubleNullOptions) (*QueriesDoubleNullResponse, error) {
+func (client *queriesOperations) DoubleNull(ctx context.Context, options *QueriesDoubleNullOptions) (*http.Response, error) {
 	req, err := client.doubleNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -685,15 +685,15 @@ func (client *queriesOperations) doubleNullCreateRequest(u url.URL, options *Que
 }
 
 // doubleNullHandleResponse handles the DoubleNull response.
-func (client *queriesOperations) doubleNullHandleResponse(resp *azcore.Response) (*QueriesDoubleNullResponse, error) {
+func (client *queriesOperations) doubleNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesDoubleNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // EnumNull - Get null (no query parameter in url)
-func (client *queriesOperations) EnumNull(ctx context.Context, options *QueriesEnumNullOptions) (*QueriesEnumNullResponse, error) {
+func (client *queriesOperations) EnumNull(ctx context.Context, options *QueriesEnumNullOptions) (*http.Response, error) {
 	req, err := client.enumNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -723,15 +723,15 @@ func (client *queriesOperations) enumNullCreateRequest(u url.URL, options *Queri
 }
 
 // enumNullHandleResponse handles the EnumNull response.
-func (client *queriesOperations) enumNullHandleResponse(resp *azcore.Response) (*QueriesEnumNullResponse, error) {
+func (client *queriesOperations) enumNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesEnumNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // EnumValid - Get using uri with query parameter 'green color'
-func (client *queriesOperations) EnumValid(ctx context.Context, options *QueriesEnumValidOptions) (*QueriesEnumValidResponse, error) {
+func (client *queriesOperations) EnumValid(ctx context.Context, options *QueriesEnumValidOptions) (*http.Response, error) {
 	req, err := client.enumValidCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -761,15 +761,15 @@ func (client *queriesOperations) enumValidCreateRequest(u url.URL, options *Quer
 }
 
 // enumValidHandleResponse handles the EnumValid response.
-func (client *queriesOperations) enumValidHandleResponse(resp *azcore.Response) (*QueriesEnumValidResponse, error) {
+func (client *queriesOperations) enumValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesEnumValidResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // FloatNull - Get null numeric value (no query parameter)
-func (client *queriesOperations) FloatNull(ctx context.Context, options *QueriesFloatNullOptions) (*QueriesFloatNullResponse, error) {
+func (client *queriesOperations) FloatNull(ctx context.Context, options *QueriesFloatNullOptions) (*http.Response, error) {
 	req, err := client.floatNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -799,15 +799,15 @@ func (client *queriesOperations) floatNullCreateRequest(u url.URL, options *Quer
 }
 
 // floatNullHandleResponse handles the FloatNull response.
-func (client *queriesOperations) floatNullHandleResponse(resp *azcore.Response) (*QueriesFloatNullResponse, error) {
+func (client *queriesOperations) floatNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesFloatNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // FloatScientificNegative - Get '-1.034E-20' numeric value
-func (client *queriesOperations) FloatScientificNegative(ctx context.Context) (*QueriesFloatScientificNegativeResponse, error) {
+func (client *queriesOperations) FloatScientificNegative(ctx context.Context) (*http.Response, error) {
 	req, err := client.floatScientificNegativeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -835,15 +835,15 @@ func (client *queriesOperations) floatScientificNegativeCreateRequest(u url.URL)
 }
 
 // floatScientificNegativeHandleResponse handles the FloatScientificNegative response.
-func (client *queriesOperations) floatScientificNegativeHandleResponse(resp *azcore.Response) (*QueriesFloatScientificNegativeResponse, error) {
+func (client *queriesOperations) floatScientificNegativeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesFloatScientificNegativeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // FloatScientificPositive - Get '1.034E+20' numeric value
-func (client *queriesOperations) FloatScientificPositive(ctx context.Context) (*QueriesFloatScientificPositiveResponse, error) {
+func (client *queriesOperations) FloatScientificPositive(ctx context.Context) (*http.Response, error) {
 	req, err := client.floatScientificPositiveCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -871,15 +871,15 @@ func (client *queriesOperations) floatScientificPositiveCreateRequest(u url.URL)
 }
 
 // floatScientificPositiveHandleResponse handles the FloatScientificPositive response.
-func (client *queriesOperations) floatScientificPositiveHandleResponse(resp *azcore.Response) (*QueriesFloatScientificPositiveResponse, error) {
+func (client *queriesOperations) floatScientificPositiveHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesFloatScientificPositiveResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetBooleanFalse - Get false Boolean value on path
-func (client *queriesOperations) GetBooleanFalse(ctx context.Context) (*QueriesGetBooleanFalseResponse, error) {
+func (client *queriesOperations) GetBooleanFalse(ctx context.Context) (*http.Response, error) {
 	req, err := client.getBooleanFalseCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -907,15 +907,15 @@ func (client *queriesOperations) getBooleanFalseCreateRequest(u url.URL) (*azcor
 }
 
 // getBooleanFalseHandleResponse handles the GetBooleanFalse response.
-func (client *queriesOperations) getBooleanFalseHandleResponse(resp *azcore.Response) (*QueriesGetBooleanFalseResponse, error) {
+func (client *queriesOperations) getBooleanFalseHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesGetBooleanFalseResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetBooleanNull - Get null Boolean value on query (query string should be absent)
-func (client *queriesOperations) GetBooleanNull(ctx context.Context, options *QueriesGetBooleanNullOptions) (*QueriesGetBooleanNullResponse, error) {
+func (client *queriesOperations) GetBooleanNull(ctx context.Context, options *QueriesGetBooleanNullOptions) (*http.Response, error) {
 	req, err := client.getBooleanNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -945,15 +945,15 @@ func (client *queriesOperations) getBooleanNullCreateRequest(u url.URL, options 
 }
 
 // getBooleanNullHandleResponse handles the GetBooleanNull response.
-func (client *queriesOperations) getBooleanNullHandleResponse(resp *azcore.Response) (*QueriesGetBooleanNullResponse, error) {
+func (client *queriesOperations) getBooleanNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesGetBooleanNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetBooleanTrue - Get true Boolean value on path
-func (client *queriesOperations) GetBooleanTrue(ctx context.Context) (*QueriesGetBooleanTrueResponse, error) {
+func (client *queriesOperations) GetBooleanTrue(ctx context.Context) (*http.Response, error) {
 	req, err := client.getBooleanTrueCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -981,15 +981,15 @@ func (client *queriesOperations) getBooleanTrueCreateRequest(u url.URL) (*azcore
 }
 
 // getBooleanTrueHandleResponse handles the GetBooleanTrue response.
-func (client *queriesOperations) getBooleanTrueHandleResponse(resp *azcore.Response) (*QueriesGetBooleanTrueResponse, error) {
+func (client *queriesOperations) getBooleanTrueHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesGetBooleanTrueResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetIntNegativeOneMillion - Get '-1000000' integer value
-func (client *queriesOperations) GetIntNegativeOneMillion(ctx context.Context) (*QueriesGetIntNegativeOneMillionResponse, error) {
+func (client *queriesOperations) GetIntNegativeOneMillion(ctx context.Context) (*http.Response, error) {
 	req, err := client.getIntNegativeOneMillionCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -1017,15 +1017,15 @@ func (client *queriesOperations) getIntNegativeOneMillionCreateRequest(u url.URL
 }
 
 // getIntNegativeOneMillionHandleResponse handles the GetIntNegativeOneMillion response.
-func (client *queriesOperations) getIntNegativeOneMillionHandleResponse(resp *azcore.Response) (*QueriesGetIntNegativeOneMillionResponse, error) {
+func (client *queriesOperations) getIntNegativeOneMillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesGetIntNegativeOneMillionResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetIntNull - Get null integer value (no query parameter)
-func (client *queriesOperations) GetIntNull(ctx context.Context, options *QueriesGetIntNullOptions) (*QueriesGetIntNullResponse, error) {
+func (client *queriesOperations) GetIntNull(ctx context.Context, options *QueriesGetIntNullOptions) (*http.Response, error) {
 	req, err := client.getIntNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -1055,15 +1055,15 @@ func (client *queriesOperations) getIntNullCreateRequest(u url.URL, options *Que
 }
 
 // getIntNullHandleResponse handles the GetIntNull response.
-func (client *queriesOperations) getIntNullHandleResponse(resp *azcore.Response) (*QueriesGetIntNullResponse, error) {
+func (client *queriesOperations) getIntNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesGetIntNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetIntOneMillion - Get '1000000' integer value
-func (client *queriesOperations) GetIntOneMillion(ctx context.Context) (*QueriesGetIntOneMillionResponse, error) {
+func (client *queriesOperations) GetIntOneMillion(ctx context.Context) (*http.Response, error) {
 	req, err := client.getIntOneMillionCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -1091,15 +1091,15 @@ func (client *queriesOperations) getIntOneMillionCreateRequest(u url.URL) (*azco
 }
 
 // getIntOneMillionHandleResponse handles the GetIntOneMillion response.
-func (client *queriesOperations) getIntOneMillionHandleResponse(resp *azcore.Response) (*QueriesGetIntOneMillionResponse, error) {
+func (client *queriesOperations) getIntOneMillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesGetIntOneMillionResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetLongNull - Get 'null 64 bit integer value (no query param in uri)
-func (client *queriesOperations) GetLongNull(ctx context.Context, options *QueriesGetLongNullOptions) (*QueriesGetLongNullResponse, error) {
+func (client *queriesOperations) GetLongNull(ctx context.Context, options *QueriesGetLongNullOptions) (*http.Response, error) {
 	req, err := client.getLongNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -1129,15 +1129,15 @@ func (client *queriesOperations) getLongNullCreateRequest(u url.URL, options *Qu
 }
 
 // getLongNullHandleResponse handles the GetLongNull response.
-func (client *queriesOperations) getLongNullHandleResponse(resp *azcore.Response) (*QueriesGetLongNullResponse, error) {
+func (client *queriesOperations) getLongNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesGetLongNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
-func (client *queriesOperations) GetNegativeTenBillion(ctx context.Context) (*QueriesGetNegativeTenBillionResponse, error) {
+func (client *queriesOperations) GetNegativeTenBillion(ctx context.Context) (*http.Response, error) {
 	req, err := client.getNegativeTenBillionCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -1165,15 +1165,15 @@ func (client *queriesOperations) getNegativeTenBillionCreateRequest(u url.URL) (
 }
 
 // getNegativeTenBillionHandleResponse handles the GetNegativeTenBillion response.
-func (client *queriesOperations) getNegativeTenBillionHandleResponse(resp *azcore.Response) (*QueriesGetNegativeTenBillionResponse, error) {
+func (client *queriesOperations) getNegativeTenBillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesGetNegativeTenBillionResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // GetTenBillion - Get '10000000000' 64 bit integer value
-func (client *queriesOperations) GetTenBillion(ctx context.Context) (*QueriesGetTenBillionResponse, error) {
+func (client *queriesOperations) GetTenBillion(ctx context.Context) (*http.Response, error) {
 	req, err := client.getTenBillionCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -1201,15 +1201,15 @@ func (client *queriesOperations) getTenBillionCreateRequest(u url.URL) (*azcore.
 }
 
 // getTenBillionHandleResponse handles the GetTenBillion response.
-func (client *queriesOperations) getTenBillionHandleResponse(resp *azcore.Response) (*QueriesGetTenBillionResponse, error) {
+func (client *queriesOperations) getTenBillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesGetTenBillionResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // StringEmpty - Get ''
-func (client *queriesOperations) StringEmpty(ctx context.Context) (*QueriesStringEmptyResponse, error) {
+func (client *queriesOperations) StringEmpty(ctx context.Context) (*http.Response, error) {
 	req, err := client.stringEmptyCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -1237,15 +1237,15 @@ func (client *queriesOperations) stringEmptyCreateRequest(u url.URL) (*azcore.Re
 }
 
 // stringEmptyHandleResponse handles the StringEmpty response.
-func (client *queriesOperations) stringEmptyHandleResponse(resp *azcore.Response) (*QueriesStringEmptyResponse, error) {
+func (client *queriesOperations) stringEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesStringEmptyResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // StringNull - Get null (no query parameter in url)
-func (client *queriesOperations) StringNull(ctx context.Context, options *QueriesStringNullOptions) (*QueriesStringNullResponse, error) {
+func (client *queriesOperations) StringNull(ctx context.Context, options *QueriesStringNullOptions) (*http.Response, error) {
 	req, err := client.stringNullCreateRequest(*client.u, options)
 	if err != nil {
 		return nil, err
@@ -1275,15 +1275,15 @@ func (client *queriesOperations) stringNullCreateRequest(u url.URL, options *Que
 }
 
 // stringNullHandleResponse handles the StringNull response.
-func (client *queriesOperations) stringNullHandleResponse(resp *azcore.Response) (*QueriesStringNullResponse, error) {
+func (client *queriesOperations) stringNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesStringNullResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
-func (client *queriesOperations) StringURLEncoded(ctx context.Context) (*QueriesStringURLEncodedResponse, error) {
+func (client *queriesOperations) StringURLEncoded(ctx context.Context) (*http.Response, error) {
 	req, err := client.stringUrlEncodedCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -1311,15 +1311,15 @@ func (client *queriesOperations) stringUrlEncodedCreateRequest(u url.URL) (*azco
 }
 
 // stringUrlEncodedHandleResponse handles the StringURLEncoded response.
-func (client *queriesOperations) stringUrlEncodedHandleResponse(resp *azcore.Response) (*QueriesStringURLEncodedResponse, error) {
+func (client *queriesOperations) stringUrlEncodedHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesStringURLEncodedResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
-func (client *queriesOperations) StringUnicode(ctx context.Context) (*QueriesStringUnicodeResponse, error) {
+func (client *queriesOperations) StringUnicode(ctx context.Context) (*http.Response, error) {
 	req, err := client.stringUnicodeCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -1347,9 +1347,9 @@ func (client *queriesOperations) stringUnicodeCreateRequest(u url.URL) (*azcore.
 }
 
 // stringUnicodeHandleResponse handles the StringUnicode response.
-func (client *queriesOperations) stringUnicodeHandleResponse(resp *azcore.Response) (*QueriesStringUnicodeResponse, error) {
+func (client *queriesOperations) stringUnicodeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	return &QueriesStringUnicodeResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }

--- a/test/autorest/generated/xmlgroup/models.go
+++ b/test/autorest/generated/xmlgroup/models.go
@@ -62,6 +62,15 @@ type AppleBarrel struct {
 	GoodApples *[]string `xml:"GoodApples>Apple"`
 }
 
+// AppleBarrelResponse is the response envelope for operations that return a AppleBarrel type.
+type AppleBarrelResponse struct {
+	// A barrel of apples.
+	AppleBarrel *AppleBarrel `xml:"AppleBarrel"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+}
+
 // A banana.
 type Banana struct {
 	// The time at which you should reconsider eating this banana
@@ -96,6 +105,24 @@ func (b *Banana) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	}
 	b.Expiration = (*time.Time)(aux.Expiration)
 	return nil
+}
+
+// BananaArrayResponse is the response envelope for operations that return a []Banana type.
+type BananaArrayResponse struct {
+	// Array of Banana
+	Bananas *[]Banana `xml:"banana"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+}
+
+// BananaResponse is the response envelope for operations that return a Banana type.
+type BananaResponse struct {
+	// A banana.
+	Banana *Banana `xml:"banana"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // An Azure Storage blob
@@ -306,6 +333,14 @@ type JSONOutput struct {
 	ID *int32 `json:"id,omitempty"`
 }
 
+// JSONOutputResponse is the response envelope for operations that return a JSONOutput type.
+type JSONOutputResponse struct {
+	JSONOutput *JSONOutput
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+}
+
 // An enumeration of blobs
 type ListBlobsResponse struct {
 	Blobs           *Blobs  `xml:"Blobs"`
@@ -318,6 +353,15 @@ type ListBlobsResponse struct {
 	ServiceEndpoint *string `xml:"ServiceEndpoint,attr"`
 }
 
+// ListBlobsResponseResponse is the response envelope for operations that return a ListBlobsResponse type.
+type ListBlobsResponseResponse struct {
+	// An enumeration of blobs
+	EnumerationResults *ListBlobsResponse `xml:"EnumerationResults"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+}
+
 // An enumeration of containers
 type ListContainersResponse struct {
 	Containers      *[]Container `xml:"Containers>Container"`
@@ -326,6 +370,15 @@ type ListContainersResponse struct {
 	NextMarker      *string      `xml:"NextMarker"`
 	Prefix          *string      `xml:"Prefix"`
 	ServiceEndpoint *string      `xml:"ServiceEndpoint,attr"`
+}
+
+// ListContainersResponseResponse is the response envelope for operations that return a ListContainersResponse type.
+type ListContainersResponseResponse struct {
+	// An enumeration of containers
+	EnumerationResults *ListContainersResponse `xml:"EnumerationResults"`
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 // Azure Analytics Logging settings.
@@ -379,6 +432,15 @@ type RootWithRefAndMeta struct {
 	Something *string `xml:"Something"`
 }
 
+// RootWithRefAndMetaResponse is the response envelope for operations that return a RootWithRefAndMeta type.
+type RootWithRefAndMetaResponse struct {
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
+	// I am root, and I ref a model WITH meta
+	RootWithRefAndMeta *RootWithRefAndMeta `xml:"RootWithRefAndMeta"`
+}
+
 // I am root, and I ref a model with no meta
 type RootWithRefAndNoMeta struct {
 	// XML will use RefToModel
@@ -388,6 +450,15 @@ type RootWithRefAndNoMeta struct {
 	Something *string `xml:"Something"`
 }
 
+// RootWithRefAndNoMetaResponse is the response envelope for operations that return a RootWithRefAndNoMeta type.
+type RootWithRefAndNoMetaResponse struct {
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
+	// I am root, and I ref a model with no meta
+	RootWithRefAndNoMeta *RootWithRefAndNoMeta `xml:"RootWithRefAndNoMeta"`
+}
+
 // signed identifier
 type SignedIDentifier struct {
 	// The access policy
@@ -395,6 +466,15 @@ type SignedIDentifier struct {
 
 	// a unique id
 	ID *string `xml:"Id"`
+}
+
+// SignedIDentifierArrayResponse is the response envelope for operations that return a []SignedIDentifier type.
+type SignedIDentifierArrayResponse struct {
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
+	// a collection of signed identifiers
+	SignedIdentifiers *[]SignedIDentifier `xml:"SignedIdentifier"`
 }
 
 // A slide in a slideshow
@@ -423,6 +503,15 @@ func (s Slideshow) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return e.EncodeElement(aux, start)
 }
 
+// SlideshowResponse is the response envelope for operations that return a Slideshow type.
+type SlideshowResponse struct {
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
+	// Data about a slideshow
+	Slideshow *Slideshow `xml:"slideshow"`
+}
+
 // Storage Service Properties.
 type StorageServiceProperties struct {
 	// The set of CORS rules.
@@ -445,98 +534,8 @@ type StorageServiceProperties struct {
 	MinuteMetrics *Metrics `xml:"MinuteMetrics"`
 }
 
-// XMLGetACLsResponse contains the response from method XML.GetACLs.
-type XMLGetACLsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
-	// a collection of signed identifiers
-	SignedIdentifiers *[]SignedIDentifier `xml:"SignedIdentifier"`
-}
-
-// XMLGetComplexTypeRefNoMetaResponse contains the response from method XML.GetComplexTypeRefNoMeta.
-type XMLGetComplexTypeRefNoMetaResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
-	// I am root, and I ref a model with no meta
-	RootWithRefAndNoMeta *RootWithRefAndNoMeta `xml:"RootWithRefAndNoMeta"`
-}
-
-// XMLGetComplexTypeRefWithMetaResponse contains the response from method XML.GetComplexTypeRefWithMeta.
-type XMLGetComplexTypeRefWithMetaResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
-	// I am root, and I ref a model WITH meta
-	RootWithRefAndMeta *RootWithRefAndMeta `xml:"RootWithRefAndMeta"`
-}
-
-// XMLGetEmptyChildElementResponse contains the response from method XML.GetEmptyChildElement.
-type XMLGetEmptyChildElementResponse struct {
-	// A banana.
-	Banana *Banana `xml:"banana"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLGetEmptyListResponse contains the response from method XML.GetEmptyList.
-type XMLGetEmptyListResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-
-	// Data about a slideshow
-	Slideshow *Slideshow `xml:"slideshow"`
-}
-
-// XMLGetEmptyRootListResponse contains the response from method XML.GetEmptyRootList.
-type XMLGetEmptyRootListResponse struct {
-	// Array of Banana
-	Bananas *[]Banana `xml:"banana"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLGetEmptyWrappedListsResponse contains the response from method XML.GetEmptyWrappedLists.
-type XMLGetEmptyWrappedListsResponse struct {
-	// A barrel of apples.
-	AppleBarrel *AppleBarrel `xml:"AppleBarrel"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLGetHeadersResponse contains the response from method XML.GetHeaders.
-type XMLGetHeadersResponse struct {
-	// CustomHeader contains the information returned from the CustomHeader header response.
-	CustomHeader *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLGetRootListResponse contains the response from method XML.GetRootList.
-type XMLGetRootListResponse struct {
-	// Array of Banana
-	Bananas *[]Banana `xml:"banana"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLGetRootListSingleItemResponse contains the response from method XML.GetRootListSingleItem.
-type XMLGetRootListSingleItemResponse struct {
-	// Array of Banana
-	Bananas *[]Banana `xml:"banana"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLGetServicePropertiesResponse contains the response from method XML.GetServiceProperties.
-type XMLGetServicePropertiesResponse struct {
+// StorageServicePropertiesResponse is the response envelope for operations that return a StorageServiceProperties type.
+type StorageServicePropertiesResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
@@ -544,124 +543,11 @@ type XMLGetServicePropertiesResponse struct {
 	StorageServiceProperties *StorageServiceProperties `xml:"StorageServiceProperties"`
 }
 
-// XMLGetSimpleResponse contains the response from method XML.GetSimple.
-type XMLGetSimpleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
+// XMLGetHeadersResponse contains the response from method XML.GetHeaders.
+type XMLGetHeadersResponse struct {
+	// CustomHeader contains the information returned from the Custom-Header header response.
+	CustomHeader *string
 
-	// Data about a slideshow
-	Slideshow *Slideshow `xml:"slideshow"`
-}
-
-// XMLGetWrappedListsResponse contains the response from method XML.GetWrappedLists.
-type XMLGetWrappedListsResponse struct {
-	// A barrel of apples.
-	AppleBarrel *AppleBarrel `xml:"AppleBarrel"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLJSONInputResponse contains the response from method XML.JSONInput.
-type XMLJSONInputResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLJSONOutputResponse contains the response from method XML.JSONOutput.
-type XMLJSONOutputResponse struct {
-	JSONOutput *JSONOutput
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLListBlobsResponse contains the response from method XML.ListBlobs.
-type XMLListBlobsResponse struct {
-	// An enumeration of blobs
-	EnumerationResults *ListBlobsResponse `xml:"EnumerationResults"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLListContainersResponse contains the response from method XML.ListContainers.
-type XMLListContainersResponse struct {
-	// An enumeration of containers
-	EnumerationResults *ListContainersResponse `xml:"EnumerationResults"`
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLPutACLsResponse contains the response from method XML.PutACLs.
-type XMLPutACLsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLPutComplexTypeRefNoMetaResponse contains the response from method XML.PutComplexTypeRefNoMeta.
-type XMLPutComplexTypeRefNoMetaResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLPutComplexTypeRefWithMetaResponse contains the response from method XML.PutComplexTypeRefWithMeta.
-type XMLPutComplexTypeRefWithMetaResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLPutEmptyChildElementResponse contains the response from method XML.PutEmptyChildElement.
-type XMLPutEmptyChildElementResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLPutEmptyListResponse contains the response from method XML.PutEmptyList.
-type XMLPutEmptyListResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLPutEmptyRootListResponse contains the response from method XML.PutEmptyRootList.
-type XMLPutEmptyRootListResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLPutEmptyWrappedListsResponse contains the response from method XML.PutEmptyWrappedLists.
-type XMLPutEmptyWrappedListsResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLPutRootListResponse contains the response from method XML.PutRootList.
-type XMLPutRootListResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLPutRootListSingleItemResponse contains the response from method XML.PutRootListSingleItem.
-type XMLPutRootListSingleItemResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLPutServicePropertiesResponse contains the response from method XML.PutServiceProperties.
-type XMLPutServicePropertiesResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLPutSimpleResponse contains the response from method XML.PutSimple.
-type XMLPutSimpleResponse struct {
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// XMLPutWrappedListsResponse contains the response from method XML.PutWrappedLists.
-type XMLPutWrappedListsResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }

--- a/test/autorest/generated/xmlgroup/xml.go
+++ b/test/autorest/generated/xmlgroup/xml.go
@@ -18,63 +18,63 @@ import (
 // XMLOperations contains the methods for the XML group.
 type XMLOperations interface {
 	// GetACLs - Gets storage ACLs for a container.
-	GetACLs(ctx context.Context) (*XMLGetACLsResponse, error)
+	GetACLs(ctx context.Context) (*SignedIDentifierArrayResponse, error)
 	// GetComplexTypeRefNoMeta - Get a complex type that has a ref to a complex type with no XML node
-	GetComplexTypeRefNoMeta(ctx context.Context) (*XMLGetComplexTypeRefNoMetaResponse, error)
+	GetComplexTypeRefNoMeta(ctx context.Context) (*RootWithRefAndNoMetaResponse, error)
 	// GetComplexTypeRefWithMeta - Get a complex type that has a ref to a complex type with XML node
-	GetComplexTypeRefWithMeta(ctx context.Context) (*XMLGetComplexTypeRefWithMetaResponse, error)
+	GetComplexTypeRefWithMeta(ctx context.Context) (*RootWithRefAndMetaResponse, error)
 	// GetEmptyChildElement - Gets an XML document with an empty child element.
-	GetEmptyChildElement(ctx context.Context) (*XMLGetEmptyChildElementResponse, error)
+	GetEmptyChildElement(ctx context.Context) (*BananaResponse, error)
 	// GetEmptyList - Get an empty list.
-	GetEmptyList(ctx context.Context) (*XMLGetEmptyListResponse, error)
+	GetEmptyList(ctx context.Context) (*SlideshowResponse, error)
 	// GetEmptyRootList - Gets an empty list as the root element.
-	GetEmptyRootList(ctx context.Context) (*XMLGetEmptyRootListResponse, error)
+	GetEmptyRootList(ctx context.Context) (*BananaArrayResponse, error)
 	// GetEmptyWrappedLists - Gets some empty wrapped lists.
-	GetEmptyWrappedLists(ctx context.Context) (*XMLGetEmptyWrappedListsResponse, error)
+	GetEmptyWrappedLists(ctx context.Context) (*AppleBarrelResponse, error)
 	// GetHeaders - Get strongly-typed response headers.
 	GetHeaders(ctx context.Context) (*XMLGetHeadersResponse, error)
 	// GetRootList - Gets a list as the root element.
-	GetRootList(ctx context.Context) (*XMLGetRootListResponse, error)
+	GetRootList(ctx context.Context) (*BananaArrayResponse, error)
 	// GetRootListSingleItem - Gets a list with a single item.
-	GetRootListSingleItem(ctx context.Context) (*XMLGetRootListSingleItemResponse, error)
+	GetRootListSingleItem(ctx context.Context) (*BananaArrayResponse, error)
 	// GetServiceProperties - Gets storage service properties.
-	GetServiceProperties(ctx context.Context) (*XMLGetServicePropertiesResponse, error)
+	GetServiceProperties(ctx context.Context) (*StorageServicePropertiesResponse, error)
 	// GetSimple - Get a simple XML document
-	GetSimple(ctx context.Context) (*XMLGetSimpleResponse, error)
+	GetSimple(ctx context.Context) (*SlideshowResponse, error)
 	// GetWrappedLists - Get an XML document with multiple wrapped lists
-	GetWrappedLists(ctx context.Context) (*XMLGetWrappedListsResponse, error)
+	GetWrappedLists(ctx context.Context) (*AppleBarrelResponse, error)
 	// JSONInput - A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42
-	JSONInput(ctx context.Context, properties JSONInput) (*XMLJSONInputResponse, error)
+	JSONInput(ctx context.Context, properties JSONInput) (*http.Response, error)
 	// JSONOutput - A Swagger with XML that has one operation that returns JSON. ID number 42
-	JSONOutput(ctx context.Context) (*XMLJSONOutputResponse, error)
+	JSONOutput(ctx context.Context) (*JSONOutputResponse, error)
 	// ListBlobs - Lists blobs in a storage container.
-	ListBlobs(ctx context.Context) (*XMLListBlobsResponse, error)
+	ListBlobs(ctx context.Context) (*ListBlobsResponseResponse, error)
 	// ListContainers - Lists containers in a storage account.
-	ListContainers(ctx context.Context) (*XMLListContainersResponse, error)
+	ListContainers(ctx context.Context) (*ListContainersResponseResponse, error)
 	// PutACLs - Puts storage ACLs for a container.
-	PutACLs(ctx context.Context, properties []SignedIDentifier) (*XMLPutACLsResponse, error)
+	PutACLs(ctx context.Context, properties []SignedIDentifier) (*http.Response, error)
 	// PutComplexTypeRefNoMeta - Puts a complex type that has a ref to a complex type with no XML node
-	PutComplexTypeRefNoMeta(ctx context.Context, model RootWithRefAndNoMeta) (*XMLPutComplexTypeRefNoMetaResponse, error)
+	PutComplexTypeRefNoMeta(ctx context.Context, model RootWithRefAndNoMeta) (*http.Response, error)
 	// PutComplexTypeRefWithMeta - Puts a complex type that has a ref to a complex type with XML node
-	PutComplexTypeRefWithMeta(ctx context.Context, model RootWithRefAndMeta) (*XMLPutComplexTypeRefWithMetaResponse, error)
+	PutComplexTypeRefWithMeta(ctx context.Context, model RootWithRefAndMeta) (*http.Response, error)
 	// PutEmptyChildElement - Puts a value with an empty child element.
-	PutEmptyChildElement(ctx context.Context, banana Banana) (*XMLPutEmptyChildElementResponse, error)
+	PutEmptyChildElement(ctx context.Context, banana Banana) (*http.Response, error)
 	// PutEmptyList - Puts an empty list.
-	PutEmptyList(ctx context.Context, slideshow Slideshow) (*XMLPutEmptyListResponse, error)
+	PutEmptyList(ctx context.Context, slideshow Slideshow) (*http.Response, error)
 	// PutEmptyRootList - Puts an empty list as the root element.
-	PutEmptyRootList(ctx context.Context, bananas []Banana) (*XMLPutEmptyRootListResponse, error)
+	PutEmptyRootList(ctx context.Context, bananas []Banana) (*http.Response, error)
 	// PutEmptyWrappedLists - Puts some empty wrapped lists.
-	PutEmptyWrappedLists(ctx context.Context, appleBarrel AppleBarrel) (*XMLPutEmptyWrappedListsResponse, error)
+	PutEmptyWrappedLists(ctx context.Context, appleBarrel AppleBarrel) (*http.Response, error)
 	// PutRootList - Puts a list as the root element.
-	PutRootList(ctx context.Context, bananas []Banana) (*XMLPutRootListResponse, error)
+	PutRootList(ctx context.Context, bananas []Banana) (*http.Response, error)
 	// PutRootListSingleItem - Puts a list with a single item.
-	PutRootListSingleItem(ctx context.Context, bananas []Banana) (*XMLPutRootListSingleItemResponse, error)
+	PutRootListSingleItem(ctx context.Context, bananas []Banana) (*http.Response, error)
 	// PutServiceProperties - Puts storage service properties.
-	PutServiceProperties(ctx context.Context, properties StorageServiceProperties) (*XMLPutServicePropertiesResponse, error)
+	PutServiceProperties(ctx context.Context, properties StorageServiceProperties) (*http.Response, error)
 	// PutSimple - Put a simple XML document
-	PutSimple(ctx context.Context, slideshow Slideshow) (*XMLPutSimpleResponse, error)
+	PutSimple(ctx context.Context, slideshow Slideshow) (*http.Response, error)
 	// PutWrappedLists - Put an XML document with multiple wrapped lists
-	PutWrappedLists(ctx context.Context, wrappedLists AppleBarrel) (*XMLPutWrappedListsResponse, error)
+	PutWrappedLists(ctx context.Context, wrappedLists AppleBarrel) (*http.Response, error)
 }
 
 // xmlOperations implements the XMLOperations interface.
@@ -83,7 +83,7 @@ type xmlOperations struct {
 }
 
 // GetACLs - Gets storage ACLs for a container.
-func (client *xmlOperations) GetACLs(ctx context.Context) (*XMLGetACLsResponse, error) {
+func (client *xmlOperations) GetACLs(ctx context.Context) (*SignedIDentifierArrayResponse, error) {
 	req, err := client.getAcLsCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -112,16 +112,16 @@ func (client *xmlOperations) getAcLsCreateRequest(u url.URL) (*azcore.Request, e
 }
 
 // getAcLsHandleResponse handles the GetACLs response.
-func (client *xmlOperations) getAcLsHandleResponse(resp *azcore.Response) (*XMLGetACLsResponse, error) {
+func (client *xmlOperations) getAcLsHandleResponse(resp *azcore.Response) (*SignedIDentifierArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
-	result := XMLGetACLsResponse{RawResponse: resp.Response}
+	result := SignedIDentifierArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result)
 }
 
 // GetComplexTypeRefNoMeta - Get a complex type that has a ref to a complex type with no XML node
-func (client *xmlOperations) GetComplexTypeRefNoMeta(ctx context.Context) (*XMLGetComplexTypeRefNoMetaResponse, error) {
+func (client *xmlOperations) GetComplexTypeRefNoMeta(ctx context.Context) (*RootWithRefAndNoMetaResponse, error) {
 	req, err := client.getComplexTypeRefNoMetaCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -146,16 +146,16 @@ func (client *xmlOperations) getComplexTypeRefNoMetaCreateRequest(u url.URL) (*a
 }
 
 // getComplexTypeRefNoMetaHandleResponse handles the GetComplexTypeRefNoMeta response.
-func (client *xmlOperations) getComplexTypeRefNoMetaHandleResponse(resp *azcore.Response) (*XMLGetComplexTypeRefNoMetaResponse, error) {
+func (client *xmlOperations) getComplexTypeRefNoMetaHandleResponse(resp *azcore.Response) (*RootWithRefAndNoMetaResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
-	result := XMLGetComplexTypeRefNoMetaResponse{RawResponse: resp.Response}
+	result := RootWithRefAndNoMetaResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.RootWithRefAndNoMeta)
 }
 
 // GetComplexTypeRefWithMeta - Get a complex type that has a ref to a complex type with XML node
-func (client *xmlOperations) GetComplexTypeRefWithMeta(ctx context.Context) (*XMLGetComplexTypeRefWithMetaResponse, error) {
+func (client *xmlOperations) GetComplexTypeRefWithMeta(ctx context.Context) (*RootWithRefAndMetaResponse, error) {
 	req, err := client.getComplexTypeRefWithMetaCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -180,16 +180,16 @@ func (client *xmlOperations) getComplexTypeRefWithMetaCreateRequest(u url.URL) (
 }
 
 // getComplexTypeRefWithMetaHandleResponse handles the GetComplexTypeRefWithMeta response.
-func (client *xmlOperations) getComplexTypeRefWithMetaHandleResponse(resp *azcore.Response) (*XMLGetComplexTypeRefWithMetaResponse, error) {
+func (client *xmlOperations) getComplexTypeRefWithMetaHandleResponse(resp *azcore.Response) (*RootWithRefAndMetaResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
-	result := XMLGetComplexTypeRefWithMetaResponse{RawResponse: resp.Response}
+	result := RootWithRefAndMetaResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.RootWithRefAndMeta)
 }
 
 // GetEmptyChildElement - Gets an XML document with an empty child element.
-func (client *xmlOperations) GetEmptyChildElement(ctx context.Context) (*XMLGetEmptyChildElementResponse, error) {
+func (client *xmlOperations) GetEmptyChildElement(ctx context.Context) (*BananaResponse, error) {
 	req, err := client.getEmptyChildElementCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -214,16 +214,16 @@ func (client *xmlOperations) getEmptyChildElementCreateRequest(u url.URL) (*azco
 }
 
 // getEmptyChildElementHandleResponse handles the GetEmptyChildElement response.
-func (client *xmlOperations) getEmptyChildElementHandleResponse(resp *azcore.Response) (*XMLGetEmptyChildElementResponse, error) {
+func (client *xmlOperations) getEmptyChildElementHandleResponse(resp *azcore.Response) (*BananaResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
-	result := XMLGetEmptyChildElementResponse{RawResponse: resp.Response}
+	result := BananaResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.Banana)
 }
 
 // GetEmptyList - Get an empty list.
-func (client *xmlOperations) GetEmptyList(ctx context.Context) (*XMLGetEmptyListResponse, error) {
+func (client *xmlOperations) GetEmptyList(ctx context.Context) (*SlideshowResponse, error) {
 	req, err := client.getEmptyListCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -248,16 +248,16 @@ func (client *xmlOperations) getEmptyListCreateRequest(u url.URL) (*azcore.Reque
 }
 
 // getEmptyListHandleResponse handles the GetEmptyList response.
-func (client *xmlOperations) getEmptyListHandleResponse(resp *azcore.Response) (*XMLGetEmptyListResponse, error) {
+func (client *xmlOperations) getEmptyListHandleResponse(resp *azcore.Response) (*SlideshowResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
-	result := XMLGetEmptyListResponse{RawResponse: resp.Response}
+	result := SlideshowResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.Slideshow)
 }
 
 // GetEmptyRootList - Gets an empty list as the root element.
-func (client *xmlOperations) GetEmptyRootList(ctx context.Context) (*XMLGetEmptyRootListResponse, error) {
+func (client *xmlOperations) GetEmptyRootList(ctx context.Context) (*BananaArrayResponse, error) {
 	req, err := client.getEmptyRootListCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -282,16 +282,16 @@ func (client *xmlOperations) getEmptyRootListCreateRequest(u url.URL) (*azcore.R
 }
 
 // getEmptyRootListHandleResponse handles the GetEmptyRootList response.
-func (client *xmlOperations) getEmptyRootListHandleResponse(resp *azcore.Response) (*XMLGetEmptyRootListResponse, error) {
+func (client *xmlOperations) getEmptyRootListHandleResponse(resp *azcore.Response) (*BananaArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
-	result := XMLGetEmptyRootListResponse{RawResponse: resp.Response}
+	result := BananaArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result)
 }
 
 // GetEmptyWrappedLists - Gets some empty wrapped lists.
-func (client *xmlOperations) GetEmptyWrappedLists(ctx context.Context) (*XMLGetEmptyWrappedListsResponse, error) {
+func (client *xmlOperations) GetEmptyWrappedLists(ctx context.Context) (*AppleBarrelResponse, error) {
 	req, err := client.getEmptyWrappedListsCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -316,11 +316,11 @@ func (client *xmlOperations) getEmptyWrappedListsCreateRequest(u url.URL) (*azco
 }
 
 // getEmptyWrappedListsHandleResponse handles the GetEmptyWrappedLists response.
-func (client *xmlOperations) getEmptyWrappedListsHandleResponse(resp *azcore.Response) (*XMLGetEmptyWrappedListsResponse, error) {
+func (client *xmlOperations) getEmptyWrappedListsHandleResponse(resp *azcore.Response) (*AppleBarrelResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
-	result := XMLGetEmptyWrappedListsResponse{RawResponse: resp.Response}
+	result := AppleBarrelResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.AppleBarrel)
 }
 
@@ -354,12 +354,14 @@ func (client *xmlOperations) getHeadersHandleResponse(resp *azcore.Response) (*X
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
+	result := XMLGetHeadersResponse{RawResponse: resp.Response}
 	customHeader := resp.Header.Get("Custom-Header")
-	return &XMLGetHeadersResponse{RawResponse: resp.Response, CustomHeader: &customHeader}, nil
+	result.CustomHeader = &customHeader
+	return &result, nil
 }
 
 // GetRootList - Gets a list as the root element.
-func (client *xmlOperations) GetRootList(ctx context.Context) (*XMLGetRootListResponse, error) {
+func (client *xmlOperations) GetRootList(ctx context.Context) (*BananaArrayResponse, error) {
 	req, err := client.getRootListCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -384,16 +386,16 @@ func (client *xmlOperations) getRootListCreateRequest(u url.URL) (*azcore.Reques
 }
 
 // getRootListHandleResponse handles the GetRootList response.
-func (client *xmlOperations) getRootListHandleResponse(resp *azcore.Response) (*XMLGetRootListResponse, error) {
+func (client *xmlOperations) getRootListHandleResponse(resp *azcore.Response) (*BananaArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
-	result := XMLGetRootListResponse{RawResponse: resp.Response}
+	result := BananaArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result)
 }
 
 // GetRootListSingleItem - Gets a list with a single item.
-func (client *xmlOperations) GetRootListSingleItem(ctx context.Context) (*XMLGetRootListSingleItemResponse, error) {
+func (client *xmlOperations) GetRootListSingleItem(ctx context.Context) (*BananaArrayResponse, error) {
 	req, err := client.getRootListSingleItemCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -418,16 +420,16 @@ func (client *xmlOperations) getRootListSingleItemCreateRequest(u url.URL) (*azc
 }
 
 // getRootListSingleItemHandleResponse handles the GetRootListSingleItem response.
-func (client *xmlOperations) getRootListSingleItemHandleResponse(resp *azcore.Response) (*XMLGetRootListSingleItemResponse, error) {
+func (client *xmlOperations) getRootListSingleItemHandleResponse(resp *azcore.Response) (*BananaArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
-	result := XMLGetRootListSingleItemResponse{RawResponse: resp.Response}
+	result := BananaArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result)
 }
 
 // GetServiceProperties - Gets storage service properties.
-func (client *xmlOperations) GetServiceProperties(ctx context.Context) (*XMLGetServicePropertiesResponse, error) {
+func (client *xmlOperations) GetServiceProperties(ctx context.Context) (*StorageServicePropertiesResponse, error) {
 	req, err := client.getServicePropertiesCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -456,16 +458,16 @@ func (client *xmlOperations) getServicePropertiesCreateRequest(u url.URL) (*azco
 }
 
 // getServicePropertiesHandleResponse handles the GetServiceProperties response.
-func (client *xmlOperations) getServicePropertiesHandleResponse(resp *azcore.Response) (*XMLGetServicePropertiesResponse, error) {
+func (client *xmlOperations) getServicePropertiesHandleResponse(resp *azcore.Response) (*StorageServicePropertiesResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
-	result := XMLGetServicePropertiesResponse{RawResponse: resp.Response}
+	result := StorageServicePropertiesResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.StorageServiceProperties)
 }
 
 // GetSimple - Get a simple XML document
-func (client *xmlOperations) GetSimple(ctx context.Context) (*XMLGetSimpleResponse, error) {
+func (client *xmlOperations) GetSimple(ctx context.Context) (*SlideshowResponse, error) {
 	req, err := client.getSimpleCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -490,16 +492,16 @@ func (client *xmlOperations) getSimpleCreateRequest(u url.URL) (*azcore.Request,
 }
 
 // getSimpleHandleResponse handles the GetSimple response.
-func (client *xmlOperations) getSimpleHandleResponse(resp *azcore.Response) (*XMLGetSimpleResponse, error) {
+func (client *xmlOperations) getSimpleHandleResponse(resp *azcore.Response) (*SlideshowResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, newError(resp)
 	}
-	result := XMLGetSimpleResponse{RawResponse: resp.Response}
+	result := SlideshowResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.Slideshow)
 }
 
 // GetWrappedLists - Get an XML document with multiple wrapped lists
-func (client *xmlOperations) GetWrappedLists(ctx context.Context) (*XMLGetWrappedListsResponse, error) {
+func (client *xmlOperations) GetWrappedLists(ctx context.Context) (*AppleBarrelResponse, error) {
 	req, err := client.getWrappedListsCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -524,16 +526,16 @@ func (client *xmlOperations) getWrappedListsCreateRequest(u url.URL) (*azcore.Re
 }
 
 // getWrappedListsHandleResponse handles the GetWrappedLists response.
-func (client *xmlOperations) getWrappedListsHandleResponse(resp *azcore.Response) (*XMLGetWrappedListsResponse, error) {
+func (client *xmlOperations) getWrappedListsHandleResponse(resp *azcore.Response) (*AppleBarrelResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
-	result := XMLGetWrappedListsResponse{RawResponse: resp.Response}
+	result := AppleBarrelResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.AppleBarrel)
 }
 
 // JSONInput - A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42
-func (client *xmlOperations) JSONInput(ctx context.Context, properties JSONInput) (*XMLJSONInputResponse, error) {
+func (client *xmlOperations) JSONInput(ctx context.Context, properties JSONInput) (*http.Response, error) {
 	req, err := client.jsonInputCreateRequest(*client.u, properties)
 	if err != nil {
 		return nil, err
@@ -562,15 +564,15 @@ func (client *xmlOperations) jsonInputCreateRequest(u url.URL, properties JSONIn
 }
 
 // jsonInputHandleResponse handles the JSONInput response.
-func (client *xmlOperations) jsonInputHandleResponse(resp *azcore.Response) (*XMLJSONInputResponse, error) {
+func (client *xmlOperations) jsonInputHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
-	return &XMLJSONInputResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // JSONOutput - A Swagger with XML that has one operation that returns JSON. ID number 42
-func (client *xmlOperations) JSONOutput(ctx context.Context) (*XMLJSONOutputResponse, error) {
+func (client *xmlOperations) JSONOutput(ctx context.Context) (*JSONOutputResponse, error) {
 	req, err := client.jsonOutputCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -595,16 +597,16 @@ func (client *xmlOperations) jsonOutputCreateRequest(u url.URL) (*azcore.Request
 }
 
 // jsonOutputHandleResponse handles the JSONOutput response.
-func (client *xmlOperations) jsonOutputHandleResponse(resp *azcore.Response) (*XMLJSONOutputResponse, error) {
+func (client *xmlOperations) jsonOutputHandleResponse(resp *azcore.Response) (*JSONOutputResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
-	result := XMLJSONOutputResponse{RawResponse: resp.Response}
+	result := JSONOutputResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.JSONOutput)
 }
 
 // ListBlobs - Lists blobs in a storage container.
-func (client *xmlOperations) ListBlobs(ctx context.Context) (*XMLListBlobsResponse, error) {
+func (client *xmlOperations) ListBlobs(ctx context.Context) (*ListBlobsResponseResponse, error) {
 	req, err := client.listBlobsCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -633,16 +635,16 @@ func (client *xmlOperations) listBlobsCreateRequest(u url.URL) (*azcore.Request,
 }
 
 // listBlobsHandleResponse handles the ListBlobs response.
-func (client *xmlOperations) listBlobsHandleResponse(resp *azcore.Response) (*XMLListBlobsResponse, error) {
+func (client *xmlOperations) listBlobsHandleResponse(resp *azcore.Response) (*ListBlobsResponseResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
-	result := XMLListBlobsResponse{RawResponse: resp.Response}
+	result := ListBlobsResponseResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.EnumerationResults)
 }
 
 // ListContainers - Lists containers in a storage account.
-func (client *xmlOperations) ListContainers(ctx context.Context) (*XMLListContainersResponse, error) {
+func (client *xmlOperations) ListContainers(ctx context.Context) (*ListContainersResponseResponse, error) {
 	req, err := client.listContainersCreateRequest(*client.u)
 	if err != nil {
 		return nil, err
@@ -670,16 +672,16 @@ func (client *xmlOperations) listContainersCreateRequest(u url.URL) (*azcore.Req
 }
 
 // listContainersHandleResponse handles the ListContainers response.
-func (client *xmlOperations) listContainersHandleResponse(resp *azcore.Response) (*XMLListContainersResponse, error) {
+func (client *xmlOperations) listContainersHandleResponse(resp *azcore.Response) (*ListContainersResponseResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, errors.New(resp.Status)
 	}
-	result := XMLListContainersResponse{RawResponse: resp.Response}
+	result := ListContainersResponseResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.EnumerationResults)
 }
 
 // PutACLs - Puts storage ACLs for a container.
-func (client *xmlOperations) PutACLs(ctx context.Context, properties []SignedIDentifier) (*XMLPutACLsResponse, error) {
+func (client *xmlOperations) PutACLs(ctx context.Context, properties []SignedIDentifier) (*http.Response, error) {
 	req, err := client.putAcLsCreateRequest(*client.u, properties)
 	if err != nil {
 		return nil, err
@@ -716,15 +718,15 @@ func (client *xmlOperations) putAcLsCreateRequest(u url.URL, properties []Signed
 }
 
 // putAcLsHandleResponse handles the PutACLs response.
-func (client *xmlOperations) putAcLsHandleResponse(resp *azcore.Response) (*XMLPutACLsResponse, error) {
+func (client *xmlOperations) putAcLsHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return nil, errors.New(resp.Status)
 	}
-	return &XMLPutACLsResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutComplexTypeRefNoMeta - Puts a complex type that has a ref to a complex type with no XML node
-func (client *xmlOperations) PutComplexTypeRefNoMeta(ctx context.Context, model RootWithRefAndNoMeta) (*XMLPutComplexTypeRefNoMetaResponse, error) {
+func (client *xmlOperations) PutComplexTypeRefNoMeta(ctx context.Context, model RootWithRefAndNoMeta) (*http.Response, error) {
 	req, err := client.putComplexTypeRefNoMetaCreateRequest(*client.u, model)
 	if err != nil {
 		return nil, err
@@ -753,15 +755,15 @@ func (client *xmlOperations) putComplexTypeRefNoMetaCreateRequest(u url.URL, mod
 }
 
 // putComplexTypeRefNoMetaHandleResponse handles the PutComplexTypeRefNoMeta response.
-func (client *xmlOperations) putComplexTypeRefNoMetaHandleResponse(resp *azcore.Response) (*XMLPutComplexTypeRefNoMetaResponse, error) {
+func (client *xmlOperations) putComplexTypeRefNoMetaHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return nil, errors.New(resp.Status)
 	}
-	return &XMLPutComplexTypeRefNoMetaResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutComplexTypeRefWithMeta - Puts a complex type that has a ref to a complex type with XML node
-func (client *xmlOperations) PutComplexTypeRefWithMeta(ctx context.Context, model RootWithRefAndMeta) (*XMLPutComplexTypeRefWithMetaResponse, error) {
+func (client *xmlOperations) PutComplexTypeRefWithMeta(ctx context.Context, model RootWithRefAndMeta) (*http.Response, error) {
 	req, err := client.putComplexTypeRefWithMetaCreateRequest(*client.u, model)
 	if err != nil {
 		return nil, err
@@ -790,15 +792,15 @@ func (client *xmlOperations) putComplexTypeRefWithMetaCreateRequest(u url.URL, m
 }
 
 // putComplexTypeRefWithMetaHandleResponse handles the PutComplexTypeRefWithMeta response.
-func (client *xmlOperations) putComplexTypeRefWithMetaHandleResponse(resp *azcore.Response) (*XMLPutComplexTypeRefWithMetaResponse, error) {
+func (client *xmlOperations) putComplexTypeRefWithMetaHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return nil, errors.New(resp.Status)
 	}
-	return &XMLPutComplexTypeRefWithMetaResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutEmptyChildElement - Puts a value with an empty child element.
-func (client *xmlOperations) PutEmptyChildElement(ctx context.Context, banana Banana) (*XMLPutEmptyChildElementResponse, error) {
+func (client *xmlOperations) PutEmptyChildElement(ctx context.Context, banana Banana) (*http.Response, error) {
 	req, err := client.putEmptyChildElementCreateRequest(*client.u, banana)
 	if err != nil {
 		return nil, err
@@ -827,15 +829,15 @@ func (client *xmlOperations) putEmptyChildElementCreateRequest(u url.URL, banana
 }
 
 // putEmptyChildElementHandleResponse handles the PutEmptyChildElement response.
-func (client *xmlOperations) putEmptyChildElementHandleResponse(resp *azcore.Response) (*XMLPutEmptyChildElementResponse, error) {
+func (client *xmlOperations) putEmptyChildElementHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return nil, errors.New(resp.Status)
 	}
-	return &XMLPutEmptyChildElementResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutEmptyList - Puts an empty list.
-func (client *xmlOperations) PutEmptyList(ctx context.Context, slideshow Slideshow) (*XMLPutEmptyListResponse, error) {
+func (client *xmlOperations) PutEmptyList(ctx context.Context, slideshow Slideshow) (*http.Response, error) {
 	req, err := client.putEmptyListCreateRequest(*client.u, slideshow)
 	if err != nil {
 		return nil, err
@@ -864,15 +866,15 @@ func (client *xmlOperations) putEmptyListCreateRequest(u url.URL, slideshow Slid
 }
 
 // putEmptyListHandleResponse handles the PutEmptyList response.
-func (client *xmlOperations) putEmptyListHandleResponse(resp *azcore.Response) (*XMLPutEmptyListResponse, error) {
+func (client *xmlOperations) putEmptyListHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return nil, errors.New(resp.Status)
 	}
-	return &XMLPutEmptyListResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutEmptyRootList - Puts an empty list as the root element.
-func (client *xmlOperations) PutEmptyRootList(ctx context.Context, bananas []Banana) (*XMLPutEmptyRootListResponse, error) {
+func (client *xmlOperations) PutEmptyRootList(ctx context.Context, bananas []Banana) (*http.Response, error) {
 	req, err := client.putEmptyRootListCreateRequest(*client.u, bananas)
 	if err != nil {
 		return nil, err
@@ -905,15 +907,15 @@ func (client *xmlOperations) putEmptyRootListCreateRequest(u url.URL, bananas []
 }
 
 // putEmptyRootListHandleResponse handles the PutEmptyRootList response.
-func (client *xmlOperations) putEmptyRootListHandleResponse(resp *azcore.Response) (*XMLPutEmptyRootListResponse, error) {
+func (client *xmlOperations) putEmptyRootListHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return nil, errors.New(resp.Status)
 	}
-	return &XMLPutEmptyRootListResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutEmptyWrappedLists - Puts some empty wrapped lists.
-func (client *xmlOperations) PutEmptyWrappedLists(ctx context.Context, appleBarrel AppleBarrel) (*XMLPutEmptyWrappedListsResponse, error) {
+func (client *xmlOperations) PutEmptyWrappedLists(ctx context.Context, appleBarrel AppleBarrel) (*http.Response, error) {
 	req, err := client.putEmptyWrappedListsCreateRequest(*client.u, appleBarrel)
 	if err != nil {
 		return nil, err
@@ -942,15 +944,15 @@ func (client *xmlOperations) putEmptyWrappedListsCreateRequest(u url.URL, appleB
 }
 
 // putEmptyWrappedListsHandleResponse handles the PutEmptyWrappedLists response.
-func (client *xmlOperations) putEmptyWrappedListsHandleResponse(resp *azcore.Response) (*XMLPutEmptyWrappedListsResponse, error) {
+func (client *xmlOperations) putEmptyWrappedListsHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return nil, errors.New(resp.Status)
 	}
-	return &XMLPutEmptyWrappedListsResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutRootList - Puts a list as the root element.
-func (client *xmlOperations) PutRootList(ctx context.Context, bananas []Banana) (*XMLPutRootListResponse, error) {
+func (client *xmlOperations) PutRootList(ctx context.Context, bananas []Banana) (*http.Response, error) {
 	req, err := client.putRootListCreateRequest(*client.u, bananas)
 	if err != nil {
 		return nil, err
@@ -983,15 +985,15 @@ func (client *xmlOperations) putRootListCreateRequest(u url.URL, bananas []Banan
 }
 
 // putRootListHandleResponse handles the PutRootList response.
-func (client *xmlOperations) putRootListHandleResponse(resp *azcore.Response) (*XMLPutRootListResponse, error) {
+func (client *xmlOperations) putRootListHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return nil, errors.New(resp.Status)
 	}
-	return &XMLPutRootListResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutRootListSingleItem - Puts a list with a single item.
-func (client *xmlOperations) PutRootListSingleItem(ctx context.Context, bananas []Banana) (*XMLPutRootListSingleItemResponse, error) {
+func (client *xmlOperations) PutRootListSingleItem(ctx context.Context, bananas []Banana) (*http.Response, error) {
 	req, err := client.putRootListSingleItemCreateRequest(*client.u, bananas)
 	if err != nil {
 		return nil, err
@@ -1024,15 +1026,15 @@ func (client *xmlOperations) putRootListSingleItemCreateRequest(u url.URL, banan
 }
 
 // putRootListSingleItemHandleResponse handles the PutRootListSingleItem response.
-func (client *xmlOperations) putRootListSingleItemHandleResponse(resp *azcore.Response) (*XMLPutRootListSingleItemResponse, error) {
+func (client *xmlOperations) putRootListSingleItemHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return nil, errors.New(resp.Status)
 	}
-	return &XMLPutRootListSingleItemResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutServiceProperties - Puts storage service properties.
-func (client *xmlOperations) PutServiceProperties(ctx context.Context, properties StorageServiceProperties) (*XMLPutServicePropertiesResponse, error) {
+func (client *xmlOperations) PutServiceProperties(ctx context.Context, properties StorageServiceProperties) (*http.Response, error) {
 	req, err := client.putServicePropertiesCreateRequest(*client.u, properties)
 	if err != nil {
 		return nil, err
@@ -1065,15 +1067,15 @@ func (client *xmlOperations) putServicePropertiesCreateRequest(u url.URL, proper
 }
 
 // putServicePropertiesHandleResponse handles the PutServiceProperties response.
-func (client *xmlOperations) putServicePropertiesHandleResponse(resp *azcore.Response) (*XMLPutServicePropertiesResponse, error) {
+func (client *xmlOperations) putServicePropertiesHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return nil, errors.New(resp.Status)
 	}
-	return &XMLPutServicePropertiesResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutSimple - Put a simple XML document
-func (client *xmlOperations) PutSimple(ctx context.Context, slideshow Slideshow) (*XMLPutSimpleResponse, error) {
+func (client *xmlOperations) PutSimple(ctx context.Context, slideshow Slideshow) (*http.Response, error) {
 	req, err := client.putSimpleCreateRequest(*client.u, slideshow)
 	if err != nil {
 		return nil, err
@@ -1102,15 +1104,15 @@ func (client *xmlOperations) putSimpleCreateRequest(u url.URL, slideshow Slidesh
 }
 
 // putSimpleHandleResponse handles the PutSimple response.
-func (client *xmlOperations) putSimpleHandleResponse(resp *azcore.Response) (*XMLPutSimpleResponse, error) {
+func (client *xmlOperations) putSimpleHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return nil, newError(resp)
 	}
-	return &XMLPutSimpleResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }
 
 // PutWrappedLists - Put an XML document with multiple wrapped lists
-func (client *xmlOperations) PutWrappedLists(ctx context.Context, wrappedLists AppleBarrel) (*XMLPutWrappedListsResponse, error) {
+func (client *xmlOperations) PutWrappedLists(ctx context.Context, wrappedLists AppleBarrel) (*http.Response, error) {
 	req, err := client.putWrappedListsCreateRequest(*client.u, wrappedLists)
 	if err != nil {
 		return nil, err
@@ -1139,9 +1141,9 @@ func (client *xmlOperations) putWrappedListsCreateRequest(u url.URL, wrappedList
 }
 
 // putWrappedListsHandleResponse handles the PutWrappedLists response.
-func (client *xmlOperations) putWrappedListsHandleResponse(resp *azcore.Response) (*XMLPutWrappedListsResponse, error) {
+func (client *xmlOperations) putWrappedListsHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return nil, newError(resp)
 	}
-	return &XMLPutWrappedListsResponse{RawResponse: resp.Response}, nil
+	return resp.Response, nil
 }

--- a/test/autorest/headergroup/headergroup_test.go
+++ b/test/autorest/headergroup/headergroup_test.go
@@ -45,13 +45,13 @@ func TestHeaderParamBool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamBool: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 
 	result, err = client.ParamBool(context.Background(), "false", false)
 	if err != nil {
 		t.Fatalf("ParamBool: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 // TODO this required a change in the generated code so that it outputs base64.STDEncoding.EncodeToString()
@@ -61,7 +61,7 @@ func TestHeaderParamByte(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamByte: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHeaderParamDate(t *testing.T) {
@@ -74,7 +74,7 @@ func TestHeaderParamDate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamDate: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHeaderParamDatetime(t *testing.T) {
@@ -87,7 +87,7 @@ func TestHeaderParamDatetime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamDatetime: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHeaderParamDatetimeRFC1123(t *testing.T) {
@@ -100,7 +100,7 @@ func TestHeaderParamDatetimeRFC1123(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamDatetimeRFC1123: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHeaderParamDouble(t *testing.T) {
@@ -109,13 +109,13 @@ func TestHeaderParamDouble(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamDouble: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 
 	result, err = client.ParamDouble(context.Background(), "negative", -3.0)
 	if err != nil {
 		t.Fatalf("ParamDouble: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 // func TestHeaderParamDuration(t *testing.T) {
@@ -128,7 +128,7 @@ func TestHeaderParamDouble(t *testing.T) {
 // 	if err != nil {
 // 		t.Fatalf("ParamDuration: %v", err)
 // 	}
-// 	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+// 	helpers.VerifyStatusCode(t, result, http.StatusOK)
 // }
 
 func TestHeaderParamEnum(t *testing.T) {
@@ -138,13 +138,13 @@ func TestHeaderParamEnum(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamEnum: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 
 	result, err = client.ParamEnum(context.Background(), "null", nil)
 	if err != nil {
 		t.Fatalf("ParamEnum: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 // func TestHeaderParamExistingKey(t *testing.T) {
@@ -153,7 +153,7 @@ func TestHeaderParamEnum(t *testing.T) {
 // 	if err != nil {
 // 		t.Fatalf("ParamExistingKey: %v", err)
 // 	}
-// 	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+// 	helpers.VerifyStatusCode(t, result, http.StatusOK)
 // }
 
 func TestHeaderParamFloat(t *testing.T) {
@@ -162,13 +162,13 @@ func TestHeaderParamFloat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamFloat: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 
 	result, err = client.ParamFloat(context.Background(), "negative", -3.0)
 	if err != nil {
 		t.Fatalf("ParamFloat: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHeaderParamInteger(t *testing.T) {
@@ -177,13 +177,13 @@ func TestHeaderParamInteger(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamInteger: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 
 	result, err = client.ParamInteger(context.Background(), "negative", -2)
 	if err != nil {
 		t.Fatalf("ParamInteger: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHeaderParamLong(t *testing.T) {
@@ -192,13 +192,13 @@ func TestHeaderParamLong(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamLong: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 
 	result, err = client.ParamLong(context.Background(), "negative", -2)
 	if err != nil {
 		t.Fatalf("ParamLong: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHeaderParamProtectedKey(t *testing.T) {
@@ -207,7 +207,7 @@ func TestHeaderParamProtectedKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamProtectedKey: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHeaderParamString(t *testing.T) {
@@ -217,20 +217,20 @@ func TestHeaderParamString(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParamString: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 
 	result, err = client.ParamString(context.Background(), "null", nil)
 	if err != nil {
 		t.Fatalf("ParamString: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 
 	val = ""
 	result, err = client.ParamString(context.Background(), "empty", &headergroup.HeaderParamStringOptions{Value: &val})
 	if err != nil {
 		t.Fatalf("ParamString: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 // TODO check why we dont check for the value returned in all of the tests below this comment
@@ -383,7 +383,7 @@ func TestHeaderResponseDouble(t *testing.T) {
 // 	if err != nil {
 // 		t.Fatalf("ResponseDuration: %v", err)
 // 	}
-// 	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+// 	helpers.VerifyStatusCode(t, result, http.StatusOK)
 // }
 
 func TestHeaderResponseEnum(t *testing.T) {

--- a/test/autorest/morecustombaseurigroup/paths_test.go
+++ b/test/autorest/morecustombaseurigroup/paths_test.go
@@ -31,5 +31,5 @@ func TestGetEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }

--- a/test/autorest/numbergroup/numbergroup_test.go
+++ b/test/autorest/numbergroup/numbergroup_test.go
@@ -178,7 +178,7 @@ func TestNumberPutBigDecimal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBigDecimal: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestNumberPutBigDecimalNegativeDecimal(t *testing.T) {
@@ -187,7 +187,7 @@ func TestNumberPutBigDecimalNegativeDecimal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBigDecimalNegativeDecimal: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestNumberPutBigDecimalPositiveDecimal(t *testing.T) {
@@ -196,7 +196,7 @@ func TestNumberPutBigDecimalPositiveDecimal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBigDecimalPositiveDecimal: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestNumberPutBigDouble(t *testing.T) {
@@ -205,7 +205,7 @@ func TestNumberPutBigDouble(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBigDouble: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestNumberPutBigDoubleNegativeDecimal(t *testing.T) {
@@ -214,7 +214,7 @@ func TestNumberPutBigDoubleNegativeDecimal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBigDoubleNegativeDecimal: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestNumberPutBigDoublePositiveDecimal(t *testing.T) {
@@ -223,7 +223,7 @@ func TestNumberPutBigDoublePositiveDecimal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBigDeoublePositiveDecimal: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestNumberPutBigFloat(t *testing.T) {
@@ -232,7 +232,7 @@ func TestNumberPutBigFloat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutBigFloat: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestNumberPutSmallDecimal(t *testing.T) {
@@ -241,7 +241,7 @@ func TestNumberPutSmallDecimal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutSmallDecimal: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestNumberPutSmallDouble(t *testing.T) {
@@ -250,7 +250,7 @@ func TestNumberPutSmallDouble(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutSmallDouble: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestNumberPutSmallFloat(t *testing.T) {
@@ -259,5 +259,5 @@ func TestNumberPutSmallFloat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutSmallFloat: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }

--- a/test/autorest/stringgroup/enum_test.go
+++ b/test/autorest/stringgroup/enum_test.go
@@ -56,7 +56,7 @@ func TestEnumPutNotExpandable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutNotExpandable: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestEnumPutReferenced(t *testing.T) {
@@ -65,7 +65,7 @@ func TestEnumPutReferenced(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutReferenced: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestEnumPutReferencedConstant(t *testing.T) {
@@ -75,6 +75,6 @@ func TestEnumPutReferencedConstant(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutReferencedConstant: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 
 }

--- a/test/autorest/stringgroup/string_test.go
+++ b/test/autorest/stringgroup/string_test.go
@@ -37,7 +37,7 @@ func TestStringPutMBCS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutMBCS: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestStringGetBase64Encoded(t *testing.T) {
@@ -57,11 +57,8 @@ func TestStringGetBase64Encoded(t *testing.T) {
 // 	if err != nil {
 // 		t.Fatalf("GetBase64URLEncoded: %v", err)
 // 	}
-// 	expected := &stringgroup.StringGetBase64URLEncodedResponse{
-// 		StatusCode: http.StatusOK,
-// 		Value:      []byte("a string that gets encoded with base64url"),
-// 	}
-// 	deepEqualOrFatal(t, result, expected)
+// 	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+// 	helpers.DeepEqualOrFatal(t, result.Value, []byte("a string that gets encoded with base64url"))
 // }
 
 func TestStringGetEmpty(t *testing.T) {
@@ -118,10 +115,7 @@ func TestStringGetWhitespace(t *testing.T) {
 // 	if err != nil {
 // 		t.Fatalf("PutBase64URLEncoded: %v", err)
 // 	}
-// 	expected := &stringgroup.StringPutBase64URLEncodedResponse{
-// 		StatusCode: http.StatusOK,
-// 	}
-// 	deepEqualOrFatal(t, result, expected)
+// 	helpers.VerifyStatusCode(t, result, http.StatusOK)
 // }
 
 func TestStringPutEmpty(t *testing.T) {
@@ -130,7 +124,7 @@ func TestStringPutEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutEmpty: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 // func TestStringPutNull(t *testing.T) {
@@ -139,10 +133,7 @@ func TestStringPutEmpty(t *testing.T) {
 // 	if err != nil {
 // 		t.Fatalf("PutNull: %v", err)
 // 	}
-// 	expected := &stringgroup.StringPutNullResponse{
-// 		StatusCode: http.StatusOK,
-// 	}
-// 	deepEqualOrFatal(t, result, expected)
+// 	helpers.VerifyStatusCode(t, result, http.StatusOK)
 // }
 
 func TestStringPutWhitespace(t *testing.T) {
@@ -151,5 +142,5 @@ func TestStringPutWhitespace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutWhitespace: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }

--- a/test/autorest/urlgroup/pathitems_test.go
+++ b/test/autorest/urlgroup/pathitems_test.go
@@ -31,7 +31,7 @@ func TestGetAllWithValues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestGetGlobalAndLocalQueryNull(t *testing.T) {
@@ -43,7 +43,7 @@ func TestGetGlobalAndLocalQueryNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestGetGlobalQueryNull(t *testing.T) {
@@ -56,7 +56,7 @@ func TestGetGlobalQueryNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestGetLocalPathItemQueryNull(t *testing.T) {
@@ -66,5 +66,5 @@ func TestGetLocalPathItemQueryNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }

--- a/test/autorest/urlgroup/queries_test.go
+++ b/test/autorest/urlgroup/queries_test.go
@@ -27,7 +27,7 @@ func TestArrayStringCsvValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestArrayStringPipesValid(t *testing.T) {
@@ -38,7 +38,7 @@ func TestArrayStringPipesValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func toByteSlicePtr(v []byte) *[]byte {
@@ -53,7 +53,7 @@ func TestByteMultiByte(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestDateTimeValid(t *testing.T) {
@@ -63,7 +63,7 @@ func TestDateTimeValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestDoubleDecimalNegative(t *testing.T) {
@@ -72,7 +72,7 @@ func TestDoubleDecimalNegative(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestEnumValid(t *testing.T) {
@@ -84,7 +84,7 @@ func TestEnumValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestFloatScientificNegative(t *testing.T) {
@@ -93,7 +93,7 @@ func TestFloatScientificNegative(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestGetBooleanTrue(t *testing.T) {
@@ -102,7 +102,7 @@ func TestGetBooleanTrue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestGetIntOneMillion(t *testing.T) {
@@ -111,7 +111,7 @@ func TestGetIntOneMillion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestGetTenBillion(t *testing.T) {
@@ -120,7 +120,7 @@ func TestGetTenBillion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestStringUnicode(t *testing.T) {
@@ -130,5 +130,5 @@ func TestStringUnicode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }

--- a/test/autorest/xmlgroup/xmlgroup_test.go
+++ b/test/autorest/xmlgroup/xmlgroup_test.go
@@ -308,7 +308,7 @@ func TestPutACLs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusCreated)
+	helpers.VerifyStatusCode(t, result, http.StatusCreated)
 }
 
 func TestPutComplexTypeRefNoMeta(t *testing.T) {
@@ -322,7 +322,7 @@ func TestPutComplexTypeRefNoMeta(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusCreated)
+	helpers.VerifyStatusCode(t, result, http.StatusCreated)
 }
 
 func TestPutComplexTypeRefWithMeta(t *testing.T) {
@@ -339,7 +339,7 @@ func TestPutEmptyChildElement(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusCreated)
+	helpers.VerifyStatusCode(t, result, http.StatusCreated)
 }
 
 func TestPutEmptyList(t *testing.T) {
@@ -350,7 +350,7 @@ func TestPutEmptyList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusCreated)
+	helpers.VerifyStatusCode(t, result, http.StatusCreated)
 }
 
 func TestPutEmptyRootList(t *testing.T) {
@@ -359,7 +359,7 @@ func TestPutEmptyRootList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusCreated)
+	helpers.VerifyStatusCode(t, result, http.StatusCreated)
 }
 
 func TestPutEmptyWrappedLists(t *testing.T) {
@@ -371,7 +371,7 @@ func TestPutEmptyWrappedLists(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusCreated)
+	helpers.VerifyStatusCode(t, result, http.StatusCreated)
 }
 
 func TestPutRootList(t *testing.T) {
@@ -391,7 +391,7 @@ func TestPutRootList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusCreated)
+	helpers.VerifyStatusCode(t, result, http.StatusCreated)
 }
 
 func TestPutRootListSingleItem(t *testing.T) {
@@ -406,7 +406,7 @@ func TestPutRootListSingleItem(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusCreated)
+	helpers.VerifyStatusCode(t, result, http.StatusCreated)
 }
 
 func TestPutServiceProperties(t *testing.T) {
@@ -444,7 +444,7 @@ func TestPutServiceProperties(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusCreated)
+	helpers.VerifyStatusCode(t, result, http.StatusCreated)
 }
 
 func TestPutSimple(t *testing.T) {
@@ -468,7 +468,7 @@ func TestPutSimple(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusCreated)
+	helpers.VerifyStatusCode(t, result, http.StatusCreated)
 }
 
 func TestPutWrappedLists(t *testing.T) {
@@ -480,5 +480,5 @@ func TestPutWrappedLists(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusCreated)
+	helpers.VerifyStatusCode(t, result, http.StatusCreated)
 }


### PR DESCRIPTION
Use the same response type for operations the return the same schema.
For operations that don't return a model, return *http.Response.
Highlight 'rush regenerate' error text in red.