### PR TITLE
Set body param for binary payloads

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -458,22 +458,18 @@ function createProtocolRequest(client: string, op: Operation, imports: ImportMan
     if (setOptionsPrefix === true) {
       body = `options.${pascalCase(body)}`;
       text += `\tif options != nil {\n`;
-      text += `\t\tif err := req.MarshalAs${mediaType}(${body}); err != nil {\n`;
-      text += `\t\t\treturn nil, err\n`;
-      text += `\t\t}\n`;
+      text += `\t\treturn req, req.MarshalAs${mediaType}(${body})\n`;
       text += '\t}\n';
+      text += '\treturn req, nil\n';
     } else {
-      text += `\tif err := req.MarshalAs${mediaType}(${body}); err != nil {\n`;
-      text += `\t\treturn nil, err\n`;
-      text += `\t}\n`;
+      text += `\treturn req, req.MarshalAs${mediaType}(${body})\n`;
     }
   } else if (mediaType === 'binary') {
     const bodyParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http!.in === 'body'; }).first();
-    text += `\tif err := req.SetBody(${bodyParam?.language.go!.name}); err != nil {\n`;
-    text += '\t\treturn nil, err\n';
-    text += '\t}\n';
+    text += `\treturn req, req.SetBody(${bodyParam?.language.go!.name})\n`;
+  } else {
+    text += `\treturn req, nil\n`;
   }
-  text += `\treturn req, nil\n`;
   text += '}\n\n';
   return text;
 }

--- a/test/autorest/generated/booleangroup/bool.go
+++ b/test/autorest/generated/booleangroup/bool.go
@@ -206,9 +206,7 @@ func (client *boolOperations) putFalseCreateRequest() (*azcore.Request, error) {
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(false); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -247,9 +245,7 @@ func (client *boolOperations) putTrueCreateRequest() (*azcore.Request, error) {
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(true); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }

--- a/test/autorest/generated/booleangroup/bool.go
+++ b/test/autorest/generated/booleangroup/bool.go
@@ -205,10 +205,7 @@ func (client *boolOperations) putFalseCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(false); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(false)
 }
 
 // putFalseHandleResponse handles the PutFalse response.
@@ -244,10 +241,7 @@ func (client *boolOperations) putTrueCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(true); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(true)
 }
 
 // putTrueHandleResponse handles the PutTrue response.

