### PR TITLE
Initial support for multiple responses

### DIFF
--- a/test/autorest/generated/httpinfrastructuregroup/httpsuccess.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpsuccess.go
@@ -305,7 +305,7 @@ func (client *httpSuccessOperations) head404CreateRequest() (*azcore.Request, er
 
 // head404HandleResponse handles the Head404 response.
 func (client *httpSuccessOperations) head404HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusNoContent) {
+	if !resp.HasStatusCode(http.StatusNoContent, http.StatusNotFound) {
 		return nil, newError(resp)
 	}
 	return resp.Response, nil

--- a/test/autorest/generated/httpinfrastructuregroup/multipleresponses.go
+++ b/test/autorest/generated/httpinfrastructuregroup/multipleresponses.go
@@ -822,7 +822,7 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultError202NoneC
 
 // get202None204NoneDefaultError202NoneHandleResponse handles the Get202None204NoneDefaultError202None response.
 func (client *multipleResponsesOperations) get202None204NoneDefaultError202NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
 		return nil, newError(resp)
 	}
 	return resp.Response, nil
@@ -858,7 +858,7 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultError204NoneC
 
 // get202None204NoneDefaultError204NoneHandleResponse handles the Get202None204NoneDefaultError204None response.
 func (client *multipleResponsesOperations) get202None204NoneDefaultError204NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
 		return nil, newError(resp)
 	}
 	return resp.Response, nil
@@ -894,7 +894,7 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultError400Valid
 
 // get202None204NoneDefaultError400ValidHandleResponse handles the Get202None204NoneDefaultError400Valid response.
 func (client *multipleResponsesOperations) get202None204NoneDefaultError400ValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
 		return nil, newError(resp)
 	}
 	return resp.Response, nil
@@ -930,7 +930,7 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultNone202Invali
 
 // get202None204NoneDefaultNone202InvalidHandleResponse handles the Get202None204NoneDefaultNone202Invalid response.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone202InvalidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
 		return nil, errors.New(resp.Status)
 	}
 	return resp.Response, nil
@@ -966,7 +966,7 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultNone204NoneCr
 
 // get202None204NoneDefaultNone204NoneHandleResponse handles the Get202None204NoneDefaultNone204None response.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone204NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
 		return nil, errors.New(resp.Status)
 	}
 	return resp.Response, nil
@@ -1002,7 +1002,7 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultNone400Invali
 
 // get202None204NoneDefaultNone400InvalidHandleResponse handles the Get202None204NoneDefaultNone400Invalid response.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone400InvalidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
 		return nil, errors.New(resp.Status)
 	}
 	return resp.Response, nil
@@ -1038,7 +1038,7 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultNone400NoneCr
 
 // get202None204NoneDefaultNone400NoneHandleResponse handles the Get202None204NoneDefaultNone400None response.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone400NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
 		return nil, errors.New(resp.Status)
 	}
 	return resp.Response, nil

--- a/test/autorest/generated/lrogroup/lroretrys.go
+++ b/test/autorest/generated/lrogroup/lroretrys.go
@@ -134,7 +134,7 @@ func (client *lroRetrysOperations) deleteProvisioning202Accepted200SucceededCrea
 
 // deleteProvisioning202Accepted200SucceededHandleResponse handles the DeleteProvisioning202Accepted200Succeeded response.
 func (client *lroRetrysOperations) deleteProvisioning202Accepted200SucceededHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
 		return nil, newCloudError(resp)
 	}
 	result := ProductResponse{RawResponse: resp.Response}
