### PR TITLE
Workaround for non-required constants

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -397,6 +397,7 @@ function createProtocolRequest(client: string, op: Operation, imports: ImportMan
         text += `\tquery.Set("${qp.language.go!.serializedName}", ${formatParamValue(qp, imports)})\n`;
       } else if (qp.schema.type === SchemaType.Constant) {
         // omit this query param. TODO once non-required constants are fixed
+        console.warn(`omitting non-required constant query parameter ${qp.language.go!.serializedName}`);
       } else if (qp.implementation === ImplementationLocation.Client) {
         // global optional param
         text += `\tif ${qp.language.go!.name} != nil {\n`;
@@ -422,6 +423,7 @@ function createProtocolRequest(client: string, op: Operation, imports: ImportMan
       text += `\treq.Header.Set("${header.language.go!.serializedName}", ${formatParamValue(header, imports)})\n`;
     } else if (header.schema.type === SchemaType.Constant) {
       // omit this header. TODO once non-required constants are fixed
+      console.warn(`omitting non-required constant header ${header.language.go!.serializedName}`);
     } else {
       text += `\tif options != nil && options.${pascalCase(header.language.go!.name)} != nil {\n`;
       text += `\t\treq.Header.Set("${header.language.go!.serializedName}", ${formatParamValue(header, imports)})\n`;

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -395,6 +395,8 @@ function createProtocolRequest(client: string, op: Operation, imports: ImportMan
     for (const qp of values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http!.in === 'query'; })) {
       if (qp.required === true) {
         text += `\tquery.Set("${qp.language.go!.serializedName}", ${formatParamValue(qp, imports)})\n`;
+      } else if (qp.schema.type === SchemaType.Constant) {
+        // omit this query param. TODO once non-required constants are fixed
       } else if (qp.implementation === ImplementationLocation.Client) {
         // global optional param
         text += `\tif ${qp.language.go!.name} != nil {\n`;
@@ -418,6 +420,8 @@ function createProtocolRequest(client: string, op: Operation, imports: ImportMan
   headerParam.forEach(header => {
     if (header.required) {
       text += `\treq.Header.Set("${header.language.go!.serializedName}", ${formatParamValue(header, imports)})\n`;
+    } else if (header.schema.type === SchemaType.Constant) {
+      // omit this header. TODO once non-required constants are fixed
     } else {
       text += `\tif options != nil && options.${pascalCase(header.language.go!.name)} != nil {\n`;
       text += `\t\treq.Header.Set("${header.language.go!.serializedName}", ${formatParamValue(header, imports)})\n`;

--- a/src/namer/namer.ts
+++ b/src/namer/namer.ts
@@ -97,6 +97,7 @@ async function process(session: Session<CodeModel>) {
         paramDetails.name = getEscapedReservedName(removePrefix(camelCase(paramDetails.name), 'XMS'), 'Parameter');
         // this is a bit of a weird case and might be due to invalid swagger in the test
         // server.  how can you have an optional parameter that's also a constant?
+        // TODO once non-required constants are fixed
         if (param.required !== true && param.schema.type !== SchemaType.Constant && !(param.schema.type === SchemaType.SealedChoice && (<SealedChoiceSchema>param.schema).choices.length === 1)) {
           optionalParams.push(param);
         }


### PR DESCRIPTION
Omit non-required constants from codegen for now.