### PR TITLE
Change the version.go to use the `Version()` function to unify behaviour with onever and module version

### DIFF
--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -80,7 +80,7 @@ namespace AutoRest.Go.Model
         {
             get
             {
-                var verStr = $"\" + Version() + \"";
+                var verStr = "\" + Version() + \"";
                 var suffix = "";
 
                 // the API version will not be populated for composite packages that span

--- a/src/Model/CodeModelGo.cs
+++ b/src/Model/CodeModelGo.cs
@@ -80,7 +80,7 @@ namespace AutoRest.Go.Model
         {
             get
             {
-                var verStr = UseOneVer ? $"\" + {OneVerString} + \"" : Version;
+                var verStr = $"\" + Version() + \"";
                 var suffix = "";
 
                 // the API version will not be populated for composite packages that span

--- a/test/src/tests/generated/additionalproperties/version.go
+++ b/test/src/tests/generated/additionalproperties/version.go
@@ -8,7 +8,7 @@ package additionalproperties
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 additionalproperties/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " additionalproperties/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/arraygroup/version.go
+++ b/test/src/tests/generated/arraygroup/version.go
@@ -8,7 +8,7 @@ package arraygroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 arraygroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " arraygroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/azurereport/version.go
+++ b/test/src/tests/generated/azurereport/version.go
@@ -8,7 +8,7 @@ package azurereport
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 azurereport/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " azurereport/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/booleangroup/version.go
+++ b/test/src/tests/generated/booleangroup/version.go
@@ -8,7 +8,7 @@ package booleangroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 booleangroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " booleangroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/bytegroup/version.go
+++ b/test/src/tests/generated/bytegroup/version.go
@@ -8,7 +8,7 @@ package bytegroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 bytegroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " bytegroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/complexgroup/version.go
+++ b/test/src/tests/generated/complexgroup/version.go
@@ -8,7 +8,7 @@ package complexgroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 complexgroup/2016-02-29"
+	return "Azure-SDK-For-Go/" + Version() + " complexgroup/2016-02-29"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/custombaseurlgroup/version.go
+++ b/test/src/tests/generated/custombaseurlgroup/version.go
@@ -8,7 +8,7 @@ package custombaseurlgroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 custombaseurlgroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " custombaseurlgroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/dategroup/version.go
+++ b/test/src/tests/generated/dategroup/version.go
@@ -8,7 +8,7 @@ package dategroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 dategroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " dategroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/datetimegroup/version.go
+++ b/test/src/tests/generated/datetimegroup/version.go
@@ -8,7 +8,7 @@ package datetimegroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 datetimegroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " datetimegroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/datetimerfc1123group/version.go
+++ b/test/src/tests/generated/datetimerfc1123group/version.go
@@ -8,7 +8,7 @@ package datetimerfc1123group
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 datetimerfc1123group/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " datetimerfc1123group/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/dictionarygroup/version.go
+++ b/test/src/tests/generated/dictionarygroup/version.go
@@ -8,7 +8,7 @@ package dictionarygroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 dictionarygroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " dictionarygroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/durationgroup/version.go
+++ b/test/src/tests/generated/durationgroup/version.go
@@ -8,7 +8,7 @@ package durationgroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 durationgroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " durationgroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/filegroup/version.go
+++ b/test/src/tests/generated/filegroup/version.go
@@ -8,7 +8,7 @@ package filegroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 filegroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " filegroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/formdatagroup/version.go
+++ b/test/src/tests/generated/formdatagroup/version.go
@@ -8,7 +8,7 @@ package formdatagroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 formdatagroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " formdatagroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/headergroup/version.go
+++ b/test/src/tests/generated/headergroup/version.go
@@ -8,7 +8,7 @@ package headergroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 headergroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " headergroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/httpinfrastructuregroup/version.go
+++ b/test/src/tests/generated/httpinfrastructuregroup/version.go
@@ -8,7 +8,7 @@ package httpinfrastructuregroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 httpinfrastructuregroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " httpinfrastructuregroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/integergroup/version.go
+++ b/test/src/tests/generated/integergroup/version.go
@@ -8,7 +8,7 @@ package integergroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 integergroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " integergroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/lrogroup/version.go
+++ b/test/src/tests/generated/lrogroup/version.go
@@ -8,7 +8,7 @@ package lrogroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 lrogroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " lrogroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/modelflatteninggroup/version.go
+++ b/test/src/tests/generated/modelflatteninggroup/version.go
@@ -8,7 +8,7 @@ package modelflatteninggroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 modelflatteninggroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " modelflatteninggroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/morecustombaseurigroup/version.go
+++ b/test/src/tests/generated/morecustombaseurigroup/version.go
@@ -8,7 +8,7 @@ package morecustombaseurigroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 morecustombaseurigroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " morecustombaseurigroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/numbergroup/version.go
+++ b/test/src/tests/generated/numbergroup/version.go
@@ -8,7 +8,7 @@ package numbergroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 numbergroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " numbergroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/optionalgroup/version.go
+++ b/test/src/tests/generated/optionalgroup/version.go
@@ -8,7 +8,7 @@ package optionalgroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 optionalgroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " optionalgroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/paginggroup/version.go
+++ b/test/src/tests/generated/paginggroup/version.go
@@ -8,7 +8,7 @@ package paginggroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 paginggroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " paginggroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/report/version.go
+++ b/test/src/tests/generated/report/version.go
@@ -8,7 +8,7 @@ package report
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 report/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " report/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/stringgroup/version.go
+++ b/test/src/tests/generated/stringgroup/version.go
@@ -8,7 +8,7 @@ package stringgroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 stringgroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " stringgroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/urlgroup/version.go
+++ b/test/src/tests/generated/urlgroup/version.go
@@ -8,7 +8,7 @@ package urlgroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 urlgroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " urlgroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/urlmultigroup/version.go
+++ b/test/src/tests/generated/urlmultigroup/version.go
@@ -8,7 +8,7 @@ package urlmultigroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 urlmultigroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " urlmultigroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/test/src/tests/generated/validationgroup/version.go
+++ b/test/src/tests/generated/validationgroup/version.go
@@ -8,7 +8,7 @@ package validationgroup
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/0.0.0 validationgroup/1.0.0"
+	return "Azure-SDK-For-Go/" + Version() + " validationgroup/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.


### PR DESCRIPTION
This PR is trying to change the `version.go` in generated code from
```go
// UserAgent returns the UserAgent string to use when sending http.Requests.
func UserAgent() string {
	return "Azure-SDK-For-Go/" + version.Number + " windowsesu/2019-09-16-preview"
}

// Version returns the semantic version (see http://semver.org) of the client.
func Version() string {
	return version.Number
}
```
to
```go
// UserAgent returns the UserAgent string to use when sending http.Requests.
func UserAgent() string {
	return "Azure-SDK-For-Go/" + Version() + " windowsesu/2019-09-16-preview"
}

// Version returns the semantic version (see http://semver.org) of the client.
func Version() string {
	return version.Number
}
```
This pattern will also apply to the version file with modules:
```go
// UserAgent returns the UserAgent string to use when sending http.Requests.
func UserAgent() string {
	return "Azure-SDK-For-Go/" + Version() + " windowsesu/2019-09-16-preview"
}

// Version returns the semantic version (see http://semver.org) of the client.
func Version() string {
	return "v0.0.0"
}
```