### PR TITLE
Add credential parameter

### DIFF
--- a/rushScripts/regeneration.js
+++ b/rushScripts/regeneration.js
@@ -45,12 +45,12 @@ for (namespace in goMappings) {
 } 
 
 const blobStorage = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/storage-dataplane-preview/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-07-07/blob.json';
-generate(blobStorage, 'azblob', 'test/storage/2019-07-07/azblob');
+generate(blobStorage, 'azblob', 'test/storage/2019-07-07/azblob', '--credential-scope="https://storage.azure.com/.default"');
 
 // helper to log the package being generated before invocation
-function generate(inputFile, namespace, outputDir) {
+function generate(inputFile, namespace, outputDir, additionalArgs) {
     console.log('generating ' + inputFile);
-    exec('autorest --use=. --clear-output-folder --license-header=MICROSOFT_MIT_NO_VERSION --input-file=' + inputFile + ' --namespace=' + namespace + ' --output-folder=' + outputDir, autorestCallback(outputDir, inputFile));
+    exec('autorest --use=. --clear-output-folder --license-header=MICROSOFT_MIT_NO_VERSION --input-file=' + inputFile + ' --namespace=' + namespace + ' --output-folder=' + outputDir + ' ' + additionalArgs, autorestCallback(outputDir, inputFile));
 }
 
 // use a function factory to create the closure so that the values of namespace and inputFile are captured on each iteration

--- a/src/autorest-configuration.md
+++ b/src/autorest-configuration.md
@@ -10,7 +10,7 @@ AutoRest needs the below config to pick this up as a plug-in - see https://githu
 
 ``` yaml !isLoaded('@autorest/remodeler') 
 use-extension:
-  "@autorest/modelerfour" : "4.12.276" 
+  "@autorest/modelerfour" : "4.13.309" 
 
 # will use highest 4.0.x 
 ```

--- a/src/package.json
+++ b/src/package.json
@@ -55,11 +55,11 @@
     "@autorest/autorest": "~3.0.6173",
     "eslint": "~6.6.0",
     "@azure-tools/codegen": "~2.4.263",
-    "@azure-tools/codemodel": "^3.7.312"
+    "@azure-tools/codemodel": "~4.13.309"
   },
   "dependencies": {
     "@azure-tools/codegen": "~2.4.263",
-    "@azure-tools/codemodel": "^3.7.312",
+    "@azure-tools/codemodel": "~4.13.309",
     "@azure-tools/autorest-extension-base": "~3.1.0",
     "@azure-tools/linq": "~3.1.0",
     "@azure-tools/tasks": "~3.0.0",

--- a/test/autorest/generated/arraygroup/client.go
+++ b/test/autorest/generated/arraygroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/azurereportgroup/client.go
+++ b/test/autorest/generated/azurereportgroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/booleangroup/client.go
+++ b/test/autorest/generated/booleangroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/bytegroup/client.go
+++ b/test/autorest/generated/bytegroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/complexgroup/client.go
+++ b/test/autorest/generated/complexgroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/complexmodelgroup/client.go
+++ b/test/autorest/generated/complexmodelgroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/custombaseurlgroup/client.go
+++ b/test/autorest/generated/custombaseurlgroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/datetimegroup/client.go
+++ b/test/autorest/generated/datetimegroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/datetimerfc1123group/client.go
+++ b/test/autorest/generated/datetimerfc1123group/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/dictionarygroup/client.go
+++ b/test/autorest/generated/dictionarygroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/filegroup/client.go
+++ b/test/autorest/generated/filegroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/headergroup/client.go
+++ b/test/autorest/generated/headergroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/httpinfrastructuregroup/client.go
+++ b/test/autorest/generated/httpinfrastructuregroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/integergroup/client.go
+++ b/test/autorest/generated/integergroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/morecustombaseurigroup/client.go
+++ b/test/autorest/generated/morecustombaseurigroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/numbergroup/client.go
+++ b/test/autorest/generated/numbergroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/optionalgroup/client.go
+++ b/test/autorest/generated/optionalgroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/paginggroup/client.go
+++ b/test/autorest/generated/paginggroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/reportgroup/client.go
+++ b/test/autorest/generated/reportgroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/stringgroup/client.go
+++ b/test/autorest/generated/stringgroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/urlgroup/client.go
+++ b/test/autorest/generated/urlgroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/urlmultigroup/client.go
+++ b/test/autorest/generated/urlmultigroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/validationgroup/client.go
+++ b/test/autorest/generated/validationgroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/autorest/generated/xmlgroup/client.go
+++ b/test/autorest/generated/xmlgroup/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 )
 
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport

--- a/test/storage/2019-07-07/azblob/client.go
+++ b/test/storage/2019-07-07/azblob/client.go
@@ -11,6 +11,9 @@ import (
 	"net/url"
 )
 
+const scope = "https://storage.azure.com/.default"
+
+// ClientOptions contains configuration settings for the default client's pipeline.
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
@@ -36,7 +39,7 @@ type Client struct {
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, cred azcore.Credential, options *ClientOptions) (*Client, error) {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -45,6 +48,7 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 		azcore.NewTelemetryPolicy(options.Telemetry),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
+		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
 		azcore.NewRequestLogPolicy(options.LogOptions))
 	return NewClientWithPipeline(endpoint, p)
 }


### PR DESCRIPTION
Add an azcore.Credential parameter to client constructors for swaggers
that require authorization; this also requires specifying the
--credential-scope parameter with an appropriate value.
Generate a doc comment for ClientOptions.