@@ -249,7 +249,7 @@ func (client *lroRetrysOperations) put201CreatingSucceeded200CreateRequest(lroRe
 
 // put201CreatingSucceeded200HandleResponse handles the Put201CreatingSucceeded200 response.
 func (client *lroRetrysOperations) put201CreatingSucceeded200HandleResponse(resp *azcore.Response) (*ProductResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return nil, newCloudError(resp)
 	}
 	result := ProductResponse{RawResponse: resp.Response}

--- a/test/autorest/generated/lrogroup/lros.go
+++ b/test/autorest/generated/lrogroup/lros.go
@@ -423,7 +423,7 @@ func (client *lrOSOperations) deleteProvisioning202Accepted200SucceededCreateReq
 
 // deleteProvisioning202Accepted200SucceededHandleResponse handles the DeleteProvisioning202Accepted200Succeeded response.
 func (client *lrOSOperations) deleteProvisioning202Accepted200SucceededHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
 		return nil, newCloudError(resp)
 	}
 	result := ProductResponse{RawResponse: resp.Response}
@@ -450,7 +450,7 @@ func (client *lrOSOperations) deleteProvisioning202DeletingFailed200CreateReques
 
 // deleteProvisioning202DeletingFailed200HandleResponse handles the DeleteProvisioning202DeletingFailed200 response.
 func (client *lrOSOperations) deleteProvisioning202DeletingFailed200HandleResponse(resp *azcore.Response) (*ProductResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
 		return nil, newCloudError(resp)
 	}
 	result := ProductResponse{RawResponse: resp.Response}
@@ -477,7 +477,7 @@ func (client *lrOSOperations) deleteProvisioning202Deletingcanceled200CreateRequ
 
 // deleteProvisioning202Deletingcanceled200HandleResponse handles the DeleteProvisioning202Deletingcanceled200 response.
 func (client *lrOSOperations) deleteProvisioning202Deletingcanceled200HandleResponse(resp *azcore.Response) (*ProductResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
 		return nil, newCloudError(resp)
 	}
 	result := ProductResponse{RawResponse: resp.Response}
