### PR TITLE
Normalize output folder path

### DIFF
--- a/src/CodeGeneratorGo.cs
+++ b/src/CodeGeneratorGo.cs
@@ -117,7 +117,7 @@ namespace AutoRest.Go
             var modRoot = Settings.Instance.Host.GetValue<string>("gomod-root").Result;
             if (!string.IsNullOrWhiteSpace(modRoot))
             {
-                var normalized = Settings.Instance.Host.GetValue<string>("output-folder").Result.Replace('\\', '/');
+                var normalized = Path.GetFullPath(Settings.Instance.Host.GetValue<string>("output-folder").Result).Replace('\\', '/');
                 var i = normalized.IndexOf(modRoot);
                 if (i == -1)
                 {

--- a/src/CodeGeneratorGo.cs
+++ b/src/CodeGeneratorGo.cs
@@ -124,11 +124,18 @@ namespace AutoRest.Go
                 {
                     throw new Exception($"didn't find module root '{modRoot}' in output path '{normalized}'");
                 }
+                var goVersion = Settings.Instance.Host.GetValue<string>("go-version").Result;
+                if (string.IsNullOrWhiteSpace(goVersion)) 
+                {
+                    goVersion = defaultGoVersion;
+                }
                 // module name is everything to the right of the start of the module root
-                var gomodTemplate = new GoModTemplate { Model = new GoMod(normalized.Substring(i)) };
+                var gomodTemplate = new GoModTemplate { Model = new GoMod(normalized.Substring(i), goVersion) };
                 await Write(gomodTemplate, $"{StagingDir()}go.mod");
             }
         }
+
+        private const string defaultGoVersion = "1.13";
 
         private string FormatFileName(string fileName)
         {

--- a/src/CodeGeneratorGo.cs
+++ b/src/CodeGeneratorGo.cs
@@ -6,6 +6,7 @@ using AutoRest.Core.Model;
 using AutoRest.Go.Model;
 using AutoRest.Go.Templates;
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;

--- a/src/Model/GoMod.cs
+++ b/src/Model/GoMod.cs
@@ -5,11 +5,14 @@ namespace AutoRest.Go.Model
 {
     public class GoMod
     {
-        public GoMod(string goMod)
+        public GoMod(string goMod, string goVersion)
         {
             Module = goMod;
+            GoVersion = goVersion;
         }
 
         public string Module { get; }
+
+        public string GoVersion { get; }
     }
 }

--- a/src/Templates/GoModTemplate.cshtml
+++ b/src/Templates/GoModTemplate.cshtml
@@ -2,4 +2,4 @@
 
 module @Model.Module
 @EmptyLine
-go 1.12
+go @Model.GoVersion


### PR DESCRIPTION
The output folder path need to be normalized first before convert to go.mod module.

Sometimes the go.mod file may produce this result:
```
module github.com/Azure/azure-sdk-for-go//services/batch/mgmt/2020-03-01/batch

go 1.12
```
This PR normalizes the output directory before converting it into a go.mod module to avoid this.

This PR also adds a new option `--go-version` to provide the golang version in go.mod