### PR TITLE
Refactor client parameters

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -5,36 +5,6 @@
 
 import { ArraySchema, Operation, Parameter, Response, Schema, SchemaResponse } from '@azure-tools/codemodel';
 
-// describes a method's signature, including parameters and return values
-export interface MethodSig {
-  params: ParamInfo[];
-  returns: string[];
-}
-
-// describes a method paramater
-export interface ParamInfo {
-  name: string;
-  type: string;
-  global: boolean;
-  required: boolean;
-  isHost: boolean;
-}
-
-export class ParamInfo implements ParamInfo {
-  name: string;
-  type: string;
-  global: boolean;
-  required: boolean;
-  isHost: boolean;
-  constructor(name: string, type: string, global: boolean, required: boolean, isHost: boolean) {
-    this.name = name;
-    this.type = type;
-    this.global = global;
-    this.required = required;
-    this.isHost = isHost;
-  }
-}
-
 // aggregates the Parameter in op.parameters and the first request
 export function aggregateParameters(op: Operation): Array<Parameter> {
   if (op.requests!.length > 1) {

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -6,7 +6,6 @@
 import { Session } from '@azure-tools/autorest-extension-base';
 import { comment } from '@azure-tools/codegen';
 import { CodeModel, Language, Parameter } from '@azure-tools/codemodel';
-import { ParamInfo } from '../common/helpers';
 
 
 // returns the common source-file preamble (license comment, package name etc)
@@ -29,11 +28,11 @@ export function sortAscending(a: string, b: string): number {
 }
 
 // returns the type name with possible * prefix
-export function formatParamInfoTypeName(param: ParamInfo): string {
+export function formatParameterTypeName(param: Parameter): string {
   if (param.required) {
-    return param.type;
+    return param.schema.language.go!.name;
   }
-  return `*${param.type}`;
+  return `*${param.schema.language.go!.name}`;
 }
 
 // returns true if the parameter should not be URL encoded
@@ -44,8 +43,8 @@ export function skipURLEncoding(param: Parameter): boolean {
   return false;
 }
 
-// sorts ParamInfo objects by their required state, ordering required before optional
-export function sortParamInfoByRequired(a: ParamInfo, b: ParamInfo): number {
+// sorts parameters by their required state, ordering required before optional
+export function sortParametersByRequired(a: Parameter, b: Parameter): number {
   if (a.required === b.required) {
     return 0;
   }

--- a/test/autorest/generated/azurereportgroup/operations.go
+++ b/test/autorest/generated/azurereportgroup/operations.go
@@ -25,7 +25,7 @@ type operations struct {
 
 // GetReport - Get test coverage report
 func (client *operations) GetReport(ctx context.Context, options *OperationsGetReportOptions) (*MapOfIntegerResponse, error) {
-	req, err := client.getReportCreateRequest(client.Host, options)
+	req, err := client.getReportCreateRequest(options)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func (client *operations) GetReport(ctx context.Context, options *OperationsGetR
 }
 
 // getReportCreateRequest creates the GetReport request.
-func (client *operations) getReportCreateRequest(Host string, options *OperationsGetReportOptions) (*azcore.Request, error) {
+func (client *operations) getReportCreateRequest(options *OperationsGetReportOptions) (*azcore.Request, error) {
 	urlPath := "/report/azure"
 	u, err := client.u.Parse(urlPath)
 	if err != nil {

--- a/test/autorest/generated/morecustombaseurigroup/paths.go
+++ b/test/autorest/generated/morecustombaseurigroup/paths.go
@@ -28,7 +28,7 @@ type pathsOperations struct {
 
 // GetEmpty - Get a 200 to test a valid base uri
 func (client *pathsOperations) GetEmpty(ctx context.Context, vault string, secret string, keyName string, options *PathsGetEmptyOptions) (*http.Response, error) {
-	req, err := client.getEmptyCreateRequest(vault, secret, client.dnsSuffix, keyName, client.subscriptionID, options)
+	req, err := client.getEmptyCreateRequest(vault, secret, keyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -44,10 +44,10 @@ func (client *pathsOperations) GetEmpty(ctx context.Context, vault string, secre
 }
 
 // getEmptyCreateRequest creates the GetEmpty request.
-func (client *pathsOperations) getEmptyCreateRequest(vault string, secret string, dnsSuffix string, keyName string, subscriptionID string, options *PathsGetEmptyOptions) (*azcore.Request, error) {
+func (client *pathsOperations) getEmptyCreateRequest(vault string, secret string, keyName string, options *PathsGetEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/customuri/{subscriptionId}/{keyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{keyName}", url.PathEscape(keyName))
-	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionID))
+	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	u, err := client.u.Parse(urlPath)
 	if err != nil {
 		return nil, err

--- a/test/autorest/generated/urlgroup/pathitems.go
+++ b/test/autorest/generated/urlgroup/pathitems.go
@@ -34,7 +34,7 @@ type pathItemsOperations struct {
 
 // GetAllWithValues - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
 func (client *pathItemsOperations) GetAllWithValues(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetAllWithValuesOptions) (*http.Response, error) {
-	req, err := client.getAllWithValuesCreateRequest(pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
+	req, err := client.getAllWithValuesCreateRequest(pathItemStringPath, localStringPath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -50,10 +50,10 @@ func (client *pathItemsOperations) GetAllWithValues(ctx context.Context, pathIte
 }
 
 // getAllWithValuesCreateRequest creates the GetAllWithValues request.
-func (client *pathItemsOperations) getAllWithValuesCreateRequest(pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetAllWithValuesOptions) (*azcore.Request, error) {
+func (client *pathItemsOperations) getAllWithValuesCreateRequest(pathItemStringPath string, localStringPath string, options *PathItemsGetAllWithValuesOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
-	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
+	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
 	u, err := client.u.Parse(urlPath)
 	if err != nil {
@@ -63,8 +63,8 @@ func (client *pathItemsOperations) getAllWithValuesCreateRequest(pathItemStringP
 	if options != nil && options.PathItemStringQuery != nil {
 		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
 	}
-	if globalStringQuery != nil {
-		query.Set("globalStringQuery", *globalStringQuery)
+	if client.globalStringQuery != nil {
+		query.Set("globalStringQuery", *client.globalStringQuery)
 	}
 	if options != nil && options.LocalStringQuery != nil {
 		query.Set("localStringQuery", *options.LocalStringQuery)
@@ -84,7 +84,7 @@ func (client *pathItemsOperations) getAllWithValuesHandleResponse(resp *azcore.R
 
 // GetGlobalAndLocalQueryNull - send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null
 func (client *pathItemsOperations) GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*http.Response, error) {
-	req, err := client.getGlobalAndLocalQueryNullCreateRequest(pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
+	req, err := client.getGlobalAndLocalQueryNullCreateRequest(pathItemStringPath, localStringPath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -100,10 +100,10 @@ func (client *pathItemsOperations) GetGlobalAndLocalQueryNull(ctx context.Contex
 }
 
 // getGlobalAndLocalQueryNullCreateRequest creates the GetGlobalAndLocalQueryNull request.
-func (client *pathItemsOperations) getGlobalAndLocalQueryNullCreateRequest(pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*azcore.Request, error) {
+func (client *pathItemsOperations) getGlobalAndLocalQueryNullCreateRequest(pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
-	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
+	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
 	u, err := client.u.Parse(urlPath)
 	if err != nil {
@@ -113,8 +113,8 @@ func (client *pathItemsOperations) getGlobalAndLocalQueryNullCreateRequest(pathI
 	if options != nil && options.PathItemStringQuery != nil {
 		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
 	}
-	if globalStringQuery != nil {
-		query.Set("globalStringQuery", *globalStringQuery)
+	if client.globalStringQuery != nil {
+		query.Set("globalStringQuery", *client.globalStringQuery)
 	}
 	if options != nil && options.LocalStringQuery != nil {
 		query.Set("localStringQuery", *options.LocalStringQuery)
@@ -134,7 +134,7 @@ func (client *pathItemsOperations) getGlobalAndLocalQueryNullHandleResponse(resp
 
 // GetGlobalQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
 func (client *pathItemsOperations) GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalQueryNullOptions) (*http.Response, error) {
-	req, err := client.getGlobalQueryNullCreateRequest(pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
+	req, err := client.getGlobalQueryNullCreateRequest(pathItemStringPath, localStringPath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -150,10 +150,10 @@ func (client *pathItemsOperations) GetGlobalQueryNull(ctx context.Context, pathI
 }
 
 // getGlobalQueryNullCreateRequest creates the GetGlobalQueryNull request.
-func (client *pathItemsOperations) getGlobalQueryNullCreateRequest(pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetGlobalQueryNullOptions) (*azcore.Request, error) {
+func (client *pathItemsOperations) getGlobalQueryNullCreateRequest(pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalQueryNullOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
-	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
+	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
 	u, err := client.u.Parse(urlPath)
 	if err != nil {
@@ -163,8 +163,8 @@ func (client *pathItemsOperations) getGlobalQueryNullCreateRequest(pathItemStrin
 	if options != nil && options.PathItemStringQuery != nil {
 		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
 	}
-	if globalStringQuery != nil {
-		query.Set("globalStringQuery", *globalStringQuery)
+	if client.globalStringQuery != nil {
+		query.Set("globalStringQuery", *client.globalStringQuery)
 	}
 	if options != nil && options.LocalStringQuery != nil {
 		query.Set("localStringQuery", *options.LocalStringQuery)
@@ -184,7 +184,7 @@ func (client *pathItemsOperations) getGlobalQueryNullHandleResponse(resp *azcore
 
 // GetLocalPathItemQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null
 func (client *pathItemsOperations) GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetLocalPathItemQueryNullOptions) (*http.Response, error) {
-	req, err := client.getLocalPathItemQueryNullCreateRequest(pathItemStringPath, client.globalStringPath, localStringPath, client.globalStringQuery, options)
+	req, err := client.getLocalPathItemQueryNullCreateRequest(pathItemStringPath, localStringPath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -200,10 +200,10 @@ func (client *pathItemsOperations) GetLocalPathItemQueryNull(ctx context.Context
 }
 
 // getLocalPathItemQueryNullCreateRequest creates the GetLocalPathItemQueryNull request.
-func (client *pathItemsOperations) getLocalPathItemQueryNullCreateRequest(pathItemStringPath string, globalStringPath string, localStringPath string, globalStringQuery *string, options *PathItemsGetLocalPathItemQueryNullOptions) (*azcore.Request, error) {
+func (client *pathItemsOperations) getLocalPathItemQueryNullCreateRequest(pathItemStringPath string, localStringPath string, options *PathItemsGetLocalPathItemQueryNullOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
-	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(globalStringPath))
+	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
 	u, err := client.u.Parse(urlPath)
 	if err != nil {
@@ -213,8 +213,8 @@ func (client *pathItemsOperations) getLocalPathItemQueryNullCreateRequest(pathIt
 	if options != nil && options.PathItemStringQuery != nil {
 		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
 	}
-	if globalStringQuery != nil {
-		query.Set("globalStringQuery", *globalStringQuery)
+	if client.globalStringQuery != nil {
+		query.Set("globalStringQuery", *client.globalStringQuery)
 	}
 	if options != nil && options.LocalStringQuery != nil {
 		query.Set("localStringQuery", *options.LocalStringQuery)

--- a/test/autorest/urlgroup/queries_test.go
+++ b/test/autorest/urlgroup/queries_test.go
@@ -57,7 +57,6 @@ func TestByteMultiByte(t *testing.T) {
 }
 
 func TestDateTimeValid(t *testing.T) {
-	t.Skip("test fails, might be bug in test server")
 	client := getQueriesClient(t)
 	result, err := client.DateTimeValid(context.Background())
 	if err != nil {
@@ -76,7 +75,6 @@ func TestDoubleDecimalNegative(t *testing.T) {
 }
 
 func TestEnumValid(t *testing.T) {
-	t.Skip("test fails, needs investigation")
 	client := getQueriesClient(t)
 	result, err := client.EnumValid(context.Background(), &urlgroup.QueriesEnumValidOptions{
 		EnumQuery: urlgroup.UriColorGreenColor.ToPtr(),
@@ -124,7 +122,7 @@ func TestGetTenBillion(t *testing.T) {
 }
 
 func TestStringUnicode(t *testing.T) {
-	t.Skip("test fails, needs investigation")
+	t.Skip("scenario NYI in test server")
 	client := getQueriesClient(t)
 	result, err := client.StringUnicode(context.Background())
 	if err != nil {

--- a/test/storage/2019-07-07/azblob/blob.go
+++ b/test/storage/2019-07-07/azblob/blob.go
@@ -1213,7 +1213,7 @@ func (client *blobOperations) releaseLeaseHandleResponse(resp *azcore.Response) 
 
 // Rename - Rename a blob/file.  By default, the destination is overwritten and if the destination already exists and has a lease the lease is broken.  This operation supports conditional HTTP requests.  For more information, see [Specifying Conditional Headers for Blob Service Operations](https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations).  To fail if the destination already exists, use a conditional request with If-None-Match: "*".
 func (client *blobOperations) Rename(ctx context.Context, renameSource string, options *BlobRenameOptions) (*BlobRenameResponse, error) {
-	req, err := client.renameCreateRequest(renameSource, client.pathRenameMode, options)
+	req, err := client.renameCreateRequest(renameSource, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1229,14 +1229,14 @@ func (client *blobOperations) Rename(ctx context.Context, renameSource string, o
 }
 
 // renameCreateRequest creates the Rename request.
-func (client *blobOperations) renameCreateRequest(renameSource string, pathRenameMode *PathRenameMode, options *BlobRenameOptions) (*azcore.Request, error) {
+func (client *blobOperations) renameCreateRequest(renameSource string, options *BlobRenameOptions) (*azcore.Request, error) {
 	u := client.u
 	query := u.Query()
 	if options != nil && options.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
-	if pathRenameMode != nil {
-		query.Set("mode", string(*pathRenameMode))
+	if client.pathRenameMode != nil {
+		query.Set("mode", string(*client.pathRenameMode))
 	}
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodPut, *u)

--- a/test/storage/2019-07-07/azblob/directory.go
+++ b/test/storage/2019-07-07/azblob/directory.go
@@ -299,7 +299,7 @@ func (client *directoryOperations) getAccessControlHandleResponse(resp *azcore.R
 
 // Rename - Rename a directory. By default, the destination is overwritten and if the destination already exists and has a lease the lease is broken. This operation supports conditional HTTP requests. For more information, see [Specifying Conditional Headers for Blob Service Operations](https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations). To fail if the destination already exists, use a conditional request with If-None-Match: "*".
 func (client *directoryOperations) Rename(ctx context.Context, renameSource string, options *DirectoryRenameOptions) (*DirectoryRenameResponse, error) {
-	req, err := client.renameCreateRequest(renameSource, client.pathRenameMode, options)
+	req, err := client.renameCreateRequest(renameSource, options)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func (client *directoryOperations) Rename(ctx context.Context, renameSource stri
 }
 
 // renameCreateRequest creates the Rename request.
-func (client *directoryOperations) renameCreateRequest(renameSource string, pathRenameMode *PathRenameMode, options *DirectoryRenameOptions) (*azcore.Request, error) {
+func (client *directoryOperations) renameCreateRequest(renameSource string, options *DirectoryRenameOptions) (*azcore.Request, error) {
 	u := client.u
 	query := u.Query()
 	if options != nil && options.Timeout != nil {
@@ -324,8 +324,8 @@ func (client *directoryOperations) renameCreateRequest(renameSource string, path
 	if options != nil && options.Marker != nil {
 		query.Set("continuation", *options.Marker)
 	}
-	if pathRenameMode != nil {
-		query.Set("mode", string(*pathRenameMode))
+	if client.pathRenameMode != nil {
+		query.Set("mode", string(*client.pathRenameMode))
 	}
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodPut, *u)


### PR DESCRIPTION
Removed redundant client parameters as they're already passed via the
method receiver (legacy from before merging generator code).
Refactored handling of parameters to use the underlying code model
types, removing a lot of needless abstractions (goodbye ParamInfo).
Enabled some tests in urlgroup that are now passing.