### PR TITLE
Fix publishing of autorest test server coverage

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -83,7 +83,9 @@ jobs:
           testResultsFiles: $(goTestPath)/report.xml
           failTaskOnFailedTests: true
 
-      - script: |
-          npm run coverage-push -- $(Build.Repository.Name) $(Build.SourceBranch) $(github-token) $(storage-coverage-user) $(storage-coverage-pass)
+      - pwsh: |
+          $currentVersion = node -p -e "require('./src/package.json').version";
+          $currentVersion="$currentVersion-$(Build.BuildNumber)";
+          cd src/node_modules/@microsoft.azure/autorest.testserver;
+          npm run coverage-push -- $(Build.Repository.Name) $(Build.SourceBranch) $(github-token) $(storage-coverage-user) $(storage-coverage-pass) $currentVersion;
         displayName: 'Publish AutoRest Test Server Coverage Report'
-        workingDirectory: src/node_modules/@microsoft.azure/autorest.testserver

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -83,9 +83,10 @@ jobs:
           testResultsFiles: $(goTestPath)/report.xml
           failTaskOnFailedTests: true
 
-      - pwsh: |
-          $currentVersion = node -p -e "require('./src/package.json').version";
-          $currentVersion="$currentVersion-$(Build.BuildNumber)";
-          cd src/node_modules/@microsoft.azure/autorest.testserver;
-          npm run coverage-push -- $(Build.Repository.Name) $(Build.SourceBranch) $(github-token) $(storage-coverage-user) $(storage-coverage-pass) $currentVersion;
-        displayName: 'Publish AutoRest Test Server Coverage Report'
+      - ${{if ne(variables['Build.Reason'], 'PullRequest')}}:
+        - pwsh: |
+            $currentVersion = node -p -e "require('./src/package.json').version";
+            $currentVersion="$currentVersion-$(Build.BuildNumber)";
+            cd src/node_modules/@microsoft.azure/autorest.testserver;
+            npm run coverage-push -- $(Build.Repository.Name) $(Build.SourceBranch) $(github-token) $(storage-coverage-user) $(storage-coverage-pass) $currentVersion;
+          displayName: 'Publish AutoRest Test Server Coverage Report'

--- a/src/package.json
+++ b/src/package.json
@@ -51,7 +51,7 @@
     "typescript": "~3.7.2",
     "@typescript-eslint/eslint-plugin": "~2.6.0",
     "@typescript-eslint/parser": "~2.6.0",
-    "@microsoft.azure/autorest.testserver": "2.10.17",
+    "@microsoft.azure/autorest.testserver": "2.10.19",
     "@autorest/autorest": "~3.0.6173",
     "eslint": "~6.6.0",
     "@azure-tools/codegen": "~2.1.0",

--- a/test/autorest/generated/stringgroup/string.go
+++ b/test/autorest/generated/stringgroup/string.go
@@ -32,7 +32,7 @@ type StringOperations interface {
 	// PutBase64URLEncoded - Put value that is base64url encoded
 	PutBase64URLEncoded(ctx context.Context, stringBody []byte) (*http.Response, error)
 	// PutEmpty - Set string value empty ''
-	PutEmpty(ctx context.Context, stringBody string) (*http.Response, error)
+	PutEmpty(ctx context.Context) (*http.Response, error)
 	// PutMBCS - Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
 	PutMBCS(ctx context.Context) (*http.Response, error)
 	// PutNull - Set string value null
@@ -384,8 +384,8 @@ func (client *stringOperations) putBase64UrlEncodedHandleResponse(resp *azcore.R
 }
 
 // PutEmpty - Set string value empty ''
-func (client *stringOperations) PutEmpty(ctx context.Context, stringBody string) (*http.Response, error) {
-	req, err := client.putEmptyCreateRequest(stringBody)
+func (client *stringOperations) PutEmpty(ctx context.Context) (*http.Response, error) {
+	req, err := client.putEmptyCreateRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -401,14 +401,14 @@ func (client *stringOperations) PutEmpty(ctx context.Context, stringBody string)
 }
 
 // putEmptyCreateRequest creates the PutEmpty request.
-func (client *stringOperations) putEmptyCreateRequest(stringBody string) (*azcore.Request, error) {
+func (client *stringOperations) putEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/empty"
 	u, err := client.u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(stringBody); err != nil {
+	if err := req.MarshalAsJSON(""); err != nil {
 		if err != nil {
 			return nil, err
 		}

--- a/test/autorest/stringgroup/string_test.go
+++ b/test/autorest/stringgroup/string_test.go
@@ -120,7 +120,7 @@ func TestStringGetWhitespace(t *testing.T) {
 
 func TestStringPutEmpty(t *testing.T) {
 	client := getStringClient(t)
-	result, err := client.PutEmpty(context.Background(), "")
+	result, err := client.PutEmpty(context.Background())
 	if err != nil {
 		t.Fatalf("PutEmpty: %v", err)
 	}


### PR DESCRIPTION
Specify the generator version when publishing results as the auto
detection logic for package.json doesn't work when using rush for
package management.  This required updating to the latest autorest
test server which introduced some swagger changes.