--- a/test/autorest/generated/bytegroup/byte.go
+++ b/test/autorest/generated/bytegroup/byte.go
@@ -203,10 +203,7 @@ func (client *byteOperations) putNonAsciiCreateRequest(byteBody []byte) (*azcore
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(byteBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(byteBody)
 }
 
 // putNonAsciiHandleResponse handles the PutNonASCII response.

--- a/test/autorest/generated/bytegroup/byte.go
+++ b/test/autorest/generated/bytegroup/byte.go
@@ -204,9 +204,7 @@ func (client *byteOperations) putNonAsciiCreateRequest(byteBody []byte) (*azcore
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(byteBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }

--- a/test/autorest/generated/complexmodelgroup/operations.go
+++ b/test/autorest/generated/complexmodelgroup/operations.go
@@ -58,10 +58,7 @@ func (client *operations) createCreateRequest(subscriptionId string, resourceGro
 	query.Set("api-version", "2014-04-01-preview")
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodPost, *u)
-	if err := req.MarshalAsJSON(bodyParameter); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(bodyParameter)
 }
 
 // createHandleResponse handles the Create response.
@@ -145,10 +142,7 @@ func (client *operations) updateCreateRequest(subscriptionId string, resourceGro
 	query.Set("api-version", "2014-04-01-preview")
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(bodyParameter); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(bodyParameter)
 }
 
 // updateHandleResponse handles the Update response.

--- a/test/autorest/generated/complexmodelgroup/operations.go
+++ b/test/autorest/generated/complexmodelgroup/operations.go
@@ -59,9 +59,7 @@ func (client *operations) createCreateRequest(subscriptionId string, resourceGro
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodPost, *u)
 	if err := req.MarshalAsJSON(bodyParameter); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -148,9 +146,7 @@ func (client *operations) updateCreateRequest(subscriptionId string, resourceGro
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(bodyParameter); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }

--- a/test/autorest/generated/datetimegroup/datetime.go
+++ b/test/autorest/generated/datetimegroup/datetime.go
@@ -649,9 +649,7 @@ func (client *datetimeOperations) putLocalNegativeOffsetMaxDateTimeCreateRequest
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(datetimeBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -690,9 +688,7 @@ func (client *datetimeOperations) putLocalNegativeOffsetMinDateTimeCreateRequest
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(datetimeBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -731,9 +727,7 @@ func (client *datetimeOperations) putLocalPositiveOffsetMaxDateTimeCreateRequest
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(datetimeBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -772,9 +766,7 @@ func (client *datetimeOperations) putLocalPositiveOffsetMinDateTimeCreateRequest
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(datetimeBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -813,9 +805,7 @@ func (client *datetimeOperations) putUtcMaxDateTimeCreateRequest(datetimeBody ti
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(datetimeBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -854,9 +844,7 @@ func (client *datetimeOperations) putUtcMaxDateTime7DigitsCreateRequest(datetime
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(datetimeBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -895,9 +883,7 @@ func (client *datetimeOperations) putUtcMinDateTimeCreateRequest(datetimeBody ti
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(datetimeBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }

--- a/test/autorest/generated/datetimegroup/datetime.go
+++ b/test/autorest/generated/datetimegroup/datetime.go
@@ -648,10 +648,7 @@ func (client *datetimeOperations) putLocalNegativeOffsetMaxDateTimeCreateRequest
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(datetimeBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(datetimeBody)
 }
 
 // putLocalNegativeOffsetMaxDateTimeHandleResponse handles the PutLocalNegativeOffsetMaxDateTime response.
@@ -687,10 +684,7 @@ func (client *datetimeOperations) putLocalNegativeOffsetMinDateTimeCreateRequest
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(datetimeBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(datetimeBody)
 }
 
 // putLocalNegativeOffsetMinDateTimeHandleResponse handles the PutLocalNegativeOffsetMinDateTime response.
@@ -726,10 +720,7 @@ func (client *datetimeOperations) putLocalPositiveOffsetMaxDateTimeCreateRequest
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(datetimeBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(datetimeBody)
 }
 
 // putLocalPositiveOffsetMaxDateTimeHandleResponse handles the PutLocalPositiveOffsetMaxDateTime response.
@@ -765,10 +756,7 @@ func (client *datetimeOperations) putLocalPositiveOffsetMinDateTimeCreateRequest
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(datetimeBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(datetimeBody)
 }
 
 // putLocalPositiveOffsetMinDateTimeHandleResponse handles the PutLocalPositiveOffsetMinDateTime response.
@@ -804,10 +792,7 @@ func (client *datetimeOperations) putUtcMaxDateTimeCreateRequest(datetimeBody ti
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(datetimeBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(datetimeBody)
 }
 
 // putUtcMaxDateTimeHandleResponse handles the PutUTCMaxDateTime response.
@@ -843,10 +828,7 @@ func (client *datetimeOperations) putUtcMaxDateTime7DigitsCreateRequest(datetime
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(datetimeBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(datetimeBody)
 }
 
 // putUtcMaxDateTime7DigitsHandleResponse handles the PutUTCMaxDateTime7Digits response.
@@ -882,10 +864,7 @@ func (client *datetimeOperations) putUtcMinDateTimeCreateRequest(datetimeBody ti
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(datetimeBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(datetimeBody)
 }
 
 // putUtcMinDateTimeHandleResponse handles the PutUTCMinDateTime response.

--- a/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
+++ b/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
@@ -346,9 +346,7 @@ func (client *datetimerfc1123Operations) putUtcMaxDateTimeCreateRequest(datetime
 	req := azcore.NewRequest(http.MethodPut, *u)
 	aux := timeRFC1123(datetimeBody)
 	if err := req.MarshalAsJSON(aux); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -388,9 +386,7 @@ func (client *datetimerfc1123Operations) putUtcMinDateTimeCreateRequest(datetime
 	req := azcore.NewRequest(http.MethodPut, *u)
 	aux := timeRFC1123(datetimeBody)
 	if err := req.MarshalAsJSON(aux); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }

--- a/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
+++ b/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
@@ -345,10 +345,7 @@ func (client *datetimerfc1123Operations) putUtcMaxDateTimeCreateRequest(datetime
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	aux := timeRFC1123(datetimeBody)
-	if err := req.MarshalAsJSON(aux); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(aux)
 }
 
 // putUtcMaxDateTimeHandleResponse handles the PutUTCMaxDateTime response.
@@ -385,10 +382,7 @@ func (client *datetimerfc1123Operations) putUtcMinDateTimeCreateRequest(datetime
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	aux := timeRFC1123(datetimeBody)
-	if err := req.MarshalAsJSON(aux); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(aux)
 }
 
 // putUtcMinDateTimeHandleResponse handles the PutUTCMinDateTime response.

--- a/test/autorest/generated/numbergroup/number.go
+++ b/test/autorest/generated/numbergroup/number.go
@@ -611,10 +611,7 @@ func (client *numberOperations) putBigDecimalCreateRequest(numberBody float64) (
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(numberBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(numberBody)
 }
 
 // putBigDecimalHandleResponse handles the PutBigDecimal response.
@@ -650,10 +647,7 @@ func (client *numberOperations) putBigDecimalNegativeDecimalCreateRequest() (*az
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(-99999999.99); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(-99999999.99)
 }
 
 // putBigDecimalNegativeDecimalHandleResponse handles the PutBigDecimalNegativeDecimal response.
@@ -689,10 +683,7 @@ func (client *numberOperations) putBigDecimalPositiveDecimalCreateRequest() (*az
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(99999999.99); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(99999999.99)
 }
 
 // putBigDecimalPositiveDecimalHandleResponse handles the PutBigDecimalPositiveDecimal response.
@@ -728,10 +719,7 @@ func (client *numberOperations) putBigDoubleCreateRequest(numberBody float64) (*
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(numberBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(numberBody)
 }
 
 // putBigDoubleHandleResponse handles the PutBigDouble response.
@@ -767,10 +755,7 @@ func (client *numberOperations) putBigDoubleNegativeDecimalCreateRequest() (*azc
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(-99999999.99); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(-99999999.99)
 }
 
 // putBigDoubleNegativeDecimalHandleResponse handles the PutBigDoubleNegativeDecimal response.
@@ -806,10 +791,7 @@ func (client *numberOperations) putBigDoublePositiveDecimalCreateRequest() (*azc
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(99999999.99); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(99999999.99)
 }
 
 // putBigDoublePositiveDecimalHandleResponse handles the PutBigDoublePositiveDecimal response.
@@ -845,10 +827,7 @@ func (client *numberOperations) putBigFloatCreateRequest(numberBody float32) (*a
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(numberBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(numberBody)
 }
 
 // putBigFloatHandleResponse handles the PutBigFloat response.
@@ -884,10 +863,7 @@ func (client *numberOperations) putSmallDecimalCreateRequest(numberBody float64)
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(numberBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(numberBody)
 }
 
 // putSmallDecimalHandleResponse handles the PutSmallDecimal response.
@@ -923,10 +899,7 @@ func (client *numberOperations) putSmallDoubleCreateRequest(numberBody float64) 
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(numberBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(numberBody)
 }
 
 // putSmallDoubleHandleResponse handles the PutSmallDouble response.
@@ -962,10 +935,7 @@ func (client *numberOperations) putSmallFloatCreateRequest(numberBody float32) (
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(numberBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(numberBody)
 }
 
 // putSmallFloatHandleResponse handles the PutSmallFloat response.

--- a/test/autorest/generated/numbergroup/number.go
+++ b/test/autorest/generated/numbergroup/number.go
@@ -612,9 +612,7 @@ func (client *numberOperations) putBigDecimalCreateRequest(numberBody float64) (
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(numberBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -653,9 +651,7 @@ func (client *numberOperations) putBigDecimalNegativeDecimalCreateRequest() (*az
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(-99999999.99); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -694,9 +690,7 @@ func (client *numberOperations) putBigDecimalPositiveDecimalCreateRequest() (*az
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(99999999.99); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -735,9 +729,7 @@ func (client *numberOperations) putBigDoubleCreateRequest(numberBody float64) (*
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(numberBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -776,9 +768,7 @@ func (client *numberOperations) putBigDoubleNegativeDecimalCreateRequest() (*azc
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(-99999999.99); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -817,9 +807,7 @@ func (client *numberOperations) putBigDoublePositiveDecimalCreateRequest() (*azc
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(99999999.99); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -858,9 +846,7 @@ func (client *numberOperations) putBigFloatCreateRequest(numberBody float32) (*a
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(numberBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -899,9 +885,7 @@ func (client *numberOperations) putSmallDecimalCreateRequest(numberBody float64)
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(numberBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -940,9 +924,7 @@ func (client *numberOperations) putSmallDoubleCreateRequest(numberBody float64) 
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(numberBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -981,9 +963,7 @@ func (client *numberOperations) putSmallFloatCreateRequest(numberBody float32) (
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(numberBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }

--- a/test/autorest/generated/stringgroup/enum.go
+++ b/test/autorest/generated/stringgroup/enum.go
@@ -169,9 +169,7 @@ func (client *enumOperations) putNotExpandableCreateRequest(stringBody Colors) (
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(stringBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -210,9 +208,7 @@ func (client *enumOperations) putReferencedCreateRequest(enumStringBody Colors) 
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(enumStringBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -251,9 +247,7 @@ func (client *enumOperations) putReferencedConstantCreateRequest(enumStringBody 
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(enumStringBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }

--- a/test/autorest/generated/stringgroup/enum.go
+++ b/test/autorest/generated/stringgroup/enum.go
@@ -168,10 +168,7 @@ func (client *enumOperations) putNotExpandableCreateRequest(stringBody Colors) (
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(stringBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(stringBody)
 }
 
 // putNotExpandableHandleResponse handles the PutNotExpandable response.
@@ -207,10 +204,7 @@ func (client *enumOperations) putReferencedCreateRequest(enumStringBody Colors) 
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(enumStringBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(enumStringBody)
 }
 
 // putReferencedHandleResponse handles the PutReferenced response.
@@ -246,10 +240,7 @@ func (client *enumOperations) putReferencedConstantCreateRequest(enumStringBody 
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(enumStringBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(enumStringBody)
 }
 
 // putReferencedConstantHandleResponse handles the PutReferencedConstant response.

--- a/test/autorest/generated/stringgroup/string.go
+++ b/test/autorest/generated/stringgroup/string.go
@@ -368,9 +368,7 @@ func (client *stringOperations) putBase64UrlEncodedCreateRequest(stringBody []by
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(stringBody); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -409,9 +407,7 @@ func (client *stringOperations) putEmptyCreateRequest() (*azcore.Request, error)
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(""); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -450,9 +446,7 @@ func (client *stringOperations) putMbcsCreateRequest() (*azcore.Request, error) 
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON("啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€"); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -492,9 +486,7 @@ func (client *stringOperations) putNullCreateRequest(options *StringPutNullOptio
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if options != nil {
 		if err := req.MarshalAsJSON(options.StringBody); err != nil {
-			if err != nil {
-				return nil, err
-			}
+			return nil, err
 		}
 	}
 	return req, nil
@@ -534,9 +526,7 @@ func (client *stringOperations) putWhitespaceCreateRequest() (*azcore.Request, e
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON("    Now is the time for all good men to come to the aid of their country    "); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }

--- a/test/autorest/generated/stringgroup/string.go
+++ b/test/autorest/generated/stringgroup/string.go
@@ -367,10 +367,7 @@ func (client *stringOperations) putBase64UrlEncodedCreateRequest(stringBody []by
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(stringBody); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(stringBody)
 }
 
 // putBase64UrlEncodedHandleResponse handles the PutBase64URLEncoded response.
@@ -406,10 +403,7 @@ func (client *stringOperations) putEmptyCreateRequest() (*azcore.Request, error)
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(""); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON("")
 }
 
 // putEmptyHandleResponse handles the PutEmpty response.
@@ -445,10 +439,7 @@ func (client *stringOperations) putMbcsCreateRequest() (*azcore.Request, error) 
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON("啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€"); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON("啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€")
 }
 
 // putMbcsHandleResponse handles the PutMBCS response.
@@ -485,9 +476,7 @@ func (client *stringOperations) putNullCreateRequest(options *StringPutNullOptio
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if options != nil {
-		if err := req.MarshalAsJSON(options.StringBody); err != nil {
-			return nil, err
-		}
+		return req, req.MarshalAsJSON(options.StringBody)
 	}
 	return req, nil
 }
@@ -525,10 +514,7 @@ func (client *stringOperations) putWhitespaceCreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON("    Now is the time for all good men to come to the aid of their country    "); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON("    Now is the time for all good men to come to the aid of their country    ")
 }
 
 // putWhitespaceHandleResponse handles the PutWhitespace response.

--- a/test/autorest/generated/xmlgroup/xml.go
+++ b/test/autorest/generated/xmlgroup/xml.go
@@ -596,10 +596,7 @@ func (client *xmlOperations) jsonInputCreateRequest(properties JSONInput) (*azco
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsJSON(properties); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsJSON(properties)
 }
 
 // jsonInputHandleResponse handles the JSONInput response.
@@ -761,10 +758,7 @@ func (client *xmlOperations) putAcLsCreateRequest(properties []SignedIDentifier)
 		XMLName    xml.Name            `xml:"SignedIdentifiers"`
 		Properties *[]SignedIDentifier `xml:"SignedIdentifier"`
 	}
-	if err := req.MarshalAsXML(wrapper{Properties: &properties}); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(wrapper{Properties: &properties})
 }
 
 // putAcLsHandleResponse handles the PutACLs response.
@@ -800,10 +794,7 @@ func (client *xmlOperations) putComplexTypeRefNoMetaCreateRequest(model RootWith
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsXML(model); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(model)
 }
 
 // putComplexTypeRefNoMetaHandleResponse handles the PutComplexTypeRefNoMeta response.
@@ -839,10 +830,7 @@ func (client *xmlOperations) putComplexTypeRefWithMetaCreateRequest(model RootWi
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsXML(model); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(model)
 }
 
 // putComplexTypeRefWithMetaHandleResponse handles the PutComplexTypeRefWithMeta response.
@@ -878,10 +866,7 @@ func (client *xmlOperations) putEmptyChildElementCreateRequest(banana Banana) (*
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsXML(banana); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(banana)
 }
 
 // putEmptyChildElementHandleResponse handles the PutEmptyChildElement response.
@@ -917,10 +902,7 @@ func (client *xmlOperations) putEmptyListCreateRequest(slideshow Slideshow) (*az
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsXML(slideshow); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(slideshow)
 }
 
 // putEmptyListHandleResponse handles the PutEmptyList response.
@@ -960,10 +942,7 @@ func (client *xmlOperations) putEmptyRootListCreateRequest(bananas []Banana) (*a
 		XMLName xml.Name  `xml:"bananas"`
 		Bananas *[]Banana `xml:"banana"`
 	}
-	if err := req.MarshalAsXML(wrapper{Bananas: &bananas}); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(wrapper{Bananas: &bananas})
 }
 
 // putEmptyRootListHandleResponse handles the PutEmptyRootList response.
@@ -999,10 +978,7 @@ func (client *xmlOperations) putEmptyWrappedListsCreateRequest(appleBarrel Apple
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsXML(appleBarrel); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(appleBarrel)
 }
 
 // putEmptyWrappedListsHandleResponse handles the PutEmptyWrappedLists response.
@@ -1042,10 +1018,7 @@ func (client *xmlOperations) putRootListCreateRequest(bananas []Banana) (*azcore
 		XMLName xml.Name  `xml:"bananas"`
 		Bananas *[]Banana `xml:"banana"`
 	}
-	if err := req.MarshalAsXML(wrapper{Bananas: &bananas}); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(wrapper{Bananas: &bananas})
 }
 
 // putRootListHandleResponse handles the PutRootList response.
@@ -1085,10 +1058,7 @@ func (client *xmlOperations) putRootListSingleItemCreateRequest(bananas []Banana
 		XMLName xml.Name  `xml:"bananas"`
 		Bananas *[]Banana `xml:"banana"`
 	}
-	if err := req.MarshalAsXML(wrapper{Bananas: &bananas}); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(wrapper{Bananas: &bananas})
 }
 
 // putRootListSingleItemHandleResponse handles the PutRootListSingleItem response.
@@ -1128,10 +1098,7 @@ func (client *xmlOperations) putServicePropertiesCreateRequest(properties Storag
 	query.Set("restype", "service")
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsXML(properties); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(properties)
 }
 
 // putServicePropertiesHandleResponse handles the PutServiceProperties response.
@@ -1167,10 +1134,7 @@ func (client *xmlOperations) putSimpleCreateRequest(slideshow Slideshow) (*azcor
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsXML(slideshow); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(slideshow)
 }
 
 // putSimpleHandleResponse handles the PutSimple response.
@@ -1206,10 +1170,7 @@ func (client *xmlOperations) putWrappedListsCreateRequest(wrappedLists AppleBarr
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if err := req.MarshalAsXML(wrappedLists); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(wrappedLists)
 }
 
 // putWrappedListsHandleResponse handles the PutWrappedLists response.

--- a/test/autorest/generated/xmlgroup/xml.go
+++ b/test/autorest/generated/xmlgroup/xml.go
@@ -597,9 +597,7 @@ func (client *xmlOperations) jsonInputCreateRequest(properties JSONInput) (*azco
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsJSON(properties); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -764,9 +762,7 @@ func (client *xmlOperations) putAcLsCreateRequest(properties []SignedIDentifier)
 		Properties *[]SignedIDentifier `xml:"SignedIdentifier"`
 	}
 	if err := req.MarshalAsXML(wrapper{Properties: &properties}); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -805,9 +801,7 @@ func (client *xmlOperations) putComplexTypeRefNoMetaCreateRequest(model RootWith
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsXML(model); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -846,9 +840,7 @@ func (client *xmlOperations) putComplexTypeRefWithMetaCreateRequest(model RootWi
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsXML(model); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -887,9 +879,7 @@ func (client *xmlOperations) putEmptyChildElementCreateRequest(banana Banana) (*
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsXML(banana); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -928,9 +918,7 @@ func (client *xmlOperations) putEmptyListCreateRequest(slideshow Slideshow) (*az
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsXML(slideshow); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -973,9 +961,7 @@ func (client *xmlOperations) putEmptyRootListCreateRequest(bananas []Banana) (*a
 		Bananas *[]Banana `xml:"banana"`
 	}
 	if err := req.MarshalAsXML(wrapper{Bananas: &bananas}); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -1014,9 +1000,7 @@ func (client *xmlOperations) putEmptyWrappedListsCreateRequest(appleBarrel Apple
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsXML(appleBarrel); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -1059,9 +1043,7 @@ func (client *xmlOperations) putRootListCreateRequest(bananas []Banana) (*azcore
 		Bananas *[]Banana `xml:"banana"`
 	}
 	if err := req.MarshalAsXML(wrapper{Bananas: &bananas}); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -1104,9 +1086,7 @@ func (client *xmlOperations) putRootListSingleItemCreateRequest(bananas []Banana
 		Bananas *[]Banana `xml:"banana"`
 	}
 	if err := req.MarshalAsXML(wrapper{Bananas: &bananas}); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -1149,9 +1129,7 @@ func (client *xmlOperations) putServicePropertiesCreateRequest(properties Storag
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsXML(properties); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -1190,9 +1168,7 @@ func (client *xmlOperations) putSimpleCreateRequest(slideshow Slideshow) (*azcor
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsXML(slideshow); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -1231,9 +1207,7 @@ func (client *xmlOperations) putWrappedListsCreateRequest(wrappedLists AppleBarr
 	}
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if err := req.MarshalAsXML(wrappedLists); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }

--- a/test/storage/2019-07-07/azblob/appendblob.go
+++ b/test/storage/2019-07-07/azblob/appendblob.go
@@ -98,10 +98,7 @@ func (client *appendBlobOperations) appendBlockCreateRequest(contentLength int64
 	if options != nil && options.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
-	if err := req.SetBody(body); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.SetBody(body)
 }
 
 // appendBlockHandleResponse handles the AppendBlock response.

--- a/test/storage/2019-07-07/azblob/appendblob.go
+++ b/test/storage/2019-07-07/azblob/appendblob.go
@@ -98,6 +98,9 @@ func (client *appendBlobOperations) appendBlockCreateRequest(contentLength int64
 	if options != nil && options.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
+	if err := req.SetBody(body); err != nil {
+		return nil, err
+	}
 	return req, nil
 }
 

--- a/test/storage/2019-07-07/azblob/blockblob.go
+++ b/test/storage/2019-07-07/azblob/blockblob.go
@@ -120,9 +120,7 @@ func (client *blockBlobOperations) commitBlockListCreateRequest(blocks BlockLook
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
 	if err := req.MarshalAsXML(blocks); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -298,6 +296,9 @@ func (client *blockBlobOperations) stageBlockCreateRequest(blockId string, conte
 	req.Header.Set("x-ms-version", "2019-07-07")
 	if options != nil && options.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
+	}
+	if err := req.SetBody(body); err != nil {
+		return nil, err
 	}
 	return req, nil
 }
@@ -532,6 +533,9 @@ func (client *blockBlobOperations) uploadCreateRequest(contentLength int64, body
 	req.Header.Set("x-ms-version", "2019-07-07")
 	if options != nil && options.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
+	}
+	if err := req.SetBody(body); err != nil {
+		return nil, err
 	}
 	return req, nil
 }

--- a/test/storage/2019-07-07/azblob/blockblob.go
+++ b/test/storage/2019-07-07/azblob/blockblob.go
@@ -119,10 +119,7 @@ func (client *blockBlobOperations) commitBlockListCreateRequest(blocks BlockLook
 	if options != nil && options.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
-	if err := req.MarshalAsXML(blocks); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(blocks)
 }
 
 // commitBlockListHandleResponse handles the CommitBlockList response.
@@ -297,10 +294,7 @@ func (client *blockBlobOperations) stageBlockCreateRequest(blockId string, conte
 	if options != nil && options.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
-	if err := req.SetBody(body); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.SetBody(body)
 }
 
 // stageBlockHandleResponse handles the StageBlock response.
@@ -534,10 +528,7 @@ func (client *blockBlobOperations) uploadCreateRequest(contentLength int64, body
 	if options != nil && options.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
-	if err := req.SetBody(body); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.SetBody(body)
 }
 
 // uploadHandleResponse handles the Upload response.

--- a/test/storage/2019-07-07/azblob/container.go
+++ b/test/storage/2019-07-07/azblob/container.go
@@ -970,10 +970,7 @@ func (client *containerOperations) setAccessPolicyCreateRequest(options *Contain
 		XMLName      xml.Name            `xml:"SignedIdentifiers"`
 		ContainerAcl *[]SignedIDentifier `xml:"SignedIdentifier"`
 	}
-	if err := req.MarshalAsXML(wrapper{ContainerAcl: options.ContainerAcl}); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(wrapper{ContainerAcl: options.ContainerAcl})
 }
 
 // setAccessPolicyHandleResponse handles the SetAccessPolicy response.

--- a/test/storage/2019-07-07/azblob/container.go
+++ b/test/storage/2019-07-07/azblob/container.go
@@ -971,9 +971,7 @@ func (client *containerOperations) setAccessPolicyCreateRequest(options *Contain
 		ContainerAcl *[]SignedIDentifier `xml:"SignedIdentifier"`
 	}
 	if err := req.MarshalAsXML(wrapper{ContainerAcl: options.ContainerAcl}); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }

--- a/test/storage/2019-07-07/azblob/pageblob.go
+++ b/test/storage/2019-07-07/azblob/pageblob.go
@@ -793,6 +793,9 @@ func (client *pageBlobOperations) uploadPagesCreateRequest(contentLength int64, 
 	if options != nil && options.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
+	if err := req.SetBody(body); err != nil {
+		return nil, err
+	}
 	return req, nil
 }
 

--- a/test/storage/2019-07-07/azblob/pageblob.go
+++ b/test/storage/2019-07-07/azblob/pageblob.go
@@ -793,10 +793,7 @@ func (client *pageBlobOperations) uploadPagesCreateRequest(contentLength int64, 
 	if options != nil && options.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
-	if err := req.SetBody(body); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.SetBody(body)
 }
 
 // uploadPagesHandleResponse handles the UploadPages response.

--- a/test/storage/2019-07-07/azblob/service.go
+++ b/test/storage/2019-07-07/azblob/service.go
@@ -229,9 +229,7 @@ func (client *serviceOperations) getUserDelegationKeyCreateRequest(keyInfo KeyIn
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
 	if err := req.MarshalAsXML(keyInfo); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -353,9 +351,7 @@ func (client *serviceOperations) setPropertiesCreateRequest(storageServiceProper
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
 	if err := req.MarshalAsXML(storageServiceProperties); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }
@@ -410,9 +406,7 @@ func (client *serviceOperations) submitBatchCreateRequest(contentLength int64, m
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
 	if err := req.MarshalAsXML(body); err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return req, nil
 }

--- a/test/storage/2019-07-07/azblob/service.go
+++ b/test/storage/2019-07-07/azblob/service.go
@@ -228,10 +228,7 @@ func (client *serviceOperations) getUserDelegationKeyCreateRequest(keyInfo KeyIn
 	if options != nil && options.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
-	if err := req.MarshalAsXML(keyInfo); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(keyInfo)
 }
 
 // getUserDelegationKeyHandleResponse handles the GetUserDelegationKey response.
@@ -350,10 +347,7 @@ func (client *serviceOperations) setPropertiesCreateRequest(storageServiceProper
 	if options != nil && options.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
-	if err := req.MarshalAsXML(storageServiceProperties); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(storageServiceProperties)
 }
 
 // setPropertiesHandleResponse handles the SetProperties response.
@@ -405,10 +399,7 @@ func (client *serviceOperations) submitBatchCreateRequest(contentLength int64, m
 	if options != nil && options.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
-	if err := req.MarshalAsXML(body); err != nil {
-		return nil, err
-	}
-	return req, nil
+	return req, req.MarshalAsXML(body)
 }
 
 // submitBatchHandleResponse handles the SubmitBatch response.


### PR DESCRIPTION
For operations that take a binary request, call req.SetBody().
Removed redundant error check.