### PR TITLE
Remove url.URL param from helper methods

### DIFF
--- a/src/generator/client.ts
+++ b/src/generator/client.ts
@@ -12,6 +12,7 @@ import { ContentPreamble, formatParamInfoTypeName, ImportManager, ParamInfo, sor
 // generates content for client.go
 export async function generateClient(session: Session<CodeModel>): Promise<string> {
   // add standard imports
+  imports.add('fmt');
   imports.add('net/url');
   imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore');
 
@@ -75,6 +76,9 @@ export async function generateClient(session: Session<CodeModel>): Promise<strin
   text += `\t${urlVar}, err := url.Parse(endpoint)\n`;
   text += '\tif err != nil {\n';
   text += '\t\treturn nil, err\n';
+  text += '\t}\n';
+  text += `\tif ${urlVar}.Scheme == "" {\n`;
+  text += '\t\treturn nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)\n';
   text += '\t}\n';
   text += `\treturn &Client{${urlVar}: ${urlVar}, ${pipelineVar}: ${pipelineVar}}, nil\n`;
   text += '}\n\n';

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -156,7 +156,6 @@ export function generateParameterInfo(op: Operation): ParamInfo[] {
       continue;
     }
     if (param.language.go!.name === 'host' || param.language.go!.name === '$host') {
-      // don't include the URL param as we include that elsewhere as a url.URL
       continue;
     }
     if (param.implementation === ImplementationLocation.Method && param.required !== true) {
@@ -262,4 +261,12 @@ export function isArraySchema(resp: Schema): resp is ArraySchema {
 // returns SchemaResponse type predicate if the response has a schema
 export function isSchemaResponse(resp?: Response): resp is SchemaResponse {
   return (resp as SchemaResponse).schema !== undefined;
+}
+
+// returns true if the parameter should not be URL encoded
+export function skipURLEncoding(param: Parameter): boolean {
+  if (param.extensions) {
+    return param.extensions['x-ms-skip-url-encoding'] === true;
+  }
+  return false;
 }

--- a/test/autorest/generated/booleangroup/bool.go
+++ b/test/autorest/generated/booleangroup/bool.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"net/url"
-	"path"
 )
 
 // BoolOperations contains the methods for the Bool group.
@@ -36,7 +34,7 @@ type boolOperations struct {
 
 // GetFalse - Get false Boolean value
 func (client *boolOperations) GetFalse(ctx context.Context) (*BoolResponse, error) {
-	req, err := client.getFalseCreateRequest(*client.u)
+	req, err := client.getFalseCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -52,10 +50,13 @@ func (client *boolOperations) GetFalse(ctx context.Context) (*BoolResponse, erro
 }
 
 // getFalseCreateRequest creates the GetFalse request.
-func (client *boolOperations) getFalseCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *boolOperations) getFalseCreateRequest() (*azcore.Request, error) {
 	urlPath := "/bool/false"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -70,7 +71,7 @@ func (client *boolOperations) getFalseHandleResponse(resp *azcore.Response) (*Bo
 
 // GetInvalid - Get invalid Boolean value
 func (client *boolOperations) GetInvalid(ctx context.Context) (*BoolResponse, error) {
-	req, err := client.getInvalidCreateRequest(*client.u)
+	req, err := client.getInvalidCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -86,10 +87,13 @@ func (client *boolOperations) GetInvalid(ctx context.Context) (*BoolResponse, er
 }
 
 // getInvalidCreateRequest creates the GetInvalid request.
-func (client *boolOperations) getInvalidCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *boolOperations) getInvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/bool/invalid"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -104,7 +108,7 @@ func (client *boolOperations) getInvalidHandleResponse(resp *azcore.Response) (*
 
 // GetNull - Get null Boolean value
 func (client *boolOperations) GetNull(ctx context.Context) (*BoolResponse, error) {
-	req, err := client.getNullCreateRequest(*client.u)
+	req, err := client.getNullCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -120,10 +124,13 @@ func (client *boolOperations) GetNull(ctx context.Context) (*BoolResponse, error
 }
 
 // getNullCreateRequest creates the GetNull request.
-func (client *boolOperations) getNullCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *boolOperations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/bool/null"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -138,7 +145,7 @@ func (client *boolOperations) getNullHandleResponse(resp *azcore.Response) (*Boo
 
 // GetTrue - Get true Boolean value
 func (client *boolOperations) GetTrue(ctx context.Context) (*BoolResponse, error) {
-	req, err := client.getTrueCreateRequest(*client.u)
+	req, err := client.getTrueCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -154,10 +161,13 @@ func (client *boolOperations) GetTrue(ctx context.Context) (*BoolResponse, error
 }
 
 // getTrueCreateRequest creates the GetTrue request.
-func (client *boolOperations) getTrueCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *boolOperations) getTrueCreateRequest() (*azcore.Request, error) {
 	urlPath := "/bool/true"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -172,7 +182,7 @@ func (client *boolOperations) getTrueHandleResponse(resp *azcore.Response) (*Boo
 
 // PutFalse - Set Boolean value false
 func (client *boolOperations) PutFalse(ctx context.Context) (*http.Response, error) {
-	req, err := client.putFalseCreateRequest(*client.u)
+	req, err := client.putFalseCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -188,11 +198,14 @@ func (client *boolOperations) PutFalse(ctx context.Context) (*http.Response, err
 }
 
 // putFalseCreateRequest creates the PutFalse request.
-func (client *boolOperations) putFalseCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *boolOperations) putFalseCreateRequest() (*azcore.Request, error) {
 	urlPath := "/bool/false"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(false)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(false)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +222,7 @@ func (client *boolOperations) putFalseHandleResponse(resp *azcore.Response) (*ht
 
 // PutTrue - Set Boolean value true
 func (client *boolOperations) PutTrue(ctx context.Context) (*http.Response, error) {
-	req, err := client.putTrueCreateRequest(*client.u)
+	req, err := client.putTrueCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -225,11 +238,14 @@ func (client *boolOperations) PutTrue(ctx context.Context) (*http.Response, erro
 }
 
 // putTrueCreateRequest creates the PutTrue request.
-func (client *boolOperations) putTrueCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *boolOperations) putTrueCreateRequest() (*azcore.Request, error) {
 	urlPath := "/bool/true"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(true)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(true)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/booleangroup/client.go
+++ b/test/autorest/generated/booleangroup/client.go
@@ -6,6 +6,7 @@
 package booleangroup
 
 import (
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
 )
@@ -62,6 +63,9 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
+	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
 	return &Client{u: u, p: p}, nil
 }

--- a/test/autorest/generated/bytegroup/byte.go
+++ b/test/autorest/generated/bytegroup/byte.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"net/url"
-	"path"
 )
 
 // ByteOperations contains the methods for the Byte group.
@@ -34,7 +32,7 @@ type byteOperations struct {
 
 // GetEmpty - Get empty byte value ''
 func (client *byteOperations) GetEmpty(ctx context.Context) (*ByteArrayResponse, error) {
-	req, err := client.getEmptyCreateRequest(*client.u)
+	req, err := client.getEmptyCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -50,10 +48,13 @@ func (client *byteOperations) GetEmpty(ctx context.Context) (*ByteArrayResponse,
 }
 
 // getEmptyCreateRequest creates the GetEmpty request.
-func (client *byteOperations) getEmptyCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *byteOperations) getEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/byte/empty"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -68,7 +69,7 @@ func (client *byteOperations) getEmptyHandleResponse(resp *azcore.Response) (*By
 
 // GetInvalid - Get invalid byte value ':::SWAGGER::::'
 func (client *byteOperations) GetInvalid(ctx context.Context) (*ByteArrayResponse, error) {
-	req, err := client.getInvalidCreateRequest(*client.u)
+	req, err := client.getInvalidCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -84,10 +85,13 @@ func (client *byteOperations) GetInvalid(ctx context.Context) (*ByteArrayRespons
 }
 
 // getInvalidCreateRequest creates the GetInvalid request.
-func (client *byteOperations) getInvalidCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *byteOperations) getInvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/byte/invalid"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -102,7 +106,7 @@ func (client *byteOperations) getInvalidHandleResponse(resp *azcore.Response) (*
 
 // GetNonASCII - Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
 func (client *byteOperations) GetNonASCII(ctx context.Context) (*ByteArrayResponse, error) {
-	req, err := client.getNonAsciiCreateRequest(*client.u)
+	req, err := client.getNonAsciiCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -118,10 +122,13 @@ func (client *byteOperations) GetNonASCII(ctx context.Context) (*ByteArrayRespon
 }
 
 // getNonAsciiCreateRequest creates the GetNonASCII request.
-func (client *byteOperations) getNonAsciiCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *byteOperations) getNonAsciiCreateRequest() (*azcore.Request, error) {
 	urlPath := "/byte/nonAscii"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -136,7 +143,7 @@ func (client *byteOperations) getNonAsciiHandleResponse(resp *azcore.Response) (
 
 // GetNull - Get null byte value
 func (client *byteOperations) GetNull(ctx context.Context) (*ByteArrayResponse, error) {
-	req, err := client.getNullCreateRequest(*client.u)
+	req, err := client.getNullCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -152,10 +159,13 @@ func (client *byteOperations) GetNull(ctx context.Context) (*ByteArrayResponse, 
 }
 
 // getNullCreateRequest creates the GetNull request.
-func (client *byteOperations) getNullCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *byteOperations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/byte/null"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -170,7 +180,7 @@ func (client *byteOperations) getNullHandleResponse(resp *azcore.Response) (*Byt
 
 // PutNonASCII - Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
 func (client *byteOperations) PutNonASCII(ctx context.Context, byteBody []byte) (*http.Response, error) {
-	req, err := client.putNonAsciiCreateRequest(*client.u, byteBody)
+	req, err := client.putNonAsciiCreateRequest(byteBody)
 	if err != nil {
 		return nil, err
 	}
@@ -186,11 +196,14 @@ func (client *byteOperations) PutNonASCII(ctx context.Context, byteBody []byte) 
 }
 
 // putNonAsciiCreateRequest creates the PutNonASCII request.
-func (client *byteOperations) putNonAsciiCreateRequest(u url.URL, byteBody []byte) (*azcore.Request, error) {
+func (client *byteOperations) putNonAsciiCreateRequest(byteBody []byte) (*azcore.Request, error) {
 	urlPath := "/byte/nonAscii"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(byteBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(byteBody)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/bytegroup/client.go
+++ b/test/autorest/generated/bytegroup/client.go
@@ -6,6 +6,7 @@
 package bytegroup
 
 import (
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
 )
@@ -62,6 +63,9 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
+	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
 	return &Client{u: u, p: p}, nil
 }

--- a/test/autorest/generated/complexmodelgroup/client.go
+++ b/test/autorest/generated/complexmodelgroup/client.go
@@ -6,6 +6,7 @@
 package complexmodelgroup
 
 import (
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
 )
@@ -62,6 +63,9 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
+	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
 	return &Client{u: u, p: p}, nil
 }

--- a/test/autorest/generated/complexmodelgroup/operations.go
+++ b/test/autorest/generated/complexmodelgroup/operations.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -31,7 +30,7 @@ type operations struct {
 
 // Create - Resets products.
 func (client *operations) Create(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*CatalogDictionaryResponse, error) {
-	req, err := client.createCreateRequest(*client.u, subscriptionId, resourceGroupName, bodyParameter)
+	req, err := client.createCreateRequest(subscriptionId, resourceGroupName, bodyParameter)
 	if err != nil {
 		return nil, err
 	}
@@ -47,16 +46,19 @@ func (client *operations) Create(ctx context.Context, subscriptionId string, res
 }
 
 // createCreateRequest creates the Create request.
-func (client *operations) createCreateRequest(u url.URL, subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*azcore.Request, error) {
+func (client *operations) createCreateRequest(subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("apiVersion", "2014-04-01-preview")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodPost, u)
-	err := req.MarshalAsJSON(bodyParameter)
+	req := azcore.NewRequest(http.MethodPost, *u)
+	err = req.MarshalAsJSON(bodyParameter)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +76,7 @@ func (client *operations) createHandleResponse(resp *azcore.Response) (*CatalogD
 
 // List - The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.
 func (client *operations) List(ctx context.Context, resourceGroupName string) (*CatalogArrayResponse, error) {
-	req, err := client.listCreateRequest(*client.u, resourceGroupName)
+	req, err := client.listCreateRequest(resourceGroupName)
 	if err != nil {
 		return nil, err
 	}
@@ -90,15 +92,18 @@ func (client *operations) List(ctx context.Context, resourceGroupName string) (*
 }
 
 // listCreateRequest creates the List request.
-func (client *operations) listCreateRequest(u url.URL, resourceGroupName string) (*azcore.Request, error) {
+func (client *operations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape("123456"))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("apiVersion", "2014-04-01-preview")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -113,7 +118,7 @@ func (client *operations) listHandleResponse(resp *azcore.Response) (*CatalogArr
 
 // Update - Resets products.
 func (client *operations) Update(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*CatalogArrayResponse, error) {
-	req, err := client.updateCreateRequest(*client.u, subscriptionId, resourceGroupName, bodyParameter)
+	req, err := client.updateCreateRequest(subscriptionId, resourceGroupName, bodyParameter)
 	if err != nil {
 		return nil, err
 	}
@@ -129,16 +134,19 @@ func (client *operations) Update(ctx context.Context, subscriptionId string, res
 }
 
 // updateCreateRequest creates the Update request.
-func (client *operations) updateCreateRequest(u url.URL, subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*azcore.Request, error) {
+func (client *operations) updateCreateRequest(subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("apiVersion", "2014-04-01-preview")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(bodyParameter)
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(bodyParameter)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/custombaseurlgroup/client.go
+++ b/test/autorest/generated/custombaseurlgroup/client.go
@@ -6,6 +6,7 @@
 package custombaseurlgroup
 
 import (
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
 )
@@ -62,6 +63,9 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
+	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
 	return &Client{u: u, p: p}, nil
 }

--- a/test/autorest/generated/custombaseurlgroup/paths.go
+++ b/test/autorest/generated/custombaseurlgroup/paths.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"net/url"
-	"path"
 )
 
 // PathsOperations contains the methods for the Paths group.
@@ -26,7 +24,7 @@ type pathsOperations struct {
 
 // GetEmpty - Get a 200 to test a valid base uri
 func (client *pathsOperations) GetEmpty(ctx context.Context, accountName string) (*http.Response, error) {
-	req, err := client.getEmptyCreateRequest(*client.u, accountName)
+	req, err := client.getEmptyCreateRequest(accountName)
 	if err != nil {
 		return nil, err
 	}
@@ -42,10 +40,13 @@ func (client *pathsOperations) GetEmpty(ctx context.Context, accountName string)
 }
 
 // getEmptyCreateRequest creates the GetEmpty request.
-func (client *pathsOperations) getEmptyCreateRequest(u url.URL, accountName string) (*azcore.Request, error) {
+func (client *pathsOperations) getEmptyCreateRequest(accountName string) (*azcore.Request, error) {
 	urlPath := "/customuri"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 

--- a/test/autorest/generated/datetimegroup/client.go
+++ b/test/autorest/generated/datetimegroup/client.go
@@ -6,6 +6,7 @@
 package datetimegroup
 
 import (
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
 )
@@ -62,6 +63,9 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
+	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
 	return &Client{u: u, p: p}, nil
 }

--- a/test/autorest/generated/datetimegroup/datetime.go
+++ b/test/autorest/generated/datetimegroup/datetime.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"net/url"
-	"path"
 	"time"
 )
 
@@ -67,7 +65,7 @@ type datetimeOperations struct {
 
 // GetInvalid - Get invalid datetime value
 func (client *datetimeOperations) GetInvalid(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getInvalidCreateRequest(*client.u)
+	req, err := client.getInvalidCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -83,10 +81,13 @@ func (client *datetimeOperations) GetInvalid(ctx context.Context) (*TimeResponse
 }
 
 // getInvalidCreateRequest creates the GetInvalid request.
-func (client *datetimeOperations) getInvalidCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimeOperations) getInvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/invalid"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -104,7 +105,7 @@ func (client *datetimeOperations) getInvalidHandleResponse(resp *azcore.Response
 
 // GetLocalNegativeOffsetLowercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00
 func (client *datetimeOperations) GetLocalNegativeOffsetLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest(*client.u)
+	req, err := client.getLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -120,10 +121,13 @@ func (client *datetimeOperations) GetLocalNegativeOffsetLowercaseMaxDateTime(ctx
 }
 
 // getLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest creates the GetLocalNegativeOffsetLowercaseMaxDateTime request.
-func (client *datetimeOperations) getLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimeOperations) getLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/max/localnegativeoffset/lowercase"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -141,7 +145,7 @@ func (client *datetimeOperations) getLocalNegativeOffsetLowercaseMaxDateTimeHand
 
 // GetLocalNegativeOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00-14:00
 func (client *datetimeOperations) GetLocalNegativeOffsetMinDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getLocalNegativeOffsetMinDateTimeCreateRequest(*client.u)
+	req, err := client.getLocalNegativeOffsetMinDateTimeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -157,10 +161,13 @@ func (client *datetimeOperations) GetLocalNegativeOffsetMinDateTime(ctx context.
 }
 
 // getLocalNegativeOffsetMinDateTimeCreateRequest creates the GetLocalNegativeOffsetMinDateTime request.
-func (client *datetimeOperations) getLocalNegativeOffsetMinDateTimeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimeOperations) getLocalNegativeOffsetMinDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/min/localnegativeoffset"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -178,7 +185,7 @@ func (client *datetimeOperations) getLocalNegativeOffsetMinDateTimeHandleRespons
 
 // GetLocalNegativeOffsetUppercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00
 func (client *datetimeOperations) GetLocalNegativeOffsetUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest(*client.u)
+	req, err := client.getLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -194,10 +201,13 @@ func (client *datetimeOperations) GetLocalNegativeOffsetUppercaseMaxDateTime(ctx
 }
 
 // getLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest creates the GetLocalNegativeOffsetUppercaseMaxDateTime request.
-func (client *datetimeOperations) getLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimeOperations) getLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/max/localnegativeoffset/uppercase"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -215,7 +225,7 @@ func (client *datetimeOperations) getLocalNegativeOffsetUppercaseMaxDateTimeHand
 
 // GetLocalPositiveOffsetLowercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00
 func (client *datetimeOperations) GetLocalPositiveOffsetLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest(*client.u)
+	req, err := client.getLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -231,10 +241,13 @@ func (client *datetimeOperations) GetLocalPositiveOffsetLowercaseMaxDateTime(ctx
 }
 
 // getLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest creates the GetLocalPositiveOffsetLowercaseMaxDateTime request.
-func (client *datetimeOperations) getLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimeOperations) getLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/max/localpositiveoffset/lowercase"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -252,7 +265,7 @@ func (client *datetimeOperations) getLocalPositiveOffsetLowercaseMaxDateTimeHand
 
 // GetLocalPositiveOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00+14:00
 func (client *datetimeOperations) GetLocalPositiveOffsetMinDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getLocalPositiveOffsetMinDateTimeCreateRequest(*client.u)
+	req, err := client.getLocalPositiveOffsetMinDateTimeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -268,10 +281,13 @@ func (client *datetimeOperations) GetLocalPositiveOffsetMinDateTime(ctx context.
 }
 
 // getLocalPositiveOffsetMinDateTimeCreateRequest creates the GetLocalPositiveOffsetMinDateTime request.
-func (client *datetimeOperations) getLocalPositiveOffsetMinDateTimeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimeOperations) getLocalPositiveOffsetMinDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/min/localpositiveoffset"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -289,7 +305,7 @@ func (client *datetimeOperations) getLocalPositiveOffsetMinDateTimeHandleRespons
 
 // GetLocalPositiveOffsetUppercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00
 func (client *datetimeOperations) GetLocalPositiveOffsetUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest(*client.u)
+	req, err := client.getLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -305,10 +321,13 @@ func (client *datetimeOperations) GetLocalPositiveOffsetUppercaseMaxDateTime(ctx
 }
 
 // getLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest creates the GetLocalPositiveOffsetUppercaseMaxDateTime request.
-func (client *datetimeOperations) getLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimeOperations) getLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/max/localpositiveoffset/uppercase"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -326,7 +345,7 @@ func (client *datetimeOperations) getLocalPositiveOffsetUppercaseMaxDateTimeHand
 
 // GetNull - Get null datetime value
 func (client *datetimeOperations) GetNull(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getNullCreateRequest(*client.u)
+	req, err := client.getNullCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -342,10 +361,13 @@ func (client *datetimeOperations) GetNull(ctx context.Context) (*TimeResponse, e
 }
 
 // getNullCreateRequest creates the GetNull request.
-func (client *datetimeOperations) getNullCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimeOperations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/null"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -363,7 +385,7 @@ func (client *datetimeOperations) getNullHandleResponse(resp *azcore.Response) (
 
 // GetOverflow - Get overflow datetime value
 func (client *datetimeOperations) GetOverflow(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getOverflowCreateRequest(*client.u)
+	req, err := client.getOverflowCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -379,10 +401,13 @@ func (client *datetimeOperations) GetOverflow(ctx context.Context) (*TimeRespons
 }
 
 // getOverflowCreateRequest creates the GetOverflow request.
-func (client *datetimeOperations) getOverflowCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimeOperations) getOverflowCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/overflow"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -400,7 +425,7 @@ func (client *datetimeOperations) getOverflowHandleResponse(resp *azcore.Respons
 
 // GetUTCLowercaseMaxDateTime - Get max datetime value 9999-12-31t23:59:59.999z
 func (client *datetimeOperations) GetUTCLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getUtcLowercaseMaxDateTimeCreateRequest(*client.u)
+	req, err := client.getUtcLowercaseMaxDateTimeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -416,10 +441,13 @@ func (client *datetimeOperations) GetUTCLowercaseMaxDateTime(ctx context.Context
 }
 
 // getUtcLowercaseMaxDateTimeCreateRequest creates the GetUTCLowercaseMaxDateTime request.
-func (client *datetimeOperations) getUtcLowercaseMaxDateTimeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimeOperations) getUtcLowercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/max/utc/lowercase"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -437,7 +465,7 @@ func (client *datetimeOperations) getUtcLowercaseMaxDateTimeHandleResponse(resp 
 
 // GetUTCMinDateTime - Get min datetime value 0001-01-01T00:00:00Z
 func (client *datetimeOperations) GetUTCMinDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getUtcMinDateTimeCreateRequest(*client.u)
+	req, err := client.getUtcMinDateTimeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -453,10 +481,13 @@ func (client *datetimeOperations) GetUTCMinDateTime(ctx context.Context) (*TimeR
 }
 
 // getUtcMinDateTimeCreateRequest creates the GetUTCMinDateTime request.
-func (client *datetimeOperations) getUtcMinDateTimeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimeOperations) getUtcMinDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/min/utc"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -474,7 +505,7 @@ func (client *datetimeOperations) getUtcMinDateTimeHandleResponse(resp *azcore.R
 
 // GetUTCUppercaseMaxDateTime - Get max datetime value 9999-12-31T23:59:59.999Z
 func (client *datetimeOperations) GetUTCUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getUtcUppercaseMaxDateTimeCreateRequest(*client.u)
+	req, err := client.getUtcUppercaseMaxDateTimeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -490,10 +521,13 @@ func (client *datetimeOperations) GetUTCUppercaseMaxDateTime(ctx context.Context
 }
 
 // getUtcUppercaseMaxDateTimeCreateRequest creates the GetUTCUppercaseMaxDateTime request.
-func (client *datetimeOperations) getUtcUppercaseMaxDateTimeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimeOperations) getUtcUppercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/max/utc/uppercase"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -511,7 +545,7 @@ func (client *datetimeOperations) getUtcUppercaseMaxDateTimeHandleResponse(resp 
 
 // GetUTCUppercaseMaxDateTime7Digits - Get max datetime value 9999-12-31T23:59:59.9999999Z
 func (client *datetimeOperations) GetUTCUppercaseMaxDateTime7Digits(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getUtcUppercaseMaxDateTime7DigitsCreateRequest(*client.u)
+	req, err := client.getUtcUppercaseMaxDateTime7DigitsCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -527,10 +561,13 @@ func (client *datetimeOperations) GetUTCUppercaseMaxDateTime7Digits(ctx context.
 }
 
 // getUtcUppercaseMaxDateTime7DigitsCreateRequest creates the GetUTCUppercaseMaxDateTime7Digits request.
-func (client *datetimeOperations) getUtcUppercaseMaxDateTime7DigitsCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimeOperations) getUtcUppercaseMaxDateTime7DigitsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/max/utc7ms/uppercase"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -548,7 +585,7 @@ func (client *datetimeOperations) getUtcUppercaseMaxDateTime7DigitsHandleRespons
 
 // GetUnderflow - Get underflow datetime value
 func (client *datetimeOperations) GetUnderflow(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getUnderflowCreateRequest(*client.u)
+	req, err := client.getUnderflowCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -564,10 +601,13 @@ func (client *datetimeOperations) GetUnderflow(ctx context.Context) (*TimeRespon
 }
 
 // getUnderflowCreateRequest creates the GetUnderflow request.
-func (client *datetimeOperations) getUnderflowCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimeOperations) getUnderflowCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/underflow"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -585,7 +625,7 @@ func (client *datetimeOperations) getUnderflowHandleResponse(resp *azcore.Respon
 
 // PutLocalNegativeOffsetMaxDateTime - Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00
 func (client *datetimeOperations) PutLocalNegativeOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.putLocalNegativeOffsetMaxDateTimeCreateRequest(*client.u, datetimeBody)
+	req, err := client.putLocalNegativeOffsetMaxDateTimeCreateRequest(datetimeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -601,11 +641,14 @@ func (client *datetimeOperations) PutLocalNegativeOffsetMaxDateTime(ctx context.
 }
 
 // putLocalNegativeOffsetMaxDateTimeCreateRequest creates the PutLocalNegativeOffsetMaxDateTime request.
-func (client *datetimeOperations) putLocalNegativeOffsetMaxDateTimeCreateRequest(u url.URL, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *datetimeOperations) putLocalNegativeOffsetMaxDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetime/max/localnegativeoffset"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(datetimeBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(datetimeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -622,7 +665,7 @@ func (client *datetimeOperations) putLocalNegativeOffsetMaxDateTimeHandleRespons
 
 // PutLocalNegativeOffsetMinDateTime - Put min datetime value 0001-01-01T00:00:00-14:00
 func (client *datetimeOperations) PutLocalNegativeOffsetMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.putLocalNegativeOffsetMinDateTimeCreateRequest(*client.u, datetimeBody)
+	req, err := client.putLocalNegativeOffsetMinDateTimeCreateRequest(datetimeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -638,11 +681,14 @@ func (client *datetimeOperations) PutLocalNegativeOffsetMinDateTime(ctx context.
 }
 
 // putLocalNegativeOffsetMinDateTimeCreateRequest creates the PutLocalNegativeOffsetMinDateTime request.
-func (client *datetimeOperations) putLocalNegativeOffsetMinDateTimeCreateRequest(u url.URL, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *datetimeOperations) putLocalNegativeOffsetMinDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetime/min/localnegativeoffset"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(datetimeBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(datetimeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -659,7 +705,7 @@ func (client *datetimeOperations) putLocalNegativeOffsetMinDateTimeHandleRespons
 
 // PutLocalPositiveOffsetMaxDateTime - Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00
 func (client *datetimeOperations) PutLocalPositiveOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.putLocalPositiveOffsetMaxDateTimeCreateRequest(*client.u, datetimeBody)
+	req, err := client.putLocalPositiveOffsetMaxDateTimeCreateRequest(datetimeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -675,11 +721,14 @@ func (client *datetimeOperations) PutLocalPositiveOffsetMaxDateTime(ctx context.
 }
 
 // putLocalPositiveOffsetMaxDateTimeCreateRequest creates the PutLocalPositiveOffsetMaxDateTime request.
-func (client *datetimeOperations) putLocalPositiveOffsetMaxDateTimeCreateRequest(u url.URL, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *datetimeOperations) putLocalPositiveOffsetMaxDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetime/max/localpositiveoffset"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(datetimeBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(datetimeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -696,7 +745,7 @@ func (client *datetimeOperations) putLocalPositiveOffsetMaxDateTimeHandleRespons
 
 // PutLocalPositiveOffsetMinDateTime - Put min datetime value 0001-01-01T00:00:00+14:00
 func (client *datetimeOperations) PutLocalPositiveOffsetMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.putLocalPositiveOffsetMinDateTimeCreateRequest(*client.u, datetimeBody)
+	req, err := client.putLocalPositiveOffsetMinDateTimeCreateRequest(datetimeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -712,11 +761,14 @@ func (client *datetimeOperations) PutLocalPositiveOffsetMinDateTime(ctx context.
 }
 
 // putLocalPositiveOffsetMinDateTimeCreateRequest creates the PutLocalPositiveOffsetMinDateTime request.
-func (client *datetimeOperations) putLocalPositiveOffsetMinDateTimeCreateRequest(u url.URL, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *datetimeOperations) putLocalPositiveOffsetMinDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetime/min/localpositiveoffset"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(datetimeBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(datetimeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -733,7 +785,7 @@ func (client *datetimeOperations) putLocalPositiveOffsetMinDateTimeHandleRespons
 
 // PutUTCMaxDateTime - Put max datetime value 9999-12-31T23:59:59.999Z
 func (client *datetimeOperations) PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.putUtcMaxDateTimeCreateRequest(*client.u, datetimeBody)
+	req, err := client.putUtcMaxDateTimeCreateRequest(datetimeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -749,11 +801,14 @@ func (client *datetimeOperations) PutUTCMaxDateTime(ctx context.Context, datetim
 }
 
 // putUtcMaxDateTimeCreateRequest creates the PutUTCMaxDateTime request.
-func (client *datetimeOperations) putUtcMaxDateTimeCreateRequest(u url.URL, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *datetimeOperations) putUtcMaxDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetime/max/utc"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(datetimeBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(datetimeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -770,7 +825,7 @@ func (client *datetimeOperations) putUtcMaxDateTimeHandleResponse(resp *azcore.R
 
 // PutUTCMaxDateTime7Digits - Put max datetime value 9999-12-31T23:59:59.9999999Z
 func (client *datetimeOperations) PutUTCMaxDateTime7Digits(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.putUtcMaxDateTime7DigitsCreateRequest(*client.u, datetimeBody)
+	req, err := client.putUtcMaxDateTime7DigitsCreateRequest(datetimeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -786,11 +841,14 @@ func (client *datetimeOperations) PutUTCMaxDateTime7Digits(ctx context.Context, 
 }
 
 // putUtcMaxDateTime7DigitsCreateRequest creates the PutUTCMaxDateTime7Digits request.
-func (client *datetimeOperations) putUtcMaxDateTime7DigitsCreateRequest(u url.URL, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *datetimeOperations) putUtcMaxDateTime7DigitsCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetime/max/utc7ms"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(datetimeBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(datetimeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -807,7 +865,7 @@ func (client *datetimeOperations) putUtcMaxDateTime7DigitsHandleResponse(resp *a
 
 // PutUTCMinDateTime - Put min datetime value 0001-01-01T00:00:00Z
 func (client *datetimeOperations) PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.putUtcMinDateTimeCreateRequest(*client.u, datetimeBody)
+	req, err := client.putUtcMinDateTimeCreateRequest(datetimeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -823,11 +881,14 @@ func (client *datetimeOperations) PutUTCMinDateTime(ctx context.Context, datetim
 }
 
 // putUtcMinDateTimeCreateRequest creates the PutUTCMinDateTime request.
-func (client *datetimeOperations) putUtcMinDateTimeCreateRequest(u url.URL, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *datetimeOperations) putUtcMinDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetime/min/utc"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(datetimeBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(datetimeBody)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/datetimerfc1123group/client.go
+++ b/test/autorest/generated/datetimerfc1123group/client.go
@@ -6,6 +6,7 @@
 package datetimerfc1123group
 
 import (
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
 )
@@ -62,6 +63,9 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
+	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
 	return &Client{u: u, p: p}, nil
 }

--- a/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
+++ b/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"net/url"
-	"path"
 	"time"
 )
 
@@ -43,7 +41,7 @@ type datetimerfc1123Operations struct {
 
 // GetInvalid - Get invalid datetime value
 func (client *datetimerfc1123Operations) GetInvalid(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getInvalidCreateRequest(*client.u)
+	req, err := client.getInvalidCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -59,10 +57,13 @@ func (client *datetimerfc1123Operations) GetInvalid(ctx context.Context) (*TimeR
 }
 
 // getInvalidCreateRequest creates the GetInvalid request.
-func (client *datetimerfc1123Operations) getInvalidCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimerfc1123Operations) getInvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/invalid"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -80,7 +81,7 @@ func (client *datetimerfc1123Operations) getInvalidHandleResponse(resp *azcore.R
 
 // GetNull - Get null datetime value
 func (client *datetimerfc1123Operations) GetNull(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getNullCreateRequest(*client.u)
+	req, err := client.getNullCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -96,10 +97,13 @@ func (client *datetimerfc1123Operations) GetNull(ctx context.Context) (*TimeResp
 }
 
 // getNullCreateRequest creates the GetNull request.
-func (client *datetimerfc1123Operations) getNullCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimerfc1123Operations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/null"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -117,7 +121,7 @@ func (client *datetimerfc1123Operations) getNullHandleResponse(resp *azcore.Resp
 
 // GetOverflow - Get overflow datetime value
 func (client *datetimerfc1123Operations) GetOverflow(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getOverflowCreateRequest(*client.u)
+	req, err := client.getOverflowCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -133,10 +137,13 @@ func (client *datetimerfc1123Operations) GetOverflow(ctx context.Context) (*Time
 }
 
 // getOverflowCreateRequest creates the GetOverflow request.
-func (client *datetimerfc1123Operations) getOverflowCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimerfc1123Operations) getOverflowCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/overflow"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -154,7 +161,7 @@ func (client *datetimerfc1123Operations) getOverflowHandleResponse(resp *azcore.
 
 // GetUTCLowercaseMaxDateTime - Get max datetime value fri, 31 dec 9999 23:59:59 gmt
 func (client *datetimerfc1123Operations) GetUTCLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getUtcLowercaseMaxDateTimeCreateRequest(*client.u)
+	req, err := client.getUtcLowercaseMaxDateTimeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -170,10 +177,13 @@ func (client *datetimerfc1123Operations) GetUTCLowercaseMaxDateTime(ctx context.
 }
 
 // getUtcLowercaseMaxDateTimeCreateRequest creates the GetUTCLowercaseMaxDateTime request.
-func (client *datetimerfc1123Operations) getUtcLowercaseMaxDateTimeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimerfc1123Operations) getUtcLowercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/max/lowercase"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -191,7 +201,7 @@ func (client *datetimerfc1123Operations) getUtcLowercaseMaxDateTimeHandleRespons
 
 // GetUTCMinDateTime - Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT
 func (client *datetimerfc1123Operations) GetUTCMinDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getUtcMinDateTimeCreateRequest(*client.u)
+	req, err := client.getUtcMinDateTimeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -207,10 +217,13 @@ func (client *datetimerfc1123Operations) GetUTCMinDateTime(ctx context.Context) 
 }
 
 // getUtcMinDateTimeCreateRequest creates the GetUTCMinDateTime request.
-func (client *datetimerfc1123Operations) getUtcMinDateTimeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimerfc1123Operations) getUtcMinDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/min"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -228,7 +241,7 @@ func (client *datetimerfc1123Operations) getUtcMinDateTimeHandleResponse(resp *a
 
 // GetUTCUppercaseMaxDateTime - Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT
 func (client *datetimerfc1123Operations) GetUTCUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getUtcUppercaseMaxDateTimeCreateRequest(*client.u)
+	req, err := client.getUtcUppercaseMaxDateTimeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -244,10 +257,13 @@ func (client *datetimerfc1123Operations) GetUTCUppercaseMaxDateTime(ctx context.
 }
 
 // getUtcUppercaseMaxDateTimeCreateRequest creates the GetUTCUppercaseMaxDateTime request.
-func (client *datetimerfc1123Operations) getUtcUppercaseMaxDateTimeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimerfc1123Operations) getUtcUppercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/max/uppercase"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -265,7 +281,7 @@ func (client *datetimerfc1123Operations) getUtcUppercaseMaxDateTimeHandleRespons
 
 // GetUnderflow - Get underflow datetime value
 func (client *datetimerfc1123Operations) GetUnderflow(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.getUnderflowCreateRequest(*client.u)
+	req, err := client.getUnderflowCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -281,10 +297,13 @@ func (client *datetimerfc1123Operations) GetUnderflow(ctx context.Context) (*Tim
 }
 
 // getUnderflowCreateRequest creates the GetUnderflow request.
-func (client *datetimerfc1123Operations) getUnderflowCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *datetimerfc1123Operations) getUnderflowCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/underflow"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -302,7 +321,7 @@ func (client *datetimerfc1123Operations) getUnderflowHandleResponse(resp *azcore
 
 // PutUTCMaxDateTime - Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT
 func (client *datetimerfc1123Operations) PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.putUtcMaxDateTimeCreateRequest(*client.u, datetimeBody)
+	req, err := client.putUtcMaxDateTimeCreateRequest(datetimeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -318,12 +337,15 @@ func (client *datetimerfc1123Operations) PutUTCMaxDateTime(ctx context.Context, 
 }
 
 // putUtcMaxDateTimeCreateRequest creates the PutUTCMaxDateTime request.
-func (client *datetimerfc1123Operations) putUtcMaxDateTimeCreateRequest(u url.URL, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *datetimerfc1123Operations) putUtcMaxDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/max"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
 	aux := timeRFC1123(datetimeBody)
-	err := req.MarshalAsJSON(aux)
+	err = req.MarshalAsJSON(aux)
 	if err != nil {
 		return nil, err
 	}
@@ -340,7 +362,7 @@ func (client *datetimerfc1123Operations) putUtcMaxDateTimeHandleResponse(resp *a
 
 // PutUTCMinDateTime - Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT
 func (client *datetimerfc1123Operations) PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.putUtcMinDateTimeCreateRequest(*client.u, datetimeBody)
+	req, err := client.putUtcMinDateTimeCreateRequest(datetimeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -356,12 +378,15 @@ func (client *datetimerfc1123Operations) PutUTCMinDateTime(ctx context.Context, 
 }
 
 // putUtcMinDateTimeCreateRequest creates the PutUTCMinDateTime request.
-func (client *datetimerfc1123Operations) putUtcMinDateTimeCreateRequest(u url.URL, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *datetimerfc1123Operations) putUtcMinDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/min"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
 	aux := timeRFC1123(datetimeBody)
-	err := req.MarshalAsJSON(aux)
+	err = req.MarshalAsJSON(aux)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/filegroup/client.go
+++ b/test/autorest/generated/filegroup/client.go
@@ -6,6 +6,7 @@
 package filegroup
 
 import (
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
 )
@@ -62,6 +63,9 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
+	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
 	return &Client{u: u, p: p}, nil
 }

--- a/test/autorest/generated/filegroup/files.go
+++ b/test/autorest/generated/filegroup/files.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"net/url"
-	"path"
 )
 
 // FilesOperations contains the methods for the Files group.
@@ -30,7 +28,7 @@ type filesOperations struct {
 
 // GetEmptyFile - Get empty file
 func (client *filesOperations) GetEmptyFile(ctx context.Context) (*http.Response, error) {
-	req, err := client.getEmptyFileCreateRequest(*client.u)
+	req, err := client.getEmptyFileCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -46,10 +44,13 @@ func (client *filesOperations) GetEmptyFile(ctx context.Context) (*http.Response
 }
 
 // getEmptyFileCreateRequest creates the GetEmptyFile request.
-func (client *filesOperations) getEmptyFileCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *filesOperations) getEmptyFileCreateRequest() (*azcore.Request, error) {
 	urlPath := "/files/stream/empty"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	req.SkipBodyDownload()
 	return req, nil
 }
@@ -64,7 +65,7 @@ func (client *filesOperations) getEmptyFileHandleResponse(resp *azcore.Response)
 
 // GetFile - Get file
 func (client *filesOperations) GetFile(ctx context.Context) (*http.Response, error) {
-	req, err := client.getFileCreateRequest(*client.u)
+	req, err := client.getFileCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -80,10 +81,13 @@ func (client *filesOperations) GetFile(ctx context.Context) (*http.Response, err
 }
 
 // getFileCreateRequest creates the GetFile request.
-func (client *filesOperations) getFileCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *filesOperations) getFileCreateRequest() (*azcore.Request, error) {
 	urlPath := "/files/stream/nonempty"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	req.SkipBodyDownload()
 	return req, nil
 }
@@ -98,7 +102,7 @@ func (client *filesOperations) getFileHandleResponse(resp *azcore.Response) (*ht
 
 // GetFileLarge - Get a large file
 func (client *filesOperations) GetFileLarge(ctx context.Context) (*http.Response, error) {
-	req, err := client.getFileLargeCreateRequest(*client.u)
+	req, err := client.getFileLargeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -114,10 +118,13 @@ func (client *filesOperations) GetFileLarge(ctx context.Context) (*http.Response
 }
 
 // getFileLargeCreateRequest creates the GetFileLarge request.
-func (client *filesOperations) getFileLargeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *filesOperations) getFileLargeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/files/stream/verylarge"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	req.SkipBodyDownload()
 	return req, nil
 }

--- a/test/autorest/generated/headergroup/client.go
+++ b/test/autorest/generated/headergroup/client.go
@@ -6,6 +6,7 @@
 package headergroup
 
 import (
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
 )
@@ -62,6 +63,9 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
+	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
 	return &Client{u: u, p: p}, nil
 }

--- a/test/autorest/generated/headergroup/header.go
+++ b/test/autorest/generated/headergroup/header.go
@@ -10,8 +10,6 @@ import (
 	"encoding/base64"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"net/url"
-	"path"
 	"strconv"
 	"time"
 )
@@ -85,7 +83,7 @@ type headerOperations struct {
 
 // CustomRequestID - Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
 func (client *headerOperations) CustomRequestID(ctx context.Context) (*http.Response, error) {
-	req, err := client.customRequestIdCreateRequest(*client.u)
+	req, err := client.customRequestIdCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -101,10 +99,13 @@ func (client *headerOperations) CustomRequestID(ctx context.Context) (*http.Resp
 }
 
 // customRequestIdCreateRequest creates the CustomRequestID request.
-func (client *headerOperations) customRequestIdCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *headerOperations) customRequestIdCreateRequest() (*azcore.Request, error) {
 	urlPath := "/header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	return req, nil
 }
 
@@ -118,7 +119,7 @@ func (client *headerOperations) customRequestIdHandleResponse(resp *azcore.Respo
 
 // ParamBool - Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false
 func (client *headerOperations) ParamBool(ctx context.Context, scenario string, value bool) (*http.Response, error) {
-	req, err := client.paramBoolCreateRequest(*client.u, scenario, value)
+	req, err := client.paramBoolCreateRequest(scenario, value)
 	if err != nil {
 		return nil, err
 	}
@@ -134,10 +135,13 @@ func (client *headerOperations) ParamBool(ctx context.Context, scenario string, 
 }
 
 // paramBoolCreateRequest creates the ParamBool request.
-func (client *headerOperations) paramBoolCreateRequest(u url.URL, scenario string, value bool) (*azcore.Request, error) {
+func (client *headerOperations) paramBoolCreateRequest(scenario string, value bool) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/bool"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", strconv.FormatBool(value))
 	return req, nil
@@ -153,7 +157,7 @@ func (client *headerOperations) paramBoolHandleResponse(resp *azcore.Response) (
 
 // ParamByte - Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩"
 func (client *headerOperations) ParamByte(ctx context.Context, scenario string, value []byte) (*http.Response, error) {
-	req, err := client.paramByteCreateRequest(*client.u, scenario, value)
+	req, err := client.paramByteCreateRequest(scenario, value)
 	if err != nil {
 		return nil, err
 	}
@@ -169,10 +173,13 @@ func (client *headerOperations) ParamByte(ctx context.Context, scenario string, 
 }
 
 // paramByteCreateRequest creates the ParamByte request.
-func (client *headerOperations) paramByteCreateRequest(u url.URL, scenario string, value []byte) (*azcore.Request, error) {
+func (client *headerOperations) paramByteCreateRequest(scenario string, value []byte) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/byte"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", base64.StdEncoding.EncodeToString(value))
 	return req, nil
@@ -188,7 +195,7 @@ func (client *headerOperations) paramByteHandleResponse(resp *azcore.Response) (
 
 // ParamDate - Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01"
 func (client *headerOperations) ParamDate(ctx context.Context, scenario string, value time.Time) (*http.Response, error) {
-	req, err := client.paramDateCreateRequest(*client.u, scenario, value)
+	req, err := client.paramDateCreateRequest(scenario, value)
 	if err != nil {
 		return nil, err
 	}
@@ -204,10 +211,13 @@ func (client *headerOperations) ParamDate(ctx context.Context, scenario string, 
 }
 
 // paramDateCreateRequest creates the ParamDate request.
-func (client *headerOperations) paramDateCreateRequest(u url.URL, scenario string, value time.Time) (*azcore.Request, error) {
+func (client *headerOperations) paramDateCreateRequest(scenario string, value time.Time) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/date"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", value.Format("2006-01-02"))
 	return req, nil
@@ -223,7 +233,7 @@ func (client *headerOperations) paramDateHandleResponse(resp *azcore.Response) (
 
 // ParamDatetime - Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z"
 func (client *headerOperations) ParamDatetime(ctx context.Context, scenario string, value time.Time) (*http.Response, error) {
-	req, err := client.paramDatetimeCreateRequest(*client.u, scenario, value)
+	req, err := client.paramDatetimeCreateRequest(scenario, value)
 	if err != nil {
 		return nil, err
 	}
@@ -239,10 +249,13 @@ func (client *headerOperations) ParamDatetime(ctx context.Context, scenario stri
 }
 
 // paramDatetimeCreateRequest creates the ParamDatetime request.
-func (client *headerOperations) paramDatetimeCreateRequest(u url.URL, scenario string, value time.Time) (*azcore.Request, error) {
+func (client *headerOperations) paramDatetimeCreateRequest(scenario string, value time.Time) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/datetime"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", value.Format(time.RFC3339))
 	return req, nil
@@ -258,7 +271,7 @@ func (client *headerOperations) paramDatetimeHandleResponse(resp *azcore.Respons
 
 // ParamDatetimeRFC1123 - Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT"
 func (client *headerOperations) ParamDatetimeRFC1123(ctx context.Context, scenario string, options *HeaderParamDatetimeRFC1123Options) (*http.Response, error) {
-	req, err := client.paramDatetimeRfc1123CreateRequest(*client.u, scenario, options)
+	req, err := client.paramDatetimeRfc1123CreateRequest(scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -274,10 +287,13 @@ func (client *headerOperations) ParamDatetimeRFC1123(ctx context.Context, scenar
 }
 
 // paramDatetimeRfc1123CreateRequest creates the ParamDatetimeRFC1123 request.
-func (client *headerOperations) paramDatetimeRfc1123CreateRequest(u url.URL, scenario string, options *HeaderParamDatetimeRFC1123Options) (*azcore.Request, error) {
+func (client *headerOperations) paramDatetimeRfc1123CreateRequest(scenario string, options *HeaderParamDatetimeRFC1123Options) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/datetimerfc1123"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	if options != nil && options.Value != nil {
 		req.Header.Set("value", options.Value.Format(time.RFC1123))
@@ -295,7 +311,7 @@ func (client *headerOperations) paramDatetimeRfc1123HandleResponse(resp *azcore.
 
 // ParamDouble - Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0
 func (client *headerOperations) ParamDouble(ctx context.Context, scenario string, value float64) (*http.Response, error) {
-	req, err := client.paramDoubleCreateRequest(*client.u, scenario, value)
+	req, err := client.paramDoubleCreateRequest(scenario, value)
 	if err != nil {
 		return nil, err
 	}
@@ -311,10 +327,13 @@ func (client *headerOperations) ParamDouble(ctx context.Context, scenario string
 }
 
 // paramDoubleCreateRequest creates the ParamDouble request.
-func (client *headerOperations) paramDoubleCreateRequest(u url.URL, scenario string, value float64) (*azcore.Request, error) {
+func (client *headerOperations) paramDoubleCreateRequest(scenario string, value float64) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/double"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", strconv.FormatFloat(value, 'f', -1, 64))
 	return req, nil
@@ -330,7 +349,7 @@ func (client *headerOperations) paramDoubleHandleResponse(resp *azcore.Response)
 
 // ParamDuration - Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S"
 func (client *headerOperations) ParamDuration(ctx context.Context, scenario string, value time.Duration) (*http.Response, error) {
-	req, err := client.paramDurationCreateRequest(*client.u, scenario, value)
+	req, err := client.paramDurationCreateRequest(scenario, value)
 	if err != nil {
 		return nil, err
 	}
@@ -346,10 +365,13 @@ func (client *headerOperations) ParamDuration(ctx context.Context, scenario stri
 }
 
 // paramDurationCreateRequest creates the ParamDuration request.
-func (client *headerOperations) paramDurationCreateRequest(u url.URL, scenario string, value time.Duration) (*azcore.Request, error) {
+func (client *headerOperations) paramDurationCreateRequest(scenario string, value time.Duration) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/duration"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", value.String())
 	return req, nil
@@ -365,7 +387,7 @@ func (client *headerOperations) paramDurationHandleResponse(resp *azcore.Respons
 
 // ParamEnum - Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null
 func (client *headerOperations) ParamEnum(ctx context.Context, scenario string, options *HeaderParamEnumOptions) (*http.Response, error) {
-	req, err := client.paramEnumCreateRequest(*client.u, scenario, options)
+	req, err := client.paramEnumCreateRequest(scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -381,10 +403,13 @@ func (client *headerOperations) ParamEnum(ctx context.Context, scenario string, 
 }
 
 // paramEnumCreateRequest creates the ParamEnum request.
-func (client *headerOperations) paramEnumCreateRequest(u url.URL, scenario string, options *HeaderParamEnumOptions) (*azcore.Request, error) {
+func (client *headerOperations) paramEnumCreateRequest(scenario string, options *HeaderParamEnumOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/enum"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	if options != nil && options.Value != nil {
 		req.Header.Set("value", string(*options.Value))
@@ -402,7 +427,7 @@ func (client *headerOperations) paramEnumHandleResponse(resp *azcore.Response) (
 
 // ParamExistingKey - Send a post request with header value "User-Agent": "overwrite"
 func (client *headerOperations) ParamExistingKey(ctx context.Context, userAgent string) (*http.Response, error) {
-	req, err := client.paramExistingKeyCreateRequest(*client.u, userAgent)
+	req, err := client.paramExistingKeyCreateRequest(userAgent)
 	if err != nil {
 		return nil, err
 	}
@@ -418,10 +443,13 @@ func (client *headerOperations) ParamExistingKey(ctx context.Context, userAgent 
 }
 
 // paramExistingKeyCreateRequest creates the ParamExistingKey request.
-func (client *headerOperations) paramExistingKeyCreateRequest(u url.URL, userAgent string) (*azcore.Request, error) {
+func (client *headerOperations) paramExistingKeyCreateRequest(userAgent string) (*azcore.Request, error) {
 	urlPath := "/header/param/existingkey"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("User-Agent", userAgent)
 	return req, nil
 }
@@ -436,7 +464,7 @@ func (client *headerOperations) paramExistingKeyHandleResponse(resp *azcore.Resp
 
 // ParamFloat - Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0
 func (client *headerOperations) ParamFloat(ctx context.Context, scenario string, value float32) (*http.Response, error) {
-	req, err := client.paramFloatCreateRequest(*client.u, scenario, value)
+	req, err := client.paramFloatCreateRequest(scenario, value)
 	if err != nil {
 		return nil, err
 	}
@@ -452,10 +480,13 @@ func (client *headerOperations) ParamFloat(ctx context.Context, scenario string,
 }
 
 // paramFloatCreateRequest creates the ParamFloat request.
-func (client *headerOperations) paramFloatCreateRequest(u url.URL, scenario string, value float32) (*azcore.Request, error) {
+func (client *headerOperations) paramFloatCreateRequest(scenario string, value float32) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/float"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", strconv.FormatFloat(float64(value), 'f', -1, 32))
 	return req, nil
@@ -471,7 +502,7 @@ func (client *headerOperations) paramFloatHandleResponse(resp *azcore.Response) 
 
 // ParamInteger - Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2
 func (client *headerOperations) ParamInteger(ctx context.Context, scenario string, value int32) (*http.Response, error) {
-	req, err := client.paramIntegerCreateRequest(*client.u, scenario, value)
+	req, err := client.paramIntegerCreateRequest(scenario, value)
 	if err != nil {
 		return nil, err
 	}
@@ -487,10 +518,13 @@ func (client *headerOperations) ParamInteger(ctx context.Context, scenario strin
 }
 
 // paramIntegerCreateRequest creates the ParamInteger request.
-func (client *headerOperations) paramIntegerCreateRequest(u url.URL, scenario string, value int32) (*azcore.Request, error) {
+func (client *headerOperations) paramIntegerCreateRequest(scenario string, value int32) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/integer"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", strconv.FormatInt(int64(value), 10))
 	return req, nil
@@ -506,7 +540,7 @@ func (client *headerOperations) paramIntegerHandleResponse(resp *azcore.Response
 
 // ParamLong - Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2
 func (client *headerOperations) ParamLong(ctx context.Context, scenario string, value int64) (*http.Response, error) {
-	req, err := client.paramLongCreateRequest(*client.u, scenario, value)
+	req, err := client.paramLongCreateRequest(scenario, value)
 	if err != nil {
 		return nil, err
 	}
@@ -522,10 +556,13 @@ func (client *headerOperations) ParamLong(ctx context.Context, scenario string, 
 }
 
 // paramLongCreateRequest creates the ParamLong request.
-func (client *headerOperations) paramLongCreateRequest(u url.URL, scenario string, value int64) (*azcore.Request, error) {
+func (client *headerOperations) paramLongCreateRequest(scenario string, value int64) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/long"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", strconv.FormatInt(value, 10))
 	return req, nil
@@ -541,7 +578,7 @@ func (client *headerOperations) paramLongHandleResponse(resp *azcore.Response) (
 
 // ParamProtectedKey - Send a post request with header value "Content-Type": "text/html"
 func (client *headerOperations) ParamProtectedKey(ctx context.Context, contentType string) (*http.Response, error) {
-	req, err := client.paramProtectedKeyCreateRequest(*client.u, contentType)
+	req, err := client.paramProtectedKeyCreateRequest(contentType)
 	if err != nil {
 		return nil, err
 	}
@@ -557,10 +594,13 @@ func (client *headerOperations) ParamProtectedKey(ctx context.Context, contentTy
 }
 
 // paramProtectedKeyCreateRequest creates the ParamProtectedKey request.
-func (client *headerOperations) paramProtectedKeyCreateRequest(u url.URL, contentType string) (*azcore.Request, error) {
+func (client *headerOperations) paramProtectedKeyCreateRequest(contentType string) (*azcore.Request, error) {
 	urlPath := "/header/param/protectedkey"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("Content-Type", contentType)
 	return req, nil
 }
@@ -575,7 +615,7 @@ func (client *headerOperations) paramProtectedKeyHandleResponse(resp *azcore.Res
 
 // ParamString - Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": ""
 func (client *headerOperations) ParamString(ctx context.Context, scenario string, options *HeaderParamStringOptions) (*http.Response, error) {
-	req, err := client.paramStringCreateRequest(*client.u, scenario, options)
+	req, err := client.paramStringCreateRequest(scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -591,10 +631,13 @@ func (client *headerOperations) ParamString(ctx context.Context, scenario string
 }
 
 // paramStringCreateRequest creates the ParamString request.
-func (client *headerOperations) paramStringCreateRequest(u url.URL, scenario string, options *HeaderParamStringOptions) (*azcore.Request, error) {
+func (client *headerOperations) paramStringCreateRequest(scenario string, options *HeaderParamStringOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/string"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	if options != nil && options.Value != nil {
 		req.Header.Set("value", *options.Value)
@@ -612,7 +655,7 @@ func (client *headerOperations) paramStringHandleResponse(resp *azcore.Response)
 
 // ResponseBool - Get a response with header value "value": true or false
 func (client *headerOperations) ResponseBool(ctx context.Context, scenario string) (*HeaderResponseBoolResponse, error) {
-	req, err := client.responseBoolCreateRequest(*client.u, scenario)
+	req, err := client.responseBoolCreateRequest(scenario)
 	if err != nil {
 		return nil, err
 	}
@@ -628,10 +671,13 @@ func (client *headerOperations) ResponseBool(ctx context.Context, scenario strin
 }
 
 // responseBoolCreateRequest creates the ResponseBool request.
-func (client *headerOperations) responseBoolCreateRequest(u url.URL, scenario string) (*azcore.Request, error) {
+func (client *headerOperations) responseBoolCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/bool"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	return req, nil
 }
@@ -652,7 +698,7 @@ func (client *headerOperations) responseBoolHandleResponse(resp *azcore.Response
 
 // ResponseByte - Get a response with header values "啊齄丂狛狜隣郎隣兀﨩"
 func (client *headerOperations) ResponseByte(ctx context.Context, scenario string) (*HeaderResponseByteResponse, error) {
-	req, err := client.responseByteCreateRequest(*client.u, scenario)
+	req, err := client.responseByteCreateRequest(scenario)
 	if err != nil {
 		return nil, err
 	}
@@ -668,10 +714,13 @@ func (client *headerOperations) ResponseByte(ctx context.Context, scenario strin
 }
 
 // responseByteCreateRequest creates the ResponseByte request.
-func (client *headerOperations) responseByteCreateRequest(u url.URL, scenario string) (*azcore.Request, error) {
+func (client *headerOperations) responseByteCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/byte"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	return req, nil
 }
@@ -692,7 +741,7 @@ func (client *headerOperations) responseByteHandleResponse(resp *azcore.Response
 
 // ResponseDate - Get a response with header values "2010-01-01" or "0001-01-01"
 func (client *headerOperations) ResponseDate(ctx context.Context, scenario string) (*HeaderResponseDateResponse, error) {
-	req, err := client.responseDateCreateRequest(*client.u, scenario)
+	req, err := client.responseDateCreateRequest(scenario)
 	if err != nil {
 		return nil, err
 	}
@@ -708,10 +757,13 @@ func (client *headerOperations) ResponseDate(ctx context.Context, scenario strin
 }
 
 // responseDateCreateRequest creates the ResponseDate request.
-func (client *headerOperations) responseDateCreateRequest(u url.URL, scenario string) (*azcore.Request, error) {
+func (client *headerOperations) responseDateCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/date"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	return req, nil
 }
@@ -732,7 +784,7 @@ func (client *headerOperations) responseDateHandleResponse(resp *azcore.Response
 
 // ResponseDatetime - Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
 func (client *headerOperations) ResponseDatetime(ctx context.Context, scenario string) (*HeaderResponseDatetimeResponse, error) {
-	req, err := client.responseDatetimeCreateRequest(*client.u, scenario)
+	req, err := client.responseDatetimeCreateRequest(scenario)
 	if err != nil {
 		return nil, err
 	}
@@ -748,10 +800,13 @@ func (client *headerOperations) ResponseDatetime(ctx context.Context, scenario s
 }
 
 // responseDatetimeCreateRequest creates the ResponseDatetime request.
-func (client *headerOperations) responseDatetimeCreateRequest(u url.URL, scenario string) (*azcore.Request, error) {
+func (client *headerOperations) responseDatetimeCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/datetime"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	return req, nil
 }
@@ -772,7 +827,7 @@ func (client *headerOperations) responseDatetimeHandleResponse(resp *azcore.Resp
 
 // ResponseDatetimeRFC1123 - Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
 func (client *headerOperations) ResponseDatetimeRFC1123(ctx context.Context, scenario string) (*HeaderResponseDatetimeRFC1123Response, error) {
-	req, err := client.responseDatetimeRfc1123CreateRequest(*client.u, scenario)
+	req, err := client.responseDatetimeRfc1123CreateRequest(scenario)
 	if err != nil {
 		return nil, err
 	}
@@ -788,10 +843,13 @@ func (client *headerOperations) ResponseDatetimeRFC1123(ctx context.Context, sce
 }
 
 // responseDatetimeRfc1123CreateRequest creates the ResponseDatetimeRFC1123 request.
-func (client *headerOperations) responseDatetimeRfc1123CreateRequest(u url.URL, scenario string) (*azcore.Request, error) {
+func (client *headerOperations) responseDatetimeRfc1123CreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/datetimerfc1123"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	return req, nil
 }
@@ -812,7 +870,7 @@ func (client *headerOperations) responseDatetimeRfc1123HandleResponse(resp *azco
 
 // ResponseDouble - Get a response with header value "value": 7e120 or -3.0
 func (client *headerOperations) ResponseDouble(ctx context.Context, scenario string) (*HeaderResponseDoubleResponse, error) {
-	req, err := client.responseDoubleCreateRequest(*client.u, scenario)
+	req, err := client.responseDoubleCreateRequest(scenario)
 	if err != nil {
 		return nil, err
 	}
@@ -828,10 +886,13 @@ func (client *headerOperations) ResponseDouble(ctx context.Context, scenario str
 }
 
 // responseDoubleCreateRequest creates the ResponseDouble request.
-func (client *headerOperations) responseDoubleCreateRequest(u url.URL, scenario string) (*azcore.Request, error) {
+func (client *headerOperations) responseDoubleCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/double"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	return req, nil
 }
@@ -852,7 +913,7 @@ func (client *headerOperations) responseDoubleHandleResponse(resp *azcore.Respon
 
 // ResponseDuration - Get a response with header values "P123DT22H14M12.011S"
 func (client *headerOperations) ResponseDuration(ctx context.Context, scenario string) (*HeaderResponseDurationResponse, error) {
-	req, err := client.responseDurationCreateRequest(*client.u, scenario)
+	req, err := client.responseDurationCreateRequest(scenario)
 	if err != nil {
 		return nil, err
 	}
@@ -868,10 +929,13 @@ func (client *headerOperations) ResponseDuration(ctx context.Context, scenario s
 }
 
 // responseDurationCreateRequest creates the ResponseDuration request.
-func (client *headerOperations) responseDurationCreateRequest(u url.URL, scenario string) (*azcore.Request, error) {
+func (client *headerOperations) responseDurationCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/duration"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	return req, nil
 }
@@ -892,7 +956,7 @@ func (client *headerOperations) responseDurationHandleResponse(resp *azcore.Resp
 
 // ResponseEnum - Get a response with header values "GREY" or null
 func (client *headerOperations) ResponseEnum(ctx context.Context, scenario string) (*HeaderResponseEnumResponse, error) {
-	req, err := client.responseEnumCreateRequest(*client.u, scenario)
+	req, err := client.responseEnumCreateRequest(scenario)
 	if err != nil {
 		return nil, err
 	}
@@ -908,10 +972,13 @@ func (client *headerOperations) ResponseEnum(ctx context.Context, scenario strin
 }
 
 // responseEnumCreateRequest creates the ResponseEnum request.
-func (client *headerOperations) responseEnumCreateRequest(u url.URL, scenario string) (*azcore.Request, error) {
+func (client *headerOperations) responseEnumCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/enum"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	return req, nil
 }
@@ -929,7 +996,7 @@ func (client *headerOperations) responseEnumHandleResponse(resp *azcore.Response
 
 // ResponseExistingKey - Get a response with header value "User-Agent": "overwrite"
 func (client *headerOperations) ResponseExistingKey(ctx context.Context) (*HeaderResponseExistingKeyResponse, error) {
-	req, err := client.responseExistingKeyCreateRequest(*client.u)
+	req, err := client.responseExistingKeyCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -945,10 +1012,13 @@ func (client *headerOperations) ResponseExistingKey(ctx context.Context) (*Heade
 }
 
 // responseExistingKeyCreateRequest creates the ResponseExistingKey request.
-func (client *headerOperations) responseExistingKeyCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *headerOperations) responseExistingKeyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/header/response/existingkey"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	return req, nil
 }
 
@@ -965,7 +1035,7 @@ func (client *headerOperations) responseExistingKeyHandleResponse(resp *azcore.R
 
 // ResponseFloat - Get a response with header value "value": 0.07 or -3.0
 func (client *headerOperations) ResponseFloat(ctx context.Context, scenario string) (*HeaderResponseFloatResponse, error) {
-	req, err := client.responseFloatCreateRequest(*client.u, scenario)
+	req, err := client.responseFloatCreateRequest(scenario)
 	if err != nil {
 		return nil, err
 	}
@@ -981,10 +1051,13 @@ func (client *headerOperations) ResponseFloat(ctx context.Context, scenario stri
 }
 
 // responseFloatCreateRequest creates the ResponseFloat request.
-func (client *headerOperations) responseFloatCreateRequest(u url.URL, scenario string) (*azcore.Request, error) {
+func (client *headerOperations) responseFloatCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/float"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	return req, nil
 }
@@ -1006,7 +1079,7 @@ func (client *headerOperations) responseFloatHandleResponse(resp *azcore.Respons
 
 // ResponseInteger - Get a response with header value "value": 1 or -2
 func (client *headerOperations) ResponseInteger(ctx context.Context, scenario string) (*HeaderResponseIntegerResponse, error) {
-	req, err := client.responseIntegerCreateRequest(*client.u, scenario)
+	req, err := client.responseIntegerCreateRequest(scenario)
 	if err != nil {
 		return nil, err
 	}
@@ -1022,10 +1095,13 @@ func (client *headerOperations) ResponseInteger(ctx context.Context, scenario st
 }
 
 // responseIntegerCreateRequest creates the ResponseInteger request.
-func (client *headerOperations) responseIntegerCreateRequest(u url.URL, scenario string) (*azcore.Request, error) {
+func (client *headerOperations) responseIntegerCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/integer"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	return req, nil
 }
@@ -1047,7 +1123,7 @@ func (client *headerOperations) responseIntegerHandleResponse(resp *azcore.Respo
 
 // ResponseLong - Get a response with header value "value": 105 or -2
 func (client *headerOperations) ResponseLong(ctx context.Context, scenario string) (*HeaderResponseLongResponse, error) {
-	req, err := client.responseLongCreateRequest(*client.u, scenario)
+	req, err := client.responseLongCreateRequest(scenario)
 	if err != nil {
 		return nil, err
 	}
@@ -1063,10 +1139,13 @@ func (client *headerOperations) ResponseLong(ctx context.Context, scenario strin
 }
 
 // responseLongCreateRequest creates the ResponseLong request.
-func (client *headerOperations) responseLongCreateRequest(u url.URL, scenario string) (*azcore.Request, error) {
+func (client *headerOperations) responseLongCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/long"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	return req, nil
 }
@@ -1087,7 +1166,7 @@ func (client *headerOperations) responseLongHandleResponse(resp *azcore.Response
 
 // ResponseProtectedKey - Get a response with header value "Content-Type": "text/html"
 func (client *headerOperations) ResponseProtectedKey(ctx context.Context) (*HeaderResponseProtectedKeyResponse, error) {
-	req, err := client.responseProtectedKeyCreateRequest(*client.u)
+	req, err := client.responseProtectedKeyCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -1103,10 +1182,13 @@ func (client *headerOperations) ResponseProtectedKey(ctx context.Context) (*Head
 }
 
 // responseProtectedKeyCreateRequest creates the ResponseProtectedKey request.
-func (client *headerOperations) responseProtectedKeyCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *headerOperations) responseProtectedKeyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/header/response/protectedkey"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	return req, nil
 }
 
@@ -1123,7 +1205,7 @@ func (client *headerOperations) responseProtectedKeyHandleResponse(resp *azcore.
 
 // ResponseString - Get a response with header values "The quick brown fox jumps over the lazy dog" or null or ""
 func (client *headerOperations) ResponseString(ctx context.Context, scenario string) (*HeaderResponseStringResponse, error) {
-	req, err := client.responseStringCreateRequest(*client.u, scenario)
+	req, err := client.responseStringCreateRequest(scenario)
 	if err != nil {
 		return nil, err
 	}
@@ -1139,10 +1221,13 @@ func (client *headerOperations) ResponseString(ctx context.Context, scenario str
 }
 
 // responseStringCreateRequest creates the ResponseString request.
-func (client *headerOperations) responseStringCreateRequest(u url.URL, scenario string) (*azcore.Request, error) {
+func (client *headerOperations) responseStringCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/string"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPost, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPost, *u)
 	req.Header.Set("scenario", scenario)
 	return req, nil
 }

--- a/test/autorest/generated/morecustombaseurigroup/client.go
+++ b/test/autorest/generated/morecustombaseurigroup/client.go
@@ -6,6 +6,7 @@
 package morecustombaseurigroup
 
 import (
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
 )
@@ -54,6 +55,9 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
+	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
 	return &Client{u: u, p: p}, nil
 }

--- a/test/autorest/generated/numbergroup/client.go
+++ b/test/autorest/generated/numbergroup/client.go
@@ -6,6 +6,7 @@
 package numbergroup
 
 import (
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
 )
@@ -62,6 +63,9 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
+	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
 	return &Client{u: u, p: p}, nil
 }

--- a/test/autorest/generated/numbergroup/number.go
+++ b/test/autorest/generated/numbergroup/number.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"net/url"
-	"path"
 )
 
 // NumberOperations contains the methods for the Number group.
@@ -72,7 +70,7 @@ type numberOperations struct {
 
 // GetBigDecimal - Get big decimal value 2.5976931e+101
 func (client *numberOperations) GetBigDecimal(ctx context.Context) (*Float64Response, error) {
-	req, err := client.getBigDecimalCreateRequest(*client.u)
+	req, err := client.getBigDecimalCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -88,10 +86,13 @@ func (client *numberOperations) GetBigDecimal(ctx context.Context) (*Float64Resp
 }
 
 // getBigDecimalCreateRequest creates the GetBigDecimal request.
-func (client *numberOperations) getBigDecimalCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) getBigDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/2.5976931e+101"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -106,7 +107,7 @@ func (client *numberOperations) getBigDecimalHandleResponse(resp *azcore.Respons
 
 // GetBigDecimalNegativeDecimal - Get big decimal value -99999999.99
 func (client *numberOperations) GetBigDecimalNegativeDecimal(ctx context.Context) (*Float64Response, error) {
-	req, err := client.getBigDecimalNegativeDecimalCreateRequest(*client.u)
+	req, err := client.getBigDecimalNegativeDecimalCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -122,10 +123,13 @@ func (client *numberOperations) GetBigDecimalNegativeDecimal(ctx context.Context
 }
 
 // getBigDecimalNegativeDecimalCreateRequest creates the GetBigDecimalNegativeDecimal request.
-func (client *numberOperations) getBigDecimalNegativeDecimalCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) getBigDecimalNegativeDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/-99999999.99"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -140,7 +144,7 @@ func (client *numberOperations) getBigDecimalNegativeDecimalHandleResponse(resp 
 
 // GetBigDecimalPositiveDecimal - Get big decimal value 99999999.99
 func (client *numberOperations) GetBigDecimalPositiveDecimal(ctx context.Context) (*Float64Response, error) {
-	req, err := client.getBigDecimalPositiveDecimalCreateRequest(*client.u)
+	req, err := client.getBigDecimalPositiveDecimalCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -156,10 +160,13 @@ func (client *numberOperations) GetBigDecimalPositiveDecimal(ctx context.Context
 }
 
 // getBigDecimalPositiveDecimalCreateRequest creates the GetBigDecimalPositiveDecimal request.
-func (client *numberOperations) getBigDecimalPositiveDecimalCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) getBigDecimalPositiveDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/99999999.99"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -174,7 +181,7 @@ func (client *numberOperations) getBigDecimalPositiveDecimalHandleResponse(resp 
 
 // GetBigDouble - Get big double value 2.5976931e+101
 func (client *numberOperations) GetBigDouble(ctx context.Context) (*Float64Response, error) {
-	req, err := client.getBigDoubleCreateRequest(*client.u)
+	req, err := client.getBigDoubleCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -190,10 +197,13 @@ func (client *numberOperations) GetBigDouble(ctx context.Context) (*Float64Respo
 }
 
 // getBigDoubleCreateRequest creates the GetBigDouble request.
-func (client *numberOperations) getBigDoubleCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) getBigDoubleCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/double/2.5976931e+101"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -208,7 +218,7 @@ func (client *numberOperations) getBigDoubleHandleResponse(resp *azcore.Response
 
 // GetBigDoubleNegativeDecimal - Get big double value -99999999.99
 func (client *numberOperations) GetBigDoubleNegativeDecimal(ctx context.Context) (*Float64Response, error) {
-	req, err := client.getBigDoubleNegativeDecimalCreateRequest(*client.u)
+	req, err := client.getBigDoubleNegativeDecimalCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -224,10 +234,13 @@ func (client *numberOperations) GetBigDoubleNegativeDecimal(ctx context.Context)
 }
 
 // getBigDoubleNegativeDecimalCreateRequest creates the GetBigDoubleNegativeDecimal request.
-func (client *numberOperations) getBigDoubleNegativeDecimalCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) getBigDoubleNegativeDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/double/-99999999.99"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -242,7 +255,7 @@ func (client *numberOperations) getBigDoubleNegativeDecimalHandleResponse(resp *
 
 // GetBigDoublePositiveDecimal - Get big double value 99999999.99
 func (client *numberOperations) GetBigDoublePositiveDecimal(ctx context.Context) (*Float64Response, error) {
-	req, err := client.getBigDoublePositiveDecimalCreateRequest(*client.u)
+	req, err := client.getBigDoublePositiveDecimalCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -258,10 +271,13 @@ func (client *numberOperations) GetBigDoublePositiveDecimal(ctx context.Context)
 }
 
 // getBigDoublePositiveDecimalCreateRequest creates the GetBigDoublePositiveDecimal request.
-func (client *numberOperations) getBigDoublePositiveDecimalCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) getBigDoublePositiveDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/double/99999999.99"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -276,7 +292,7 @@ func (client *numberOperations) getBigDoublePositiveDecimalHandleResponse(resp *
 
 // GetBigFloat - Get big float value 3.402823e+20
 func (client *numberOperations) GetBigFloat(ctx context.Context) (*Float32Response, error) {
-	req, err := client.getBigFloatCreateRequest(*client.u)
+	req, err := client.getBigFloatCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -292,10 +308,13 @@ func (client *numberOperations) GetBigFloat(ctx context.Context) (*Float32Respon
 }
 
 // getBigFloatCreateRequest creates the GetBigFloat request.
-func (client *numberOperations) getBigFloatCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) getBigFloatCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/float/3.402823e+20"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -310,7 +329,7 @@ func (client *numberOperations) getBigFloatHandleResponse(resp *azcore.Response)
 
 // GetInvalidDecimal - Get invalid decimal Number value
 func (client *numberOperations) GetInvalidDecimal(ctx context.Context) (*Float64Response, error) {
-	req, err := client.getInvalidDecimalCreateRequest(*client.u)
+	req, err := client.getInvalidDecimalCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -326,10 +345,13 @@ func (client *numberOperations) GetInvalidDecimal(ctx context.Context) (*Float64
 }
 
 // getInvalidDecimalCreateRequest creates the GetInvalidDecimal request.
-func (client *numberOperations) getInvalidDecimalCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) getInvalidDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/invaliddecimal"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -344,7 +366,7 @@ func (client *numberOperations) getInvalidDecimalHandleResponse(resp *azcore.Res
 
 // GetInvalidDouble - Get invalid double Number value
 func (client *numberOperations) GetInvalidDouble(ctx context.Context) (*Float64Response, error) {
-	req, err := client.getInvalidDoubleCreateRequest(*client.u)
+	req, err := client.getInvalidDoubleCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -360,10 +382,13 @@ func (client *numberOperations) GetInvalidDouble(ctx context.Context) (*Float64R
 }
 
 // getInvalidDoubleCreateRequest creates the GetInvalidDouble request.
-func (client *numberOperations) getInvalidDoubleCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) getInvalidDoubleCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/invaliddouble"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -378,7 +403,7 @@ func (client *numberOperations) getInvalidDoubleHandleResponse(resp *azcore.Resp
 
 // GetInvalidFloat - Get invalid float Number value
 func (client *numberOperations) GetInvalidFloat(ctx context.Context) (*Float32Response, error) {
-	req, err := client.getInvalidFloatCreateRequest(*client.u)
+	req, err := client.getInvalidFloatCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -394,10 +419,13 @@ func (client *numberOperations) GetInvalidFloat(ctx context.Context) (*Float32Re
 }
 
 // getInvalidFloatCreateRequest creates the GetInvalidFloat request.
-func (client *numberOperations) getInvalidFloatCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) getInvalidFloatCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/invalidfloat"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -412,7 +440,7 @@ func (client *numberOperations) getInvalidFloatHandleResponse(resp *azcore.Respo
 
 // GetNull - Get null Number value
 func (client *numberOperations) GetNull(ctx context.Context) (*Float32Response, error) {
-	req, err := client.getNullCreateRequest(*client.u)
+	req, err := client.getNullCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -428,10 +456,13 @@ func (client *numberOperations) GetNull(ctx context.Context) (*Float32Response, 
 }
 
 // getNullCreateRequest creates the GetNull request.
-func (client *numberOperations) getNullCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/null"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -446,7 +477,7 @@ func (client *numberOperations) getNullHandleResponse(resp *azcore.Response) (*F
 
 // GetSmallDecimal - Get small decimal value 2.5976931e-101
 func (client *numberOperations) GetSmallDecimal(ctx context.Context) (*Float64Response, error) {
-	req, err := client.getSmallDecimalCreateRequest(*client.u)
+	req, err := client.getSmallDecimalCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -462,10 +493,13 @@ func (client *numberOperations) GetSmallDecimal(ctx context.Context) (*Float64Re
 }
 
 // getSmallDecimalCreateRequest creates the GetSmallDecimal request.
-func (client *numberOperations) getSmallDecimalCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) getSmallDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/small/decimal/2.5976931e-101"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -480,7 +514,7 @@ func (client *numberOperations) getSmallDecimalHandleResponse(resp *azcore.Respo
 
 // GetSmallDouble - Get big double value 2.5976931e-101
 func (client *numberOperations) GetSmallDouble(ctx context.Context) (*Float64Response, error) {
-	req, err := client.getSmallDoubleCreateRequest(*client.u)
+	req, err := client.getSmallDoubleCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -496,10 +530,13 @@ func (client *numberOperations) GetSmallDouble(ctx context.Context) (*Float64Res
 }
 
 // getSmallDoubleCreateRequest creates the GetSmallDouble request.
-func (client *numberOperations) getSmallDoubleCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) getSmallDoubleCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/small/double/2.5976931e-101"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -514,7 +551,7 @@ func (client *numberOperations) getSmallDoubleHandleResponse(resp *azcore.Respon
 
 // GetSmallFloat - Get big double value 3.402823e-20
 func (client *numberOperations) GetSmallFloat(ctx context.Context) (*Float64Response, error) {
-	req, err := client.getSmallFloatCreateRequest(*client.u)
+	req, err := client.getSmallFloatCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -530,10 +567,13 @@ func (client *numberOperations) GetSmallFloat(ctx context.Context) (*Float64Resp
 }
 
 // getSmallFloatCreateRequest creates the GetSmallFloat request.
-func (client *numberOperations) getSmallFloatCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) getSmallFloatCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/small/float/3.402823e-20"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -548,7 +588,7 @@ func (client *numberOperations) getSmallFloatHandleResponse(resp *azcore.Respons
 
 // PutBigDecimal - Put big decimal value 2.5976931e+101
 func (client *numberOperations) PutBigDecimal(ctx context.Context, numberBody float64) (*http.Response, error) {
-	req, err := client.putBigDecimalCreateRequest(*client.u, numberBody)
+	req, err := client.putBigDecimalCreateRequest(numberBody)
 	if err != nil {
 		return nil, err
 	}
@@ -564,11 +604,14 @@ func (client *numberOperations) PutBigDecimal(ctx context.Context, numberBody fl
 }
 
 // putBigDecimalCreateRequest creates the PutBigDecimal request.
-func (client *numberOperations) putBigDecimalCreateRequest(u url.URL, numberBody float64) (*azcore.Request, error) {
+func (client *numberOperations) putBigDecimalCreateRequest(numberBody float64) (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/2.5976931e+101"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(numberBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(numberBody)
 	if err != nil {
 		return nil, err
 	}
@@ -585,7 +628,7 @@ func (client *numberOperations) putBigDecimalHandleResponse(resp *azcore.Respons
 
 // PutBigDecimalNegativeDecimal - Put big decimal value -99999999.99
 func (client *numberOperations) PutBigDecimalNegativeDecimal(ctx context.Context) (*http.Response, error) {
-	req, err := client.putBigDecimalNegativeDecimalCreateRequest(*client.u)
+	req, err := client.putBigDecimalNegativeDecimalCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -601,11 +644,14 @@ func (client *numberOperations) PutBigDecimalNegativeDecimal(ctx context.Context
 }
 
 // putBigDecimalNegativeDecimalCreateRequest creates the PutBigDecimalNegativeDecimal request.
-func (client *numberOperations) putBigDecimalNegativeDecimalCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) putBigDecimalNegativeDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/-99999999.99"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(-99999999.99)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(-99999999.99)
 	if err != nil {
 		return nil, err
 	}
@@ -622,7 +668,7 @@ func (client *numberOperations) putBigDecimalNegativeDecimalHandleResponse(resp 
 
 // PutBigDecimalPositiveDecimal - Put big decimal value 99999999.99
 func (client *numberOperations) PutBigDecimalPositiveDecimal(ctx context.Context) (*http.Response, error) {
-	req, err := client.putBigDecimalPositiveDecimalCreateRequest(*client.u)
+	req, err := client.putBigDecimalPositiveDecimalCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -638,11 +684,14 @@ func (client *numberOperations) PutBigDecimalPositiveDecimal(ctx context.Context
 }
 
 // putBigDecimalPositiveDecimalCreateRequest creates the PutBigDecimalPositiveDecimal request.
-func (client *numberOperations) putBigDecimalPositiveDecimalCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) putBigDecimalPositiveDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/99999999.99"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(99999999.99)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(99999999.99)
 	if err != nil {
 		return nil, err
 	}
@@ -659,7 +708,7 @@ func (client *numberOperations) putBigDecimalPositiveDecimalHandleResponse(resp 
 
 // PutBigDouble - Put big double value 2.5976931e+101
 func (client *numberOperations) PutBigDouble(ctx context.Context, numberBody float64) (*http.Response, error) {
-	req, err := client.putBigDoubleCreateRequest(*client.u, numberBody)
+	req, err := client.putBigDoubleCreateRequest(numberBody)
 	if err != nil {
 		return nil, err
 	}
@@ -675,11 +724,14 @@ func (client *numberOperations) PutBigDouble(ctx context.Context, numberBody flo
 }
 
 // putBigDoubleCreateRequest creates the PutBigDouble request.
-func (client *numberOperations) putBigDoubleCreateRequest(u url.URL, numberBody float64) (*azcore.Request, error) {
+func (client *numberOperations) putBigDoubleCreateRequest(numberBody float64) (*azcore.Request, error) {
 	urlPath := "/number/big/double/2.5976931e+101"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(numberBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(numberBody)
 	if err != nil {
 		return nil, err
 	}
@@ -696,7 +748,7 @@ func (client *numberOperations) putBigDoubleHandleResponse(resp *azcore.Response
 
 // PutBigDoubleNegativeDecimal - Put big double value -99999999.99
 func (client *numberOperations) PutBigDoubleNegativeDecimal(ctx context.Context) (*http.Response, error) {
-	req, err := client.putBigDoubleNegativeDecimalCreateRequest(*client.u)
+	req, err := client.putBigDoubleNegativeDecimalCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -712,11 +764,14 @@ func (client *numberOperations) PutBigDoubleNegativeDecimal(ctx context.Context)
 }
 
 // putBigDoubleNegativeDecimalCreateRequest creates the PutBigDoubleNegativeDecimal request.
-func (client *numberOperations) putBigDoubleNegativeDecimalCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) putBigDoubleNegativeDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/double/-99999999.99"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(-99999999.99)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(-99999999.99)
 	if err != nil {
 		return nil, err
 	}
@@ -733,7 +788,7 @@ func (client *numberOperations) putBigDoubleNegativeDecimalHandleResponse(resp *
 
 // PutBigDoublePositiveDecimal - Put big double value 99999999.99
 func (client *numberOperations) PutBigDoublePositiveDecimal(ctx context.Context) (*http.Response, error) {
-	req, err := client.putBigDoublePositiveDecimalCreateRequest(*client.u)
+	req, err := client.putBigDoublePositiveDecimalCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -749,11 +804,14 @@ func (client *numberOperations) PutBigDoublePositiveDecimal(ctx context.Context)
 }
 
 // putBigDoublePositiveDecimalCreateRequest creates the PutBigDoublePositiveDecimal request.
-func (client *numberOperations) putBigDoublePositiveDecimalCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *numberOperations) putBigDoublePositiveDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/double/99999999.99"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(99999999.99)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(99999999.99)
 	if err != nil {
 		return nil, err
 	}
@@ -770,7 +828,7 @@ func (client *numberOperations) putBigDoublePositiveDecimalHandleResponse(resp *
 
 // PutBigFloat - Put big float value 3.402823e+20
 func (client *numberOperations) PutBigFloat(ctx context.Context, numberBody float32) (*http.Response, error) {
-	req, err := client.putBigFloatCreateRequest(*client.u, numberBody)
+	req, err := client.putBigFloatCreateRequest(numberBody)
 	if err != nil {
 		return nil, err
 	}
@@ -786,11 +844,14 @@ func (client *numberOperations) PutBigFloat(ctx context.Context, numberBody floa
 }
 
 // putBigFloatCreateRequest creates the PutBigFloat request.
-func (client *numberOperations) putBigFloatCreateRequest(u url.URL, numberBody float32) (*azcore.Request, error) {
+func (client *numberOperations) putBigFloatCreateRequest(numberBody float32) (*azcore.Request, error) {
 	urlPath := "/number/big/float/3.402823e+20"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(numberBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(numberBody)
 	if err != nil {
 		return nil, err
 	}
@@ -807,7 +868,7 @@ func (client *numberOperations) putBigFloatHandleResponse(resp *azcore.Response)
 
 // PutSmallDecimal - Put small decimal value 2.5976931e-101
 func (client *numberOperations) PutSmallDecimal(ctx context.Context, numberBody float64) (*http.Response, error) {
-	req, err := client.putSmallDecimalCreateRequest(*client.u, numberBody)
+	req, err := client.putSmallDecimalCreateRequest(numberBody)
 	if err != nil {
 		return nil, err
 	}
@@ -823,11 +884,14 @@ func (client *numberOperations) PutSmallDecimal(ctx context.Context, numberBody 
 }
 
 // putSmallDecimalCreateRequest creates the PutSmallDecimal request.
-func (client *numberOperations) putSmallDecimalCreateRequest(u url.URL, numberBody float64) (*azcore.Request, error) {
+func (client *numberOperations) putSmallDecimalCreateRequest(numberBody float64) (*azcore.Request, error) {
 	urlPath := "/number/small/decimal/2.5976931e-101"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(numberBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(numberBody)
 	if err != nil {
 		return nil, err
 	}
@@ -844,7 +908,7 @@ func (client *numberOperations) putSmallDecimalHandleResponse(resp *azcore.Respo
 
 // PutSmallDouble - Put small double value 2.5976931e-101
 func (client *numberOperations) PutSmallDouble(ctx context.Context, numberBody float64) (*http.Response, error) {
-	req, err := client.putSmallDoubleCreateRequest(*client.u, numberBody)
+	req, err := client.putSmallDoubleCreateRequest(numberBody)
 	if err != nil {
 		return nil, err
 	}
@@ -860,11 +924,14 @@ func (client *numberOperations) PutSmallDouble(ctx context.Context, numberBody f
 }
 
 // putSmallDoubleCreateRequest creates the PutSmallDouble request.
-func (client *numberOperations) putSmallDoubleCreateRequest(u url.URL, numberBody float64) (*azcore.Request, error) {
+func (client *numberOperations) putSmallDoubleCreateRequest(numberBody float64) (*azcore.Request, error) {
 	urlPath := "/number/small/double/2.5976931e-101"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(numberBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(numberBody)
 	if err != nil {
 		return nil, err
 	}
@@ -881,7 +948,7 @@ func (client *numberOperations) putSmallDoubleHandleResponse(resp *azcore.Respon
 
 // PutSmallFloat - Put small float value 3.402823e-20
 func (client *numberOperations) PutSmallFloat(ctx context.Context, numberBody float32) (*http.Response, error) {
-	req, err := client.putSmallFloatCreateRequest(*client.u, numberBody)
+	req, err := client.putSmallFloatCreateRequest(numberBody)
 	if err != nil {
 		return nil, err
 	}
@@ -897,11 +964,14 @@ func (client *numberOperations) PutSmallFloat(ctx context.Context, numberBody fl
 }
 
 // putSmallFloatCreateRequest creates the PutSmallFloat request.
-func (client *numberOperations) putSmallFloatCreateRequest(u url.URL, numberBody float32) (*azcore.Request, error) {
+func (client *numberOperations) putSmallFloatCreateRequest(numberBody float32) (*azcore.Request, error) {
 	urlPath := "/number/small/float/3.402823e-20"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(numberBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(numberBody)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/stringgroup/client.go
+++ b/test/autorest/generated/stringgroup/client.go
@@ -6,6 +6,7 @@
 package stringgroup
 
 import (
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
 )
@@ -62,6 +63,9 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
+	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
 	return &Client{u: u, p: p}, nil
 }

--- a/test/autorest/generated/stringgroup/enum.go
+++ b/test/autorest/generated/stringgroup/enum.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"net/url"
-	"path"
 )
 
 // EnumOperations contains the methods for the Enum group.
@@ -36,7 +34,7 @@ type enumOperations struct {
 
 // GetNotExpandable - Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
 func (client *enumOperations) GetNotExpandable(ctx context.Context) (*ColorsResponse, error) {
-	req, err := client.getNotExpandableCreateRequest(*client.u)
+	req, err := client.getNotExpandableCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -52,10 +50,13 @@ func (client *enumOperations) GetNotExpandable(ctx context.Context) (*ColorsResp
 }
 
 // getNotExpandableCreateRequest creates the GetNotExpandable request.
-func (client *enumOperations) getNotExpandableCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *enumOperations) getNotExpandableCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/enum/notExpandable"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -70,7 +71,7 @@ func (client *enumOperations) getNotExpandableHandleResponse(resp *azcore.Respon
 
 // GetReferenced - Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
 func (client *enumOperations) GetReferenced(ctx context.Context) (*ColorsResponse, error) {
-	req, err := client.getReferencedCreateRequest(*client.u)
+	req, err := client.getReferencedCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -86,10 +87,13 @@ func (client *enumOperations) GetReferenced(ctx context.Context) (*ColorsRespons
 }
 
 // getReferencedCreateRequest creates the GetReferenced request.
-func (client *enumOperations) getReferencedCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *enumOperations) getReferencedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/enum/Referenced"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -104,7 +108,7 @@ func (client *enumOperations) getReferencedHandleResponse(resp *azcore.Response)
 
 // GetReferencedConstant - Get value 'green-color' from the constant.
 func (client *enumOperations) GetReferencedConstant(ctx context.Context) (*RefColorConstantResponse, error) {
-	req, err := client.getReferencedConstantCreateRequest(*client.u)
+	req, err := client.getReferencedConstantCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -120,10 +124,13 @@ func (client *enumOperations) GetReferencedConstant(ctx context.Context) (*RefCo
 }
 
 // getReferencedConstantCreateRequest creates the GetReferencedConstant request.
-func (client *enumOperations) getReferencedConstantCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *enumOperations) getReferencedConstantCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/enum/ReferencedConstant"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -138,7 +145,7 @@ func (client *enumOperations) getReferencedConstantHandleResponse(resp *azcore.R
 
 // PutNotExpandable - Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
 func (client *enumOperations) PutNotExpandable(ctx context.Context, stringBody Colors) (*http.Response, error) {
-	req, err := client.putNotExpandableCreateRequest(*client.u, stringBody)
+	req, err := client.putNotExpandableCreateRequest(stringBody)
 	if err != nil {
 		return nil, err
 	}
@@ -154,11 +161,14 @@ func (client *enumOperations) PutNotExpandable(ctx context.Context, stringBody C
 }
 
 // putNotExpandableCreateRequest creates the PutNotExpandable request.
-func (client *enumOperations) putNotExpandableCreateRequest(u url.URL, stringBody Colors) (*azcore.Request, error) {
+func (client *enumOperations) putNotExpandableCreateRequest(stringBody Colors) (*azcore.Request, error) {
 	urlPath := "/string/enum/notExpandable"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(stringBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(stringBody)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +185,7 @@ func (client *enumOperations) putNotExpandableHandleResponse(resp *azcore.Respon
 
 // PutReferenced - Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
 func (client *enumOperations) PutReferenced(ctx context.Context, enumStringBody Colors) (*http.Response, error) {
-	req, err := client.putReferencedCreateRequest(*client.u, enumStringBody)
+	req, err := client.putReferencedCreateRequest(enumStringBody)
 	if err != nil {
 		return nil, err
 	}
@@ -191,11 +201,14 @@ func (client *enumOperations) PutReferenced(ctx context.Context, enumStringBody 
 }
 
 // putReferencedCreateRequest creates the PutReferenced request.
-func (client *enumOperations) putReferencedCreateRequest(u url.URL, enumStringBody Colors) (*azcore.Request, error) {
+func (client *enumOperations) putReferencedCreateRequest(enumStringBody Colors) (*azcore.Request, error) {
 	urlPath := "/string/enum/Referenced"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(enumStringBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(enumStringBody)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +225,7 @@ func (client *enumOperations) putReferencedHandleResponse(resp *azcore.Response)
 
 // PutReferencedConstant - Sends value 'green-color' from a constant
 func (client *enumOperations) PutReferencedConstant(ctx context.Context, enumStringBody RefColorConstant) (*http.Response, error) {
-	req, err := client.putReferencedConstantCreateRequest(*client.u, enumStringBody)
+	req, err := client.putReferencedConstantCreateRequest(enumStringBody)
 	if err != nil {
 		return nil, err
 	}
@@ -228,11 +241,14 @@ func (client *enumOperations) PutReferencedConstant(ctx context.Context, enumStr
 }
 
 // putReferencedConstantCreateRequest creates the PutReferencedConstant request.
-func (client *enumOperations) putReferencedConstantCreateRequest(u url.URL, enumStringBody RefColorConstant) (*azcore.Request, error) {
+func (client *enumOperations) putReferencedConstantCreateRequest(enumStringBody RefColorConstant) (*azcore.Request, error) {
 	urlPath := "/string/enum/ReferencedConstant"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(enumStringBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(enumStringBody)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/stringgroup/string.go
+++ b/test/autorest/generated/stringgroup/string.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"net/url"
-	"path"
 )
 
 // StringOperations contains the methods for the String group.
@@ -50,7 +48,7 @@ type stringOperations struct {
 
 // GetBase64Encoded - Get value that is base64 encoded
 func (client *stringOperations) GetBase64Encoded(ctx context.Context) (*ByteArrayResponse, error) {
-	req, err := client.getBase64EncodedCreateRequest(*client.u)
+	req, err := client.getBase64EncodedCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -66,10 +64,13 @@ func (client *stringOperations) GetBase64Encoded(ctx context.Context) (*ByteArra
 }
 
 // getBase64EncodedCreateRequest creates the GetBase64Encoded request.
-func (client *stringOperations) getBase64EncodedCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *stringOperations) getBase64EncodedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/base64Encoding"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -84,7 +85,7 @@ func (client *stringOperations) getBase64EncodedHandleResponse(resp *azcore.Resp
 
 // GetBase64URLEncoded - Get value that is base64url encoded
 func (client *stringOperations) GetBase64URLEncoded(ctx context.Context) (*ByteArrayResponse, error) {
-	req, err := client.getBase64UrlEncodedCreateRequest(*client.u)
+	req, err := client.getBase64UrlEncodedCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -100,10 +101,13 @@ func (client *stringOperations) GetBase64URLEncoded(ctx context.Context) (*ByteA
 }
 
 // getBase64UrlEncodedCreateRequest creates the GetBase64URLEncoded request.
-func (client *stringOperations) getBase64UrlEncodedCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *stringOperations) getBase64UrlEncodedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/base64UrlEncoding"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -118,7 +122,7 @@ func (client *stringOperations) getBase64UrlEncodedHandleResponse(resp *azcore.R
 
 // GetEmpty - Get empty string value value ''
 func (client *stringOperations) GetEmpty(ctx context.Context) (*StringResponse, error) {
-	req, err := client.getEmptyCreateRequest(*client.u)
+	req, err := client.getEmptyCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -134,10 +138,13 @@ func (client *stringOperations) GetEmpty(ctx context.Context) (*StringResponse, 
 }
 
 // getEmptyCreateRequest creates the GetEmpty request.
-func (client *stringOperations) getEmptyCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *stringOperations) getEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/empty"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -152,7 +159,7 @@ func (client *stringOperations) getEmptyHandleResponse(resp *azcore.Response) (*
 
 // GetMBCS - Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
 func (client *stringOperations) GetMBCS(ctx context.Context) (*StringResponse, error) {
-	req, err := client.getMbcsCreateRequest(*client.u)
+	req, err := client.getMbcsCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -168,10 +175,13 @@ func (client *stringOperations) GetMBCS(ctx context.Context) (*StringResponse, e
 }
 
 // getMbcsCreateRequest creates the GetMBCS request.
-func (client *stringOperations) getMbcsCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *stringOperations) getMbcsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/mbcs"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -186,7 +196,7 @@ func (client *stringOperations) getMbcsHandleResponse(resp *azcore.Response) (*S
 
 // GetNotProvided - Get String value when no string value is sent in response payload
 func (client *stringOperations) GetNotProvided(ctx context.Context) (*StringResponse, error) {
-	req, err := client.getNotProvidedCreateRequest(*client.u)
+	req, err := client.getNotProvidedCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -202,10 +212,13 @@ func (client *stringOperations) GetNotProvided(ctx context.Context) (*StringResp
 }
 
 // getNotProvidedCreateRequest creates the GetNotProvided request.
-func (client *stringOperations) getNotProvidedCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *stringOperations) getNotProvidedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/notProvided"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -220,7 +233,7 @@ func (client *stringOperations) getNotProvidedHandleResponse(resp *azcore.Respon
 
 // GetNull - Get null string value value
 func (client *stringOperations) GetNull(ctx context.Context) (*StringResponse, error) {
-	req, err := client.getNullCreateRequest(*client.u)
+	req, err := client.getNullCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -236,10 +249,13 @@ func (client *stringOperations) GetNull(ctx context.Context) (*StringResponse, e
 }
 
 // getNullCreateRequest creates the GetNull request.
-func (client *stringOperations) getNullCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *stringOperations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/null"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -254,7 +270,7 @@ func (client *stringOperations) getNullHandleResponse(resp *azcore.Response) (*S
 
 // GetNullBase64URLEncoded - Get null value that is expected to be base64url encoded
 func (client *stringOperations) GetNullBase64URLEncoded(ctx context.Context) (*ByteArrayResponse, error) {
-	req, err := client.getNullBase64UrlEncodedCreateRequest(*client.u)
+	req, err := client.getNullBase64UrlEncodedCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -270,10 +286,13 @@ func (client *stringOperations) GetNullBase64URLEncoded(ctx context.Context) (*B
 }
 
 // getNullBase64UrlEncodedCreateRequest creates the GetNullBase64URLEncoded request.
-func (client *stringOperations) getNullBase64UrlEncodedCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *stringOperations) getNullBase64UrlEncodedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/nullBase64UrlEncoding"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -288,7 +307,7 @@ func (client *stringOperations) getNullBase64UrlEncodedHandleResponse(resp *azco
 
 // GetWhitespace - Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
 func (client *stringOperations) GetWhitespace(ctx context.Context) (*StringResponse, error) {
-	req, err := client.getWhitespaceCreateRequest(*client.u)
+	req, err := client.getWhitespaceCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -304,10 +323,13 @@ func (client *stringOperations) GetWhitespace(ctx context.Context) (*StringRespo
 }
 
 // getWhitespaceCreateRequest creates the GetWhitespace request.
-func (client *stringOperations) getWhitespaceCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *stringOperations) getWhitespaceCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/whitespace"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -322,7 +344,7 @@ func (client *stringOperations) getWhitespaceHandleResponse(resp *azcore.Respons
 
 // PutBase64URLEncoded - Put value that is base64url encoded
 func (client *stringOperations) PutBase64URLEncoded(ctx context.Context, stringBody []byte) (*http.Response, error) {
-	req, err := client.putBase64UrlEncodedCreateRequest(*client.u, stringBody)
+	req, err := client.putBase64UrlEncodedCreateRequest(stringBody)
 	if err != nil {
 		return nil, err
 	}
@@ -338,11 +360,14 @@ func (client *stringOperations) PutBase64URLEncoded(ctx context.Context, stringB
 }
 
 // putBase64UrlEncodedCreateRequest creates the PutBase64URLEncoded request.
-func (client *stringOperations) putBase64UrlEncodedCreateRequest(u url.URL, stringBody []byte) (*azcore.Request, error) {
+func (client *stringOperations) putBase64UrlEncodedCreateRequest(stringBody []byte) (*azcore.Request, error) {
 	urlPath := "/string/base64UrlEncoding"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(stringBody)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(stringBody)
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +384,7 @@ func (client *stringOperations) putBase64UrlEncodedHandleResponse(resp *azcore.R
 
 // PutEmpty - Set string value empty ''
 func (client *stringOperations) PutEmpty(ctx context.Context) (*http.Response, error) {
-	req, err := client.putEmptyCreateRequest(*client.u)
+	req, err := client.putEmptyCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -375,11 +400,14 @@ func (client *stringOperations) PutEmpty(ctx context.Context) (*http.Response, e
 }
 
 // putEmptyCreateRequest creates the PutEmpty request.
-func (client *stringOperations) putEmptyCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *stringOperations) putEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/empty"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON("")
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON("")
 	if err != nil {
 		return nil, err
 	}
@@ -396,7 +424,7 @@ func (client *stringOperations) putEmptyHandleResponse(resp *azcore.Response) (*
 
 // PutMBCS - Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
 func (client *stringOperations) PutMBCS(ctx context.Context) (*http.Response, error) {
-	req, err := client.putMbcsCreateRequest(*client.u)
+	req, err := client.putMbcsCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -412,11 +440,14 @@ func (client *stringOperations) PutMBCS(ctx context.Context) (*http.Response, er
 }
 
 // putMbcsCreateRequest creates the PutMBCS request.
-func (client *stringOperations) putMbcsCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *stringOperations) putMbcsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/mbcs"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON("啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€")
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON("啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€")
 	if err != nil {
 		return nil, err
 	}
@@ -433,7 +464,7 @@ func (client *stringOperations) putMbcsHandleResponse(resp *azcore.Response) (*h
 
 // PutNull - Set string value null
 func (client *stringOperations) PutNull(ctx context.Context) (*http.Response, error) {
-	req, err := client.putNullCreateRequest(*client.u)
+	req, err := client.putNullCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -449,11 +480,14 @@ func (client *stringOperations) PutNull(ctx context.Context) (*http.Response, er
 }
 
 // putNullCreateRequest creates the PutNull request.
-func (client *stringOperations) putNullCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *stringOperations) putNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/null"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(nil)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -470,7 +504,7 @@ func (client *stringOperations) putNullHandleResponse(resp *azcore.Response) (*h
 
 // PutWhitespace - Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
 func (client *stringOperations) PutWhitespace(ctx context.Context) (*http.Response, error) {
-	req, err := client.putWhitespaceCreateRequest(*client.u)
+	req, err := client.putWhitespaceCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -486,11 +520,14 @@ func (client *stringOperations) PutWhitespace(ctx context.Context) (*http.Respon
 }
 
 // putWhitespaceCreateRequest creates the PutWhitespace request.
-func (client *stringOperations) putWhitespaceCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *stringOperations) putWhitespaceCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/whitespace"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON("    Now is the time for all good men to come to the aid of their country    ")
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON("    Now is the time for all good men to come to the aid of their country    ")
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/urlgroup/client.go
+++ b/test/autorest/generated/urlgroup/client.go
@@ -6,6 +6,7 @@
 package urlgroup
 
 import (
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
 )
@@ -62,6 +63,9 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
+	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
 	return &Client{u: u, p: p}, nil
 }

--- a/test/autorest/generated/urlgroup/pathitems.go
+++ b/test/autorest/generated/urlgroup/pathitems.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -35,7 +34,7 @@ type pathItemsOperations struct {
 
 // GetAllWithValues - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
 func (client *pathItemsOperations) GetAllWithValues(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetAllWithValuesOptions) (*http.Response, error) {
-	req, err := client.getAllWithValuesCreateRequest(*client.u, pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
+	req, err := client.getAllWithValuesCreateRequest(pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
 	if err != nil {
 		return nil, err
 	}
@@ -51,12 +50,15 @@ func (client *pathItemsOperations) GetAllWithValues(ctx context.Context, pathIte
 }
 
 // getAllWithValuesCreateRequest creates the GetAllWithValues request.
-func (client *pathItemsOperations) getAllWithValuesCreateRequest(u url.URL, pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetAllWithValuesOptions) (*azcore.Request, error) {
+func (client *pathItemsOperations) getAllWithValuesCreateRequest(pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetAllWithValuesOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.PathItemStringQuery != nil {
 		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
@@ -68,7 +70,7 @@ func (client *pathItemsOperations) getAllWithValuesCreateRequest(u url.URL, path
 		query.Set("localStringQuery", *options.LocalStringQuery)
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -82,7 +84,7 @@ func (client *pathItemsOperations) getAllWithValuesHandleResponse(resp *azcore.R
 
 // GetGlobalAndLocalQueryNull - send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null
 func (client *pathItemsOperations) GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*http.Response, error) {
-	req, err := client.getGlobalAndLocalQueryNullCreateRequest(*client.u, pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
+	req, err := client.getGlobalAndLocalQueryNullCreateRequest(pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
 	if err != nil {
 		return nil, err
 	}
@@ -98,12 +100,15 @@ func (client *pathItemsOperations) GetGlobalAndLocalQueryNull(ctx context.Contex
 }
 
 // getGlobalAndLocalQueryNullCreateRequest creates the GetGlobalAndLocalQueryNull request.
-func (client *pathItemsOperations) getGlobalAndLocalQueryNullCreateRequest(u url.URL, pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*azcore.Request, error) {
+func (client *pathItemsOperations) getGlobalAndLocalQueryNullCreateRequest(pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.PathItemStringQuery != nil {
 		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
@@ -115,7 +120,7 @@ func (client *pathItemsOperations) getGlobalAndLocalQueryNullCreateRequest(u url
 		query.Set("localStringQuery", *options.LocalStringQuery)
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -129,7 +134,7 @@ func (client *pathItemsOperations) getGlobalAndLocalQueryNullHandleResponse(resp
 
 // GetGlobalQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
 func (client *pathItemsOperations) GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalQueryNullOptions) (*http.Response, error) {
-	req, err := client.getGlobalQueryNullCreateRequest(*client.u, pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
+	req, err := client.getGlobalQueryNullCreateRequest(pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
 	if err != nil {
 		return nil, err
 	}
@@ -145,12 +150,15 @@ func (client *pathItemsOperations) GetGlobalQueryNull(ctx context.Context, pathI
 }
 
 // getGlobalQueryNullCreateRequest creates the GetGlobalQueryNull request.
-func (client *pathItemsOperations) getGlobalQueryNullCreateRequest(u url.URL, pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetGlobalQueryNullOptions) (*azcore.Request, error) {
+func (client *pathItemsOperations) getGlobalQueryNullCreateRequest(pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetGlobalQueryNullOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.PathItemStringQuery != nil {
 		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
@@ -162,7 +170,7 @@ func (client *pathItemsOperations) getGlobalQueryNullCreateRequest(u url.URL, pa
 		query.Set("localStringQuery", *options.LocalStringQuery)
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -176,7 +184,7 @@ func (client *pathItemsOperations) getGlobalQueryNullHandleResponse(resp *azcore
 
 // GetLocalPathItemQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null
 func (client *pathItemsOperations) GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetLocalPathItemQueryNullOptions) (*http.Response, error) {
-	req, err := client.getLocalPathItemQueryNullCreateRequest(*client.u, pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
+	req, err := client.getLocalPathItemQueryNullCreateRequest(pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
 	if err != nil {
 		return nil, err
 	}
@@ -192,12 +200,15 @@ func (client *pathItemsOperations) GetLocalPathItemQueryNull(ctx context.Context
 }
 
 // getLocalPathItemQueryNullCreateRequest creates the GetLocalPathItemQueryNull request.
-func (client *pathItemsOperations) getLocalPathItemQueryNullCreateRequest(u url.URL, pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetLocalPathItemQueryNullOptions) (*azcore.Request, error) {
+func (client *pathItemsOperations) getLocalPathItemQueryNullCreateRequest(pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetLocalPathItemQueryNullOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.PathItemStringQuery != nil {
 		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
@@ -209,7 +220,7 @@ func (client *pathItemsOperations) getLocalPathItemQueryNullCreateRequest(u url.
 		query.Set("localStringQuery", *options.LocalStringQuery)
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 

--- a/test/autorest/generated/urlgroup/paths.go
+++ b/test/autorest/generated/urlgroup/paths.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -81,7 +80,7 @@ type pathsOperations struct {
 
 // ArrayCSVInPath - Get an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
 func (client *pathsOperations) ArrayCSVInPath(ctx context.Context, arrayPath []string) (*http.Response, error) {
-	req, err := client.arrayCsvInPathCreateRequest(*client.u, arrayPath)
+	req, err := client.arrayCsvInPathCreateRequest(arrayPath)
 	if err != nil {
 		return nil, err
 	}
@@ -97,11 +96,14 @@ func (client *pathsOperations) ArrayCSVInPath(ctx context.Context, arrayPath []s
 }
 
 // arrayCsvInPathCreateRequest creates the ArrayCSVInPath request.
-func (client *pathsOperations) arrayCsvInPathCreateRequest(u url.URL, arrayPath []string) (*azcore.Request, error) {
+func (client *pathsOperations) arrayCsvInPathCreateRequest(arrayPath []string) (*azcore.Request, error) {
 	urlPath := "/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{arrayPath}", url.PathEscape(strings.Join(arrayPath, ",")))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -115,7 +117,7 @@ func (client *pathsOperations) arrayCsvInPathHandleResponse(resp *azcore.Respons
 
 // Base64URL - Get 'lorem' encoded value as 'bG9yZW0' (base64url)
 func (client *pathsOperations) Base64URL(ctx context.Context, base64UrlPath []byte) (*http.Response, error) {
-	req, err := client.base64UrlCreateRequest(*client.u, base64UrlPath)
+	req, err := client.base64UrlCreateRequest(base64UrlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -131,11 +133,14 @@ func (client *pathsOperations) Base64URL(ctx context.Context, base64UrlPath []by
 }
 
 // base64UrlCreateRequest creates the Base64URL request.
-func (client *pathsOperations) base64UrlCreateRequest(u url.URL, base64UrlPath []byte) (*azcore.Request, error) {
+func (client *pathsOperations) base64UrlCreateRequest(base64UrlPath []byte) (*azcore.Request, error) {
 	urlPath := "/paths/string/bG9yZW0/{base64UrlPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{base64UrlPath}", url.PathEscape(base64.StdEncoding.EncodeToString(base64UrlPath)))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -149,7 +154,7 @@ func (client *pathsOperations) base64UrlHandleResponse(resp *azcore.Response) (*
 
 // ByteEmpty - Get '' as byte array
 func (client *pathsOperations) ByteEmpty(ctx context.Context) (*http.Response, error) {
-	req, err := client.byteEmptyCreateRequest(*client.u)
+	req, err := client.byteEmptyCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -165,11 +170,14 @@ func (client *pathsOperations) ByteEmpty(ctx context.Context) (*http.Response, e
 }
 
 // byteEmptyCreateRequest creates the ByteEmpty request.
-func (client *pathsOperations) byteEmptyCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) byteEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/byte/empty/{bytePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(""))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -183,7 +191,7 @@ func (client *pathsOperations) byteEmptyHandleResponse(resp *azcore.Response) (*
 
 // ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
 func (client *pathsOperations) ByteMultiByte(ctx context.Context, bytePath []byte) (*http.Response, error) {
-	req, err := client.byteMultiByteCreateRequest(*client.u, bytePath)
+	req, err := client.byteMultiByteCreateRequest(bytePath)
 	if err != nil {
 		return nil, err
 	}
@@ -199,11 +207,14 @@ func (client *pathsOperations) ByteMultiByte(ctx context.Context, bytePath []byt
 }
 
 // byteMultiByteCreateRequest creates the ByteMultiByte request.
-func (client *pathsOperations) byteMultiByteCreateRequest(u url.URL, bytePath []byte) (*azcore.Request, error) {
+func (client *pathsOperations) byteMultiByteCreateRequest(bytePath []byte) (*azcore.Request, error) {
 	urlPath := "/paths/byte/multibyte/{bytePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(base64.StdEncoding.EncodeToString(bytePath)))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -217,7 +228,7 @@ func (client *pathsOperations) byteMultiByteHandleResponse(resp *azcore.Response
 
 // ByteNull - Get null as byte array (should throw)
 func (client *pathsOperations) ByteNull(ctx context.Context, bytePath []byte) (*http.Response, error) {
-	req, err := client.byteNullCreateRequest(*client.u, bytePath)
+	req, err := client.byteNullCreateRequest(bytePath)
 	if err != nil {
 		return nil, err
 	}
@@ -233,11 +244,14 @@ func (client *pathsOperations) ByteNull(ctx context.Context, bytePath []byte) (*
 }
 
 // byteNullCreateRequest creates the ByteNull request.
-func (client *pathsOperations) byteNullCreateRequest(u url.URL, bytePath []byte) (*azcore.Request, error) {
+func (client *pathsOperations) byteNullCreateRequest(bytePath []byte) (*azcore.Request, error) {
 	urlPath := "/paths/byte/null/{bytePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(base64.StdEncoding.EncodeToString(bytePath)))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -251,7 +265,7 @@ func (client *pathsOperations) byteNullHandleResponse(resp *azcore.Response) (*h
 
 // DateNull - Get null as date - this should throw or be unusable on the client side, depending on date representation
 func (client *pathsOperations) DateNull(ctx context.Context, datePath time.Time) (*http.Response, error) {
-	req, err := client.dateNullCreateRequest(*client.u, datePath)
+	req, err := client.dateNullCreateRequest(datePath)
 	if err != nil {
 		return nil, err
 	}
@@ -267,11 +281,14 @@ func (client *pathsOperations) DateNull(ctx context.Context, datePath time.Time)
 }
 
 // dateNullCreateRequest creates the DateNull request.
-func (client *pathsOperations) dateNullCreateRequest(u url.URL, datePath time.Time) (*azcore.Request, error) {
+func (client *pathsOperations) dateNullCreateRequest(datePath time.Time) (*azcore.Request, error) {
 	urlPath := "/paths/date/null/{datePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{datePath}", url.PathEscape(datePath.Format("2006-01-02")))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -285,7 +302,7 @@ func (client *pathsOperations) dateNullHandleResponse(resp *azcore.Response) (*h
 
 // DateTimeNull - Get null as date-time, should be disallowed or throw depending on representation of date-time
 func (client *pathsOperations) DateTimeNull(ctx context.Context, dateTimePath time.Time) (*http.Response, error) {
-	req, err := client.dateTimeNullCreateRequest(*client.u, dateTimePath)
+	req, err := client.dateTimeNullCreateRequest(dateTimePath)
 	if err != nil {
 		return nil, err
 	}
@@ -301,11 +318,14 @@ func (client *pathsOperations) DateTimeNull(ctx context.Context, dateTimePath ti
 }
 
 // dateTimeNullCreateRequest creates the DateTimeNull request.
-func (client *pathsOperations) dateTimeNullCreateRequest(u url.URL, dateTimePath time.Time) (*azcore.Request, error) {
+func (client *pathsOperations) dateTimeNullCreateRequest(dateTimePath time.Time) (*azcore.Request, error) {
 	urlPath := "/paths/datetime/null/{dateTimePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{dateTimePath}", url.PathEscape(dateTimePath.Format(time.RFC3339)))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -319,7 +339,7 @@ func (client *pathsOperations) dateTimeNullHandleResponse(resp *azcore.Response)
 
 // DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
 func (client *pathsOperations) DateTimeValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.dateTimeValidCreateRequest(*client.u)
+	req, err := client.dateTimeValidCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -335,11 +355,14 @@ func (client *pathsOperations) DateTimeValid(ctx context.Context) (*http.Respons
 }
 
 // dateTimeValidCreateRequest creates the DateTimeValid request.
-func (client *pathsOperations) dateTimeValidCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) dateTimeValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{dateTimePath}", url.PathEscape("2012-01-01T01:01:01Z"))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -353,7 +376,7 @@ func (client *pathsOperations) dateTimeValidHandleResponse(resp *azcore.Response
 
 // DateValid - Get '2012-01-01' as date
 func (client *pathsOperations) DateValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.dateValidCreateRequest(*client.u)
+	req, err := client.dateValidCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -369,11 +392,14 @@ func (client *pathsOperations) DateValid(ctx context.Context) (*http.Response, e
 }
 
 // dateValidCreateRequest creates the DateValid request.
-func (client *pathsOperations) dateValidCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) dateValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/date/2012-01-01/{datePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{datePath}", url.PathEscape("2012-01-01"))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -387,7 +413,7 @@ func (client *pathsOperations) dateValidHandleResponse(resp *azcore.Response) (*
 
 // DoubleDecimalNegative - Get '-9999999.999' numeric value
 func (client *pathsOperations) DoubleDecimalNegative(ctx context.Context) (*http.Response, error) {
-	req, err := client.doubleDecimalNegativeCreateRequest(*client.u)
+	req, err := client.doubleDecimalNegativeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -403,11 +429,14 @@ func (client *pathsOperations) DoubleDecimalNegative(ctx context.Context) (*http
 }
 
 // doubleDecimalNegativeCreateRequest creates the DoubleDecimalNegative request.
-func (client *pathsOperations) doubleDecimalNegativeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) doubleDecimalNegativeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/double/-9999999.999/{doublePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{doublePath}", url.PathEscape("-9999999.999"))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -421,7 +450,7 @@ func (client *pathsOperations) doubleDecimalNegativeHandleResponse(resp *azcore.
 
 // DoubleDecimalPositive - Get '9999999.999' numeric value
 func (client *pathsOperations) DoubleDecimalPositive(ctx context.Context) (*http.Response, error) {
-	req, err := client.doubleDecimalPositiveCreateRequest(*client.u)
+	req, err := client.doubleDecimalPositiveCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -437,11 +466,14 @@ func (client *pathsOperations) DoubleDecimalPositive(ctx context.Context) (*http
 }
 
 // doubleDecimalPositiveCreateRequest creates the DoubleDecimalPositive request.
-func (client *pathsOperations) doubleDecimalPositiveCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) doubleDecimalPositiveCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/double/9999999.999/{doublePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{doublePath}", url.PathEscape("9999999.999"))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -455,7 +487,7 @@ func (client *pathsOperations) doubleDecimalPositiveHandleResponse(resp *azcore.
 
 // EnumNull - Get null (should throw on the client before the request is sent on wire)
 func (client *pathsOperations) EnumNull(ctx context.Context, enumPath UriColor) (*http.Response, error) {
-	req, err := client.enumNullCreateRequest(*client.u, enumPath)
+	req, err := client.enumNullCreateRequest(enumPath)
 	if err != nil {
 		return nil, err
 	}
@@ -471,11 +503,14 @@ func (client *pathsOperations) EnumNull(ctx context.Context, enumPath UriColor) 
 }
 
 // enumNullCreateRequest creates the EnumNull request.
-func (client *pathsOperations) enumNullCreateRequest(u url.URL, enumPath UriColor) (*azcore.Request, error) {
+func (client *pathsOperations) enumNullCreateRequest(enumPath UriColor) (*azcore.Request, error) {
 	urlPath := "/paths/string/null/{enumPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{enumPath}", url.PathEscape(string(enumPath)))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -489,7 +524,7 @@ func (client *pathsOperations) enumNullHandleResponse(resp *azcore.Response) (*h
 
 // EnumValid - Get using uri with 'green color' in path parameter
 func (client *pathsOperations) EnumValid(ctx context.Context, enumPath UriColor) (*http.Response, error) {
-	req, err := client.enumValidCreateRequest(*client.u, enumPath)
+	req, err := client.enumValidCreateRequest(enumPath)
 	if err != nil {
 		return nil, err
 	}
@@ -505,11 +540,14 @@ func (client *pathsOperations) EnumValid(ctx context.Context, enumPath UriColor)
 }
 
 // enumValidCreateRequest creates the EnumValid request.
-func (client *pathsOperations) enumValidCreateRequest(u url.URL, enumPath UriColor) (*azcore.Request, error) {
+func (client *pathsOperations) enumValidCreateRequest(enumPath UriColor) (*azcore.Request, error) {
 	urlPath := "/paths/enum/green%20color/{enumPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{enumPath}", url.PathEscape(string(enumPath)))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -523,7 +561,7 @@ func (client *pathsOperations) enumValidHandleResponse(resp *azcore.Response) (*
 
 // FloatScientificNegative - Get '-1.034E-20' numeric value
 func (client *pathsOperations) FloatScientificNegative(ctx context.Context) (*http.Response, error) {
-	req, err := client.floatScientificNegativeCreateRequest(*client.u)
+	req, err := client.floatScientificNegativeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -539,11 +577,14 @@ func (client *pathsOperations) FloatScientificNegative(ctx context.Context) (*ht
 }
 
 // floatScientificNegativeCreateRequest creates the FloatScientificNegative request.
-func (client *pathsOperations) floatScientificNegativeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) floatScientificNegativeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/float/-1.034E-20/{floatPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{floatPath}", url.PathEscape("-1.034e-20"))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -557,7 +598,7 @@ func (client *pathsOperations) floatScientificNegativeHandleResponse(resp *azcor
 
 // FloatScientificPositive - Get '1.034E+20' numeric value
 func (client *pathsOperations) FloatScientificPositive(ctx context.Context) (*http.Response, error) {
-	req, err := client.floatScientificPositiveCreateRequest(*client.u)
+	req, err := client.floatScientificPositiveCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -573,11 +614,14 @@ func (client *pathsOperations) FloatScientificPositive(ctx context.Context) (*ht
 }
 
 // floatScientificPositiveCreateRequest creates the FloatScientificPositive request.
-func (client *pathsOperations) floatScientificPositiveCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) floatScientificPositiveCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/float/1.034E+20/{floatPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{floatPath}", url.PathEscape("103400000000000000000"))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -591,7 +635,7 @@ func (client *pathsOperations) floatScientificPositiveHandleResponse(resp *azcor
 
 // GetBooleanFalse - Get false Boolean value on path
 func (client *pathsOperations) GetBooleanFalse(ctx context.Context) (*http.Response, error) {
-	req, err := client.getBooleanFalseCreateRequest(*client.u)
+	req, err := client.getBooleanFalseCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -607,11 +651,14 @@ func (client *pathsOperations) GetBooleanFalse(ctx context.Context) (*http.Respo
 }
 
 // getBooleanFalseCreateRequest creates the GetBooleanFalse request.
-func (client *pathsOperations) getBooleanFalseCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) getBooleanFalseCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/bool/false/{boolPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{boolPath}", url.PathEscape("false"))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -625,7 +672,7 @@ func (client *pathsOperations) getBooleanFalseHandleResponse(resp *azcore.Respon
 
 // GetBooleanTrue - Get true Boolean value on path
 func (client *pathsOperations) GetBooleanTrue(ctx context.Context) (*http.Response, error) {
-	req, err := client.getBooleanTrueCreateRequest(*client.u)
+	req, err := client.getBooleanTrueCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -641,11 +688,14 @@ func (client *pathsOperations) GetBooleanTrue(ctx context.Context) (*http.Respon
 }
 
 // getBooleanTrueCreateRequest creates the GetBooleanTrue request.
-func (client *pathsOperations) getBooleanTrueCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) getBooleanTrueCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/bool/true/{boolPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{boolPath}", url.PathEscape("true"))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -659,7 +709,7 @@ func (client *pathsOperations) getBooleanTrueHandleResponse(resp *azcore.Respons
 
 // GetIntNegativeOneMillion - Get '-1000000' integer value
 func (client *pathsOperations) GetIntNegativeOneMillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.getIntNegativeOneMillionCreateRequest(*client.u)
+	req, err := client.getIntNegativeOneMillionCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -675,11 +725,14 @@ func (client *pathsOperations) GetIntNegativeOneMillion(ctx context.Context) (*h
 }
 
 // getIntNegativeOneMillionCreateRequest creates the GetIntNegativeOneMillion request.
-func (client *pathsOperations) getIntNegativeOneMillionCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) getIntNegativeOneMillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/int/-1000000/{intPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{intPath}", url.PathEscape("-1000000"))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -693,7 +746,7 @@ func (client *pathsOperations) getIntNegativeOneMillionHandleResponse(resp *azco
 
 // GetIntOneMillion - Get '1000000' integer value
 func (client *pathsOperations) GetIntOneMillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.getIntOneMillionCreateRequest(*client.u)
+	req, err := client.getIntOneMillionCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -709,11 +762,14 @@ func (client *pathsOperations) GetIntOneMillion(ctx context.Context) (*http.Resp
 }
 
 // getIntOneMillionCreateRequest creates the GetIntOneMillion request.
-func (client *pathsOperations) getIntOneMillionCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) getIntOneMillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/int/1000000/{intPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{intPath}", url.PathEscape("1000000"))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -727,7 +783,7 @@ func (client *pathsOperations) getIntOneMillionHandleResponse(resp *azcore.Respo
 
 // GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
 func (client *pathsOperations) GetNegativeTenBillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.getNegativeTenBillionCreateRequest(*client.u)
+	req, err := client.getNegativeTenBillionCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -743,11 +799,14 @@ func (client *pathsOperations) GetNegativeTenBillion(ctx context.Context) (*http
 }
 
 // getNegativeTenBillionCreateRequest creates the GetNegativeTenBillion request.
-func (client *pathsOperations) getNegativeTenBillionCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) getNegativeTenBillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/long/-10000000000/{longPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{longPath}", url.PathEscape("-10000000000"))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -761,7 +820,7 @@ func (client *pathsOperations) getNegativeTenBillionHandleResponse(resp *azcore.
 
 // GetTenBillion - Get '10000000000' 64 bit integer value
 func (client *pathsOperations) GetTenBillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.getTenBillionCreateRequest(*client.u)
+	req, err := client.getTenBillionCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -777,11 +836,14 @@ func (client *pathsOperations) GetTenBillion(ctx context.Context) (*http.Respons
 }
 
 // getTenBillionCreateRequest creates the GetTenBillion request.
-func (client *pathsOperations) getTenBillionCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) getTenBillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/long/10000000000/{longPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{longPath}", url.PathEscape("10000000000"))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -795,7 +857,7 @@ func (client *pathsOperations) getTenBillionHandleResponse(resp *azcore.Response
 
 // StringEmpty - Get ''
 func (client *pathsOperations) StringEmpty(ctx context.Context) (*http.Response, error) {
-	req, err := client.stringEmptyCreateRequest(*client.u)
+	req, err := client.stringEmptyCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -811,11 +873,14 @@ func (client *pathsOperations) StringEmpty(ctx context.Context) (*http.Response,
 }
 
 // stringEmptyCreateRequest creates the StringEmpty request.
-func (client *pathsOperations) stringEmptyCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) stringEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/string/empty/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape(""))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -829,7 +894,7 @@ func (client *pathsOperations) stringEmptyHandleResponse(resp *azcore.Response) 
 
 // StringNull - Get null (should throw)
 func (client *pathsOperations) StringNull(ctx context.Context, stringPath string) (*http.Response, error) {
-	req, err := client.stringNullCreateRequest(*client.u, stringPath)
+	req, err := client.stringNullCreateRequest(stringPath)
 	if err != nil {
 		return nil, err
 	}
@@ -845,11 +910,14 @@ func (client *pathsOperations) StringNull(ctx context.Context, stringPath string
 }
 
 // stringNullCreateRequest creates the StringNull request.
-func (client *pathsOperations) stringNullCreateRequest(u url.URL, stringPath string) (*azcore.Request, error) {
+func (client *pathsOperations) stringNullCreateRequest(stringPath string) (*azcore.Request, error) {
 	urlPath := "/paths/string/null/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape(stringPath))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -863,7 +931,7 @@ func (client *pathsOperations) stringNullHandleResponse(resp *azcore.Response) (
 
 // StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
 func (client *pathsOperations) StringURLEncoded(ctx context.Context) (*http.Response, error) {
-	req, err := client.stringUrlEncodedCreateRequest(*client.u)
+	req, err := client.stringUrlEncodedCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -879,11 +947,14 @@ func (client *pathsOperations) StringURLEncoded(ctx context.Context) (*http.Resp
 }
 
 // stringUrlEncodedCreateRequest creates the StringURLEncoded request.
-func (client *pathsOperations) stringUrlEncodedCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) stringUrlEncodedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape("begin!*'();:@ &=+$,/?#[]end"))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -897,7 +968,7 @@ func (client *pathsOperations) stringUrlEncodedHandleResponse(resp *azcore.Respo
 
 // StringURLNonEncoded - Get 'begin!*'();:@&=+$,end
 func (client *pathsOperations) StringURLNonEncoded(ctx context.Context) (*http.Response, error) {
-	req, err := client.stringUrlNonEncodedCreateRequest(*client.u)
+	req, err := client.stringUrlNonEncodedCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -913,11 +984,14 @@ func (client *pathsOperations) StringURLNonEncoded(ctx context.Context) (*http.R
 }
 
 // stringUrlNonEncodedCreateRequest creates the StringURLNonEncoded request.
-func (client *pathsOperations) stringUrlNonEncodedCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) stringUrlNonEncodedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/string/begin!*'();:@&=+$,end/{stringPath}"
-	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape("begin!*'();:@&=+$,end"))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", "begin!*'();:@&=+$,end")
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -931,7 +1005,7 @@ func (client *pathsOperations) stringUrlNonEncodedHandleResponse(resp *azcore.Re
 
 // StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
 func (client *pathsOperations) StringUnicode(ctx context.Context) (*http.Response, error) {
-	req, err := client.stringUnicodeCreateRequest(*client.u)
+	req, err := client.stringUnicodeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -947,11 +1021,14 @@ func (client *pathsOperations) StringUnicode(ctx context.Context) (*http.Respons
 }
 
 // stringUnicodeCreateRequest creates the StringUnicode request.
-func (client *pathsOperations) stringUnicodeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *pathsOperations) stringUnicodeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/string/unicode/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape("啊齄丂狛狜隣郎隣兀﨩"))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -965,7 +1042,7 @@ func (client *pathsOperations) stringUnicodeHandleResponse(resp *azcore.Response
 
 // UnixTimeURL - Get the date 2016-04-13 encoded value as '1460505600' (Unix time)
 func (client *pathsOperations) UnixTimeURL(ctx context.Context, unixTimeUrlPath time.Time) (*http.Response, error) {
-	req, err := client.unixTimeUrlCreateRequest(*client.u, unixTimeUrlPath)
+	req, err := client.unixTimeUrlCreateRequest(unixTimeUrlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -981,11 +1058,14 @@ func (client *pathsOperations) UnixTimeURL(ctx context.Context, unixTimeUrlPath 
 }
 
 // unixTimeUrlCreateRequest creates the UnixTimeURL request.
-func (client *pathsOperations) unixTimeUrlCreateRequest(u url.URL, unixTimeUrlPath time.Time) (*azcore.Request, error) {
+func (client *pathsOperations) unixTimeUrlCreateRequest(unixTimeUrlPath time.Time) (*azcore.Request, error) {
 	urlPath := "/paths/int/1460505600/{unixTimeUrlPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{unixTimeUrlPath}", url.PathEscape(unixTimeUrlPath.String()))
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 

--- a/test/autorest/generated/urlgroup/queries.go
+++ b/test/autorest/generated/urlgroup/queries.go
@@ -10,8 +10,6 @@ import (
 	"encoding/base64"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"net/url"
-	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -96,7 +94,7 @@ type queriesOperations struct {
 
 // ArrayStringCSVEmpty - Get an empty array [] of string using the csv-array format
 func (client *queriesOperations) ArrayStringCSVEmpty(ctx context.Context, options *QueriesArrayStringCSVEmptyOptions) (*http.Response, error) {
-	req, err := client.arrayStringCsvEmptyCreateRequest(*client.u, options)
+	req, err := client.arrayStringCsvEmptyCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -112,15 +110,18 @@ func (client *queriesOperations) ArrayStringCSVEmpty(ctx context.Context, option
 }
 
 // arrayStringCsvEmptyCreateRequest creates the ArrayStringCSVEmpty request.
-func (client *queriesOperations) arrayStringCsvEmptyCreateRequest(u url.URL, options *QueriesArrayStringCSVEmptyOptions) (*azcore.Request, error) {
+func (client *queriesOperations) arrayStringCsvEmptyCreateRequest(options *QueriesArrayStringCSVEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/csv/string/empty"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.ArrayQuery != nil {
 		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, ","))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -134,7 +135,7 @@ func (client *queriesOperations) arrayStringCsvEmptyHandleResponse(resp *azcore.
 
 // ArrayStringCSVNull - Get a null array of string using the csv-array format
 func (client *queriesOperations) ArrayStringCSVNull(ctx context.Context, options *QueriesArrayStringCSVNullOptions) (*http.Response, error) {
-	req, err := client.arrayStringCsvNullCreateRequest(*client.u, options)
+	req, err := client.arrayStringCsvNullCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -150,15 +151,18 @@ func (client *queriesOperations) ArrayStringCSVNull(ctx context.Context, options
 }
 
 // arrayStringCsvNullCreateRequest creates the ArrayStringCSVNull request.
-func (client *queriesOperations) arrayStringCsvNullCreateRequest(u url.URL, options *QueriesArrayStringCSVNullOptions) (*azcore.Request, error) {
+func (client *queriesOperations) arrayStringCsvNullCreateRequest(options *QueriesArrayStringCSVNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/csv/string/null"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.ArrayQuery != nil {
 		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, ","))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -172,7 +176,7 @@ func (client *queriesOperations) arrayStringCsvNullHandleResponse(resp *azcore.R
 
 // ArrayStringCSVValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
 func (client *queriesOperations) ArrayStringCSVValid(ctx context.Context, options *QueriesArrayStringCSVValidOptions) (*http.Response, error) {
-	req, err := client.arrayStringCsvValidCreateRequest(*client.u, options)
+	req, err := client.arrayStringCsvValidCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -188,15 +192,18 @@ func (client *queriesOperations) ArrayStringCSVValid(ctx context.Context, option
 }
 
 // arrayStringCsvValidCreateRequest creates the ArrayStringCSVValid request.
-func (client *queriesOperations) arrayStringCsvValidCreateRequest(u url.URL, options *QueriesArrayStringCSVValidOptions) (*azcore.Request, error) {
+func (client *queriesOperations) arrayStringCsvValidCreateRequest(options *QueriesArrayStringCSVValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/csv/string/valid"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.ArrayQuery != nil {
 		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, ","))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -210,7 +217,7 @@ func (client *queriesOperations) arrayStringCsvValidHandleResponse(resp *azcore.
 
 // ArrayStringPipesValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array format
 func (client *queriesOperations) ArrayStringPipesValid(ctx context.Context, options *QueriesArrayStringPipesValidOptions) (*http.Response, error) {
-	req, err := client.arrayStringPipesValidCreateRequest(*client.u, options)
+	req, err := client.arrayStringPipesValidCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -226,15 +233,18 @@ func (client *queriesOperations) ArrayStringPipesValid(ctx context.Context, opti
 }
 
 // arrayStringPipesValidCreateRequest creates the ArrayStringPipesValid request.
-func (client *queriesOperations) arrayStringPipesValidCreateRequest(u url.URL, options *QueriesArrayStringPipesValidOptions) (*azcore.Request, error) {
+func (client *queriesOperations) arrayStringPipesValidCreateRequest(options *QueriesArrayStringPipesValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/pipes/string/valid"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.ArrayQuery != nil {
 		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, "|"))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -248,7 +258,7 @@ func (client *queriesOperations) arrayStringPipesValidHandleResponse(resp *azcor
 
 // ArrayStringSsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format
 func (client *queriesOperations) ArrayStringSsvValid(ctx context.Context, options *QueriesArrayStringSsvValidOptions) (*http.Response, error) {
-	req, err := client.arrayStringSsvValidCreateRequest(*client.u, options)
+	req, err := client.arrayStringSsvValidCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -264,15 +274,18 @@ func (client *queriesOperations) ArrayStringSsvValid(ctx context.Context, option
 }
 
 // arrayStringSsvValidCreateRequest creates the ArrayStringSsvValid request.
-func (client *queriesOperations) arrayStringSsvValidCreateRequest(u url.URL, options *QueriesArrayStringSsvValidOptions) (*azcore.Request, error) {
+func (client *queriesOperations) arrayStringSsvValidCreateRequest(options *QueriesArrayStringSsvValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/ssv/string/valid"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.ArrayQuery != nil {
 		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, " "))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -286,7 +299,7 @@ func (client *queriesOperations) arrayStringSsvValidHandleResponse(resp *azcore.
 
 // ArrayStringTsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array format
 func (client *queriesOperations) ArrayStringTsvValid(ctx context.Context, options *QueriesArrayStringTsvValidOptions) (*http.Response, error) {
-	req, err := client.arrayStringTsvValidCreateRequest(*client.u, options)
+	req, err := client.arrayStringTsvValidCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -302,15 +315,18 @@ func (client *queriesOperations) ArrayStringTsvValid(ctx context.Context, option
 }
 
 // arrayStringTsvValidCreateRequest creates the ArrayStringTsvValid request.
-func (client *queriesOperations) arrayStringTsvValidCreateRequest(u url.URL, options *QueriesArrayStringTsvValidOptions) (*azcore.Request, error) {
+func (client *queriesOperations) arrayStringTsvValidCreateRequest(options *QueriesArrayStringTsvValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/tsv/string/valid"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.ArrayQuery != nil {
 		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, "\t"))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -324,7 +340,7 @@ func (client *queriesOperations) arrayStringTsvValidHandleResponse(resp *azcore.
 
 // ByteEmpty - Get '' as byte array
 func (client *queriesOperations) ByteEmpty(ctx context.Context) (*http.Response, error) {
-	req, err := client.byteEmptyCreateRequest(*client.u)
+	req, err := client.byteEmptyCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -340,13 +356,16 @@ func (client *queriesOperations) ByteEmpty(ctx context.Context) (*http.Response,
 }
 
 // byteEmptyCreateRequest creates the ByteEmpty request.
-func (client *queriesOperations) byteEmptyCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) byteEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/byte/empty"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("byteQuery", "")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -360,7 +379,7 @@ func (client *queriesOperations) byteEmptyHandleResponse(resp *azcore.Response) 
 
 // ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
 func (client *queriesOperations) ByteMultiByte(ctx context.Context, options *QueriesByteMultiByteOptions) (*http.Response, error) {
-	req, err := client.byteMultiByteCreateRequest(*client.u, options)
+	req, err := client.byteMultiByteCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -376,15 +395,18 @@ func (client *queriesOperations) ByteMultiByte(ctx context.Context, options *Que
 }
 
 // byteMultiByteCreateRequest creates the ByteMultiByte request.
-func (client *queriesOperations) byteMultiByteCreateRequest(u url.URL, options *QueriesByteMultiByteOptions) (*azcore.Request, error) {
+func (client *queriesOperations) byteMultiByteCreateRequest(options *QueriesByteMultiByteOptions) (*azcore.Request, error) {
 	urlPath := "/queries/byte/multibyte"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.ByteQuery != nil {
 		query.Set("byteQuery", base64.StdEncoding.EncodeToString(*options.ByteQuery))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -398,7 +420,7 @@ func (client *queriesOperations) byteMultiByteHandleResponse(resp *azcore.Respon
 
 // ByteNull - Get null as byte array (no query parameters in uri)
 func (client *queriesOperations) ByteNull(ctx context.Context, options *QueriesByteNullOptions) (*http.Response, error) {
-	req, err := client.byteNullCreateRequest(*client.u, options)
+	req, err := client.byteNullCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -414,15 +436,18 @@ func (client *queriesOperations) ByteNull(ctx context.Context, options *QueriesB
 }
 
 // byteNullCreateRequest creates the ByteNull request.
-func (client *queriesOperations) byteNullCreateRequest(u url.URL, options *QueriesByteNullOptions) (*azcore.Request, error) {
+func (client *queriesOperations) byteNullCreateRequest(options *QueriesByteNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/byte/null"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.ByteQuery != nil {
 		query.Set("byteQuery", base64.StdEncoding.EncodeToString(*options.ByteQuery))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -436,7 +461,7 @@ func (client *queriesOperations) byteNullHandleResponse(resp *azcore.Response) (
 
 // DateNull - Get null as date - this should result in no query parameters in uri
 func (client *queriesOperations) DateNull(ctx context.Context, options *QueriesDateNullOptions) (*http.Response, error) {
-	req, err := client.dateNullCreateRequest(*client.u, options)
+	req, err := client.dateNullCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -452,15 +477,18 @@ func (client *queriesOperations) DateNull(ctx context.Context, options *QueriesD
 }
 
 // dateNullCreateRequest creates the DateNull request.
-func (client *queriesOperations) dateNullCreateRequest(u url.URL, options *QueriesDateNullOptions) (*azcore.Request, error) {
+func (client *queriesOperations) dateNullCreateRequest(options *QueriesDateNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/date/null"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.DateQuery != nil {
 		query.Set("dateQuery", options.DateQuery.Format("2006-01-02"))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -474,7 +502,7 @@ func (client *queriesOperations) dateNullHandleResponse(resp *azcore.Response) (
 
 // DateTimeNull - Get null as date-time, should result in no query parameters in uri
 func (client *queriesOperations) DateTimeNull(ctx context.Context, options *QueriesDateTimeNullOptions) (*http.Response, error) {
-	req, err := client.dateTimeNullCreateRequest(*client.u, options)
+	req, err := client.dateTimeNullCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -490,15 +518,18 @@ func (client *queriesOperations) DateTimeNull(ctx context.Context, options *Quer
 }
 
 // dateTimeNullCreateRequest creates the DateTimeNull request.
-func (client *queriesOperations) dateTimeNullCreateRequest(u url.URL, options *QueriesDateTimeNullOptions) (*azcore.Request, error) {
+func (client *queriesOperations) dateTimeNullCreateRequest(options *QueriesDateTimeNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/datetime/null"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.DateTimeQuery != nil {
 		query.Set("dateTimeQuery", options.DateTimeQuery.Format(time.RFC3339))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -512,7 +543,7 @@ func (client *queriesOperations) dateTimeNullHandleResponse(resp *azcore.Respons
 
 // DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
 func (client *queriesOperations) DateTimeValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.dateTimeValidCreateRequest(*client.u)
+	req, err := client.dateTimeValidCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -528,13 +559,16 @@ func (client *queriesOperations) DateTimeValid(ctx context.Context) (*http.Respo
 }
 
 // dateTimeValidCreateRequest creates the DateTimeValid request.
-func (client *queriesOperations) dateTimeValidCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) dateTimeValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/datetime/2012-01-01T01%3A01%3A01Z"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("dateTimeQuery", "2012-01-01T01:01:01Z")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -548,7 +582,7 @@ func (client *queriesOperations) dateTimeValidHandleResponse(resp *azcore.Respon
 
 // DateValid - Get '2012-01-01' as date
 func (client *queriesOperations) DateValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.dateValidCreateRequest(*client.u)
+	req, err := client.dateValidCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -564,13 +598,16 @@ func (client *queriesOperations) DateValid(ctx context.Context) (*http.Response,
 }
 
 // dateValidCreateRequest creates the DateValid request.
-func (client *queriesOperations) dateValidCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) dateValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/date/2012-01-01"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("dateQuery", "2012-01-01")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -584,7 +621,7 @@ func (client *queriesOperations) dateValidHandleResponse(resp *azcore.Response) 
 
 // DoubleDecimalNegative - Get '-9999999.999' numeric value
 func (client *queriesOperations) DoubleDecimalNegative(ctx context.Context) (*http.Response, error) {
-	req, err := client.doubleDecimalNegativeCreateRequest(*client.u)
+	req, err := client.doubleDecimalNegativeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -600,13 +637,16 @@ func (client *queriesOperations) DoubleDecimalNegative(ctx context.Context) (*ht
 }
 
 // doubleDecimalNegativeCreateRequest creates the DoubleDecimalNegative request.
-func (client *queriesOperations) doubleDecimalNegativeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) doubleDecimalNegativeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/double/-9999999.999"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("doubleQuery", "-9999999.999")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -620,7 +660,7 @@ func (client *queriesOperations) doubleDecimalNegativeHandleResponse(resp *azcor
 
 // DoubleDecimalPositive - Get '9999999.999' numeric value
 func (client *queriesOperations) DoubleDecimalPositive(ctx context.Context) (*http.Response, error) {
-	req, err := client.doubleDecimalPositiveCreateRequest(*client.u)
+	req, err := client.doubleDecimalPositiveCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -636,13 +676,16 @@ func (client *queriesOperations) DoubleDecimalPositive(ctx context.Context) (*ht
 }
 
 // doubleDecimalPositiveCreateRequest creates the DoubleDecimalPositive request.
-func (client *queriesOperations) doubleDecimalPositiveCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) doubleDecimalPositiveCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/double/9999999.999"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("doubleQuery", "9999999.999")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -656,7 +699,7 @@ func (client *queriesOperations) doubleDecimalPositiveHandleResponse(resp *azcor
 
 // DoubleNull - Get null numeric value (no query parameter)
 func (client *queriesOperations) DoubleNull(ctx context.Context, options *QueriesDoubleNullOptions) (*http.Response, error) {
-	req, err := client.doubleNullCreateRequest(*client.u, options)
+	req, err := client.doubleNullCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -672,15 +715,18 @@ func (client *queriesOperations) DoubleNull(ctx context.Context, options *Querie
 }
 
 // doubleNullCreateRequest creates the DoubleNull request.
-func (client *queriesOperations) doubleNullCreateRequest(u url.URL, options *QueriesDoubleNullOptions) (*azcore.Request, error) {
+func (client *queriesOperations) doubleNullCreateRequest(options *QueriesDoubleNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/double/null"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.DoubleQuery != nil {
 		query.Set("doubleQuery", strconv.FormatFloat(*options.DoubleQuery, 'f', -1, 64))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -694,7 +740,7 @@ func (client *queriesOperations) doubleNullHandleResponse(resp *azcore.Response)
 
 // EnumNull - Get null (no query parameter in url)
 func (client *queriesOperations) EnumNull(ctx context.Context, options *QueriesEnumNullOptions) (*http.Response, error) {
-	req, err := client.enumNullCreateRequest(*client.u, options)
+	req, err := client.enumNullCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -710,15 +756,18 @@ func (client *queriesOperations) EnumNull(ctx context.Context, options *QueriesE
 }
 
 // enumNullCreateRequest creates the EnumNull request.
-func (client *queriesOperations) enumNullCreateRequest(u url.URL, options *QueriesEnumNullOptions) (*azcore.Request, error) {
+func (client *queriesOperations) enumNullCreateRequest(options *QueriesEnumNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/enum/null"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.EnumQuery != nil {
 		query.Set("enumQuery", string(*options.EnumQuery))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -732,7 +781,7 @@ func (client *queriesOperations) enumNullHandleResponse(resp *azcore.Response) (
 
 // EnumValid - Get using uri with query parameter 'green color'
 func (client *queriesOperations) EnumValid(ctx context.Context, options *QueriesEnumValidOptions) (*http.Response, error) {
-	req, err := client.enumValidCreateRequest(*client.u, options)
+	req, err := client.enumValidCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -748,15 +797,18 @@ func (client *queriesOperations) EnumValid(ctx context.Context, options *Queries
 }
 
 // enumValidCreateRequest creates the EnumValid request.
-func (client *queriesOperations) enumValidCreateRequest(u url.URL, options *QueriesEnumValidOptions) (*azcore.Request, error) {
+func (client *queriesOperations) enumValidCreateRequest(options *QueriesEnumValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/enum/green%20color"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.EnumQuery != nil {
 		query.Set("enumQuery", string(*options.EnumQuery))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -770,7 +822,7 @@ func (client *queriesOperations) enumValidHandleResponse(resp *azcore.Response) 
 
 // FloatNull - Get null numeric value (no query parameter)
 func (client *queriesOperations) FloatNull(ctx context.Context, options *QueriesFloatNullOptions) (*http.Response, error) {
-	req, err := client.floatNullCreateRequest(*client.u, options)
+	req, err := client.floatNullCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -786,15 +838,18 @@ func (client *queriesOperations) FloatNull(ctx context.Context, options *Queries
 }
 
 // floatNullCreateRequest creates the FloatNull request.
-func (client *queriesOperations) floatNullCreateRequest(u url.URL, options *QueriesFloatNullOptions) (*azcore.Request, error) {
+func (client *queriesOperations) floatNullCreateRequest(options *QueriesFloatNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/float/null"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.FloatQuery != nil {
 		query.Set("floatQuery", strconv.FormatFloat(float64(*options.FloatQuery), 'f', -1, 32))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -808,7 +863,7 @@ func (client *queriesOperations) floatNullHandleResponse(resp *azcore.Response) 
 
 // FloatScientificNegative - Get '-1.034E-20' numeric value
 func (client *queriesOperations) FloatScientificNegative(ctx context.Context) (*http.Response, error) {
-	req, err := client.floatScientificNegativeCreateRequest(*client.u)
+	req, err := client.floatScientificNegativeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -824,13 +879,16 @@ func (client *queriesOperations) FloatScientificNegative(ctx context.Context) (*
 }
 
 // floatScientificNegativeCreateRequest creates the FloatScientificNegative request.
-func (client *queriesOperations) floatScientificNegativeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) floatScientificNegativeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/float/-1.034E-20"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("floatQuery", "-1.034e-20")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -844,7 +902,7 @@ func (client *queriesOperations) floatScientificNegativeHandleResponse(resp *azc
 
 // FloatScientificPositive - Get '1.034E+20' numeric value
 func (client *queriesOperations) FloatScientificPositive(ctx context.Context) (*http.Response, error) {
-	req, err := client.floatScientificPositiveCreateRequest(*client.u)
+	req, err := client.floatScientificPositiveCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -860,13 +918,16 @@ func (client *queriesOperations) FloatScientificPositive(ctx context.Context) (*
 }
 
 // floatScientificPositiveCreateRequest creates the FloatScientificPositive request.
-func (client *queriesOperations) floatScientificPositiveCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) floatScientificPositiveCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/float/1.034E+20"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("floatQuery", "103400000000000000000")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -880,7 +941,7 @@ func (client *queriesOperations) floatScientificPositiveHandleResponse(resp *azc
 
 // GetBooleanFalse - Get false Boolean value on path
 func (client *queriesOperations) GetBooleanFalse(ctx context.Context) (*http.Response, error) {
-	req, err := client.getBooleanFalseCreateRequest(*client.u)
+	req, err := client.getBooleanFalseCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -896,13 +957,16 @@ func (client *queriesOperations) GetBooleanFalse(ctx context.Context) (*http.Res
 }
 
 // getBooleanFalseCreateRequest creates the GetBooleanFalse request.
-func (client *queriesOperations) getBooleanFalseCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) getBooleanFalseCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/bool/false"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("boolQuery", "false")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -916,7 +980,7 @@ func (client *queriesOperations) getBooleanFalseHandleResponse(resp *azcore.Resp
 
 // GetBooleanNull - Get null Boolean value on query (query string should be absent)
 func (client *queriesOperations) GetBooleanNull(ctx context.Context, options *QueriesGetBooleanNullOptions) (*http.Response, error) {
-	req, err := client.getBooleanNullCreateRequest(*client.u, options)
+	req, err := client.getBooleanNullCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -932,15 +996,18 @@ func (client *queriesOperations) GetBooleanNull(ctx context.Context, options *Qu
 }
 
 // getBooleanNullCreateRequest creates the GetBooleanNull request.
-func (client *queriesOperations) getBooleanNullCreateRequest(u url.URL, options *QueriesGetBooleanNullOptions) (*azcore.Request, error) {
+func (client *queriesOperations) getBooleanNullCreateRequest(options *QueriesGetBooleanNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/bool/null"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.BoolQuery != nil {
 		query.Set("boolQuery", strconv.FormatBool(*options.BoolQuery))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -954,7 +1021,7 @@ func (client *queriesOperations) getBooleanNullHandleResponse(resp *azcore.Respo
 
 // GetBooleanTrue - Get true Boolean value on path
 func (client *queriesOperations) GetBooleanTrue(ctx context.Context) (*http.Response, error) {
-	req, err := client.getBooleanTrueCreateRequest(*client.u)
+	req, err := client.getBooleanTrueCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -970,13 +1037,16 @@ func (client *queriesOperations) GetBooleanTrue(ctx context.Context) (*http.Resp
 }
 
 // getBooleanTrueCreateRequest creates the GetBooleanTrue request.
-func (client *queriesOperations) getBooleanTrueCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) getBooleanTrueCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/bool/true"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("boolQuery", "true")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -990,7 +1060,7 @@ func (client *queriesOperations) getBooleanTrueHandleResponse(resp *azcore.Respo
 
 // GetIntNegativeOneMillion - Get '-1000000' integer value
 func (client *queriesOperations) GetIntNegativeOneMillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.getIntNegativeOneMillionCreateRequest(*client.u)
+	req, err := client.getIntNegativeOneMillionCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -1006,13 +1076,16 @@ func (client *queriesOperations) GetIntNegativeOneMillion(ctx context.Context) (
 }
 
 // getIntNegativeOneMillionCreateRequest creates the GetIntNegativeOneMillion request.
-func (client *queriesOperations) getIntNegativeOneMillionCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) getIntNegativeOneMillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/int/-1000000"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("intQuery", "-1000000")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -1026,7 +1099,7 @@ func (client *queriesOperations) getIntNegativeOneMillionHandleResponse(resp *az
 
 // GetIntNull - Get null integer value (no query parameter)
 func (client *queriesOperations) GetIntNull(ctx context.Context, options *QueriesGetIntNullOptions) (*http.Response, error) {
-	req, err := client.getIntNullCreateRequest(*client.u, options)
+	req, err := client.getIntNullCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -1042,15 +1115,18 @@ func (client *queriesOperations) GetIntNull(ctx context.Context, options *Querie
 }
 
 // getIntNullCreateRequest creates the GetIntNull request.
-func (client *queriesOperations) getIntNullCreateRequest(u url.URL, options *QueriesGetIntNullOptions) (*azcore.Request, error) {
+func (client *queriesOperations) getIntNullCreateRequest(options *QueriesGetIntNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/int/null"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.IntQuery != nil {
 		query.Set("intQuery", strconv.FormatInt(int64(*options.IntQuery), 10))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -1064,7 +1140,7 @@ func (client *queriesOperations) getIntNullHandleResponse(resp *azcore.Response)
 
 // GetIntOneMillion - Get '1000000' integer value
 func (client *queriesOperations) GetIntOneMillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.getIntOneMillionCreateRequest(*client.u)
+	req, err := client.getIntOneMillionCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -1080,13 +1156,16 @@ func (client *queriesOperations) GetIntOneMillion(ctx context.Context) (*http.Re
 }
 
 // getIntOneMillionCreateRequest creates the GetIntOneMillion request.
-func (client *queriesOperations) getIntOneMillionCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) getIntOneMillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/int/1000000"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("intQuery", "1000000")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -1100,7 +1179,7 @@ func (client *queriesOperations) getIntOneMillionHandleResponse(resp *azcore.Res
 
 // GetLongNull - Get 'null 64 bit integer value (no query param in uri)
 func (client *queriesOperations) GetLongNull(ctx context.Context, options *QueriesGetLongNullOptions) (*http.Response, error) {
-	req, err := client.getLongNullCreateRequest(*client.u, options)
+	req, err := client.getLongNullCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -1116,15 +1195,18 @@ func (client *queriesOperations) GetLongNull(ctx context.Context, options *Queri
 }
 
 // getLongNullCreateRequest creates the GetLongNull request.
-func (client *queriesOperations) getLongNullCreateRequest(u url.URL, options *QueriesGetLongNullOptions) (*azcore.Request, error) {
+func (client *queriesOperations) getLongNullCreateRequest(options *QueriesGetLongNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/long/null"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.LongQuery != nil {
 		query.Set("longQuery", strconv.FormatInt(*options.LongQuery, 10))
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -1138,7 +1220,7 @@ func (client *queriesOperations) getLongNullHandleResponse(resp *azcore.Response
 
 // GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
 func (client *queriesOperations) GetNegativeTenBillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.getNegativeTenBillionCreateRequest(*client.u)
+	req, err := client.getNegativeTenBillionCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -1154,13 +1236,16 @@ func (client *queriesOperations) GetNegativeTenBillion(ctx context.Context) (*ht
 }
 
 // getNegativeTenBillionCreateRequest creates the GetNegativeTenBillion request.
-func (client *queriesOperations) getNegativeTenBillionCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) getNegativeTenBillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/long/-10000000000"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("longQuery", "-10000000000")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -1174,7 +1259,7 @@ func (client *queriesOperations) getNegativeTenBillionHandleResponse(resp *azcor
 
 // GetTenBillion - Get '10000000000' 64 bit integer value
 func (client *queriesOperations) GetTenBillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.getTenBillionCreateRequest(*client.u)
+	req, err := client.getTenBillionCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -1190,13 +1275,16 @@ func (client *queriesOperations) GetTenBillion(ctx context.Context) (*http.Respo
 }
 
 // getTenBillionCreateRequest creates the GetTenBillion request.
-func (client *queriesOperations) getTenBillionCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) getTenBillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/long/10000000000"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("longQuery", "10000000000")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -1210,7 +1298,7 @@ func (client *queriesOperations) getTenBillionHandleResponse(resp *azcore.Respon
 
 // StringEmpty - Get ''
 func (client *queriesOperations) StringEmpty(ctx context.Context) (*http.Response, error) {
-	req, err := client.stringEmptyCreateRequest(*client.u)
+	req, err := client.stringEmptyCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -1226,13 +1314,16 @@ func (client *queriesOperations) StringEmpty(ctx context.Context) (*http.Respons
 }
 
 // stringEmptyCreateRequest creates the StringEmpty request.
-func (client *queriesOperations) stringEmptyCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) stringEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/string/empty"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("stringQuery", "")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -1246,7 +1337,7 @@ func (client *queriesOperations) stringEmptyHandleResponse(resp *azcore.Response
 
 // StringNull - Get null (no query parameter in url)
 func (client *queriesOperations) StringNull(ctx context.Context, options *QueriesStringNullOptions) (*http.Response, error) {
-	req, err := client.stringNullCreateRequest(*client.u, options)
+	req, err := client.stringNullCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -1262,15 +1353,18 @@ func (client *queriesOperations) StringNull(ctx context.Context, options *Querie
 }
 
 // stringNullCreateRequest creates the StringNull request.
-func (client *queriesOperations) stringNullCreateRequest(u url.URL, options *QueriesStringNullOptions) (*azcore.Request, error) {
+func (client *queriesOperations) stringNullCreateRequest(options *QueriesStringNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/string/null"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if options != nil && options.StringQuery != nil {
 		query.Set("stringQuery", *options.StringQuery)
 	}
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -1284,7 +1378,7 @@ func (client *queriesOperations) stringNullHandleResponse(resp *azcore.Response)
 
 // StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
 func (client *queriesOperations) StringURLEncoded(ctx context.Context) (*http.Response, error) {
-	req, err := client.stringUrlEncodedCreateRequest(*client.u)
+	req, err := client.stringUrlEncodedCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -1300,13 +1394,16 @@ func (client *queriesOperations) StringURLEncoded(ctx context.Context) (*http.Re
 }
 
 // stringUrlEncodedCreateRequest creates the StringURLEncoded request.
-func (client *queriesOperations) stringUrlEncodedCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) stringUrlEncodedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("stringQuery", "begin!*'();:@ &=+$,/?#[]end")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -1320,7 +1417,7 @@ func (client *queriesOperations) stringUrlEncodedHandleResponse(resp *azcore.Res
 
 // StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
 func (client *queriesOperations) StringUnicode(ctx context.Context) (*http.Response, error) {
-	req, err := client.stringUnicodeCreateRequest(*client.u)
+	req, err := client.stringUnicodeCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -1336,13 +1433,16 @@ func (client *queriesOperations) StringUnicode(ctx context.Context) (*http.Respo
 }
 
 // stringUnicodeCreateRequest creates the StringUnicode request.
-func (client *queriesOperations) stringUnicodeCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *queriesOperations) stringUnicodeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/string/unicode/"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("stringQuery", "啊齄丂狛狜隣郎隣兀﨩")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 

--- a/test/autorest/generated/xmlgroup/client.go
+++ b/test/autorest/generated/xmlgroup/client.go
@@ -6,6 +6,7 @@
 package xmlgroup
 
 import (
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
 )
@@ -62,6 +63,9 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
+	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
 	return &Client{u: u, p: p}, nil
 }

--- a/test/autorest/generated/xmlgroup/xml.go
+++ b/test/autorest/generated/xmlgroup/xml.go
@@ -11,8 +11,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"net/url"
-	"path"
 )
 
 // XMLOperations contains the methods for the XML group.
@@ -84,7 +82,7 @@ type xmlOperations struct {
 
 // GetACLs - Gets storage ACLs for a container.
 func (client *xmlOperations) GetACLs(ctx context.Context) (*SignedIDentifierArrayResponse, error) {
-	req, err := client.getAcLsCreateRequest(*client.u)
+	req, err := client.getAcLsCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -100,14 +98,17 @@ func (client *xmlOperations) GetACLs(ctx context.Context) (*SignedIDentifierArra
 }
 
 // getAcLsCreateRequest creates the GetACLs request.
-func (client *xmlOperations) getAcLsCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) getAcLsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/mycontainer"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "acl")
 	query.Set("restype", "container")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -122,7 +123,7 @@ func (client *xmlOperations) getAcLsHandleResponse(resp *azcore.Response) (*Sign
 
 // GetComplexTypeRefNoMeta - Get a complex type that has a ref to a complex type with no XML node
 func (client *xmlOperations) GetComplexTypeRefNoMeta(ctx context.Context) (*RootWithRefAndNoMetaResponse, error) {
-	req, err := client.getComplexTypeRefNoMetaCreateRequest(*client.u)
+	req, err := client.getComplexTypeRefNoMetaCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -138,10 +139,13 @@ func (client *xmlOperations) GetComplexTypeRefNoMeta(ctx context.Context) (*Root
 }
 
 // getComplexTypeRefNoMetaCreateRequest creates the GetComplexTypeRefNoMeta request.
-func (client *xmlOperations) getComplexTypeRefNoMetaCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) getComplexTypeRefNoMetaCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/complex-type-ref-no-meta"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -156,7 +160,7 @@ func (client *xmlOperations) getComplexTypeRefNoMetaHandleResponse(resp *azcore.
 
 // GetComplexTypeRefWithMeta - Get a complex type that has a ref to a complex type with XML node
 func (client *xmlOperations) GetComplexTypeRefWithMeta(ctx context.Context) (*RootWithRefAndMetaResponse, error) {
-	req, err := client.getComplexTypeRefWithMetaCreateRequest(*client.u)
+	req, err := client.getComplexTypeRefWithMetaCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -172,10 +176,13 @@ func (client *xmlOperations) GetComplexTypeRefWithMeta(ctx context.Context) (*Ro
 }
 
 // getComplexTypeRefWithMetaCreateRequest creates the GetComplexTypeRefWithMeta request.
-func (client *xmlOperations) getComplexTypeRefWithMetaCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) getComplexTypeRefWithMetaCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/complex-type-ref-with-meta"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -190,7 +197,7 @@ func (client *xmlOperations) getComplexTypeRefWithMetaHandleResponse(resp *azcor
 
 // GetEmptyChildElement - Gets an XML document with an empty child element.
 func (client *xmlOperations) GetEmptyChildElement(ctx context.Context) (*BananaResponse, error) {
-	req, err := client.getEmptyChildElementCreateRequest(*client.u)
+	req, err := client.getEmptyChildElementCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -206,10 +213,13 @@ func (client *xmlOperations) GetEmptyChildElement(ctx context.Context) (*BananaR
 }
 
 // getEmptyChildElementCreateRequest creates the GetEmptyChildElement request.
-func (client *xmlOperations) getEmptyChildElementCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) getEmptyChildElementCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/empty-child-element"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -224,7 +234,7 @@ func (client *xmlOperations) getEmptyChildElementHandleResponse(resp *azcore.Res
 
 // GetEmptyList - Get an empty list.
 func (client *xmlOperations) GetEmptyList(ctx context.Context) (*SlideshowResponse, error) {
-	req, err := client.getEmptyListCreateRequest(*client.u)
+	req, err := client.getEmptyListCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -240,10 +250,13 @@ func (client *xmlOperations) GetEmptyList(ctx context.Context) (*SlideshowRespon
 }
 
 // getEmptyListCreateRequest creates the GetEmptyList request.
-func (client *xmlOperations) getEmptyListCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) getEmptyListCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/empty-list"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -258,7 +271,7 @@ func (client *xmlOperations) getEmptyListHandleResponse(resp *azcore.Response) (
 
 // GetEmptyRootList - Gets an empty list as the root element.
 func (client *xmlOperations) GetEmptyRootList(ctx context.Context) (*BananaArrayResponse, error) {
-	req, err := client.getEmptyRootListCreateRequest(*client.u)
+	req, err := client.getEmptyRootListCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -274,10 +287,13 @@ func (client *xmlOperations) GetEmptyRootList(ctx context.Context) (*BananaArray
 }
 
 // getEmptyRootListCreateRequest creates the GetEmptyRootList request.
-func (client *xmlOperations) getEmptyRootListCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) getEmptyRootListCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/empty-root-list"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -292,7 +308,7 @@ func (client *xmlOperations) getEmptyRootListHandleResponse(resp *azcore.Respons
 
 // GetEmptyWrappedLists - Gets some empty wrapped lists.
 func (client *xmlOperations) GetEmptyWrappedLists(ctx context.Context) (*AppleBarrelResponse, error) {
-	req, err := client.getEmptyWrappedListsCreateRequest(*client.u)
+	req, err := client.getEmptyWrappedListsCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -308,10 +324,13 @@ func (client *xmlOperations) GetEmptyWrappedLists(ctx context.Context) (*AppleBa
 }
 
 // getEmptyWrappedListsCreateRequest creates the GetEmptyWrappedLists request.
-func (client *xmlOperations) getEmptyWrappedListsCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) getEmptyWrappedListsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/empty-wrapped-lists"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -326,7 +345,7 @@ func (client *xmlOperations) getEmptyWrappedListsHandleResponse(resp *azcore.Res
 
 // GetHeaders - Get strongly-typed response headers.
 func (client *xmlOperations) GetHeaders(ctx context.Context) (*XMLGetHeadersResponse, error) {
-	req, err := client.getHeadersCreateRequest(*client.u)
+	req, err := client.getHeadersCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -342,10 +361,13 @@ func (client *xmlOperations) GetHeaders(ctx context.Context) (*XMLGetHeadersResp
 }
 
 // getHeadersCreateRequest creates the GetHeaders request.
-func (client *xmlOperations) getHeadersCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) getHeadersCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/headers"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -362,7 +384,7 @@ func (client *xmlOperations) getHeadersHandleResponse(resp *azcore.Response) (*X
 
 // GetRootList - Gets a list as the root element.
 func (client *xmlOperations) GetRootList(ctx context.Context) (*BananaArrayResponse, error) {
-	req, err := client.getRootListCreateRequest(*client.u)
+	req, err := client.getRootListCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -378,10 +400,13 @@ func (client *xmlOperations) GetRootList(ctx context.Context) (*BananaArrayRespo
 }
 
 // getRootListCreateRequest creates the GetRootList request.
-func (client *xmlOperations) getRootListCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) getRootListCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/root-list"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -396,7 +421,7 @@ func (client *xmlOperations) getRootListHandleResponse(resp *azcore.Response) (*
 
 // GetRootListSingleItem - Gets a list with a single item.
 func (client *xmlOperations) GetRootListSingleItem(ctx context.Context) (*BananaArrayResponse, error) {
-	req, err := client.getRootListSingleItemCreateRequest(*client.u)
+	req, err := client.getRootListSingleItemCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -412,10 +437,13 @@ func (client *xmlOperations) GetRootListSingleItem(ctx context.Context) (*Banana
 }
 
 // getRootListSingleItemCreateRequest creates the GetRootListSingleItem request.
-func (client *xmlOperations) getRootListSingleItemCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) getRootListSingleItemCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/root-list-single-item"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -430,7 +458,7 @@ func (client *xmlOperations) getRootListSingleItemHandleResponse(resp *azcore.Re
 
 // GetServiceProperties - Gets storage service properties.
 func (client *xmlOperations) GetServiceProperties(ctx context.Context) (*StorageServicePropertiesResponse, error) {
-	req, err := client.getServicePropertiesCreateRequest(*client.u)
+	req, err := client.getServicePropertiesCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -446,14 +474,17 @@ func (client *xmlOperations) GetServiceProperties(ctx context.Context) (*Storage
 }
 
 // getServicePropertiesCreateRequest creates the GetServiceProperties request.
-func (client *xmlOperations) getServicePropertiesCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) getServicePropertiesCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "properties")
 	query.Set("restype", "service")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -468,7 +499,7 @@ func (client *xmlOperations) getServicePropertiesHandleResponse(resp *azcore.Res
 
 // GetSimple - Get a simple XML document
 func (client *xmlOperations) GetSimple(ctx context.Context) (*SlideshowResponse, error) {
-	req, err := client.getSimpleCreateRequest(*client.u)
+	req, err := client.getSimpleCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -484,10 +515,13 @@ func (client *xmlOperations) GetSimple(ctx context.Context) (*SlideshowResponse,
 }
 
 // getSimpleCreateRequest creates the GetSimple request.
-func (client *xmlOperations) getSimpleCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) getSimpleCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/simple"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -502,7 +536,7 @@ func (client *xmlOperations) getSimpleHandleResponse(resp *azcore.Response) (*Sl
 
 // GetWrappedLists - Get an XML document with multiple wrapped lists
 func (client *xmlOperations) GetWrappedLists(ctx context.Context) (*AppleBarrelResponse, error) {
-	req, err := client.getWrappedListsCreateRequest(*client.u)
+	req, err := client.getWrappedListsCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -518,10 +552,13 @@ func (client *xmlOperations) GetWrappedLists(ctx context.Context) (*AppleBarrelR
 }
 
 // getWrappedListsCreateRequest creates the GetWrappedLists request.
-func (client *xmlOperations) getWrappedListsCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) getWrappedListsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/wrapped-lists"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -536,7 +573,7 @@ func (client *xmlOperations) getWrappedListsHandleResponse(resp *azcore.Response
 
 // JSONInput - A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42
 func (client *xmlOperations) JSONInput(ctx context.Context, properties JSONInput) (*http.Response, error) {
-	req, err := client.jsonInputCreateRequest(*client.u, properties)
+	req, err := client.jsonInputCreateRequest(properties)
 	if err != nil {
 		return nil, err
 	}
@@ -552,11 +589,14 @@ func (client *xmlOperations) JSONInput(ctx context.Context, properties JSONInput
 }
 
 // jsonInputCreateRequest creates the JSONInput request.
-func (client *xmlOperations) jsonInputCreateRequest(u url.URL, properties JSONInput) (*azcore.Request, error) {
+func (client *xmlOperations) jsonInputCreateRequest(properties JSONInput) (*azcore.Request, error) {
 	urlPath := "/xml/jsoninput"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsJSON(properties)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsJSON(properties)
 	if err != nil {
 		return nil, err
 	}
@@ -573,7 +613,7 @@ func (client *xmlOperations) jsonInputHandleResponse(resp *azcore.Response) (*ht
 
 // JSONOutput - A Swagger with XML that has one operation that returns JSON. ID number 42
 func (client *xmlOperations) JSONOutput(ctx context.Context) (*JSONOutputResponse, error) {
-	req, err := client.jsonOutputCreateRequest(*client.u)
+	req, err := client.jsonOutputCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -589,10 +629,13 @@ func (client *xmlOperations) JSONOutput(ctx context.Context) (*JSONOutputRespons
 }
 
 // jsonOutputCreateRequest creates the JSONOutput request.
-func (client *xmlOperations) jsonOutputCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) jsonOutputCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/jsonoutput"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodGet, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -607,7 +650,7 @@ func (client *xmlOperations) jsonOutputHandleResponse(resp *azcore.Response) (*J
 
 // ListBlobs - Lists blobs in a storage container.
 func (client *xmlOperations) ListBlobs(ctx context.Context) (*ListBlobsResponseResponse, error) {
-	req, err := client.listBlobsCreateRequest(*client.u)
+	req, err := client.listBlobsCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -623,14 +666,17 @@ func (client *xmlOperations) ListBlobs(ctx context.Context) (*ListBlobsResponseR
 }
 
 // listBlobsCreateRequest creates the ListBlobs request.
-func (client *xmlOperations) listBlobsCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) listBlobsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/mycontainer"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "list")
 	query.Set("restype", "container")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -645,7 +691,7 @@ func (client *xmlOperations) listBlobsHandleResponse(resp *azcore.Response) (*Li
 
 // ListContainers - Lists containers in a storage account.
 func (client *xmlOperations) ListContainers(ctx context.Context) (*ListContainersResponseResponse, error) {
-	req, err := client.listContainersCreateRequest(*client.u)
+	req, err := client.listContainersCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -661,13 +707,16 @@ func (client *xmlOperations) ListContainers(ctx context.Context) (*ListContainer
 }
 
 // listContainersCreateRequest creates the ListContainers request.
-func (client *xmlOperations) listContainersCreateRequest(u url.URL) (*azcore.Request, error) {
+func (client *xmlOperations) listContainersCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "list")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodGet, u)
+	req := azcore.NewRequest(http.MethodGet, *u)
 	return req, nil
 }
 
@@ -682,7 +731,7 @@ func (client *xmlOperations) listContainersHandleResponse(resp *azcore.Response)
 
 // PutACLs - Puts storage ACLs for a container.
 func (client *xmlOperations) PutACLs(ctx context.Context, properties []SignedIDentifier) (*http.Response, error) {
-	req, err := client.putAcLsCreateRequest(*client.u, properties)
+	req, err := client.putAcLsCreateRequest(properties)
 	if err != nil {
 		return nil, err
 	}
@@ -698,19 +747,22 @@ func (client *xmlOperations) PutACLs(ctx context.Context, properties []SignedIDe
 }
 
 // putAcLsCreateRequest creates the PutACLs request.
-func (client *xmlOperations) putAcLsCreateRequest(u url.URL, properties []SignedIDentifier) (*azcore.Request, error) {
+func (client *xmlOperations) putAcLsCreateRequest(properties []SignedIDentifier) (*azcore.Request, error) {
 	urlPath := "/xml/mycontainer"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "acl")
 	query.Set("restype", "container")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodPut, u)
+	req := azcore.NewRequest(http.MethodPut, *u)
 	type wrapper struct {
 		XMLName    xml.Name            `xml:"SignedIdentifiers"`
 		Properties *[]SignedIDentifier `xml:"SignedIdentifier"`
 	}
-	err := req.MarshalAsXML(wrapper{Properties: &properties})
+	err = req.MarshalAsXML(wrapper{Properties: &properties})
 	if err != nil {
 		return nil, err
 	}
@@ -727,7 +779,7 @@ func (client *xmlOperations) putAcLsHandleResponse(resp *azcore.Response) (*http
 
 // PutComplexTypeRefNoMeta - Puts a complex type that has a ref to a complex type with no XML node
 func (client *xmlOperations) PutComplexTypeRefNoMeta(ctx context.Context, model RootWithRefAndNoMeta) (*http.Response, error) {
-	req, err := client.putComplexTypeRefNoMetaCreateRequest(*client.u, model)
+	req, err := client.putComplexTypeRefNoMetaCreateRequest(model)
 	if err != nil {
 		return nil, err
 	}
@@ -743,11 +795,14 @@ func (client *xmlOperations) PutComplexTypeRefNoMeta(ctx context.Context, model 
 }
 
 // putComplexTypeRefNoMetaCreateRequest creates the PutComplexTypeRefNoMeta request.
-func (client *xmlOperations) putComplexTypeRefNoMetaCreateRequest(u url.URL, model RootWithRefAndNoMeta) (*azcore.Request, error) {
+func (client *xmlOperations) putComplexTypeRefNoMetaCreateRequest(model RootWithRefAndNoMeta) (*azcore.Request, error) {
 	urlPath := "/xml/complex-type-ref-no-meta"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsXML(model)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsXML(model)
 	if err != nil {
 		return nil, err
 	}
@@ -764,7 +819,7 @@ func (client *xmlOperations) putComplexTypeRefNoMetaHandleResponse(resp *azcore.
 
 // PutComplexTypeRefWithMeta - Puts a complex type that has a ref to a complex type with XML node
 func (client *xmlOperations) PutComplexTypeRefWithMeta(ctx context.Context, model RootWithRefAndMeta) (*http.Response, error) {
-	req, err := client.putComplexTypeRefWithMetaCreateRequest(*client.u, model)
+	req, err := client.putComplexTypeRefWithMetaCreateRequest(model)
 	if err != nil {
 		return nil, err
 	}
@@ -780,11 +835,14 @@ func (client *xmlOperations) PutComplexTypeRefWithMeta(ctx context.Context, mode
 }
 
 // putComplexTypeRefWithMetaCreateRequest creates the PutComplexTypeRefWithMeta request.
-func (client *xmlOperations) putComplexTypeRefWithMetaCreateRequest(u url.URL, model RootWithRefAndMeta) (*azcore.Request, error) {
+func (client *xmlOperations) putComplexTypeRefWithMetaCreateRequest(model RootWithRefAndMeta) (*azcore.Request, error) {
 	urlPath := "/xml/complex-type-ref-with-meta"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsXML(model)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsXML(model)
 	if err != nil {
 		return nil, err
 	}
@@ -801,7 +859,7 @@ func (client *xmlOperations) putComplexTypeRefWithMetaHandleResponse(resp *azcor
 
 // PutEmptyChildElement - Puts a value with an empty child element.
 func (client *xmlOperations) PutEmptyChildElement(ctx context.Context, banana Banana) (*http.Response, error) {
-	req, err := client.putEmptyChildElementCreateRequest(*client.u, banana)
+	req, err := client.putEmptyChildElementCreateRequest(banana)
 	if err != nil {
 		return nil, err
 	}
@@ -817,11 +875,14 @@ func (client *xmlOperations) PutEmptyChildElement(ctx context.Context, banana Ba
 }
 
 // putEmptyChildElementCreateRequest creates the PutEmptyChildElement request.
-func (client *xmlOperations) putEmptyChildElementCreateRequest(u url.URL, banana Banana) (*azcore.Request, error) {
+func (client *xmlOperations) putEmptyChildElementCreateRequest(banana Banana) (*azcore.Request, error) {
 	urlPath := "/xml/empty-child-element"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsXML(banana)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsXML(banana)
 	if err != nil {
 		return nil, err
 	}
@@ -838,7 +899,7 @@ func (client *xmlOperations) putEmptyChildElementHandleResponse(resp *azcore.Res
 
 // PutEmptyList - Puts an empty list.
 func (client *xmlOperations) PutEmptyList(ctx context.Context, slideshow Slideshow) (*http.Response, error) {
-	req, err := client.putEmptyListCreateRequest(*client.u, slideshow)
+	req, err := client.putEmptyListCreateRequest(slideshow)
 	if err != nil {
 		return nil, err
 	}
@@ -854,11 +915,14 @@ func (client *xmlOperations) PutEmptyList(ctx context.Context, slideshow Slidesh
 }
 
 // putEmptyListCreateRequest creates the PutEmptyList request.
-func (client *xmlOperations) putEmptyListCreateRequest(u url.URL, slideshow Slideshow) (*azcore.Request, error) {
+func (client *xmlOperations) putEmptyListCreateRequest(slideshow Slideshow) (*azcore.Request, error) {
 	urlPath := "/xml/empty-list"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsXML(slideshow)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsXML(slideshow)
 	if err != nil {
 		return nil, err
 	}
@@ -875,7 +939,7 @@ func (client *xmlOperations) putEmptyListHandleResponse(resp *azcore.Response) (
 
 // PutEmptyRootList - Puts an empty list as the root element.
 func (client *xmlOperations) PutEmptyRootList(ctx context.Context, bananas []Banana) (*http.Response, error) {
-	req, err := client.putEmptyRootListCreateRequest(*client.u, bananas)
+	req, err := client.putEmptyRootListCreateRequest(bananas)
 	if err != nil {
 		return nil, err
 	}
@@ -891,15 +955,18 @@ func (client *xmlOperations) PutEmptyRootList(ctx context.Context, bananas []Ban
 }
 
 // putEmptyRootListCreateRequest creates the PutEmptyRootList request.
-func (client *xmlOperations) putEmptyRootListCreateRequest(u url.URL, bananas []Banana) (*azcore.Request, error) {
+func (client *xmlOperations) putEmptyRootListCreateRequest(bananas []Banana) (*azcore.Request, error) {
 	urlPath := "/xml/empty-root-list"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
 	type wrapper struct {
 		XMLName xml.Name  `xml:"bananas"`
 		Bananas *[]Banana `xml:"banana"`
 	}
-	err := req.MarshalAsXML(wrapper{Bananas: &bananas})
+	err = req.MarshalAsXML(wrapper{Bananas: &bananas})
 	if err != nil {
 		return nil, err
 	}
@@ -916,7 +983,7 @@ func (client *xmlOperations) putEmptyRootListHandleResponse(resp *azcore.Respons
 
 // PutEmptyWrappedLists - Puts some empty wrapped lists.
 func (client *xmlOperations) PutEmptyWrappedLists(ctx context.Context, appleBarrel AppleBarrel) (*http.Response, error) {
-	req, err := client.putEmptyWrappedListsCreateRequest(*client.u, appleBarrel)
+	req, err := client.putEmptyWrappedListsCreateRequest(appleBarrel)
 	if err != nil {
 		return nil, err
 	}
@@ -932,11 +999,14 @@ func (client *xmlOperations) PutEmptyWrappedLists(ctx context.Context, appleBarr
 }
 
 // putEmptyWrappedListsCreateRequest creates the PutEmptyWrappedLists request.
-func (client *xmlOperations) putEmptyWrappedListsCreateRequest(u url.URL, appleBarrel AppleBarrel) (*azcore.Request, error) {
+func (client *xmlOperations) putEmptyWrappedListsCreateRequest(appleBarrel AppleBarrel) (*azcore.Request, error) {
 	urlPath := "/xml/empty-wrapped-lists"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsXML(appleBarrel)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsXML(appleBarrel)
 	if err != nil {
 		return nil, err
 	}
@@ -953,7 +1023,7 @@ func (client *xmlOperations) putEmptyWrappedListsHandleResponse(resp *azcore.Res
 
 // PutRootList - Puts a list as the root element.
 func (client *xmlOperations) PutRootList(ctx context.Context, bananas []Banana) (*http.Response, error) {
-	req, err := client.putRootListCreateRequest(*client.u, bananas)
+	req, err := client.putRootListCreateRequest(bananas)
 	if err != nil {
 		return nil, err
 	}
@@ -969,15 +1039,18 @@ func (client *xmlOperations) PutRootList(ctx context.Context, bananas []Banana) 
 }
 
 // putRootListCreateRequest creates the PutRootList request.
-func (client *xmlOperations) putRootListCreateRequest(u url.URL, bananas []Banana) (*azcore.Request, error) {
+func (client *xmlOperations) putRootListCreateRequest(bananas []Banana) (*azcore.Request, error) {
 	urlPath := "/xml/root-list"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
 	type wrapper struct {
 		XMLName xml.Name  `xml:"bananas"`
 		Bananas *[]Banana `xml:"banana"`
 	}
-	err := req.MarshalAsXML(wrapper{Bananas: &bananas})
+	err = req.MarshalAsXML(wrapper{Bananas: &bananas})
 	if err != nil {
 		return nil, err
 	}
@@ -994,7 +1067,7 @@ func (client *xmlOperations) putRootListHandleResponse(resp *azcore.Response) (*
 
 // PutRootListSingleItem - Puts a list with a single item.
 func (client *xmlOperations) PutRootListSingleItem(ctx context.Context, bananas []Banana) (*http.Response, error) {
-	req, err := client.putRootListSingleItemCreateRequest(*client.u, bananas)
+	req, err := client.putRootListSingleItemCreateRequest(bananas)
 	if err != nil {
 		return nil, err
 	}
@@ -1010,15 +1083,18 @@ func (client *xmlOperations) PutRootListSingleItem(ctx context.Context, bananas 
 }
 
 // putRootListSingleItemCreateRequest creates the PutRootListSingleItem request.
-func (client *xmlOperations) putRootListSingleItemCreateRequest(u url.URL, bananas []Banana) (*azcore.Request, error) {
+func (client *xmlOperations) putRootListSingleItemCreateRequest(bananas []Banana) (*azcore.Request, error) {
 	urlPath := "/xml/root-list-single-item"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
 	type wrapper struct {
 		XMLName xml.Name  `xml:"bananas"`
 		Bananas *[]Banana `xml:"banana"`
 	}
-	err := req.MarshalAsXML(wrapper{Bananas: &bananas})
+	err = req.MarshalAsXML(wrapper{Bananas: &bananas})
 	if err != nil {
 		return nil, err
 	}
@@ -1035,7 +1111,7 @@ func (client *xmlOperations) putRootListSingleItemHandleResponse(resp *azcore.Re
 
 // PutServiceProperties - Puts storage service properties.
 func (client *xmlOperations) PutServiceProperties(ctx context.Context, properties StorageServiceProperties) (*http.Response, error) {
-	req, err := client.putServicePropertiesCreateRequest(*client.u, properties)
+	req, err := client.putServicePropertiesCreateRequest(properties)
 	if err != nil {
 		return nil, err
 	}
@@ -1051,15 +1127,18 @@ func (client *xmlOperations) PutServiceProperties(ctx context.Context, propertie
 }
 
 // putServicePropertiesCreateRequest creates the PutServiceProperties request.
-func (client *xmlOperations) putServicePropertiesCreateRequest(u url.URL, properties StorageServiceProperties) (*azcore.Request, error) {
+func (client *xmlOperations) putServicePropertiesCreateRequest(properties StorageServiceProperties) (*azcore.Request, error) {
 	urlPath := "/xml/"
-	u.Path = path.Join(u.Path, urlPath)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "properties")
 	query.Set("restype", "service")
 	u.RawQuery = query.Encode()
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsXML(properties)
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsXML(properties)
 	if err != nil {
 		return nil, err
 	}
@@ -1076,7 +1155,7 @@ func (client *xmlOperations) putServicePropertiesHandleResponse(resp *azcore.Res
 
 // PutSimple - Put a simple XML document
 func (client *xmlOperations) PutSimple(ctx context.Context, slideshow Slideshow) (*http.Response, error) {
-	req, err := client.putSimpleCreateRequest(*client.u, slideshow)
+	req, err := client.putSimpleCreateRequest(slideshow)
 	if err != nil {
 		return nil, err
 	}
@@ -1092,11 +1171,14 @@ func (client *xmlOperations) PutSimple(ctx context.Context, slideshow Slideshow)
 }
 
 // putSimpleCreateRequest creates the PutSimple request.
-func (client *xmlOperations) putSimpleCreateRequest(u url.URL, slideshow Slideshow) (*azcore.Request, error) {
+func (client *xmlOperations) putSimpleCreateRequest(slideshow Slideshow) (*azcore.Request, error) {
 	urlPath := "/xml/simple"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsXML(slideshow)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsXML(slideshow)
 	if err != nil {
 		return nil, err
 	}
@@ -1113,7 +1195,7 @@ func (client *xmlOperations) putSimpleHandleResponse(resp *azcore.Response) (*ht
 
 // PutWrappedLists - Put an XML document with multiple wrapped lists
 func (client *xmlOperations) PutWrappedLists(ctx context.Context, wrappedLists AppleBarrel) (*http.Response, error) {
-	req, err := client.putWrappedListsCreateRequest(*client.u, wrappedLists)
+	req, err := client.putWrappedListsCreateRequest(wrappedLists)
 	if err != nil {
 		return nil, err
 	}
@@ -1129,11 +1211,14 @@ func (client *xmlOperations) PutWrappedLists(ctx context.Context, wrappedLists A
 }
 
 // putWrappedListsCreateRequest creates the PutWrappedLists request.
-func (client *xmlOperations) putWrappedListsCreateRequest(u url.URL, wrappedLists AppleBarrel) (*azcore.Request, error) {
+func (client *xmlOperations) putWrappedListsCreateRequest(wrappedLists AppleBarrel) (*azcore.Request, error) {
 	urlPath := "/xml/wrapped-lists"
-	u.Path = path.Join(u.Path, urlPath)
-	req := azcore.NewRequest(http.MethodPut, u)
-	err := req.MarshalAsXML(wrappedLists)
+	u, err := client.u.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req := azcore.NewRequest(http.MethodPut, *u)
+	err = req.MarshalAsXML(wrappedLists)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The base URL is on the client so it's no longer required as a parameter.
Verify that the parsed base URL has a scheme.
Skip URL-encoding of path params in presense of x-ms-skip-url-encoding.
Build the complete URL by calling the Parse() method on the base URL
and passing in the relative path.