### PR TITLE
Move enums to per-line to avoid really long lines

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -47,7 +47,6 @@ export interface PollerInfo {
   operationName: string;
   schema: Schema;
   client: string;
-  pollingMethod: string; // adding method to determine polling tracker type
   pollingError: Schema;
 }
 

--- a/src/generator/enums.ts
+++ b/src/generator/enums.ts
@@ -23,7 +23,7 @@ export async function generateEnums(session: Session<CodeModel>): Promise<string
     }
     text += `type ${enm.name} ${enm.type}\n\n`;
     const vals = new Array<string>();
-    text += 'const (\n'
+    text += 'const (\n';
     for (const val of values(enm.choices)) {
       if (hasDescription(val.language.go!)) {
         text += `\t${comment(val.language.go!.name, '// ')} - ${val.language.go!.description}\n`;
@@ -31,9 +31,13 @@ export async function generateEnums(session: Session<CodeModel>): Promise<string
       text += `\t${val.language.go!.name} ${enm.name} = "${val.value}"\n`;
       vals.push(val.language.go!.name);
     }
-    text += ")\n\n"
+    text += ')\n\n';
     text += `func ${enm.funcName}() []${enm.name} {\n`;
-    text += `\treturn []${enm.name}{${joinComma(vals, (item: string) => item)}}\n`;
+    text += `\treturn []${enm.name}{\t\n`;
+    for (const val of values(vals)) {
+      text += `\t\t${val},\n`;
+    }
+    text += '\t}\n';
     text += '}\n\n';
     text += `func (c ${enm.name}) ToPtr() *${enm.name} {\n`;
     text += '\treturn &c\n';

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -77,12 +77,6 @@ class StructDef {
     // used to track when to add an extra \n between fields that have comments
     let first = true;
     for (const prop of values(this.Properties)) {
-      // adding the Inner prefix on error types, since errors in Go have an Error() method
-      // in order to implement the error interface. This causes errors to not be able to have
-      // an Error field as well, since it would cause confusion
-      if (this.Language.errorType && prop.language.go!.name === 'Error') {
-        prop.language.go!.name = 'Inner' + prop.language.go!.name;
-      }
       if (hasDescription(prop.language.go!)) {
         if (!first) {
           // add an extra new-line between fields IFF the field

--- a/test/autorest/generated/arraygroup/enums.go
+++ b/test/autorest/generated/arraygroup/enums.go
@@ -14,7 +14,11 @@ const (
 )
 
 func PossibleEnum0Values() []Enum0 {
-	return []Enum0{Enum0Foo1, Enum0Foo2, Enum0Foo3}
+	return []Enum0{
+		Enum0Foo1,
+		Enum0Foo2,
+		Enum0Foo3,
+	}
 }
 
 func (c Enum0) ToPtr() *Enum0 {
@@ -30,7 +34,11 @@ const (
 )
 
 func PossibleEnum1Values() []Enum1 {
-	return []Enum1{Enum1Foo1, Enum1Foo2, Enum1Foo3}
+	return []Enum1{
+		Enum1Foo1,
+		Enum1Foo2,
+		Enum1Foo3,
+	}
 }
 
 func (c Enum1) ToPtr() *Enum1 {
@@ -46,7 +54,11 @@ const (
 )
 
 func PossibleFooEnumValues() []FooEnum {
-	return []FooEnum{FooEnumFoo1, FooEnumFoo2, FooEnumFoo3}
+	return []FooEnum{
+		FooEnumFoo1,
+		FooEnumFoo2,
+		FooEnumFoo3,
+	}
 }
 
 func (c FooEnum) ToPtr() *FooEnum {

--- a/test/autorest/generated/complexgroup/enums.go
+++ b/test/autorest/generated/complexgroup/enums.go
@@ -15,7 +15,12 @@ const (
 )
 
 func PossibleCMYKColorsValues() []CMYKColors {
-	return []CMYKColors{CMYKColorsBlacK, CMYKColorsCyan, CMYKColorsMagenta, CMYKColorsYellow}
+	return []CMYKColors{
+		CMYKColorsBlacK,
+		CMYKColorsCyan,
+		CMYKColorsMagenta,
+		CMYKColorsYellow,
+	}
 }
 
 func (c CMYKColors) ToPtr() *CMYKColors {
@@ -36,7 +41,13 @@ const (
 )
 
 func PossibleGoblinSharkColorValues() []GoblinSharkColor {
-	return []GoblinSharkColor{GoblinSharkColorBrown, GoblinSharkColorGray, GoblinSharkColorLowerRed, GoblinSharkColorPink, GoblinSharkColorUpperRed}
+	return []GoblinSharkColor{
+		GoblinSharkColorBrown,
+		GoblinSharkColorGray,
+		GoblinSharkColorLowerRed,
+		GoblinSharkColorPink,
+		GoblinSharkColorUpperRed,
+	}
 }
 
 func (c GoblinSharkColor) ToPtr() *GoblinSharkColor {

--- a/test/autorest/generated/headergroup/enums.go
+++ b/test/autorest/generated/headergroup/enums.go
@@ -14,7 +14,11 @@ const (
 )
 
 func PossibleGreyscaleColorsValues() []GreyscaleColors {
-	return []GreyscaleColors{GreyscaleColorsWhite, GreyscaleColorsBlack, GreyscaleColorsGrey}
+	return []GreyscaleColors{
+		GreyscaleColorsWhite,
+		GreyscaleColorsBlack,
+		GreyscaleColorsGrey,
+	}
 }
 
 func (c GreyscaleColors) ToPtr() *GreyscaleColors {

--- a/test/autorest/generated/lrogroup/enums.go
+++ b/test/autorest/generated/lrogroup/enums.go
@@ -23,7 +23,19 @@ const (
 )
 
 func PossibleOperationResultStatusValues() []OperationResultStatus {
-	return []OperationResultStatus{OperationResultStatusAccepted, OperationResultStatusCanceled, OperationResultStatusCreated, OperationResultStatusCreating, OperationResultStatusDeleted, OperationResultStatusDeleting, OperationResultStatusFailed, OperationResultStatusOk, OperationResultStatusSucceeded, OperationResultStatusUpdated, OperationResultStatusUpdating}
+	return []OperationResultStatus{
+		OperationResultStatusAccepted,
+		OperationResultStatusCanceled,
+		OperationResultStatusCreated,
+		OperationResultStatusCreating,
+		OperationResultStatusDeleted,
+		OperationResultStatusDeleting,
+		OperationResultStatusFailed,
+		OperationResultStatusOk,
+		OperationResultStatusSucceeded,
+		OperationResultStatusUpdated,
+		OperationResultStatusUpdating,
+	}
 }
 
 func (c OperationResultStatus) ToPtr() *OperationResultStatus {
@@ -47,7 +59,19 @@ const (
 )
 
 func PossibleProductPropertiesProvisioningStateValuesValues() []ProductPropertiesProvisioningStateValues {
-	return []ProductPropertiesProvisioningStateValues{ProductPropertiesProvisioningStateValuesAccepted, ProductPropertiesProvisioningStateValuesCanceled, ProductPropertiesProvisioningStateValuesCreated, ProductPropertiesProvisioningStateValuesCreating, ProductPropertiesProvisioningStateValuesDeleted, ProductPropertiesProvisioningStateValuesDeleting, ProductPropertiesProvisioningStateValuesFailed, ProductPropertiesProvisioningStateValuesOk, ProductPropertiesProvisioningStateValuesSucceeded, ProductPropertiesProvisioningStateValuesUpdated, ProductPropertiesProvisioningStateValuesUpdating}
+	return []ProductPropertiesProvisioningStateValues{
+		ProductPropertiesProvisioningStateValuesAccepted,
+		ProductPropertiesProvisioningStateValuesCanceled,
+		ProductPropertiesProvisioningStateValuesCreated,
+		ProductPropertiesProvisioningStateValuesCreating,
+		ProductPropertiesProvisioningStateValuesDeleted,
+		ProductPropertiesProvisioningStateValuesDeleting,
+		ProductPropertiesProvisioningStateValuesFailed,
+		ProductPropertiesProvisioningStateValuesOk,
+		ProductPropertiesProvisioningStateValuesSucceeded,
+		ProductPropertiesProvisioningStateValuesUpdated,
+		ProductPropertiesProvisioningStateValuesUpdating,
+	}
 }
 
 func (c ProductPropertiesProvisioningStateValues) ToPtr() *ProductPropertiesProvisioningStateValues {
@@ -71,7 +95,19 @@ const (
 )
 
 func PossibleSubProductPropertiesProvisioningStateValuesValues() []SubProductPropertiesProvisioningStateValues {
-	return []SubProductPropertiesProvisioningStateValues{SubProductPropertiesProvisioningStateValuesAccepted, SubProductPropertiesProvisioningStateValuesCanceled, SubProductPropertiesProvisioningStateValuesCreated, SubProductPropertiesProvisioningStateValuesCreating, SubProductPropertiesProvisioningStateValuesDeleted, SubProductPropertiesProvisioningStateValuesDeleting, SubProductPropertiesProvisioningStateValuesFailed, SubProductPropertiesProvisioningStateValuesOk, SubProductPropertiesProvisioningStateValuesSucceeded, SubProductPropertiesProvisioningStateValuesUpdated, SubProductPropertiesProvisioningStateValuesUpdating}
+	return []SubProductPropertiesProvisioningStateValues{
+		SubProductPropertiesProvisioningStateValuesAccepted,
+		SubProductPropertiesProvisioningStateValuesCanceled,
+		SubProductPropertiesProvisioningStateValuesCreated,
+		SubProductPropertiesProvisioningStateValuesCreating,
+		SubProductPropertiesProvisioningStateValuesDeleted,
+		SubProductPropertiesProvisioningStateValuesDeleting,
+		SubProductPropertiesProvisioningStateValuesFailed,
+		SubProductPropertiesProvisioningStateValuesOk,
+		SubProductPropertiesProvisioningStateValuesSucceeded,
+		SubProductPropertiesProvisioningStateValuesUpdated,
+		SubProductPropertiesProvisioningStateValuesUpdating,
+	}
 }
 
 func (c SubProductPropertiesProvisioningStateValues) ToPtr() *SubProductPropertiesProvisioningStateValues {

--- a/test/autorest/generated/paginggroup/enums.go
+++ b/test/autorest/generated/paginggroup/enums.go
@@ -23,7 +23,19 @@ const (
 )
 
 func PossibleOperationResultStatusValues() []OperationResultStatus {
-	return []OperationResultStatus{OperationResultStatusAccepted, OperationResultStatusCanceled, OperationResultStatusCreated, OperationResultStatusCreating, OperationResultStatusDeleted, OperationResultStatusDeleting, OperationResultStatusFailed, OperationResultStatusOk, OperationResultStatusSucceeded, OperationResultStatusUpdated, OperationResultStatusUpdating}
+	return []OperationResultStatus{
+		OperationResultStatusAccepted,
+		OperationResultStatusCanceled,
+		OperationResultStatusCreated,
+		OperationResultStatusCreating,
+		OperationResultStatusDeleted,
+		OperationResultStatusDeleting,
+		OperationResultStatusFailed,
+		OperationResultStatusOk,
+		OperationResultStatusSucceeded,
+		OperationResultStatusUpdated,
+		OperationResultStatusUpdating,
+	}
 }
 
 func (c OperationResultStatus) ToPtr() *OperationResultStatus {

--- a/test/autorest/generated/stringgroup/enums.go
+++ b/test/autorest/generated/stringgroup/enums.go
@@ -14,7 +14,11 @@ const (
 )
 
 func PossibleColorsValues() []Colors {
-	return []Colors{ColorsRedColor, ColorsGreenColor, ColorsBlueColor}
+	return []Colors{
+		ColorsRedColor,
+		ColorsGreenColor,
+		ColorsBlueColor,
+	}
 }
 
 func (c Colors) ToPtr() *Colors {

--- a/test/autorest/generated/urlgroup/enums.go
+++ b/test/autorest/generated/urlgroup/enums.go
@@ -14,7 +14,11 @@ const (
 )
 
 func PossibleUriColorValues() []UriColor {
-	return []UriColor{UriColorRedColor, UriColorGreenColor, UriColorBlueColor}
+	return []UriColor{
+		UriColorRedColor,
+		UriColorGreenColor,
+		UriColorBlueColor,
+	}
 }
 
 func (c UriColor) ToPtr() *UriColor {

--- a/test/autorest/generated/xmlgroup/enums.go
+++ b/test/autorest/generated/xmlgroup/enums.go
@@ -21,7 +21,18 @@ const (
 )
 
 func PossibleAccessTierValues() []AccessTier {
-	return []AccessTier{AccessTierArchive, AccessTierCool, AccessTierHot, AccessTierP10, AccessTierP20, AccessTierP30, AccessTierP4, AccessTierP40, AccessTierP50, AccessTierP6}
+	return []AccessTier{
+		AccessTierArchive,
+		AccessTierCool,
+		AccessTierHot,
+		AccessTierP10,
+		AccessTierP20,
+		AccessTierP30,
+		AccessTierP4,
+		AccessTierP40,
+		AccessTierP50,
+		AccessTierP6,
+	}
 }
 
 func (c AccessTier) ToPtr() *AccessTier {
@@ -36,7 +47,10 @@ const (
 )
 
 func PossibleArchiveStatusValues() []ArchiveStatus {
-	return []ArchiveStatus{ArchiveStatusRehydratePendingToCool, ArchiveStatusRehydratePendingToHot}
+	return []ArchiveStatus{
+		ArchiveStatusRehydratePendingToCool,
+		ArchiveStatusRehydratePendingToHot,
+	}
 }
 
 func (c ArchiveStatus) ToPtr() *ArchiveStatus {
@@ -52,7 +66,11 @@ const (
 )
 
 func PossibleBlobTypeValues() []BlobType {
-	return []BlobType{BlobTypeBlockBlob, BlobTypePageBlob, BlobTypeAppendBlob}
+	return []BlobType{
+		BlobTypeBlockBlob,
+		BlobTypePageBlob,
+		BlobTypeAppendBlob,
+	}
 }
 
 func (c BlobType) ToPtr() *BlobType {
@@ -69,7 +87,12 @@ const (
 )
 
 func PossibleCopyStatusTypeValues() []CopyStatusType {
-	return []CopyStatusType{CopyStatusTypePending, CopyStatusTypeSuccess, CopyStatusTypeAborted, CopyStatusTypeFailed}
+	return []CopyStatusType{
+		CopyStatusTypePending,
+		CopyStatusTypeSuccess,
+		CopyStatusTypeAborted,
+		CopyStatusTypeFailed,
+	}
 }
 
 func (c CopyStatusType) ToPtr() *CopyStatusType {
@@ -84,7 +107,10 @@ const (
 )
 
 func PossibleLeaseDurationTypeValues() []LeaseDurationType {
-	return []LeaseDurationType{LeaseDurationTypeInfinite, LeaseDurationTypeFixed}
+	return []LeaseDurationType{
+		LeaseDurationTypeInfinite,
+		LeaseDurationTypeFixed,
+	}
 }
 
 func (c LeaseDurationType) ToPtr() *LeaseDurationType {
@@ -102,7 +128,13 @@ const (
 )
 
 func PossibleLeaseStateTypeValues() []LeaseStateType {
-	return []LeaseStateType{LeaseStateTypeAvailable, LeaseStateTypeLeased, LeaseStateTypeExpired, LeaseStateTypeBreaking, LeaseStateTypeBroken}
+	return []LeaseStateType{
+		LeaseStateTypeAvailable,
+		LeaseStateTypeLeased,
+		LeaseStateTypeExpired,
+		LeaseStateTypeBreaking,
+		LeaseStateTypeBroken,
+	}
 }
 
 func (c LeaseStateType) ToPtr() *LeaseStateType {
@@ -117,7 +149,10 @@ const (
 )
 
 func PossibleLeaseStatusTypeValues() []LeaseStatusType {
-	return []LeaseStatusType{LeaseStatusTypeLocked, LeaseStatusTypeUnlocked}
+	return []LeaseStatusType{
+		LeaseStatusTypeLocked,
+		LeaseStatusTypeUnlocked,
+	}
 }
 
 func (c LeaseStatusType) ToPtr() *LeaseStatusType {
@@ -132,7 +167,10 @@ const (
 )
 
 func PossiblePublicAccessTypeValues() []PublicAccessType {
-	return []PublicAccessType{PublicAccessTypeBlob, PublicAccessTypeContainer}
+	return []PublicAccessType{
+		PublicAccessTypeBlob,
+		PublicAccessTypeContainer,
+	}
 }
 
 func (c PublicAccessType) ToPtr() *PublicAccessType {

--- a/test/storage/2019-07-07/azblob/enums.go
+++ b/test/storage/2019-07-07/azblob/enums.go
@@ -25,7 +25,22 @@ const (
 )
 
 func PossibleAccessTierValues() []AccessTier {
-	return []AccessTier{AccessTierArchive, AccessTierCool, AccessTierHot, AccessTierP10, AccessTierP15, AccessTierP20, AccessTierP30, AccessTierP4, AccessTierP40, AccessTierP50, AccessTierP6, AccessTierP60, AccessTierP70, AccessTierP80}
+	return []AccessTier{
+		AccessTierArchive,
+		AccessTierCool,
+		AccessTierHot,
+		AccessTierP10,
+		AccessTierP15,
+		AccessTierP20,
+		AccessTierP30,
+		AccessTierP4,
+		AccessTierP40,
+		AccessTierP50,
+		AccessTierP6,
+		AccessTierP60,
+		AccessTierP70,
+		AccessTierP80,
+	}
 }
 
 func (c AccessTier) ToPtr() *AccessTier {
@@ -41,7 +56,11 @@ const (
 )
 
 func PossibleAccountKindValues() []AccountKind {
-	return []AccountKind{AccountKindStorage, AccountKindBlobStorage, AccountKindStorageV2}
+	return []AccountKind{
+		AccountKindStorage,
+		AccountKindBlobStorage,
+		AccountKindStorageV2,
+	}
 }
 
 func (c AccountKind) ToPtr() *AccountKind {
@@ -56,7 +75,10 @@ const (
 )
 
 func PossibleArchiveStatusValues() []ArchiveStatus {
-	return []ArchiveStatus{ArchiveStatusRehydratePendingToCool, ArchiveStatusRehydratePendingToHot}
+	return []ArchiveStatus{
+		ArchiveStatusRehydratePendingToCool,
+		ArchiveStatusRehydratePendingToHot,
+	}
 }
 
 func (c ArchiveStatus) ToPtr() *ArchiveStatus {
@@ -72,7 +94,11 @@ const (
 )
 
 func PossibleBlobTypeValues() []BlobType {
-	return []BlobType{BlobTypeBlockBlob, BlobTypePageBlob, BlobTypeAppendBlob}
+	return []BlobType{
+		BlobTypeBlockBlob,
+		BlobTypePageBlob,
+		BlobTypeAppendBlob,
+	}
 }
 
 func (c BlobType) ToPtr() *BlobType {
@@ -88,7 +114,11 @@ const (
 )
 
 func PossibleBlockListTypeValues() []BlockListType {
-	return []BlockListType{BlockListTypeCommitted, BlockListTypeUncommitted, BlockListTypeAll}
+	return []BlockListType{
+		BlockListTypeCommitted,
+		BlockListTypeUncommitted,
+		BlockListTypeAll,
+	}
 }
 
 func (c BlockListType) ToPtr() *BlockListType {
@@ -105,7 +135,12 @@ const (
 )
 
 func PossibleCopyStatusTypeValues() []CopyStatusType {
-	return []CopyStatusType{CopyStatusTypePending, CopyStatusTypeSuccess, CopyStatusTypeAborted, CopyStatusTypeFailed}
+	return []CopyStatusType{
+		CopyStatusTypePending,
+		CopyStatusTypeSuccess,
+		CopyStatusTypeAborted,
+		CopyStatusTypeFailed,
+	}
 }
 
 func (c CopyStatusType) ToPtr() *CopyStatusType {
@@ -120,7 +155,10 @@ const (
 )
 
 func PossibleDeleteSnapshotsOptionTypeValues() []DeleteSnapshotsOptionType {
-	return []DeleteSnapshotsOptionType{DeleteSnapshotsOptionTypeInclude, DeleteSnapshotsOptionTypeOnly}
+	return []DeleteSnapshotsOptionType{
+		DeleteSnapshotsOptionTypeInclude,
+		DeleteSnapshotsOptionTypeOnly,
+	}
 }
 
 func (c DeleteSnapshotsOptionType) ToPtr() *DeleteSnapshotsOptionType {
@@ -137,7 +175,11 @@ const (
 )
 
 func PossibleGeoReplicationStatusTypeValues() []GeoReplicationStatusType {
-	return []GeoReplicationStatusType{GeoReplicationStatusTypeBootstrap, GeoReplicationStatusTypeLive, GeoReplicationStatusTypeUnavailable}
+	return []GeoReplicationStatusType{
+		GeoReplicationStatusTypeBootstrap,
+		GeoReplicationStatusTypeLive,
+		GeoReplicationStatusTypeUnavailable,
+	}
 }
 
 func (c GeoReplicationStatusType) ToPtr() *GeoReplicationStatusType {
@@ -152,7 +194,10 @@ const (
 )
 
 func PossibleLeaseDurationTypeValues() []LeaseDurationType {
-	return []LeaseDurationType{LeaseDurationTypeInfinite, LeaseDurationTypeFixed}
+	return []LeaseDurationType{
+		LeaseDurationTypeInfinite,
+		LeaseDurationTypeFixed,
+	}
 }
 
 func (c LeaseDurationType) ToPtr() *LeaseDurationType {
@@ -170,7 +215,13 @@ const (
 )
 
 func PossibleLeaseStateTypeValues() []LeaseStateType {
-	return []LeaseStateType{LeaseStateTypeAvailable, LeaseStateTypeLeased, LeaseStateTypeExpired, LeaseStateTypeBreaking, LeaseStateTypeBroken}
+	return []LeaseStateType{
+		LeaseStateTypeAvailable,
+		LeaseStateTypeLeased,
+		LeaseStateTypeExpired,
+		LeaseStateTypeBreaking,
+		LeaseStateTypeBroken,
+	}
 }
 
 func (c LeaseStateType) ToPtr() *LeaseStateType {
@@ -185,7 +236,10 @@ const (
 )
 
 func PossibleLeaseStatusTypeValues() []LeaseStatusType {
-	return []LeaseStatusType{LeaseStatusTypeLocked, LeaseStatusTypeUnlocked}
+	return []LeaseStatusType{
+		LeaseStatusTypeLocked,
+		LeaseStatusTypeUnlocked,
+	}
 }
 
 func (c LeaseStatusType) ToPtr() *LeaseStatusType {
@@ -203,7 +257,13 @@ const (
 )
 
 func PossibleListBlobsIncludeItemValues() []ListBlobsIncludeItem {
-	return []ListBlobsIncludeItem{ListBlobsIncludeItemCopy, ListBlobsIncludeItemDeleted, ListBlobsIncludeItemMetadata, ListBlobsIncludeItemSnapshots, ListBlobsIncludeItemUncommittedblobs}
+	return []ListBlobsIncludeItem{
+		ListBlobsIncludeItemCopy,
+		ListBlobsIncludeItemDeleted,
+		ListBlobsIncludeItemMetadata,
+		ListBlobsIncludeItemSnapshots,
+		ListBlobsIncludeItemUncommittedblobs,
+	}
 }
 
 func (c ListBlobsIncludeItem) ToPtr() *ListBlobsIncludeItem {
@@ -218,7 +278,10 @@ const (
 )
 
 func PossiblePathRenameModeValues() []PathRenameMode {
-	return []PathRenameMode{PathRenameModeLegacy, PathRenameModePosix}
+	return []PathRenameMode{
+		PathRenameModeLegacy,
+		PathRenameModePosix,
+	}
 }
 
 func (c PathRenameMode) ToPtr() *PathRenameMode {
@@ -242,7 +305,19 @@ const (
 )
 
 func PossiblePremiumPageBlobAccessTierValues() []PremiumPageBlobAccessTier {
-	return []PremiumPageBlobAccessTier{PremiumPageBlobAccessTierP10, PremiumPageBlobAccessTierP15, PremiumPageBlobAccessTierP20, PremiumPageBlobAccessTierP30, PremiumPageBlobAccessTierP4, PremiumPageBlobAccessTierP40, PremiumPageBlobAccessTierP50, PremiumPageBlobAccessTierP6, PremiumPageBlobAccessTierP60, PremiumPageBlobAccessTierP70, PremiumPageBlobAccessTierP80}
+	return []PremiumPageBlobAccessTier{
+		PremiumPageBlobAccessTierP10,
+		PremiumPageBlobAccessTierP15,
+		PremiumPageBlobAccessTierP20,
+		PremiumPageBlobAccessTierP30,
+		PremiumPageBlobAccessTierP4,
+		PremiumPageBlobAccessTierP40,
+		PremiumPageBlobAccessTierP50,
+		PremiumPageBlobAccessTierP6,
+		PremiumPageBlobAccessTierP60,
+		PremiumPageBlobAccessTierP70,
+		PremiumPageBlobAccessTierP80,
+	}
 }
 
 func (c PremiumPageBlobAccessTier) ToPtr() *PremiumPageBlobAccessTier {
@@ -257,7 +332,10 @@ const (
 )
 
 func PossiblePublicAccessTypeValues() []PublicAccessType {
-	return []PublicAccessType{PublicAccessTypeBlob, PublicAccessTypeContainer}
+	return []PublicAccessType{
+		PublicAccessTypeBlob,
+		PublicAccessTypeContainer,
+	}
 }
 
 func (c PublicAccessType) ToPtr() *PublicAccessType {
@@ -272,7 +350,10 @@ const (
 )
 
 func PossibleRehydratePriorityValues() []RehydratePriority {
-	return []RehydratePriority{RehydratePriorityHigh, RehydratePriorityStandard}
+	return []RehydratePriority{
+		RehydratePriorityHigh,
+		RehydratePriorityStandard,
+	}
 }
 
 func (c RehydratePriority) ToPtr() *RehydratePriority {
@@ -288,7 +369,11 @@ const (
 )
 
 func PossibleSequenceNumberActionTypeValues() []SequenceNumberActionType {
-	return []SequenceNumberActionType{SequenceNumberActionTypeMax, SequenceNumberActionTypeUpdate, SequenceNumberActionTypeIncrement}
+	return []SequenceNumberActionType{
+		SequenceNumberActionTypeMax,
+		SequenceNumberActionTypeUpdate,
+		SequenceNumberActionTypeIncrement,
+	}
 }
 
 func (c SequenceNumberActionType) ToPtr() *SequenceNumberActionType {
@@ -306,7 +391,13 @@ const (
 )
 
 func PossibleSkuNameValues() []SkuName {
-	return []SkuName{SkuNameStandardLrs, SkuNameStandardGrs, SkuNameStandardRagrs, SkuNameStandardZrs, SkuNamePremiumLrs}
+	return []SkuName{
+		SkuNameStandardLrs,
+		SkuNameStandardGrs,
+		SkuNameStandardRagrs,
+		SkuNameStandardZrs,
+		SkuNamePremiumLrs,
+	}
 }
 
 func (c SkuName) ToPtr() *SkuName {
@@ -431,7 +522,119 @@ const (
 )
 
 func PossibleStorageErrorCodeValues() []StorageErrorCode {
-	return []StorageErrorCode{StorageErrorCodeAccountAlreadyExists, StorageErrorCodeAccountBeingCreated, StorageErrorCodeAccountIsDisabled, StorageErrorCodeAppendPositionConditionNotMet, StorageErrorCodeAuthenticationFailed, StorageErrorCodeAuthorizationFailure, StorageErrorCodeAuthorizationPermissionMismatch, StorageErrorCodeAuthorizationProtocolMismatch, StorageErrorCodeAuthorizationResourceTypeMismatch, StorageErrorCodeAuthorizationServiceMismatch, StorageErrorCodeAuthorizationSourceIPMismatch, StorageErrorCodeBlobAlreadyExists, StorageErrorCodeBlobArchived, StorageErrorCodeBlobBeingRehydrated, StorageErrorCodeBlobNotArchived, StorageErrorCodeBlobNotFound, StorageErrorCodeBlobOverwritten, StorageErrorCodeBlobTierInadequateForContentLength, StorageErrorCodeBlockCountExceedsLimit, StorageErrorCodeBlockListTooLong, StorageErrorCodeCannotChangeToLowerTier, StorageErrorCodeCannotVerifyCopySource, StorageErrorCodeConditionHeadersNotSupported, StorageErrorCodeConditionNotMet, StorageErrorCodeContainerAlreadyExists, StorageErrorCodeContainerBeingDeleted, StorageErrorCodeContainerDisabled, StorageErrorCodeContainerNotFound, StorageErrorCodeContentLengthLargerThanTierLimit, StorageErrorCodeCopyAcrossAccountsNotSupported, StorageErrorCodeCopyIDMismatch, StorageErrorCodeEmptyMetadataKey, StorageErrorCodeFeatureVersionMismatch, StorageErrorCodeIncrementalCopyBlobMismatch, StorageErrorCodeIncrementalCopyOfEralierVersionSnapshotNotAllowed, StorageErrorCodeIncrementalCopySourceMustBeSnapshot, StorageErrorCodeInfiniteLeaseDurationRequired, StorageErrorCodeInsufficientAccountPermissions, StorageErrorCodeInternalError, StorageErrorCodeInvalidAuthenticationInfo, StorageErrorCodeInvalidBlobOrBlock, StorageErrorCodeInvalidBlobTier, StorageErrorCodeInvalidBlobType, StorageErrorCodeInvalidBlockID, StorageErrorCodeInvalidBlockList, StorageErrorCodeInvalidHTTPVerb, StorageErrorCodeInvalidHeaderValue, StorageErrorCodeInvalidInput, StorageErrorCodeInvalidMd5, StorageErrorCodeInvalidMetadata, StorageErrorCodeInvalidOperation, StorageErrorCodeInvalidPageRange, StorageErrorCodeInvalidQueryParameterValue, StorageErrorCodeInvalidRange, StorageErrorCodeInvalidResourceName, StorageErrorCodeInvalidSourceBlobType, StorageErrorCodeInvalidSourceBlobURL, StorageErrorCodeInvalidURI, StorageErrorCodeInvalidVersionForPageBlobOperation, StorageErrorCodeInvalidXMLDocument, StorageErrorCodeInvalidXMLNodeValue, StorageErrorCodeLeaseAlreadyBroken, StorageErrorCodeLeaseAlreadyPresent, StorageErrorCodeLeaseIDMismatchWithBlobOperation, StorageErrorCodeLeaseIDMismatchWithContainerOperation, StorageErrorCodeLeaseIDMismatchWithLeaseOperation, StorageErrorCodeLeaseIDMissing, StorageErrorCodeLeaseIsBreakingAndCannotBeAcquired, StorageErrorCodeLeaseIsBreakingAndCannotBeChanged, StorageErrorCodeLeaseIsBrokenAndCannotBeRenewed, StorageErrorCodeLeaseLost, StorageErrorCodeLeaseNotPresentWithBlobOperation, StorageErrorCodeLeaseNotPresentWithContainerOperation, StorageErrorCodeLeaseNotPresentWithLeaseOperation, StorageErrorCodeMaxBlobSizeConditionNotMet, StorageErrorCodeMd5Mismatch, StorageErrorCodeMetadataTooLarge, StorageErrorCodeMissingContentLengthHeader, StorageErrorCodeMissingRequiredHeader, StorageErrorCodeMissingRequiredQueryParameter, StorageErrorCodeMissingRequiredXMLNode, StorageErrorCodeMultipleConditionHeadersNotSupported, StorageErrorCodeNoAuthenticationInformation, StorageErrorCodeNoPendingCopyOperation, StorageErrorCodeOperationNotAllowedOnIncrementalCopyBlob, StorageErrorCodeOperationTimedOut, StorageErrorCodeOutOfRangeInput, StorageErrorCodeOutOfRangeQueryParameterValue, StorageErrorCodePendingCopyOperation, StorageErrorCodePreviousSnapshotCannotBeNewer, StorageErrorCodePreviousSnapshotNotFound, StorageErrorCodePreviousSnapshotOperationNotSupported, StorageErrorCodeRequestBodyTooLarge, StorageErrorCodeRequestURLFailedToParse, StorageErrorCodeResourceAlreadyExists, StorageErrorCodeResourceNotFound, StorageErrorCodeResourceTypeMismatch, StorageErrorCodeSequenceNumberConditionNotMet, StorageErrorCodeSequenceNumberIncrementTooLarge, StorageErrorCodeServerBusy, StorageErrorCodeSnaphotOperationRateExceeded, StorageErrorCodeSnapshotCountExceeded, StorageErrorCodeSnapshotsPresent, StorageErrorCodeSourceConditionNotMet, StorageErrorCodeSystemInUse, StorageErrorCodeTargetConditionNotMet, StorageErrorCodeUnauthorizedBlobOverwrite, StorageErrorCodeUnsupportedHTTPVerb, StorageErrorCodeUnsupportedHeader, StorageErrorCodeUnsupportedQueryParameter, StorageErrorCodeUnsupportedXMLNode}
+	return []StorageErrorCode{
+		StorageErrorCodeAccountAlreadyExists,
+		StorageErrorCodeAccountBeingCreated,
+		StorageErrorCodeAccountIsDisabled,
+		StorageErrorCodeAppendPositionConditionNotMet,
+		StorageErrorCodeAuthenticationFailed,
+		StorageErrorCodeAuthorizationFailure,
+		StorageErrorCodeAuthorizationPermissionMismatch,
+		StorageErrorCodeAuthorizationProtocolMismatch,
+		StorageErrorCodeAuthorizationResourceTypeMismatch,
+		StorageErrorCodeAuthorizationServiceMismatch,
+		StorageErrorCodeAuthorizationSourceIPMismatch,
+		StorageErrorCodeBlobAlreadyExists,
+		StorageErrorCodeBlobArchived,
+		StorageErrorCodeBlobBeingRehydrated,
+		StorageErrorCodeBlobNotArchived,
+		StorageErrorCodeBlobNotFound,
+		StorageErrorCodeBlobOverwritten,
+		StorageErrorCodeBlobTierInadequateForContentLength,
+		StorageErrorCodeBlockCountExceedsLimit,
+		StorageErrorCodeBlockListTooLong,
+		StorageErrorCodeCannotChangeToLowerTier,
+		StorageErrorCodeCannotVerifyCopySource,
+		StorageErrorCodeConditionHeadersNotSupported,
+		StorageErrorCodeConditionNotMet,
+		StorageErrorCodeContainerAlreadyExists,
+		StorageErrorCodeContainerBeingDeleted,
+		StorageErrorCodeContainerDisabled,
+		StorageErrorCodeContainerNotFound,
+		StorageErrorCodeContentLengthLargerThanTierLimit,
+		StorageErrorCodeCopyAcrossAccountsNotSupported,
+		StorageErrorCodeCopyIDMismatch,
+		StorageErrorCodeEmptyMetadataKey,
+		StorageErrorCodeFeatureVersionMismatch,
+		StorageErrorCodeIncrementalCopyBlobMismatch,
+		StorageErrorCodeIncrementalCopyOfEralierVersionSnapshotNotAllowed,
+		StorageErrorCodeIncrementalCopySourceMustBeSnapshot,
+		StorageErrorCodeInfiniteLeaseDurationRequired,
+		StorageErrorCodeInsufficientAccountPermissions,
+		StorageErrorCodeInternalError,
+		StorageErrorCodeInvalidAuthenticationInfo,
+		StorageErrorCodeInvalidBlobOrBlock,
+		StorageErrorCodeInvalidBlobTier,
+		StorageErrorCodeInvalidBlobType,
+		StorageErrorCodeInvalidBlockID,
+		StorageErrorCodeInvalidBlockList,
+		StorageErrorCodeInvalidHTTPVerb,
+		StorageErrorCodeInvalidHeaderValue,
+		StorageErrorCodeInvalidInput,
+		StorageErrorCodeInvalidMd5,
+		StorageErrorCodeInvalidMetadata,
+		StorageErrorCodeInvalidOperation,
+		StorageErrorCodeInvalidPageRange,
+		StorageErrorCodeInvalidQueryParameterValue,
+		StorageErrorCodeInvalidRange,
+		StorageErrorCodeInvalidResourceName,
+		StorageErrorCodeInvalidSourceBlobType,
+		StorageErrorCodeInvalidSourceBlobURL,
+		StorageErrorCodeInvalidURI,
+		StorageErrorCodeInvalidVersionForPageBlobOperation,
+		StorageErrorCodeInvalidXMLDocument,
+		StorageErrorCodeInvalidXMLNodeValue,
+		StorageErrorCodeLeaseAlreadyBroken,
+		StorageErrorCodeLeaseAlreadyPresent,
+		StorageErrorCodeLeaseIDMismatchWithBlobOperation,
+		StorageErrorCodeLeaseIDMismatchWithContainerOperation,
+		StorageErrorCodeLeaseIDMismatchWithLeaseOperation,
+		StorageErrorCodeLeaseIDMissing,
+		StorageErrorCodeLeaseIsBreakingAndCannotBeAcquired,
+		StorageErrorCodeLeaseIsBreakingAndCannotBeChanged,
+		StorageErrorCodeLeaseIsBrokenAndCannotBeRenewed,
+		StorageErrorCodeLeaseLost,
+		StorageErrorCodeLeaseNotPresentWithBlobOperation,
+		StorageErrorCodeLeaseNotPresentWithContainerOperation,
+		StorageErrorCodeLeaseNotPresentWithLeaseOperation,
+		StorageErrorCodeMaxBlobSizeConditionNotMet,
+		StorageErrorCodeMd5Mismatch,
+		StorageErrorCodeMetadataTooLarge,
+		StorageErrorCodeMissingContentLengthHeader,
+		StorageErrorCodeMissingRequiredHeader,
+		StorageErrorCodeMissingRequiredQueryParameter,
+		StorageErrorCodeMissingRequiredXMLNode,
+		StorageErrorCodeMultipleConditionHeadersNotSupported,
+		StorageErrorCodeNoAuthenticationInformation,
+		StorageErrorCodeNoPendingCopyOperation,
+		StorageErrorCodeOperationNotAllowedOnIncrementalCopyBlob,
+		StorageErrorCodeOperationTimedOut,
+		StorageErrorCodeOutOfRangeInput,
+		StorageErrorCodeOutOfRangeQueryParameterValue,
+		StorageErrorCodePendingCopyOperation,
+		StorageErrorCodePreviousSnapshotCannotBeNewer,
+		StorageErrorCodePreviousSnapshotNotFound,
+		StorageErrorCodePreviousSnapshotOperationNotSupported,
+		StorageErrorCodeRequestBodyTooLarge,
+		StorageErrorCodeRequestURLFailedToParse,
+		StorageErrorCodeResourceAlreadyExists,
+		StorageErrorCodeResourceNotFound,
+		StorageErrorCodeResourceTypeMismatch,
+		StorageErrorCodeSequenceNumberConditionNotMet,
+		StorageErrorCodeSequenceNumberIncrementTooLarge,
+		StorageErrorCodeServerBusy,
+		StorageErrorCodeSnaphotOperationRateExceeded,
+		StorageErrorCodeSnapshotCountExceeded,
+		StorageErrorCodeSnapshotsPresent,
+		StorageErrorCodeSourceConditionNotMet,
+		StorageErrorCodeSystemInUse,
+		StorageErrorCodeTargetConditionNotMet,
+		StorageErrorCodeUnauthorizedBlobOverwrite,
+		StorageErrorCodeUnsupportedHTTPVerb,
+		StorageErrorCodeUnsupportedHeader,
+		StorageErrorCodeUnsupportedQueryParameter,
+		StorageErrorCodeUnsupportedXMLNode,
+	}
 }
 
 func (c StorageErrorCode) ToPtr() *StorageErrorCode {


### PR DESCRIPTION
Some swaggers define dozens, or hundreds, of enum values.  Put each
value per line instead of on one really long line.
Move renaming of inner error property to transformer so other parts of
codegen can pick it up.
Removed some dead code in poller generation.