@@ -504,7 +504,7 @@ func (client *lrOSOperations) post200WithPayloadCreateRequest() (*azcore.Request
 
 // post200WithPayloadHandleResponse handles the Post200WithPayload response.
 func (client *lrOSOperations) post200WithPayloadHandleResponse(resp *azcore.Response) (*SkuResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
 		return nil, newCloudError(resp)
 	}
 	result := SkuResponse{RawResponse: resp.Response}
@@ -954,7 +954,7 @@ func (client *lrOSOperations) put201CreatingFailed200CreateRequest(lrOSPut201Cre
 
 // put201CreatingFailed200HandleResponse handles the Put201CreatingFailed200 response.
 func (client *lrOSOperations) put201CreatingFailed200HandleResponse(resp *azcore.Response) (*ProductResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return nil, newCloudError(resp)
 	}
 	result := ProductResponse{RawResponse: resp.Response}
@@ -984,7 +984,7 @@ func (client *lrOSOperations) put201CreatingSucceeded200CreateRequest(lrOSPut201
 
 // put201CreatingSucceeded200HandleResponse handles the Put201CreatingSucceeded200 response.
 func (client *lrOSOperations) put201CreatingSucceeded200HandleResponse(resp *azcore.Response) (*ProductResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return nil, newCloudError(resp)
 	}
 	result := ProductResponse{RawResponse: resp.Response}

--- a/test/autorest/generated/lrogroup/lrosads.go
+++ b/test/autorest/generated/lrogroup/lrosads.go
@@ -920,7 +920,7 @@ func (client *lrosaDsOperations) putError201NoProvisioningStatePayloadCreateRequ
 
 // putError201NoProvisioningStatePayloadHandleResponse handles the PutError201NoProvisioningStatePayload response.
 func (client *lrosaDsOperations) putError201NoProvisioningStatePayloadHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return nil, newCloudError(resp)
 	}
 	result := ProductResponse{RawResponse: resp.Response}
@@ -950,7 +950,7 @@ func (client *lrosaDsOperations) putNonRetry201Creating400CreateRequest(lrosaDsP
 
 // putNonRetry201Creating400HandleResponse handles the PutNonRetry201Creating400 response.
 func (client *lrosaDsOperations) putNonRetry201Creating400HandleResponse(resp *azcore.Response) (*ProductResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return nil, newCloudError(resp)
 	}
 	result := ProductResponse{RawResponse: resp.Response}
@@ -980,7 +980,7 @@ func (client *lrosaDsOperations) putNonRetry201Creating400InvalidJsonCreateReque
 
 // putNonRetry201Creating400InvalidJsonHandleResponse handles the PutNonRetry201Creating400InvalidJSON response.
 func (client *lrosaDsOperations) putNonRetry201Creating400InvalidJsonHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return nil, newCloudError(resp)
 	}
 	result := ProductResponse{RawResponse: resp.Response}
@@ -1010,7 +1010,7 @@ func (client *lrosaDsOperations) putNonRetry400CreateRequest(lrosaDsPutNonRetry4
 
 // putNonRetry400HandleResponse handles the PutNonRetry400 response.
 func (client *lrosaDsOperations) putNonRetry400HandleResponse(resp *azcore.Response) (*ProductResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return nil, newCloudError(resp)
 	}
 	result := ProductResponse{RawResponse: resp.Response}

--- a/test/autorest/generated/lrogroup/lroscustomheader.go
+++ b/test/autorest/generated/lrogroup/lroscustomheader.go
@@ -137,7 +137,7 @@ func (client *lrOSCustomHeaderOperations) put201CreatingSucceeded200CreateReques
 
 // put201CreatingSucceeded200HandleResponse handles the Put201CreatingSucceeded200 response.
 func (client *lrOSCustomHeaderOperations) put201CreatingSucceeded200HandleResponse(resp *azcore.Response) (*ProductResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return nil, newCloudError(resp)
 	}
 	result := ProductResponse{RawResponse: resp.Response}

--- a/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
@@ -1,0 +1,320 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package httpinfrastructuregrouptest
+
+import (
+	"context"
+	"generatortests/autorest/generated/httpinfrastructuregroup"
+	"generatortests/helpers"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/to"
+)
+
+func getMultipleResponseOperations(t *testing.T) httpinfrastructuregroup.MultipleResponsesOperations {
+	client, err := httpinfrastructuregroup.NewDefaultClient(nil)
+	if err != nil {
+		t.Fatalf("failed to create HTTPSuccess client: %v", err)
+	}
+	return client.MultipleResponsesOperations()
+}
+
+// Get200Model201ModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
+func TestGet200Model201ModelDefaultError200Valid(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200Model201ModelDefaultError200Valid(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.DeepEqualOrFatal(t, result.MyException.StatusCode, to.StringPtr("200"))
+}
+
+// Get200Model201ModelDefaultError201Valid - Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}
+func TestGet200Model201ModelDefaultError201Valid(t *testing.T) {
+	t.Skip("different return schemas NYI")
+}
+
+// Get200Model201ModelDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
+func TestGet200Model201ModelDefaultError400Valid(t *testing.T) {
+	t.Skip("different return schemas NYI")
+}
+
+// Get200Model204NoModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
+func TestGet200Model204NoModelDefaultError200Valid(t *testing.T) {
+	t.Skip("different return schemas NYI")
+}
+
+// Get200Model204NoModelDefaultError201Invalid - Send a 201 response with valid payload: {'statusCode': '201'}
+func TestGet200Model204NoModelDefaultError201Invalid(t *testing.T) {
+	t.Skip("different return schemas NYI")
+}
+
+// Get200Model204NoModelDefaultError202None - Send a 202 response with no payload:
+func TestGet200Model204NoModelDefaultError202None(t *testing.T) {
+	t.Skip("different return schemas NYI")
+}
+
+// Get200Model204NoModelDefaultError204Valid - Send a 204 response with no payload
+func TestGet200Model204NoModelDefaultError204Valid(t *testing.T) {
+	t.Skip("different return schemas NYI")
+}
+
+// Get200Model204NoModelDefaultError400Valid - Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}
+func TestGet200Model204NoModelDefaultError400Valid(t *testing.T) {
+	t.Skip("different return schemas NYI")
+}
+
+// Get200ModelA200Invalid - Send a 200 response with invalid payload {'statusCodeInvalid': '200'}
+func TestGet200ModelA200Invalid(t *testing.T) {
+	t.Skip("payload doen't match schema doesn't cause unmarshalling error")
+}
+
+// Get200ModelA200None - Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A
+func TestGet200ModelA200None(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200ModelA200None(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.MyException != nil {
+		t.Fatal("expected nil MyException")
+	}
+}
+
+// Get200ModelA200Valid - Send a 200 response with payload {'statusCode': '200'}
+func TestGet200ModelA200Valid(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200ModelA200Valid(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.DeepEqualOrFatal(t, result.MyException, &httpinfrastructuregroup.MyException{
+		StatusCode: to.StringPtr("200"),
+	})
+}
+
+// Get200ModelA201ModelC404ModelDDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
+func TestGet200ModelA201ModelC404ModelDDefaultError200Valid(t *testing.T) {
+	t.Skip("different return schemas NYI")
+}
+
+// Get200ModelA201ModelC404ModelDDefaultError201Valid - Send a 200 response with valid payload: {'httpCode': '201'}
+func TestGet200ModelA201ModelC404ModelDDefaultError201Valid(t *testing.T) {
+	t.Skip("different return schemas NYI")
+}
+
+// Get200ModelA201ModelC404ModelDDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
+func TestGet200ModelA201ModelC404ModelDDefaultError400Valid(t *testing.T) {
+	t.Skip("different return schemas NYI")
+}
+
+// Get200ModelA201ModelC404ModelDDefaultError404Valid - Send a 200 response with valid payload: {'httpStatusCode': '404'}
+func TestGet200ModelA201ModelC404ModelDDefaultError404Valid(t *testing.T) {
+	t.Skip("different return schemas NYI")
+}
+
+// Get200ModelA202Valid - Send a 202 response with payload {'statusCode': '202'}
+func TestGet200ModelA202Valid(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200ModelA200Valid(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.DeepEqualOrFatal(t, result.MyException, &httpinfrastructuregroup.MyException{
+		StatusCode: to.StringPtr("200"),
+	})
+}
+
+// Get200ModelA400Invalid - Send a 200 response with invalid payload {'statusCodeInvalid': '400'}
+func TestGet200ModelA400Invalid(t *testing.T) {
+	t.Skip("payload doen't match schema doesn't cause unmarshalling error")
+}
+
+// Get200ModelA400None - Send a 400 response with no payload client should treat as an http error with no error model
+func TestGet200ModelA400None(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200ModelA400None(context.Background())
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if result != nil {
+		t.Fatal("expected nil result")
+	}
+}
+
+// Get200ModelA400Valid - Send a 200 response with payload {'statusCode': '400'}
+func TestGet200ModelA400Valid(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200ModelA400Valid(context.Background())
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if result != nil {
+		t.Fatal("expected nil result")
+	}
+}
+
+// Get202None204NoneDefaultError202None - Send a 202 response with no payload
+func TestGet202None204NoneDefaultError202None(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get202None204NoneDefaultError202None(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, result, http.StatusAccepted)
+}
+
+// Get202None204NoneDefaultError204None - Send a 204 response with no payload
+func TestGet202None204NoneDefaultError204None(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get202None204NoneDefaultError204None(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, result, http.StatusNoContent)
+}
+
+// Get202None204NoneDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
+func TestGet202None204NoneDefaultError400Valid(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get202None204NoneDefaultError400Valid(context.Background())
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if result != nil {
+		t.Fatal("unexpected nil response")
+	}
+}
+
+// Get202None204NoneDefaultNone202Invalid - Send a 202 response with an unexpected payload {'property': 'value'}
+func TestGet202None204NoneDefaultNone202Invalid(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get202None204NoneDefaultNone202Invalid(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, result, http.StatusAccepted)
+}
+
+// Get202None204NoneDefaultNone204None - Send a 204 response with no payload
+func TestGet202None204NoneDefaultNone204None(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get202None204NoneDefaultNone204None(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, result, http.StatusNoContent)
+}
+
+// Get202None204NoneDefaultNone400Invalid - Send a 400 response with an unexpected payload {'property': 'value'}
+func TestGet202None204NoneDefaultNone400Invalid(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get202None204NoneDefaultNone400Invalid(context.Background())
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if result != nil {
+		t.Fatal("unexpected nil response")
+	}
+}
+
+// Get202None204NoneDefaultNone400None - Send a 400 response with no payload
+func TestGet202None204NoneDefaultNone400None(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get202None204NoneDefaultNone400None(context.Background())
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if result != nil {
+		t.Fatal("unexpected nil response")
+	}
+}
+
+// GetDefaultModelA200None - Send a 200 response with no payload
+func TestGetDefaultModelA200None(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.GetDefaultModelA200None(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.MyException != nil {
+		t.Fatal("expected nil MyException")
+	}
+}
+
+// GetDefaultModelA200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
+func TestGetDefaultModelA200Valid(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.GetDefaultModelA200Valid(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.DeepEqualOrFatal(t, result.MyException, &httpinfrastructuregroup.MyException{
+		StatusCode: to.StringPtr("200"),
+	})
+}
+
+// GetDefaultModelA400None - Send a 400 response with no payload
+func TestGetDefaultModelA400None(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.GetDefaultModelA400None(context.Background())
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if result != nil {
+		t.Fatal("unexpected nil response")
+	}
+}
+
+// GetDefaultModelA400Valid - Send a 400 response with valid payload: {'statusCode': '400'}
+func TestGetDefaultModelA400Valid(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.GetDefaultModelA400Valid(context.Background())
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if result != nil {
+		t.Fatal("unexpected nil response")
+	}
+}
+
+// GetDefaultNone200Invalid - Send a 200 response with invalid payload: {'statusCode': '200'}
+func TestGetDefaultNone200Invalid(t *testing.T) {
+	t.Skip("payload doen't match schema doesn't cause unmarshalling error")
+}
+
+// GetDefaultNone200None - Send a 200 response with no payload
+func TestGetDefaultNone200None(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.GetDefaultNone200None(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
+}
+
+// GetDefaultNone400Invalid - Send a 400 response with valid payload: {'statusCode': '400'}
+func TestGetDefaultNone400Invalid(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.GetDefaultNone400Invalid(context.Background())
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if result != nil {
+		t.Fatal("unexpected nil response")
+	}
+}
+
+// GetDefaultNone400None - Send a 400 response with no payload
+func TestGetDefaultNone400None(t *testing.T) {
+	client := getMultipleResponseOperations(t)
+	result, err := client.GetDefaultNone400None(context.Background())
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+	if result != nil {
+		t.Fatal("unexpected nil response")
+	}
+}

--- a/test/autorest/httpinfrastructuregroup/httpsuccess_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpsuccess_test.go
@@ -76,12 +76,10 @@ func TestHTTPSuccessHead204(t *testing.T) {
 func TestHTTPSuccessHead404(t *testing.T) {
 	client := getHTTPSuccessOperations(t)
 	result, err := client.Head404(context.Background())
-	if err == nil {
-		t.Fatalf("Expected an error but did not receive one")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if result != nil {
-		t.Fatalf("Expected a nil result")
-	}
+	helpers.VerifyStatusCode(t, result, http.StatusNotFound)
 }
 
 func TestHTTPSuccessOptions200(t *testing.T) {


### PR DESCRIPTION
Add support for operations that specify multiple response codes that
have the same schema (or no schema).