### PR TITLE
Split response error unmarshalling into its own method

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -47,7 +47,6 @@ export interface PollerInfo {
   operationName: string;
   schema: Schema;
   client: string;
-  pollingError: Schema;
 }
 
 // returns true if the operation is a long-running operation

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -366,17 +366,8 @@ function generateStructs(objects?: ObjectSchema[]): StructDef[] {
     }
     const structDef = generateStruct(obj.language.go!, props);
     if (obj.language.go!.errorType) {
-      // add error constructor function
-      let text = `func ${obj.language.go!.constructorName}(resp *azcore.Response) error {\n`;
-      text += `\terr := ${obj.language.go!.name}{}\n`;
-      text += `\tif err := resp.UnmarshalAs${(<string>obj.language.go!.marshallingFormat).toUpperCase()}(&err); err != nil {\n`;
-      text += `\t\treturn err\n`;
-      text += `\t}\n`;
-      text += '\treturn err\n';
-      text += '}\n\n';
-      structDef.Methods.push(text);
       // add Error() method
-      text = `func (e ${obj.language.go!.name}) Error() string {\n`;
+      let text = `func (e ${obj.language.go!.name}) Error() string {\n`;
       text += `\tmsg := ""\n`;
       for (const prop of values(structDef.Properties)) {
         text += `\tif e.${prop.language.go!.name} != nil {\n`;
@@ -405,7 +396,6 @@ function generateStructs(objects?: ObjectSchema[]): StructDef[] {
 
 function generateStruct(lang: Language, props?: Property[]): StructDef {
   if (lang.errorType) {
-    imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore');
     imports.add('fmt');
   }
   if (lang.responseType) {

--- a/src/transform/namer.ts
+++ b/src/transform/namer.ts
@@ -12,6 +12,7 @@ import { aggregateParameters, isLROOperation } from '../common/helpers';
 
 const requestMethodSuffix = 'CreateRequest';
 const responseMethodSuffix = 'HandleResponse';
+const errorMethodSuffix = 'HandleError';
 
 // contains extended naming information for operations
 export interface OperationNaming extends Language {
@@ -21,15 +22,18 @@ export interface OperationNaming extends Language {
 interface protocolNaming {
   requestMethod: string;
   responseMethod: string;
+  errorMethod: string;
 }
 
 class protocolMethods implements protocolNaming {
   readonly requestMethod: string;
   readonly responseMethod: string;
+  readonly errorMethod: string;
 
   constructor(name: string) {
     this.requestMethod = `${name}${requestMethodSuffix}`;
     this.responseMethod = `${name}${responseMethodSuffix}`;
+    this.errorMethod = `${name}${errorMethodSuffix}`;
   }
 }
 

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -493,7 +493,6 @@ function createResponseType(codeModel: CodeModel, group: OperationGroup, op: Ope
       operationName: camelCase(op.language.go!.name),
       schema: (<SchemaResponse>firstResp).schema,
       client: camelCase(group.language.go!.clientName),
-      pollingError: (<SchemaResponse>op.exceptions![0]).schema, // TODO this is the wrong implementation, needs to be fixed
     };
     const pollers = <Array<PollerInfo>>codeModel.language.go!.pollerTypes;
     pollers.push(poller);

--- a/test/autorest/generated/arraygroup/array.go
+++ b/test/autorest/generated/arraygroup/array.go
@@ -190,10 +190,19 @@ func (client *arrayOperations) getArrayEmptyCreateRequest() (*azcore.Request, er
 // getArrayEmptyHandleResponse handles the GetArrayEmpty response.
 func (client *arrayOperations) getArrayEmptyHandleResponse(resp *azcore.Response) (*StringArrayArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getArrayEmptyHandleError(resp)
 	}
 	result := StringArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArrayArray)
+}
+
+// getArrayEmptyHandleError handles the GetArrayEmpty error response.
+func (client *arrayOperations) getArrayEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetArrayItemEmpty - Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']]
@@ -227,10 +236,19 @@ func (client *arrayOperations) getArrayItemEmptyCreateRequest() (*azcore.Request
 // getArrayItemEmptyHandleResponse handles the GetArrayItemEmpty response.
 func (client *arrayOperations) getArrayItemEmptyHandleResponse(resp *azcore.Response) (*StringArrayArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getArrayItemEmptyHandleError(resp)
 	}
 	result := StringArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArrayArray)
+}
+
+// getArrayItemEmptyHandleError handles the GetArrayItemEmpty error response.
+func (client *arrayOperations) getArrayItemEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetArrayItemNull - Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']]
@@ -264,10 +282,19 @@ func (client *arrayOperations) getArrayItemNullCreateRequest() (*azcore.Request,
 // getArrayItemNullHandleResponse handles the GetArrayItemNull response.
 func (client *arrayOperations) getArrayItemNullHandleResponse(resp *azcore.Response) (*StringArrayArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getArrayItemNullHandleError(resp)
 	}
 	result := StringArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArrayArray)
+}
+
+// getArrayItemNullHandleError handles the GetArrayItemNull error response.
+func (client *arrayOperations) getArrayItemNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetArrayNull - Get a null array
@@ -301,10 +328,19 @@ func (client *arrayOperations) getArrayNullCreateRequest() (*azcore.Request, err
 // getArrayNullHandleResponse handles the GetArrayNull response.
 func (client *arrayOperations) getArrayNullHandleResponse(resp *azcore.Response) (*StringArrayArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getArrayNullHandleError(resp)
 	}
 	result := StringArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArrayArray)
+}
+
+// getArrayNullHandleError handles the GetArrayNull error response.
+func (client *arrayOperations) getArrayNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetArrayValid - Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
@@ -338,10 +374,19 @@ func (client *arrayOperations) getArrayValidCreateRequest() (*azcore.Request, er
 // getArrayValidHandleResponse handles the GetArrayValid response.
 func (client *arrayOperations) getArrayValidHandleResponse(resp *azcore.Response) (*StringArrayArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getArrayValidHandleError(resp)
 	}
 	result := StringArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArrayArray)
+}
+
+// getArrayValidHandleError handles the GetArrayValid error response.
+func (client *arrayOperations) getArrayValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBase64URL - Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded
@@ -375,10 +420,19 @@ func (client *arrayOperations) getBase64UrlCreateRequest() (*azcore.Request, err
 // getBase64UrlHandleResponse handles the GetBase64URL response.
 func (client *arrayOperations) getBase64UrlHandleResponse(resp *azcore.Response) (*ByteArrayArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBase64UrlHandleError(resp)
 	}
 	result := ByteArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ByteArrayArray)
+}
+
+// getBase64UrlHandleError handles the GetBase64URL error response.
+func (client *arrayOperations) getBase64UrlHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBooleanInvalidNull - Get boolean array value [true, null, false]
@@ -412,10 +466,19 @@ func (client *arrayOperations) getBooleanInvalidNullCreateRequest() (*azcore.Req
 // getBooleanInvalidNullHandleResponse handles the GetBooleanInvalidNull response.
 func (client *arrayOperations) getBooleanInvalidNullHandleResponse(resp *azcore.Response) (*BoolArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBooleanInvalidNullHandleError(resp)
 	}
 	result := BoolArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.BoolArray)
+}
+
+// getBooleanInvalidNullHandleError handles the GetBooleanInvalidNull error response.
+func (client *arrayOperations) getBooleanInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBooleanInvalidString - Get boolean array value [true, 'boolean', false]
@@ -449,10 +512,19 @@ func (client *arrayOperations) getBooleanInvalidStringCreateRequest() (*azcore.R
 // getBooleanInvalidStringHandleResponse handles the GetBooleanInvalidString response.
 func (client *arrayOperations) getBooleanInvalidStringHandleResponse(resp *azcore.Response) (*BoolArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBooleanInvalidStringHandleError(resp)
 	}
 	result := BoolArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.BoolArray)
+}
+
+// getBooleanInvalidStringHandleError handles the GetBooleanInvalidString error response.
+func (client *arrayOperations) getBooleanInvalidStringHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBooleanTfft - Get boolean array value [true, false, false, true]
@@ -486,10 +558,19 @@ func (client *arrayOperations) getBooleanTfftCreateRequest() (*azcore.Request, e
 // getBooleanTfftHandleResponse handles the GetBooleanTfft response.
 func (client *arrayOperations) getBooleanTfftHandleResponse(resp *azcore.Response) (*BoolArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBooleanTfftHandleError(resp)
 	}
 	result := BoolArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.BoolArray)
+}
+
+// getBooleanTfftHandleError handles the GetBooleanTfft error response.
+func (client *arrayOperations) getBooleanTfftHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetByteInvalidNull - Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded
@@ -523,10 +604,19 @@ func (client *arrayOperations) getByteInvalidNullCreateRequest() (*azcore.Reques
 // getByteInvalidNullHandleResponse handles the GetByteInvalidNull response.
 func (client *arrayOperations) getByteInvalidNullHandleResponse(resp *azcore.Response) (*ByteArrayArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getByteInvalidNullHandleError(resp)
 	}
 	result := ByteArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ByteArrayArray)
+}
+
+// getByteInvalidNullHandleError handles the GetByteInvalidNull error response.
+func (client *arrayOperations) getByteInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetByteValid - Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64
@@ -560,10 +650,19 @@ func (client *arrayOperations) getByteValidCreateRequest() (*azcore.Request, err
 // getByteValidHandleResponse handles the GetByteValid response.
 func (client *arrayOperations) getByteValidHandleResponse(resp *azcore.Response) (*ByteArrayArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getByteValidHandleError(resp)
 	}
 	result := ByteArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ByteArrayArray)
+}
+
+// getByteValidHandleError handles the GetByteValid error response.
+func (client *arrayOperations) getByteValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetComplexEmpty - Get empty array of complex type []
@@ -597,10 +696,19 @@ func (client *arrayOperations) getComplexEmptyCreateRequest() (*azcore.Request, 
 // getComplexEmptyHandleResponse handles the GetComplexEmpty response.
 func (client *arrayOperations) getComplexEmptyHandleResponse(resp *azcore.Response) (*ProductArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getComplexEmptyHandleError(resp)
 	}
 	result := ProductArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductArray)
+}
+
+// getComplexEmptyHandleError handles the GetComplexEmpty error response.
+func (client *arrayOperations) getComplexEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetComplexItemEmpty - Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]
@@ -634,10 +742,19 @@ func (client *arrayOperations) getComplexItemEmptyCreateRequest() (*azcore.Reque
 // getComplexItemEmptyHandleResponse handles the GetComplexItemEmpty response.
 func (client *arrayOperations) getComplexItemEmptyHandleResponse(resp *azcore.Response) (*ProductArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getComplexItemEmptyHandleError(resp)
 	}
 	result := ProductArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductArray)
+}
+
+// getComplexItemEmptyHandleError handles the GetComplexItemEmpty error response.
+func (client *arrayOperations) getComplexItemEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetComplexItemNull - Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]
@@ -671,10 +788,19 @@ func (client *arrayOperations) getComplexItemNullCreateRequest() (*azcore.Reques
 // getComplexItemNullHandleResponse handles the GetComplexItemNull response.
 func (client *arrayOperations) getComplexItemNullHandleResponse(resp *azcore.Response) (*ProductArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getComplexItemNullHandleError(resp)
 	}
 	result := ProductArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductArray)
+}
+
+// getComplexItemNullHandleError handles the GetComplexItemNull error response.
+func (client *arrayOperations) getComplexItemNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetComplexNull - Get array of complex type null value
@@ -708,10 +834,19 @@ func (client *arrayOperations) getComplexNullCreateRequest() (*azcore.Request, e
 // getComplexNullHandleResponse handles the GetComplexNull response.
 func (client *arrayOperations) getComplexNullHandleResponse(resp *azcore.Response) (*ProductArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getComplexNullHandleError(resp)
 	}
 	result := ProductArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductArray)
+}
+
+// getComplexNullHandleError handles the GetComplexNull error response.
+func (client *arrayOperations) getComplexNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetComplexValid - Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
@@ -745,10 +880,19 @@ func (client *arrayOperations) getComplexValidCreateRequest() (*azcore.Request, 
 // getComplexValidHandleResponse handles the GetComplexValid response.
 func (client *arrayOperations) getComplexValidHandleResponse(resp *azcore.Response) (*ProductArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getComplexValidHandleError(resp)
 	}
 	result := ProductArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductArray)
+}
+
+// getComplexValidHandleError handles the GetComplexValid error response.
+func (client *arrayOperations) getComplexValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateInvalidChars - Get date array value ['2011-03-22', 'date']
@@ -782,10 +926,19 @@ func (client *arrayOperations) getDateInvalidCharsCreateRequest() (*azcore.Reque
 // getDateInvalidCharsHandleResponse handles the GetDateInvalidChars response.
 func (client *arrayOperations) getDateInvalidCharsHandleResponse(resp *azcore.Response) (*TimeArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateInvalidCharsHandleError(resp)
 	}
 	result := TimeArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.TimeArray)
+}
+
+// getDateInvalidCharsHandleError handles the GetDateInvalidChars error response.
+func (client *arrayOperations) getDateInvalidCharsHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateInvalidNull - Get date array value ['2012-01-01', null, '1776-07-04']
@@ -819,10 +972,19 @@ func (client *arrayOperations) getDateInvalidNullCreateRequest() (*azcore.Reques
 // getDateInvalidNullHandleResponse handles the GetDateInvalidNull response.
 func (client *arrayOperations) getDateInvalidNullHandleResponse(resp *azcore.Response) (*TimeArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateInvalidNullHandleError(resp)
 	}
 	result := TimeArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.TimeArray)
+}
+
+// getDateInvalidNullHandleError handles the GetDateInvalidNull error response.
+func (client *arrayOperations) getDateInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateTimeInvalidChars - Get date array value ['2000-12-01t00:00:01z', 'date-time']
@@ -856,7 +1018,7 @@ func (client *arrayOperations) getDateTimeInvalidCharsCreateRequest() (*azcore.R
 // getDateTimeInvalidCharsHandleResponse handles the GetDateTimeInvalidChars response.
 func (client *arrayOperations) getDateTimeInvalidCharsHandleResponse(resp *azcore.Response) (*TimeArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateTimeInvalidCharsHandleError(resp)
 	}
 	var aux *[]timeRFC3339
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
@@ -867,6 +1029,15 @@ func (client *arrayOperations) getDateTimeInvalidCharsHandleResponse(resp *azcor
 		cp[i] = time.Time((*aux)[i])
 	}
 	return &TimeArrayResponse{RawResponse: resp.Response, TimeArray: &cp}, nil
+}
+
+// getDateTimeInvalidCharsHandleError handles the GetDateTimeInvalidChars error response.
+func (client *arrayOperations) getDateTimeInvalidCharsHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateTimeInvalidNull - Get date array value ['2000-12-01t00:00:01z', null]
@@ -900,7 +1071,7 @@ func (client *arrayOperations) getDateTimeInvalidNullCreateRequest() (*azcore.Re
 // getDateTimeInvalidNullHandleResponse handles the GetDateTimeInvalidNull response.
 func (client *arrayOperations) getDateTimeInvalidNullHandleResponse(resp *azcore.Response) (*TimeArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateTimeInvalidNullHandleError(resp)
 	}
 	var aux *[]timeRFC3339
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
@@ -911,6 +1082,15 @@ func (client *arrayOperations) getDateTimeInvalidNullHandleResponse(resp *azcore
 		cp[i] = time.Time((*aux)[i])
 	}
 	return &TimeArrayResponse{RawResponse: resp.Response, TimeArray: &cp}, nil
+}
+
+// getDateTimeInvalidNullHandleError handles the GetDateTimeInvalidNull error response.
+func (client *arrayOperations) getDateTimeInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateTimeRFC1123Valid - Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
@@ -944,7 +1124,7 @@ func (client *arrayOperations) getDateTimeRfc1123ValidCreateRequest() (*azcore.R
 // getDateTimeRfc1123ValidHandleResponse handles the GetDateTimeRFC1123Valid response.
 func (client *arrayOperations) getDateTimeRfc1123ValidHandleResponse(resp *azcore.Response) (*TimeArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateTimeRfc1123ValidHandleError(resp)
 	}
 	var aux *[]timeRFC1123
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
@@ -955,6 +1135,15 @@ func (client *arrayOperations) getDateTimeRfc1123ValidHandleResponse(resp *azcor
 		cp[i] = time.Time((*aux)[i])
 	}
 	return &TimeArrayResponse{RawResponse: resp.Response, TimeArray: &cp}, nil
+}
+
+// getDateTimeRfc1123ValidHandleError handles the GetDateTimeRFC1123Valid error response.
+func (client *arrayOperations) getDateTimeRfc1123ValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateTimeValid - Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
@@ -988,7 +1177,7 @@ func (client *arrayOperations) getDateTimeValidCreateRequest() (*azcore.Request,
 // getDateTimeValidHandleResponse handles the GetDateTimeValid response.
 func (client *arrayOperations) getDateTimeValidHandleResponse(resp *azcore.Response) (*TimeArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateTimeValidHandleError(resp)
 	}
 	var aux *[]timeRFC3339
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
@@ -999,6 +1188,15 @@ func (client *arrayOperations) getDateTimeValidHandleResponse(resp *azcore.Respo
 		cp[i] = time.Time((*aux)[i])
 	}
 	return &TimeArrayResponse{RawResponse: resp.Response, TimeArray: &cp}, nil
+}
+
+// getDateTimeValidHandleError handles the GetDateTimeValid error response.
+func (client *arrayOperations) getDateTimeValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateValid - Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12']
@@ -1032,10 +1230,19 @@ func (client *arrayOperations) getDateValidCreateRequest() (*azcore.Request, err
 // getDateValidHandleResponse handles the GetDateValid response.
 func (client *arrayOperations) getDateValidHandleResponse(resp *azcore.Response) (*TimeArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateValidHandleError(resp)
 	}
 	result := TimeArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.TimeArray)
+}
+
+// getDateValidHandleError handles the GetDateValid error response.
+func (client *arrayOperations) getDateValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDictionaryEmpty - Get an array of Dictionaries of type <string, string> with value []
@@ -1069,10 +1276,19 @@ func (client *arrayOperations) getDictionaryEmptyCreateRequest() (*azcore.Reques
 // getDictionaryEmptyHandleResponse handles the GetDictionaryEmpty response.
 func (client *arrayOperations) getDictionaryEmptyHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDictionaryEmptyHandleError(resp)
 	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MapOfStringArray)
+}
+
+// getDictionaryEmptyHandleError handles the GetDictionaryEmpty error response.
+func (client *arrayOperations) getDictionaryEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDictionaryItemEmpty - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
@@ -1106,10 +1322,19 @@ func (client *arrayOperations) getDictionaryItemEmptyCreateRequest() (*azcore.Re
 // getDictionaryItemEmptyHandleResponse handles the GetDictionaryItemEmpty response.
 func (client *arrayOperations) getDictionaryItemEmptyHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDictionaryItemEmptyHandleError(resp)
 	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MapOfStringArray)
+}
+
+// getDictionaryItemEmptyHandleError handles the GetDictionaryItemEmpty error response.
+func (client *arrayOperations) getDictionaryItemEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDictionaryItemNull - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}]
@@ -1143,10 +1368,19 @@ func (client *arrayOperations) getDictionaryItemNullCreateRequest() (*azcore.Req
 // getDictionaryItemNullHandleResponse handles the GetDictionaryItemNull response.
 func (client *arrayOperations) getDictionaryItemNullHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDictionaryItemNullHandleError(resp)
 	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MapOfStringArray)
+}
+
+// getDictionaryItemNullHandleError handles the GetDictionaryItemNull error response.
+func (client *arrayOperations) getDictionaryItemNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDictionaryNull - Get an array of Dictionaries with value null
@@ -1180,10 +1414,19 @@ func (client *arrayOperations) getDictionaryNullCreateRequest() (*azcore.Request
 // getDictionaryNullHandleResponse handles the GetDictionaryNull response.
 func (client *arrayOperations) getDictionaryNullHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDictionaryNullHandleError(resp)
 	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MapOfStringArray)
+}
+
+// getDictionaryNullHandleError handles the GetDictionaryNull error response.
+func (client *arrayOperations) getDictionaryNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDictionaryValid - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
@@ -1217,10 +1460,19 @@ func (client *arrayOperations) getDictionaryValidCreateRequest() (*azcore.Reques
 // getDictionaryValidHandleResponse handles the GetDictionaryValid response.
 func (client *arrayOperations) getDictionaryValidHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDictionaryValidHandleError(resp)
 	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MapOfStringArray)
+}
+
+// getDictionaryValidHandleError handles the GetDictionaryValid error response.
+func (client *arrayOperations) getDictionaryValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDoubleInvalidNull - Get float array value [0.0, null, -1.2e20]
@@ -1254,10 +1506,19 @@ func (client *arrayOperations) getDoubleInvalidNullCreateRequest() (*azcore.Requ
 // getDoubleInvalidNullHandleResponse handles the GetDoubleInvalidNull response.
 func (client *arrayOperations) getDoubleInvalidNullHandleResponse(resp *azcore.Response) (*Float64ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDoubleInvalidNullHandleError(resp)
 	}
 	result := Float64ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Float64Array)
+}
+
+// getDoubleInvalidNullHandleError handles the GetDoubleInvalidNull error response.
+func (client *arrayOperations) getDoubleInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDoubleInvalidString - Get boolean array value [1.0, 'number', 0.0]
@@ -1291,10 +1552,19 @@ func (client *arrayOperations) getDoubleInvalidStringCreateRequest() (*azcore.Re
 // getDoubleInvalidStringHandleResponse handles the GetDoubleInvalidString response.
 func (client *arrayOperations) getDoubleInvalidStringHandleResponse(resp *azcore.Response) (*Float64ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDoubleInvalidStringHandleError(resp)
 	}
 	result := Float64ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Float64Array)
+}
+
+// getDoubleInvalidStringHandleError handles the GetDoubleInvalidString error response.
+func (client *arrayOperations) getDoubleInvalidStringHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDoubleValid - Get float array value [0, -0.01, 1.2e20]
@@ -1328,10 +1598,19 @@ func (client *arrayOperations) getDoubleValidCreateRequest() (*azcore.Request, e
 // getDoubleValidHandleResponse handles the GetDoubleValid response.
 func (client *arrayOperations) getDoubleValidHandleResponse(resp *azcore.Response) (*Float64ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDoubleValidHandleError(resp)
 	}
 	result := Float64ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Float64Array)
+}
+
+// getDoubleValidHandleError handles the GetDoubleValid error response.
+func (client *arrayOperations) getDoubleValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDurationValid - Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S']
@@ -1365,10 +1644,19 @@ func (client *arrayOperations) getDurationValidCreateRequest() (*azcore.Request,
 // getDurationValidHandleResponse handles the GetDurationValid response.
 func (client *arrayOperations) getDurationValidHandleResponse(resp *azcore.Response) (*DurationArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDurationValidHandleError(resp)
 	}
 	result := DurationArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DurationArray)
+}
+
+// getDurationValidHandleError handles the GetDurationValid error response.
+func (client *arrayOperations) getDurationValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetEmpty - Get empty array value []
@@ -1402,10 +1690,19 @@ func (client *arrayOperations) getEmptyCreateRequest() (*azcore.Request, error) 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *arrayOperations) getEmptyHandleResponse(resp *azcore.Response) (*Int32ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getEmptyHandleError(resp)
 	}
 	result := Int32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int32Array)
+}
+
+// getEmptyHandleError handles the GetEmpty error response.
+func (client *arrayOperations) getEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetEnumValid - Get enum array value ['foo1', 'foo2', 'foo3']
@@ -1439,10 +1736,19 @@ func (client *arrayOperations) getEnumValidCreateRequest() (*azcore.Request, err
 // getEnumValidHandleResponse handles the GetEnumValid response.
 func (client *arrayOperations) getEnumValidHandleResponse(resp *azcore.Response) (*FooEnumArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getEnumValidHandleError(resp)
 	}
 	result := FooEnumArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.FooEnumArray)
+}
+
+// getEnumValidHandleError handles the GetEnumValid error response.
+func (client *arrayOperations) getEnumValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetFloatInvalidNull - Get float array value [0.0, null, -1.2e20]
@@ -1476,10 +1782,19 @@ func (client *arrayOperations) getFloatInvalidNullCreateRequest() (*azcore.Reque
 // getFloatInvalidNullHandleResponse handles the GetFloatInvalidNull response.
 func (client *arrayOperations) getFloatInvalidNullHandleResponse(resp *azcore.Response) (*Float32ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getFloatInvalidNullHandleError(resp)
 	}
 	result := Float32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Float32Array)
+}
+
+// getFloatInvalidNullHandleError handles the GetFloatInvalidNull error response.
+func (client *arrayOperations) getFloatInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetFloatInvalidString - Get boolean array value [1.0, 'number', 0.0]
@@ -1513,10 +1828,19 @@ func (client *arrayOperations) getFloatInvalidStringCreateRequest() (*azcore.Req
 // getFloatInvalidStringHandleResponse handles the GetFloatInvalidString response.
 func (client *arrayOperations) getFloatInvalidStringHandleResponse(resp *azcore.Response) (*Float32ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getFloatInvalidStringHandleError(resp)
 	}
 	result := Float32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Float32Array)
+}
+
+// getFloatInvalidStringHandleError handles the GetFloatInvalidString error response.
+func (client *arrayOperations) getFloatInvalidStringHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetFloatValid - Get float array value [0, -0.01, 1.2e20]
@@ -1550,10 +1874,19 @@ func (client *arrayOperations) getFloatValidCreateRequest() (*azcore.Request, er
 // getFloatValidHandleResponse handles the GetFloatValid response.
 func (client *arrayOperations) getFloatValidHandleResponse(resp *azcore.Response) (*Float32ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getFloatValidHandleError(resp)
 	}
 	result := Float32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Float32Array)
+}
+
+// getFloatValidHandleError handles the GetFloatValid error response.
+func (client *arrayOperations) getFloatValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetIntInvalidNull - Get integer array value [1, null, 0]
@@ -1587,10 +1920,19 @@ func (client *arrayOperations) getIntInvalidNullCreateRequest() (*azcore.Request
 // getIntInvalidNullHandleResponse handles the GetIntInvalidNull response.
 func (client *arrayOperations) getIntInvalidNullHandleResponse(resp *azcore.Response) (*Int32ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getIntInvalidNullHandleError(resp)
 	}
 	result := Int32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int32Array)
+}
+
+// getIntInvalidNullHandleError handles the GetIntInvalidNull error response.
+func (client *arrayOperations) getIntInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetIntInvalidString - Get integer array value [1, 'integer', 0]
@@ -1624,10 +1966,19 @@ func (client *arrayOperations) getIntInvalidStringCreateRequest() (*azcore.Reque
 // getIntInvalidStringHandleResponse handles the GetIntInvalidString response.
 func (client *arrayOperations) getIntInvalidStringHandleResponse(resp *azcore.Response) (*Int32ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getIntInvalidStringHandleError(resp)
 	}
 	result := Int32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int32Array)
+}
+
+// getIntInvalidStringHandleError handles the GetIntInvalidString error response.
+func (client *arrayOperations) getIntInvalidStringHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetIntegerValid - Get integer array value [1, -1, 3, 300]
@@ -1661,10 +2012,19 @@ func (client *arrayOperations) getIntegerValidCreateRequest() (*azcore.Request, 
 // getIntegerValidHandleResponse handles the GetIntegerValid response.
 func (client *arrayOperations) getIntegerValidHandleResponse(resp *azcore.Response) (*Int32ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getIntegerValidHandleError(resp)
 	}
 	result := Int32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int32Array)
+}
+
+// getIntegerValidHandleError handles the GetIntegerValid error response.
+func (client *arrayOperations) getIntegerValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetInvalid - Get invalid array [1, 2, 3
@@ -1698,10 +2058,19 @@ func (client *arrayOperations) getInvalidCreateRequest() (*azcore.Request, error
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *arrayOperations) getInvalidHandleResponse(resp *azcore.Response) (*Int32ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getInvalidHandleError(resp)
 	}
 	result := Int32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int32Array)
+}
+
+// getInvalidHandleError handles the GetInvalid error response.
+func (client *arrayOperations) getInvalidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetLongInvalidNull - Get long array value [1, null, 0]
@@ -1735,10 +2104,19 @@ func (client *arrayOperations) getLongInvalidNullCreateRequest() (*azcore.Reques
 // getLongInvalidNullHandleResponse handles the GetLongInvalidNull response.
 func (client *arrayOperations) getLongInvalidNullHandleResponse(resp *azcore.Response) (*Int64ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getLongInvalidNullHandleError(resp)
 	}
 	result := Int64ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int64Array)
+}
+
+// getLongInvalidNullHandleError handles the GetLongInvalidNull error response.
+func (client *arrayOperations) getLongInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetLongInvalidString - Get long array value [1, 'integer', 0]
@@ -1772,10 +2150,19 @@ func (client *arrayOperations) getLongInvalidStringCreateRequest() (*azcore.Requ
 // getLongInvalidStringHandleResponse handles the GetLongInvalidString response.
 func (client *arrayOperations) getLongInvalidStringHandleResponse(resp *azcore.Response) (*Int64ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getLongInvalidStringHandleError(resp)
 	}
 	result := Int64ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int64Array)
+}
+
+// getLongInvalidStringHandleError handles the GetLongInvalidString error response.
+func (client *arrayOperations) getLongInvalidStringHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetLongValid - Get integer array value [1, -1, 3, 300]
@@ -1809,10 +2196,19 @@ func (client *arrayOperations) getLongValidCreateRequest() (*azcore.Request, err
 // getLongValidHandleResponse handles the GetLongValid response.
 func (client *arrayOperations) getLongValidHandleResponse(resp *azcore.Response) (*Int64ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getLongValidHandleError(resp)
 	}
 	result := Int64ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int64Array)
+}
+
+// getLongValidHandleError handles the GetLongValid error response.
+func (client *arrayOperations) getLongValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNull - Get null array value
@@ -1846,10 +2242,19 @@ func (client *arrayOperations) getNullCreateRequest() (*azcore.Request, error) {
 // getNullHandleResponse handles the GetNull response.
 func (client *arrayOperations) getNullHandleResponse(resp *azcore.Response) (*Int32ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNullHandleError(resp)
 	}
 	result := Int32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int32Array)
+}
+
+// getNullHandleError handles the GetNull error response.
+func (client *arrayOperations) getNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetStringEnumValid - Get enum array value ['foo1', 'foo2', 'foo3']
@@ -1883,10 +2288,19 @@ func (client *arrayOperations) getStringEnumValidCreateRequest() (*azcore.Reques
 // getStringEnumValidHandleResponse handles the GetStringEnumValid response.
 func (client *arrayOperations) getStringEnumValidHandleResponse(resp *azcore.Response) (*Enum0ArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getStringEnumValidHandleError(resp)
 	}
 	result := Enum0ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Enum0Array)
+}
+
+// getStringEnumValidHandleError handles the GetStringEnumValid error response.
+func (client *arrayOperations) getStringEnumValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetStringValid - Get string array value ['foo1', 'foo2', 'foo3']
@@ -1920,10 +2334,19 @@ func (client *arrayOperations) getStringValidCreateRequest() (*azcore.Request, e
 // getStringValidHandleResponse handles the GetStringValid response.
 func (client *arrayOperations) getStringValidHandleResponse(resp *azcore.Response) (*StringArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getStringValidHandleError(resp)
 	}
 	result := StringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArray)
+}
+
+// getStringValidHandleError handles the GetStringValid error response.
+func (client *arrayOperations) getStringValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetStringWithInvalid - Get string array value ['foo', 123, 'foo2']
@@ -1957,10 +2380,19 @@ func (client *arrayOperations) getStringWithInvalidCreateRequest() (*azcore.Requ
 // getStringWithInvalidHandleResponse handles the GetStringWithInvalid response.
 func (client *arrayOperations) getStringWithInvalidHandleResponse(resp *azcore.Response) (*StringArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getStringWithInvalidHandleError(resp)
 	}
 	result := StringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArray)
+}
+
+// getStringWithInvalidHandleError handles the GetStringWithInvalid error response.
+func (client *arrayOperations) getStringWithInvalidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetStringWithNull - Get string array value ['foo', null, 'foo2']
@@ -1994,10 +2426,19 @@ func (client *arrayOperations) getStringWithNullCreateRequest() (*azcore.Request
 // getStringWithNullHandleResponse handles the GetStringWithNull response.
 func (client *arrayOperations) getStringWithNullHandleResponse(resp *azcore.Response) (*StringArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getStringWithNullHandleError(resp)
 	}
 	result := StringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArray)
+}
+
+// getStringWithNullHandleError handles the GetStringWithNull error response.
+func (client *arrayOperations) getStringWithNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetUUIDInvalidChars - Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo']
@@ -2031,10 +2472,19 @@ func (client *arrayOperations) getUuidInvalidCharsCreateRequest() (*azcore.Reque
 // getUuidInvalidCharsHandleResponse handles the GetUUIDInvalidChars response.
 func (client *arrayOperations) getUuidInvalidCharsHandleResponse(resp *azcore.Response) (*StringArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getUuidInvalidCharsHandleError(resp)
 	}
 	result := StringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArray)
+}
+
+// getUuidInvalidCharsHandleError handles the GetUUIDInvalidChars error response.
+func (client *arrayOperations) getUuidInvalidCharsHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetUUIDValid - Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
@@ -2068,10 +2518,19 @@ func (client *arrayOperations) getUuidValidCreateRequest() (*azcore.Request, err
 // getUuidValidHandleResponse handles the GetUUIDValid response.
 func (client *arrayOperations) getUuidValidHandleResponse(resp *azcore.Response) (*StringArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getUuidValidHandleError(resp)
 	}
 	result := StringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArray)
+}
+
+// getUuidValidHandleError handles the GetUUIDValid error response.
+func (client *arrayOperations) getUuidValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutArrayValid - Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
@@ -2105,9 +2564,18 @@ func (client *arrayOperations) putArrayValidCreateRequest(arrayBody [][]string) 
 // putArrayValidHandleResponse handles the PutArrayValid response.
 func (client *arrayOperations) putArrayValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putArrayValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putArrayValidHandleError handles the PutArrayValid error response.
+func (client *arrayOperations) putArrayValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutBooleanTfft - Set array value empty [true, false, false, true]
@@ -2141,9 +2609,18 @@ func (client *arrayOperations) putBooleanTfftCreateRequest(arrayBody []bool) (*a
 // putBooleanTfftHandleResponse handles the PutBooleanTfft response.
 func (client *arrayOperations) putBooleanTfftHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putBooleanTfftHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putBooleanTfftHandleError handles the PutBooleanTfft error response.
+func (client *arrayOperations) putBooleanTfftHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutByteValid - Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64
@@ -2177,9 +2654,18 @@ func (client *arrayOperations) putByteValidCreateRequest(arrayBody [][]byte) (*a
 // putByteValidHandleResponse handles the PutByteValid response.
 func (client *arrayOperations) putByteValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putByteValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putByteValidHandleError handles the PutByteValid error response.
+func (client *arrayOperations) putByteValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutComplexValid - Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
@@ -2213,9 +2699,18 @@ func (client *arrayOperations) putComplexValidCreateRequest(arrayBody []Product)
 // putComplexValidHandleResponse handles the PutComplexValid response.
 func (client *arrayOperations) putComplexValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putComplexValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putComplexValidHandleError handles the PutComplexValid error response.
+func (client *arrayOperations) putComplexValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDateTimeRFC1123Valid - Set array value  ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
@@ -2253,9 +2748,18 @@ func (client *arrayOperations) putDateTimeRfc1123ValidCreateRequest(arrayBody []
 // putDateTimeRfc1123ValidHandleResponse handles the PutDateTimeRFC1123Valid response.
 func (client *arrayOperations) putDateTimeRfc1123ValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDateTimeRfc1123ValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDateTimeRfc1123ValidHandleError handles the PutDateTimeRFC1123Valid error response.
+func (client *arrayOperations) putDateTimeRfc1123ValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDateTimeValid - Set array value  ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
@@ -2289,9 +2793,18 @@ func (client *arrayOperations) putDateTimeValidCreateRequest(arrayBody []time.Ti
 // putDateTimeValidHandleResponse handles the PutDateTimeValid response.
 func (client *arrayOperations) putDateTimeValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDateTimeValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDateTimeValidHandleError handles the PutDateTimeValid error response.
+func (client *arrayOperations) putDateTimeValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDateValid - Set array value  ['2000-12-01', '1980-01-02', '1492-10-12']
@@ -2325,9 +2838,18 @@ func (client *arrayOperations) putDateValidCreateRequest(arrayBody []time.Time) 
 // putDateValidHandleResponse handles the PutDateValid response.
 func (client *arrayOperations) putDateValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDateValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDateValidHandleError handles the PutDateValid error response.
+func (client *arrayOperations) putDateValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDictionaryValid - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
@@ -2361,9 +2883,18 @@ func (client *arrayOperations) putDictionaryValidCreateRequest(arrayBody []map[s
 // putDictionaryValidHandleResponse handles the PutDictionaryValid response.
 func (client *arrayOperations) putDictionaryValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDictionaryValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDictionaryValidHandleError handles the PutDictionaryValid error response.
+func (client *arrayOperations) putDictionaryValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDoubleValid - Set array value [0, -0.01, 1.2e20]
@@ -2397,9 +2928,18 @@ func (client *arrayOperations) putDoubleValidCreateRequest(arrayBody []float64) 
 // putDoubleValidHandleResponse handles the PutDoubleValid response.
 func (client *arrayOperations) putDoubleValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDoubleValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDoubleValidHandleError handles the PutDoubleValid error response.
+func (client *arrayOperations) putDoubleValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDurationValid - Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S']
@@ -2433,9 +2973,18 @@ func (client *arrayOperations) putDurationValidCreateRequest(arrayBody []time.Du
 // putDurationValidHandleResponse handles the PutDurationValid response.
 func (client *arrayOperations) putDurationValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDurationValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDurationValidHandleError handles the PutDurationValid error response.
+func (client *arrayOperations) putDurationValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutEmpty - Set array value empty []
@@ -2469,9 +3018,18 @@ func (client *arrayOperations) putEmptyCreateRequest(arrayBody []string) (*azcor
 // putEmptyHandleResponse handles the PutEmpty response.
 func (client *arrayOperations) putEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putEmptyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putEmptyHandleError handles the PutEmpty error response.
+func (client *arrayOperations) putEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutEnumValid - Set array value ['foo1', 'foo2', 'foo3']
@@ -2505,9 +3063,18 @@ func (client *arrayOperations) putEnumValidCreateRequest(arrayBody []FooEnum) (*
 // putEnumValidHandleResponse handles the PutEnumValid response.
 func (client *arrayOperations) putEnumValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putEnumValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putEnumValidHandleError handles the PutEnumValid error response.
+func (client *arrayOperations) putEnumValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutFloatValid - Set array value [0, -0.01, 1.2e20]
@@ -2541,9 +3108,18 @@ func (client *arrayOperations) putFloatValidCreateRequest(arrayBody []float32) (
 // putFloatValidHandleResponse handles the PutFloatValid response.
 func (client *arrayOperations) putFloatValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putFloatValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putFloatValidHandleError handles the PutFloatValid error response.
+func (client *arrayOperations) putFloatValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutIntegerValid - Set array value empty [1, -1, 3, 300]
@@ -2577,9 +3153,18 @@ func (client *arrayOperations) putIntegerValidCreateRequest(arrayBody []int32) (
 // putIntegerValidHandleResponse handles the PutIntegerValid response.
 func (client *arrayOperations) putIntegerValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putIntegerValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putIntegerValidHandleError handles the PutIntegerValid error response.
+func (client *arrayOperations) putIntegerValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutLongValid - Set array value empty [1, -1, 3, 300]
@@ -2613,9 +3198,18 @@ func (client *arrayOperations) putLongValidCreateRequest(arrayBody []int64) (*az
 // putLongValidHandleResponse handles the PutLongValid response.
 func (client *arrayOperations) putLongValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putLongValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putLongValidHandleError handles the PutLongValid error response.
+func (client *arrayOperations) putLongValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutStringEnumValid - Set array value ['foo1', 'foo2', 'foo3']
@@ -2649,9 +3243,18 @@ func (client *arrayOperations) putStringEnumValidCreateRequest(arrayBody []Enum1
 // putStringEnumValidHandleResponse handles the PutStringEnumValid response.
 func (client *arrayOperations) putStringEnumValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putStringEnumValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putStringEnumValidHandleError handles the PutStringEnumValid error response.
+func (client *arrayOperations) putStringEnumValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutStringValid - Set array value ['foo1', 'foo2', 'foo3']
@@ -2685,9 +3288,18 @@ func (client *arrayOperations) putStringValidCreateRequest(arrayBody []string) (
 // putStringValidHandleResponse handles the PutStringValid response.
 func (client *arrayOperations) putStringValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putStringValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putStringValidHandleError handles the PutStringValid error response.
+func (client *arrayOperations) putStringValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutUUIDValid - Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
@@ -2721,7 +3333,16 @@ func (client *arrayOperations) putUuidValidCreateRequest(arrayBody []string) (*a
 // putUuidValidHandleResponse handles the PutUUIDValid response.
 func (client *arrayOperations) putUuidValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putUuidValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putUuidValidHandleError handles the PutUUIDValid error response.
+func (client *arrayOperations) putUuidValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/arraygroup/models.go
+++ b/test/autorest/generated/arraygroup/models.go
@@ -7,7 +7,6 @@ package arraygroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"time"
 )
@@ -51,14 +50,6 @@ type Enum0ArrayResponse struct {
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/azurereportgroup/models.go
+++ b/test/autorest/generated/azurereportgroup/models.go
@@ -7,21 +7,12 @@ package azurereportgroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 )
 
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/azurereportgroup/operations.go
+++ b/test/autorest/generated/azurereportgroup/operations.go
@@ -59,8 +59,17 @@ func (client *operations) getReportCreateRequest(operationsGetReportOptions *Ope
 // getReportHandleResponse handles the GetReport response.
 func (client *operations) getReportHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getReportHandleError(resp)
 	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getReportHandleError handles the GetReport error response.
+func (client *operations) getReportHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/azurespecialsgroup/apiversiondefault.go
+++ b/test/autorest/generated/azurespecialsgroup/apiversiondefault.go
@@ -62,9 +62,18 @@ func (client *apiVersionDefaultOperations) getMethodGlobalNotProvidedValidCreate
 // getMethodGlobalNotProvidedValidHandleResponse handles the GetMethodGlobalNotProvidedValid response.
 func (client *apiVersionDefaultOperations) getMethodGlobalNotProvidedValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getMethodGlobalNotProvidedValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getMethodGlobalNotProvidedValidHandleError handles the GetMethodGlobalNotProvidedValid error response.
+func (client *apiVersionDefaultOperations) getMethodGlobalNotProvidedValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetMethodGlobalValid - GET method with api-version modeled in global settings.
@@ -101,9 +110,18 @@ func (client *apiVersionDefaultOperations) getMethodGlobalValidCreateRequest() (
 // getMethodGlobalValidHandleResponse handles the GetMethodGlobalValid response.
 func (client *apiVersionDefaultOperations) getMethodGlobalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getMethodGlobalValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getMethodGlobalValidHandleError handles the GetMethodGlobalValid error response.
+func (client *apiVersionDefaultOperations) getMethodGlobalValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetPathGlobalValid - GET method with api-version modeled in global settings.
@@ -140,9 +158,18 @@ func (client *apiVersionDefaultOperations) getPathGlobalValidCreateRequest() (*a
 // getPathGlobalValidHandleResponse handles the GetPathGlobalValid response.
 func (client *apiVersionDefaultOperations) getPathGlobalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getPathGlobalValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getPathGlobalValidHandleError handles the GetPathGlobalValid error response.
+func (client *apiVersionDefaultOperations) getPathGlobalValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetSwaggerGlobalValid - GET method with api-version modeled in global settings.
@@ -179,7 +206,16 @@ func (client *apiVersionDefaultOperations) getSwaggerGlobalValidCreateRequest() 
 // getSwaggerGlobalValidHandleResponse handles the GetSwaggerGlobalValid response.
 func (client *apiVersionDefaultOperations) getSwaggerGlobalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getSwaggerGlobalValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getSwaggerGlobalValidHandleError handles the GetSwaggerGlobalValid error response.
+func (client *apiVersionDefaultOperations) getSwaggerGlobalValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/azurespecialsgroup/apiversionlocal.go
+++ b/test/autorest/generated/azurespecialsgroup/apiversionlocal.go
@@ -64,9 +64,18 @@ func (client *apiVersionLocalOperations) getMethodLocalNullCreateRequest(apiVers
 // getMethodLocalNullHandleResponse handles the GetMethodLocalNull response.
 func (client *apiVersionLocalOperations) getMethodLocalNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getMethodLocalNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getMethodLocalNullHandleError handles the GetMethodLocalNull error response.
+func (client *apiVersionLocalOperations) getMethodLocalNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetMethodLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
@@ -103,9 +112,18 @@ func (client *apiVersionLocalOperations) getMethodLocalValidCreateRequest() (*az
 // getMethodLocalValidHandleResponse handles the GetMethodLocalValid response.
 func (client *apiVersionLocalOperations) getMethodLocalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getMethodLocalValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getMethodLocalValidHandleError handles the GetMethodLocalValid error response.
+func (client *apiVersionLocalOperations) getMethodLocalValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetPathLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
@@ -142,9 +160,18 @@ func (client *apiVersionLocalOperations) getPathLocalValidCreateRequest() (*azco
 // getPathLocalValidHandleResponse handles the GetPathLocalValid response.
 func (client *apiVersionLocalOperations) getPathLocalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getPathLocalValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getPathLocalValidHandleError handles the GetPathLocalValid error response.
+func (client *apiVersionLocalOperations) getPathLocalValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetSwaggerLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
@@ -181,7 +208,16 @@ func (client *apiVersionLocalOperations) getSwaggerLocalValidCreateRequest() (*a
 // getSwaggerLocalValidHandleResponse handles the GetSwaggerLocalValid response.
 func (client *apiVersionLocalOperations) getSwaggerLocalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getSwaggerLocalValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getSwaggerLocalValidHandleError handles the GetSwaggerLocalValid error response.
+func (client *apiVersionLocalOperations) getSwaggerLocalValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/azurespecialsgroup/header.go
+++ b/test/autorest/generated/azurespecialsgroup/header.go
@@ -58,13 +58,22 @@ func (client *headerOperations) customNamedRequestIdCreateRequest(fooClientReque
 // customNamedRequestIdHandleResponse handles the CustomNamedRequestID response.
 func (client *headerOperations) customNamedRequestIdHandleResponse(resp *azcore.Response) (*HeaderCustomNamedRequestIDResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.customNamedRequestIdHandleError(resp)
 	}
 	result := HeaderCustomNamedRequestIDResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("foo-request-id"); val != "" {
 		result.FooRequestId = &val
 	}
 	return &result, nil
+}
+
+// customNamedRequestIdHandleError handles the CustomNamedRequestID error response.
+func (client *headerOperations) customNamedRequestIdHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // CustomNamedRequestIDHead - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
@@ -99,13 +108,22 @@ func (client *headerOperations) customNamedRequestIdHeadCreateRequest(fooClientR
 // customNamedRequestIdHeadHandleResponse handles the CustomNamedRequestIDHead response.
 func (client *headerOperations) customNamedRequestIdHeadHandleResponse(resp *azcore.Response) (*HeaderCustomNamedRequestIDHeadResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.customNamedRequestIdHeadHandleError(resp)
 	}
 	result := HeaderCustomNamedRequestIDHeadResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("foo-request-id"); val != "" {
 		result.FooRequestId = &val
 	}
 	return &result, nil
+}
+
+// customNamedRequestIdHeadHandleError handles the CustomNamedRequestIDHead error response.
+func (client *headerOperations) customNamedRequestIdHeadHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // CustomNamedRequestIDParamGrouping - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group
@@ -140,11 +158,20 @@ func (client *headerOperations) customNamedRequestIdParamGroupingCreateRequest(h
 // customNamedRequestIdParamGroupingHandleResponse handles the CustomNamedRequestIDParamGrouping response.
 func (client *headerOperations) customNamedRequestIdParamGroupingHandleResponse(resp *azcore.Response) (*HeaderCustomNamedRequestIDParamGroupingResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.customNamedRequestIdParamGroupingHandleError(resp)
 	}
 	result := HeaderCustomNamedRequestIDParamGroupingResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("foo-request-id"); val != "" {
 		result.FooRequestId = &val
 	}
 	return &result, nil
+}
+
+// customNamedRequestIdParamGroupingHandleError handles the CustomNamedRequestIDParamGrouping error response.
+func (client *headerOperations) customNamedRequestIdParamGroupingHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/azurespecialsgroup/models.go
+++ b/test/autorest/generated/azurespecialsgroup/models.go
@@ -7,7 +7,6 @@ package azurespecialsgroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 )
 
@@ -21,14 +20,6 @@ type Error struct {
 	ConstantID *int32  `json:"constantId,omitempty"`
 	Message    *string `json:"message,omitempty"`
 	Status     *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/azurespecialsgroup/odata.go
+++ b/test/autorest/generated/azurespecialsgroup/odata.go
@@ -65,7 +65,16 @@ func (client *odataOperations) getWithFilterCreateRequest(odataGetWithFilterOpti
 // getWithFilterHandleResponse handles the GetWithFilter response.
 func (client *odataOperations) getWithFilterHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getWithFilterHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getWithFilterHandleError handles the GetWithFilter error response.
+func (client *odataOperations) getWithFilterHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/azurespecialsgroup/skipurlencoding.go
+++ b/test/autorest/generated/azurespecialsgroup/skipurlencoding.go
@@ -67,9 +67,18 @@ func (client *skipUrlEncodingOperations) getMethodPathValidCreateRequest(unencod
 // getMethodPathValidHandleResponse handles the GetMethodPathValid response.
 func (client *skipUrlEncodingOperations) getMethodPathValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getMethodPathValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getMethodPathValidHandleError handles the GetMethodPathValid error response.
+func (client *skipUrlEncodingOperations) getMethodPathValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetMethodQueryNull - Get method with unencoded query parameter with value null
@@ -108,9 +117,18 @@ func (client *skipUrlEncodingOperations) getMethodQueryNullCreateRequest(skipUrl
 // getMethodQueryNullHandleResponse handles the GetMethodQueryNull response.
 func (client *skipUrlEncodingOperations) getMethodQueryNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getMethodQueryNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getMethodQueryNullHandleError handles the GetMethodQueryNull error response.
+func (client *skipUrlEncodingOperations) getMethodQueryNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetMethodQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
@@ -147,9 +165,18 @@ func (client *skipUrlEncodingOperations) getMethodQueryValidCreateRequest(q1 str
 // getMethodQueryValidHandleResponse handles the GetMethodQueryValid response.
 func (client *skipUrlEncodingOperations) getMethodQueryValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getMethodQueryValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getMethodQueryValidHandleError handles the GetMethodQueryValid error response.
+func (client *skipUrlEncodingOperations) getMethodQueryValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetPathQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
@@ -186,9 +213,18 @@ func (client *skipUrlEncodingOperations) getPathQueryValidCreateRequest(q1 strin
 // getPathQueryValidHandleResponse handles the GetPathQueryValid response.
 func (client *skipUrlEncodingOperations) getPathQueryValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getPathQueryValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getPathQueryValidHandleError handles the GetPathQueryValid error response.
+func (client *skipUrlEncodingOperations) getPathQueryValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
@@ -223,9 +259,18 @@ func (client *skipUrlEncodingOperations) getPathValidCreateRequest(unencodedPath
 // getPathValidHandleResponse handles the GetPathValid response.
 func (client *skipUrlEncodingOperations) getPathValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getPathValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getPathValidHandleError handles the GetPathValid error response.
+func (client *skipUrlEncodingOperations) getPathValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetSwaggerPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
@@ -260,9 +305,18 @@ func (client *skipUrlEncodingOperations) getSwaggerPathValidCreateRequest() (*az
 // getSwaggerPathValidHandleResponse handles the GetSwaggerPathValid response.
 func (client *skipUrlEncodingOperations) getSwaggerPathValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getSwaggerPathValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getSwaggerPathValidHandleError handles the GetSwaggerPathValid error response.
+func (client *skipUrlEncodingOperations) getSwaggerPathValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetSwaggerQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
@@ -299,7 +353,16 @@ func (client *skipUrlEncodingOperations) getSwaggerQueryValidCreateRequest() (*a
 // getSwaggerQueryValidHandleResponse handles the GetSwaggerQueryValid response.
 func (client *skipUrlEncodingOperations) getSwaggerQueryValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getSwaggerQueryValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getSwaggerQueryValidHandleError handles the GetSwaggerQueryValid error response.
+func (client *skipUrlEncodingOperations) getSwaggerQueryValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/azurespecialsgroup/subscriptionincredentials.go
+++ b/test/autorest/generated/azurespecialsgroup/subscriptionincredentials.go
@@ -68,9 +68,18 @@ func (client *subscriptionInCredentialsOperations) postMethodGlobalNotProvidedVa
 // postMethodGlobalNotProvidedValidHandleResponse handles the PostMethodGlobalNotProvidedValid response.
 func (client *subscriptionInCredentialsOperations) postMethodGlobalNotProvidedValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postMethodGlobalNotProvidedValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postMethodGlobalNotProvidedValidHandleError handles the PostMethodGlobalNotProvidedValid error response.
+func (client *subscriptionInCredentialsOperations) postMethodGlobalNotProvidedValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostMethodGlobalNull - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call
@@ -105,9 +114,18 @@ func (client *subscriptionInCredentialsOperations) postMethodGlobalNullCreateReq
 // postMethodGlobalNullHandleResponse handles the PostMethodGlobalNull response.
 func (client *subscriptionInCredentialsOperations) postMethodGlobalNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postMethodGlobalNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postMethodGlobalNullHandleError handles the PostMethodGlobalNull error response.
+func (client *subscriptionInCredentialsOperations) postMethodGlobalNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostMethodGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
@@ -142,9 +160,18 @@ func (client *subscriptionInCredentialsOperations) postMethodGlobalValidCreateRe
 // postMethodGlobalValidHandleResponse handles the PostMethodGlobalValid response.
 func (client *subscriptionInCredentialsOperations) postMethodGlobalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postMethodGlobalValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postMethodGlobalValidHandleError handles the PostMethodGlobalValid error response.
+func (client *subscriptionInCredentialsOperations) postMethodGlobalValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostPathGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
@@ -179,9 +206,18 @@ func (client *subscriptionInCredentialsOperations) postPathGlobalValidCreateRequ
 // postPathGlobalValidHandleResponse handles the PostPathGlobalValid response.
 func (client *subscriptionInCredentialsOperations) postPathGlobalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postPathGlobalValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postPathGlobalValidHandleError handles the PostPathGlobalValid error response.
+func (client *subscriptionInCredentialsOperations) postPathGlobalValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostSwaggerGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
@@ -216,7 +252,16 @@ func (client *subscriptionInCredentialsOperations) postSwaggerGlobalValidCreateR
 // postSwaggerGlobalValidHandleResponse handles the PostSwaggerGlobalValid response.
 func (client *subscriptionInCredentialsOperations) postSwaggerGlobalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postSwaggerGlobalValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postSwaggerGlobalValidHandleError handles the PostSwaggerGlobalValid error response.
+func (client *subscriptionInCredentialsOperations) postSwaggerGlobalValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/azurespecialsgroup/subscriptioninmethod.go
+++ b/test/autorest/generated/azurespecialsgroup/subscriptioninmethod.go
@@ -62,9 +62,18 @@ func (client *subscriptionInMethodOperations) postMethodLocalNullCreateRequest(s
 // postMethodLocalNullHandleResponse handles the PostMethodLocalNull response.
 func (client *subscriptionInMethodOperations) postMethodLocalNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postMethodLocalNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postMethodLocalNullHandleError handles the PostMethodLocalNull error response.
+func (client *subscriptionInMethodOperations) postMethodLocalNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostMethodLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
@@ -99,9 +108,18 @@ func (client *subscriptionInMethodOperations) postMethodLocalValidCreateRequest(
 // postMethodLocalValidHandleResponse handles the PostMethodLocalValid response.
 func (client *subscriptionInMethodOperations) postMethodLocalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postMethodLocalValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postMethodLocalValidHandleError handles the PostMethodLocalValid error response.
+func (client *subscriptionInMethodOperations) postMethodLocalValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostPathLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
@@ -136,9 +154,18 @@ func (client *subscriptionInMethodOperations) postPathLocalValidCreateRequest(su
 // postPathLocalValidHandleResponse handles the PostPathLocalValid response.
 func (client *subscriptionInMethodOperations) postPathLocalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postPathLocalValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postPathLocalValidHandleError handles the PostPathLocalValid error response.
+func (client *subscriptionInMethodOperations) postPathLocalValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostSwaggerLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
@@ -173,7 +200,16 @@ func (client *subscriptionInMethodOperations) postSwaggerLocalValidCreateRequest
 // postSwaggerLocalValidHandleResponse handles the PostSwaggerLocalValid response.
 func (client *subscriptionInMethodOperations) postSwaggerLocalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postSwaggerLocalValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postSwaggerLocalValidHandleError handles the PostSwaggerLocalValid error response.
+func (client *subscriptionInMethodOperations) postSwaggerLocalValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/azurespecialsgroup/xmsclientrequestid.go
+++ b/test/autorest/generated/azurespecialsgroup/xmsclientrequestid.go
@@ -56,9 +56,14 @@ func (client *xmsClientRequestIdoperations) getCreateRequest() (*azcore.Request,
 // getHandleResponse handles the Get response.
 func (client *xmsClientRequestIdoperations) getHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getHandleError handles the Get error response.
+func (client *xmsClientRequestIdoperations) getHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // ParamGet - Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -93,7 +98,16 @@ func (client *xmsClientRequestIdoperations) paramGetCreateRequest(xMSClientReque
 // paramGetHandleResponse handles the ParamGet response.
 func (client *xmsClientRequestIdoperations) paramGetHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.paramGetHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// paramGetHandleError handles the ParamGet error response.
+func (client *xmsClientRequestIdoperations) paramGetHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/booleangroup/bool.go
+++ b/test/autorest/generated/booleangroup/bool.go
@@ -63,10 +63,19 @@ func (client *boolOperations) getFalseCreateRequest() (*azcore.Request, error) {
 // getFalseHandleResponse handles the GetFalse response.
 func (client *boolOperations) getFalseHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getFalseHandleError(resp)
 	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getFalseHandleError handles the GetFalse error response.
+func (client *boolOperations) getFalseHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetInvalid - Get invalid Boolean value
@@ -100,10 +109,19 @@ func (client *boolOperations) getInvalidCreateRequest() (*azcore.Request, error)
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *boolOperations) getInvalidHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getInvalidHandleError(resp)
 	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getInvalidHandleError handles the GetInvalid error response.
+func (client *boolOperations) getInvalidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNull - Get null Boolean value
@@ -137,10 +155,19 @@ func (client *boolOperations) getNullCreateRequest() (*azcore.Request, error) {
 // getNullHandleResponse handles the GetNull response.
 func (client *boolOperations) getNullHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNullHandleError(resp)
 	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getNullHandleError handles the GetNull error response.
+func (client *boolOperations) getNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetTrue - Get true Boolean value
@@ -174,10 +201,19 @@ func (client *boolOperations) getTrueCreateRequest() (*azcore.Request, error) {
 // getTrueHandleResponse handles the GetTrue response.
 func (client *boolOperations) getTrueHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getTrueHandleError(resp)
 	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getTrueHandleError handles the GetTrue error response.
+func (client *boolOperations) getTrueHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutFalse - Set Boolean value false
@@ -211,9 +247,18 @@ func (client *boolOperations) putFalseCreateRequest() (*azcore.Request, error) {
 // putFalseHandleResponse handles the PutFalse response.
 func (client *boolOperations) putFalseHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putFalseHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putFalseHandleError handles the PutFalse error response.
+func (client *boolOperations) putFalseHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutTrue - Set Boolean value true
@@ -247,7 +292,16 @@ func (client *boolOperations) putTrueCreateRequest() (*azcore.Request, error) {
 // putTrueHandleResponse handles the PutTrue response.
 func (client *boolOperations) putTrueHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putTrueHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putTrueHandleError handles the PutTrue error response.
+func (client *boolOperations) putTrueHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/booleangroup/models.go
+++ b/test/autorest/generated/booleangroup/models.go
@@ -7,7 +7,6 @@ package booleangroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 )
 
@@ -23,14 +22,6 @@ type BoolResponse struct {
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/bytegroup/byte.go
+++ b/test/autorest/generated/bytegroup/byte.go
@@ -61,10 +61,19 @@ func (client *byteOperations) getEmptyCreateRequest() (*azcore.Request, error) {
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *byteOperations) getEmptyHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getEmptyHandleError(resp)
 	}
 	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getEmptyHandleError handles the GetEmpty error response.
+func (client *byteOperations) getEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetInvalid - Get invalid byte value ':::SWAGGER::::'
@@ -98,10 +107,19 @@ func (client *byteOperations) getInvalidCreateRequest() (*azcore.Request, error)
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *byteOperations) getInvalidHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getInvalidHandleError(resp)
 	}
 	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getInvalidHandleError handles the GetInvalid error response.
+func (client *byteOperations) getInvalidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNonASCII - Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
@@ -135,10 +153,19 @@ func (client *byteOperations) getNonAsciiCreateRequest() (*azcore.Request, error
 // getNonAsciiHandleResponse handles the GetNonASCII response.
 func (client *byteOperations) getNonAsciiHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNonAsciiHandleError(resp)
 	}
 	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getNonAsciiHandleError handles the GetNonASCII error response.
+func (client *byteOperations) getNonAsciiHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNull - Get null byte value
@@ -172,10 +199,19 @@ func (client *byteOperations) getNullCreateRequest() (*azcore.Request, error) {
 // getNullHandleResponse handles the GetNull response.
 func (client *byteOperations) getNullHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNullHandleError(resp)
 	}
 	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getNullHandleError handles the GetNull error response.
+func (client *byteOperations) getNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutNonASCII - Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
@@ -209,7 +245,16 @@ func (client *byteOperations) putNonAsciiCreateRequest(byteBody []byte) (*azcore
 // putNonAsciiHandleResponse handles the PutNonASCII response.
 func (client *byteOperations) putNonAsciiHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putNonAsciiHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putNonAsciiHandleError handles the PutNonASCII error response.
+func (client *byteOperations) putNonAsciiHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/bytegroup/models.go
+++ b/test/autorest/generated/bytegroup/models.go
@@ -7,7 +7,6 @@ package bytegroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 )
 
@@ -23,14 +22,6 @@ type ByteArrayResponse struct {
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/complexgroup/array.go
+++ b/test/autorest/generated/complexgroup/array.go
@@ -61,10 +61,19 @@ func (client *arrayOperations) getEmptyCreateRequest() (*azcore.Request, error) 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *arrayOperations) getEmptyHandleResponse(resp *azcore.Response) (*ArrayWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getEmptyHandleError(resp)
 	}
 	result := ArrayWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ArrayWrapper)
+}
+
+// getEmptyHandleError handles the GetEmpty error response.
+func (client *arrayOperations) getEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNotProvided - Get complex types with array property while server doesn't provide a response payload
@@ -98,10 +107,19 @@ func (client *arrayOperations) getNotProvidedCreateRequest() (*azcore.Request, e
 // getNotProvidedHandleResponse handles the GetNotProvided response.
 func (client *arrayOperations) getNotProvidedHandleResponse(resp *azcore.Response) (*ArrayWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNotProvidedHandleError(resp)
 	}
 	result := ArrayWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ArrayWrapper)
+}
+
+// getNotProvidedHandleError handles the GetNotProvided error response.
+func (client *arrayOperations) getNotProvidedHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetValid - Get complex types with array property
@@ -135,10 +153,19 @@ func (client *arrayOperations) getValidCreateRequest() (*azcore.Request, error) 
 // getValidHandleResponse handles the GetValid response.
 func (client *arrayOperations) getValidHandleResponse(resp *azcore.Response) (*ArrayWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getValidHandleError(resp)
 	}
 	result := ArrayWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ArrayWrapper)
+}
+
+// getValidHandleError handles the GetValid error response.
+func (client *arrayOperations) getValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutEmpty - Put complex types with array property which is empty
@@ -172,9 +199,18 @@ func (client *arrayOperations) putEmptyCreateRequest(complexBody ArrayWrapper) (
 // putEmptyHandleResponse handles the PutEmpty response.
 func (client *arrayOperations) putEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putEmptyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putEmptyHandleError handles the PutEmpty error response.
+func (client *arrayOperations) putEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutValid - Put complex types with array property
@@ -208,7 +244,16 @@ func (client *arrayOperations) putValidCreateRequest(complexBody ArrayWrapper) (
 // putValidHandleResponse handles the PutValid response.
 func (client *arrayOperations) putValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putValidHandleError handles the PutValid error response.
+func (client *arrayOperations) putValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/complexgroup/basic.go
+++ b/test/autorest/generated/complexgroup/basic.go
@@ -63,10 +63,19 @@ func (client *basicOperations) getEmptyCreateRequest() (*azcore.Request, error) 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *basicOperations) getEmptyHandleResponse(resp *azcore.Response) (*BasicResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getEmptyHandleError(resp)
 	}
 	result := BasicResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Basic)
+}
+
+// getEmptyHandleError handles the GetEmpty error response.
+func (client *basicOperations) getEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetInvalid - Get a basic complex type that is invalid for the local strong type
@@ -100,10 +109,19 @@ func (client *basicOperations) getInvalidCreateRequest() (*azcore.Request, error
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *basicOperations) getInvalidHandleResponse(resp *azcore.Response) (*BasicResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getInvalidHandleError(resp)
 	}
 	result := BasicResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Basic)
+}
+
+// getInvalidHandleError handles the GetInvalid error response.
+func (client *basicOperations) getInvalidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNotProvided - Get a basic complex type while the server doesn't provide a response payload
@@ -137,10 +155,19 @@ func (client *basicOperations) getNotProvidedCreateRequest() (*azcore.Request, e
 // getNotProvidedHandleResponse handles the GetNotProvided response.
 func (client *basicOperations) getNotProvidedHandleResponse(resp *azcore.Response) (*BasicResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNotProvidedHandleError(resp)
 	}
 	result := BasicResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Basic)
+}
+
+// getNotProvidedHandleError handles the GetNotProvided error response.
+func (client *basicOperations) getNotProvidedHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNull - Get a basic complex type whose properties are null
@@ -174,10 +201,19 @@ func (client *basicOperations) getNullCreateRequest() (*azcore.Request, error) {
 // getNullHandleResponse handles the GetNull response.
 func (client *basicOperations) getNullHandleResponse(resp *azcore.Response) (*BasicResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNullHandleError(resp)
 	}
 	result := BasicResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Basic)
+}
+
+// getNullHandleError handles the GetNull error response.
+func (client *basicOperations) getNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetValid - Get complex type {id: 2, name: 'abc', color: 'YELLOW'}
@@ -211,10 +247,19 @@ func (client *basicOperations) getValidCreateRequest() (*azcore.Request, error) 
 // getValidHandleResponse handles the GetValid response.
 func (client *basicOperations) getValidHandleResponse(resp *azcore.Response) (*BasicResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getValidHandleError(resp)
 	}
 	result := BasicResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Basic)
+}
+
+// getValidHandleError handles the GetValid error response.
+func (client *basicOperations) getValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutValid - Please put {id: 2, name: 'abc', color: 'Magenta'}
@@ -251,7 +296,16 @@ func (client *basicOperations) putValidCreateRequest(complexBody Basic) (*azcore
 // putValidHandleResponse handles the PutValid response.
 func (client *basicOperations) putValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putValidHandleError handles the PutValid error response.
+func (client *basicOperations) putValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/complexgroup/dictionary.go
+++ b/test/autorest/generated/complexgroup/dictionary.go
@@ -63,10 +63,19 @@ func (client *dictionaryOperations) getEmptyCreateRequest() (*azcore.Request, er
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *dictionaryOperations) getEmptyHandleResponse(resp *azcore.Response) (*DictionaryWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getEmptyHandleError(resp)
 	}
 	result := DictionaryWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DictionaryWrapper)
+}
+
+// getEmptyHandleError handles the GetEmpty error response.
+func (client *dictionaryOperations) getEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNotProvided - Get complex types with dictionary property while server doesn't provide a response payload
@@ -100,10 +109,19 @@ func (client *dictionaryOperations) getNotProvidedCreateRequest() (*azcore.Reque
 // getNotProvidedHandleResponse handles the GetNotProvided response.
 func (client *dictionaryOperations) getNotProvidedHandleResponse(resp *azcore.Response) (*DictionaryWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNotProvidedHandleError(resp)
 	}
 	result := DictionaryWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DictionaryWrapper)
+}
+
+// getNotProvidedHandleError handles the GetNotProvided error response.
+func (client *dictionaryOperations) getNotProvidedHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNull - Get complex types with dictionary property which is null
@@ -137,10 +155,19 @@ func (client *dictionaryOperations) getNullCreateRequest() (*azcore.Request, err
 // getNullHandleResponse handles the GetNull response.
 func (client *dictionaryOperations) getNullHandleResponse(resp *azcore.Response) (*DictionaryWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNullHandleError(resp)
 	}
 	result := DictionaryWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DictionaryWrapper)
+}
+
+// getNullHandleError handles the GetNull error response.
+func (client *dictionaryOperations) getNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetValid - Get complex types with dictionary property
@@ -174,10 +201,19 @@ func (client *dictionaryOperations) getValidCreateRequest() (*azcore.Request, er
 // getValidHandleResponse handles the GetValid response.
 func (client *dictionaryOperations) getValidHandleResponse(resp *azcore.Response) (*DictionaryWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getValidHandleError(resp)
 	}
 	result := DictionaryWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DictionaryWrapper)
+}
+
+// getValidHandleError handles the GetValid error response.
+func (client *dictionaryOperations) getValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutEmpty - Put complex types with dictionary property which is empty
@@ -211,9 +247,18 @@ func (client *dictionaryOperations) putEmptyCreateRequest(complexBody Dictionary
 // putEmptyHandleResponse handles the PutEmpty response.
 func (client *dictionaryOperations) putEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putEmptyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putEmptyHandleError handles the PutEmpty error response.
+func (client *dictionaryOperations) putEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutValid - Put complex types with dictionary property
@@ -247,7 +292,16 @@ func (client *dictionaryOperations) putValidCreateRequest(complexBody Dictionary
 // putValidHandleResponse handles the PutValid response.
 func (client *dictionaryOperations) putValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putValidHandleError handles the PutValid error response.
+func (client *dictionaryOperations) putValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/complexgroup/flattencomplex.go
+++ b/test/autorest/generated/complexgroup/flattencomplex.go
@@ -52,8 +52,13 @@ func (client *flattencomplexOperations) getValidCreateRequest() (*azcore.Request
 // getValidHandleResponse handles the GetValid response.
 func (client *flattencomplexOperations) getValidHandleResponse(resp *azcore.Response) (*MyBaseTypeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getValidHandleError(resp)
 	}
 	result := MyBaseTypeResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result)
+}
+
+// getValidHandleError handles the GetValid error response.
+func (client *flattencomplexOperations) getValidHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }

--- a/test/autorest/generated/complexgroup/inheritance.go
+++ b/test/autorest/generated/complexgroup/inheritance.go
@@ -55,10 +55,19 @@ func (client *inheritanceOperations) getValidCreateRequest() (*azcore.Request, e
 // getValidHandleResponse handles the GetValid response.
 func (client *inheritanceOperations) getValidHandleResponse(resp *azcore.Response) (*SiameseResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getValidHandleError(resp)
 	}
 	result := SiameseResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Siamese)
+}
+
+// getValidHandleError handles the GetValid error response.
+func (client *inheritanceOperations) getValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutValid - Put complex types that extend others
@@ -92,7 +101,16 @@ func (client *inheritanceOperations) putValidCreateRequest(complexBody Siamese) 
 // putValidHandleResponse handles the PutValid response.
 func (client *inheritanceOperations) putValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putValidHandleError handles the PutValid error response.
+func (client *inheritanceOperations) putValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/complexgroup/models.go
+++ b/test/autorest/generated/complexgroup/models.go
@@ -8,7 +8,6 @@ package complexgroup
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"time"
 )
@@ -419,14 +418,6 @@ type DurationWrapperResponse struct {
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/complexgroup/polymorphicrecursive.go
+++ b/test/autorest/generated/complexgroup/polymorphicrecursive.go
@@ -55,10 +55,19 @@ func (client *polymorphicrecursiveOperations) getValidCreateRequest() (*azcore.R
 // getValidHandleResponse handles the GetValid response.
 func (client *polymorphicrecursiveOperations) getValidHandleResponse(resp *azcore.Response) (*FishResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getValidHandleError(resp)
 	}
 	result := FishResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result)
+}
+
+// getValidHandleError handles the GetValid error response.
+func (client *polymorphicrecursiveOperations) getValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutValid - Put complex types that are polymorphic and have recursive references
@@ -92,7 +101,16 @@ func (client *polymorphicrecursiveOperations) putValidCreateRequest(complexBody 
 // putValidHandleResponse handles the PutValid response.
 func (client *polymorphicrecursiveOperations) putValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putValidHandleError handles the PutValid error response.
+func (client *polymorphicrecursiveOperations) putValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/complexgroup/polymorphism.go
+++ b/test/autorest/generated/complexgroup/polymorphism.go
@@ -69,10 +69,19 @@ func (client *polymorphismOperations) getComplicatedCreateRequest() (*azcore.Req
 // getComplicatedHandleResponse handles the GetComplicated response.
 func (client *polymorphismOperations) getComplicatedHandleResponse(resp *azcore.Response) (*SalmonResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getComplicatedHandleError(resp)
 	}
 	result := SalmonResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result)
+}
+
+// getComplicatedHandleError handles the GetComplicated error response.
+func (client *polymorphismOperations) getComplicatedHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetComposedWithDiscriminator - Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
@@ -106,10 +115,19 @@ func (client *polymorphismOperations) getComposedWithDiscriminatorCreateRequest(
 // getComposedWithDiscriminatorHandleResponse handles the GetComposedWithDiscriminator response.
 func (client *polymorphismOperations) getComposedWithDiscriminatorHandleResponse(resp *azcore.Response) (*DotFishMarketResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getComposedWithDiscriminatorHandleError(resp)
 	}
 	result := DotFishMarketResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DotFishMarket)
+}
+
+// getComposedWithDiscriminatorHandleError handles the GetComposedWithDiscriminator error response.
+func (client *polymorphismOperations) getComposedWithDiscriminatorHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetComposedWithoutDiscriminator - Get complex object composing a polymorphic scalar property and array property with polymorphic element type, without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
@@ -143,10 +161,19 @@ func (client *polymorphismOperations) getComposedWithoutDiscriminatorCreateReque
 // getComposedWithoutDiscriminatorHandleResponse handles the GetComposedWithoutDiscriminator response.
 func (client *polymorphismOperations) getComposedWithoutDiscriminatorHandleResponse(resp *azcore.Response) (*DotFishMarketResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getComposedWithoutDiscriminatorHandleError(resp)
 	}
 	result := DotFishMarketResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DotFishMarket)
+}
+
+// getComposedWithoutDiscriminatorHandleError handles the GetComposedWithoutDiscriminator error response.
+func (client *polymorphismOperations) getComposedWithoutDiscriminatorHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDotSyntax - Get complex types that are polymorphic, JSON key contains a dot
@@ -180,10 +207,19 @@ func (client *polymorphismOperations) getDotSyntaxCreateRequest() (*azcore.Reque
 // getDotSyntaxHandleResponse handles the GetDotSyntax response.
 func (client *polymorphismOperations) getDotSyntaxHandleResponse(resp *azcore.Response) (*DotFishResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDotSyntaxHandleError(resp)
 	}
 	result := DotFishResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result)
+}
+
+// getDotSyntaxHandleError handles the GetDotSyntax error response.
+func (client *polymorphismOperations) getDotSyntaxHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetValid - Get complex types that are polymorphic
@@ -217,10 +253,19 @@ func (client *polymorphismOperations) getValidCreateRequest() (*azcore.Request, 
 // getValidHandleResponse handles the GetValid response.
 func (client *polymorphismOperations) getValidHandleResponse(resp *azcore.Response) (*FishResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getValidHandleError(resp)
 	}
 	result := FishResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result)
+}
+
+// getValidHandleError handles the GetValid error response.
+func (client *polymorphismOperations) getValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutComplicated - Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
@@ -254,9 +299,18 @@ func (client *polymorphismOperations) putComplicatedCreateRequest(complexBody Sa
 // putComplicatedHandleResponse handles the PutComplicated response.
 func (client *polymorphismOperations) putComplicatedHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putComplicatedHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putComplicatedHandleError handles the PutComplicated error response.
+func (client *polymorphismOperations) putComplicatedHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutMissingDiscriminator - Put complex types that are polymorphic, omitting the discriminator
@@ -290,10 +344,19 @@ func (client *polymorphismOperations) putMissingDiscriminatorCreateRequest(compl
 // putMissingDiscriminatorHandleResponse handles the PutMissingDiscriminator response.
 func (client *polymorphismOperations) putMissingDiscriminatorHandleResponse(resp *azcore.Response) (*SalmonResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putMissingDiscriminatorHandleError(resp)
 	}
 	result := SalmonResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result)
+}
+
+// putMissingDiscriminatorHandleError handles the PutMissingDiscriminator error response.
+func (client *polymorphismOperations) putMissingDiscriminatorHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutValid - Put complex types that are polymorphic
@@ -327,9 +390,18 @@ func (client *polymorphismOperations) putValidCreateRequest(complexBody FishType
 // putValidHandleResponse handles the PutValid response.
 func (client *polymorphismOperations) putValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putValidHandleError handles the PutValid error response.
+func (client *polymorphismOperations) putValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutValidMissingRequired - Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client
@@ -363,7 +435,16 @@ func (client *polymorphismOperations) putValidMissingRequiredCreateRequest(compl
 // putValidMissingRequiredHandleResponse handles the PutValidMissingRequired response.
 func (client *polymorphismOperations) putValidMissingRequiredHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putValidMissingRequiredHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putValidMissingRequiredHandleError handles the PutValidMissingRequired error response.
+func (client *polymorphismOperations) putValidMissingRequiredHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/complexgroup/primitive.go
+++ b/test/autorest/generated/complexgroup/primitive.go
@@ -95,10 +95,19 @@ func (client *primitiveOperations) getBoolCreateRequest() (*azcore.Request, erro
 // getBoolHandleResponse handles the GetBool response.
 func (client *primitiveOperations) getBoolHandleResponse(resp *azcore.Response) (*BooleanWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBoolHandleError(resp)
 	}
 	result := BooleanWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.BooleanWrapper)
+}
+
+// getBoolHandleError handles the GetBool error response.
+func (client *primitiveOperations) getBoolHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetByte - Get complex types with byte properties
@@ -132,10 +141,19 @@ func (client *primitiveOperations) getByteCreateRequest() (*azcore.Request, erro
 // getByteHandleResponse handles the GetByte response.
 func (client *primitiveOperations) getByteHandleResponse(resp *azcore.Response) (*ByteWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getByteHandleError(resp)
 	}
 	result := ByteWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ByteWrapper)
+}
+
+// getByteHandleError handles the GetByte error response.
+func (client *primitiveOperations) getByteHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDate - Get complex types with date properties
@@ -169,10 +187,19 @@ func (client *primitiveOperations) getDateCreateRequest() (*azcore.Request, erro
 // getDateHandleResponse handles the GetDate response.
 func (client *primitiveOperations) getDateHandleResponse(resp *azcore.Response) (*DateWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateHandleError(resp)
 	}
 	result := DateWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DateWrapper)
+}
+
+// getDateHandleError handles the GetDate error response.
+func (client *primitiveOperations) getDateHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateTime - Get complex types with datetime properties
@@ -206,10 +233,19 @@ func (client *primitiveOperations) getDateTimeCreateRequest() (*azcore.Request, 
 // getDateTimeHandleResponse handles the GetDateTime response.
 func (client *primitiveOperations) getDateTimeHandleResponse(resp *azcore.Response) (*DatetimeWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateTimeHandleError(resp)
 	}
 	result := DatetimeWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DatetimeWrapper)
+}
+
+// getDateTimeHandleError handles the GetDateTime error response.
+func (client *primitiveOperations) getDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateTimeRFC1123 - Get complex types with datetimeRfc1123 properties
@@ -243,10 +279,19 @@ func (client *primitiveOperations) getDateTimeRfc1123CreateRequest() (*azcore.Re
 // getDateTimeRfc1123HandleResponse handles the GetDateTimeRFC1123 response.
 func (client *primitiveOperations) getDateTimeRfc1123HandleResponse(resp *azcore.Response) (*Datetimerfc1123WrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateTimeRfc1123HandleError(resp)
 	}
 	result := Datetimerfc1123WrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Datetimerfc1123Wrapper)
+}
+
+// getDateTimeRfc1123HandleError handles the GetDateTimeRFC1123 error response.
+func (client *primitiveOperations) getDateTimeRfc1123HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDouble - Get complex types with double properties
@@ -280,10 +325,19 @@ func (client *primitiveOperations) getDoubleCreateRequest() (*azcore.Request, er
 // getDoubleHandleResponse handles the GetDouble response.
 func (client *primitiveOperations) getDoubleHandleResponse(resp *azcore.Response) (*DoubleWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDoubleHandleError(resp)
 	}
 	result := DoubleWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DoubleWrapper)
+}
+
+// getDoubleHandleError handles the GetDouble error response.
+func (client *primitiveOperations) getDoubleHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDuration - Get complex types with duration properties
@@ -317,10 +371,19 @@ func (client *primitiveOperations) getDurationCreateRequest() (*azcore.Request, 
 // getDurationHandleResponse handles the GetDuration response.
 func (client *primitiveOperations) getDurationHandleResponse(resp *azcore.Response) (*DurationWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDurationHandleError(resp)
 	}
 	result := DurationWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DurationWrapper)
+}
+
+// getDurationHandleError handles the GetDuration error response.
+func (client *primitiveOperations) getDurationHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetFloat - Get complex types with float properties
@@ -354,10 +417,19 @@ func (client *primitiveOperations) getFloatCreateRequest() (*azcore.Request, err
 // getFloatHandleResponse handles the GetFloat response.
 func (client *primitiveOperations) getFloatHandleResponse(resp *azcore.Response) (*FloatWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getFloatHandleError(resp)
 	}
 	result := FloatWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.FloatWrapper)
+}
+
+// getFloatHandleError handles the GetFloat error response.
+func (client *primitiveOperations) getFloatHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetInt - Get complex types with integer properties
@@ -391,10 +463,19 @@ func (client *primitiveOperations) getIntCreateRequest() (*azcore.Request, error
 // getIntHandleResponse handles the GetInt response.
 func (client *primitiveOperations) getIntHandleResponse(resp *azcore.Response) (*IntWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getIntHandleError(resp)
 	}
 	result := IntWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.IntWrapper)
+}
+
+// getIntHandleError handles the GetInt error response.
+func (client *primitiveOperations) getIntHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetLong - Get complex types with long properties
@@ -428,10 +509,19 @@ func (client *primitiveOperations) getLongCreateRequest() (*azcore.Request, erro
 // getLongHandleResponse handles the GetLong response.
 func (client *primitiveOperations) getLongHandleResponse(resp *azcore.Response) (*LongWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getLongHandleError(resp)
 	}
 	result := LongWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.LongWrapper)
+}
+
+// getLongHandleError handles the GetLong error response.
+func (client *primitiveOperations) getLongHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetString - Get complex types with string properties
@@ -465,10 +555,19 @@ func (client *primitiveOperations) getStringCreateRequest() (*azcore.Request, er
 // getStringHandleResponse handles the GetString response.
 func (client *primitiveOperations) getStringHandleResponse(resp *azcore.Response) (*StringWrapperResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getStringHandleError(resp)
 	}
 	result := StringWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringWrapper)
+}
+
+// getStringHandleError handles the GetString error response.
+func (client *primitiveOperations) getStringHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutBool - Put complex types with bool properties
@@ -502,9 +601,18 @@ func (client *primitiveOperations) putBoolCreateRequest(complexBody BooleanWrapp
 // putBoolHandleResponse handles the PutBool response.
 func (client *primitiveOperations) putBoolHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putBoolHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putBoolHandleError handles the PutBool error response.
+func (client *primitiveOperations) putBoolHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutByte - Put complex types with byte properties
@@ -538,9 +646,18 @@ func (client *primitiveOperations) putByteCreateRequest(complexBody ByteWrapper)
 // putByteHandleResponse handles the PutByte response.
 func (client *primitiveOperations) putByteHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putByteHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putByteHandleError handles the PutByte error response.
+func (client *primitiveOperations) putByteHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDate - Put complex types with date properties
@@ -574,9 +691,18 @@ func (client *primitiveOperations) putDateCreateRequest(complexBody DateWrapper)
 // putDateHandleResponse handles the PutDate response.
 func (client *primitiveOperations) putDateHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDateHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDateHandleError handles the PutDate error response.
+func (client *primitiveOperations) putDateHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDateTime - Put complex types with datetime properties
@@ -610,9 +736,18 @@ func (client *primitiveOperations) putDateTimeCreateRequest(complexBody Datetime
 // putDateTimeHandleResponse handles the PutDateTime response.
 func (client *primitiveOperations) putDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDateTimeHandleError handles the PutDateTime error response.
+func (client *primitiveOperations) putDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDateTimeRFC1123 - Put complex types with datetimeRfc1123 properties
@@ -646,9 +781,18 @@ func (client *primitiveOperations) putDateTimeRfc1123CreateRequest(complexBody D
 // putDateTimeRfc1123HandleResponse handles the PutDateTimeRFC1123 response.
 func (client *primitiveOperations) putDateTimeRfc1123HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDateTimeRfc1123HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDateTimeRfc1123HandleError handles the PutDateTimeRFC1123 error response.
+func (client *primitiveOperations) putDateTimeRfc1123HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDouble - Put complex types with double properties
@@ -682,9 +826,18 @@ func (client *primitiveOperations) putDoubleCreateRequest(complexBody DoubleWrap
 // putDoubleHandleResponse handles the PutDouble response.
 func (client *primitiveOperations) putDoubleHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDoubleHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDoubleHandleError handles the PutDouble error response.
+func (client *primitiveOperations) putDoubleHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDuration - Put complex types with duration properties
@@ -718,9 +871,18 @@ func (client *primitiveOperations) putDurationCreateRequest(complexBody Duration
 // putDurationHandleResponse handles the PutDuration response.
 func (client *primitiveOperations) putDurationHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDurationHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDurationHandleError handles the PutDuration error response.
+func (client *primitiveOperations) putDurationHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutFloat - Put complex types with float properties
@@ -754,9 +916,18 @@ func (client *primitiveOperations) putFloatCreateRequest(complexBody FloatWrappe
 // putFloatHandleResponse handles the PutFloat response.
 func (client *primitiveOperations) putFloatHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putFloatHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putFloatHandleError handles the PutFloat error response.
+func (client *primitiveOperations) putFloatHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutInt - Put complex types with integer properties
@@ -790,9 +961,18 @@ func (client *primitiveOperations) putIntCreateRequest(complexBody IntWrapper) (
 // putIntHandleResponse handles the PutInt response.
 func (client *primitiveOperations) putIntHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putIntHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putIntHandleError handles the PutInt error response.
+func (client *primitiveOperations) putIntHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutLong - Put complex types with long properties
@@ -826,9 +1006,18 @@ func (client *primitiveOperations) putLongCreateRequest(complexBody LongWrapper)
 // putLongHandleResponse handles the PutLong response.
 func (client *primitiveOperations) putLongHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putLongHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putLongHandleError handles the PutLong error response.
+func (client *primitiveOperations) putLongHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutString - Put complex types with string properties
@@ -862,7 +1051,16 @@ func (client *primitiveOperations) putStringCreateRequest(complexBody StringWrap
 // putStringHandleResponse handles the PutString response.
 func (client *primitiveOperations) putStringHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putStringHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putStringHandleError handles the PutString error response.
+func (client *primitiveOperations) putStringHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/complexgroup/readonlyproperty.go
+++ b/test/autorest/generated/complexgroup/readonlyproperty.go
@@ -55,10 +55,19 @@ func (client *readonlypropertyOperations) getValidCreateRequest() (*azcore.Reque
 // getValidHandleResponse handles the GetValid response.
 func (client *readonlypropertyOperations) getValidHandleResponse(resp *azcore.Response) (*ReadonlyObjResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getValidHandleError(resp)
 	}
 	result := ReadonlyObjResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ReadonlyObj)
+}
+
+// getValidHandleError handles the GetValid error response.
+func (client *readonlypropertyOperations) getValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutValid - Put complex types that have readonly properties
@@ -92,7 +101,16 @@ func (client *readonlypropertyOperations) putValidCreateRequest(complexBody Read
 // putValidHandleResponse handles the PutValid response.
 func (client *readonlypropertyOperations) putValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putValidHandleError handles the PutValid error response.
+func (client *readonlypropertyOperations) putValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/complexmodelgroup/models.go
+++ b/test/autorest/generated/complexmodelgroup/models.go
@@ -7,7 +7,6 @@ package complexmodelgroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 )
 
@@ -50,14 +49,6 @@ type CatalogDictionaryResponse struct {
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/complexmodelgroup/operations.go
+++ b/test/autorest/generated/complexmodelgroup/operations.go
@@ -64,10 +64,19 @@ func (client *operations) createCreateRequest(subscriptionId string, resourceGro
 // createHandleResponse handles the Create response.
 func (client *operations) createHandleResponse(resp *azcore.Response) (*CatalogDictionaryResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.createHandleError(resp)
 	}
 	result := CatalogDictionaryResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.CatalogDictionary)
+}
+
+// createHandleError handles the Create error response.
+func (client *operations) createHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // List - The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.
@@ -106,10 +115,19 @@ func (client *operations) listCreateRequest(resourceGroupName string) (*azcore.R
 // listHandleResponse handles the List response.
 func (client *operations) listHandleResponse(resp *azcore.Response) (*CatalogArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.listHandleError(resp)
 	}
 	result := CatalogArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.CatalogArray)
+}
+
+// listHandleError handles the List error response.
+func (client *operations) listHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Update - Resets products.
@@ -148,8 +166,17 @@ func (client *operations) updateCreateRequest(subscriptionId string, resourceGro
 // updateHandleResponse handles the Update response.
 func (client *operations) updateHandleResponse(resp *azcore.Response) (*CatalogArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.updateHandleError(resp)
 	}
 	result := CatalogArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.CatalogArray)
+}
+
+// updateHandleError handles the Update error response.
+func (client *operations) updateHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/custombaseurlgroup/models.go
+++ b/test/autorest/generated/custombaseurlgroup/models.go
@@ -5,22 +5,11 @@
 
 package custombaseurlgroup
 
-import (
-	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-)
+import "fmt"
 
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/custombaseurlgroup/paths.go
+++ b/test/autorest/generated/custombaseurlgroup/paths.go
@@ -53,7 +53,16 @@ func (client *pathsOperations) getEmptyCreateRequest(accountName string) (*azcor
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *pathsOperations) getEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getEmptyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getEmptyHandleError handles the GetEmpty error response.
+func (client *pathsOperations) getEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/datetimegroup/datetime.go
+++ b/test/autorest/generated/datetimegroup/datetime.go
@@ -94,11 +94,20 @@ func (client *datetimeOperations) getInvalidCreateRequest() (*azcore.Request, er
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *datetimeOperations) getInvalidHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getInvalidHandleError(resp)
 	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getInvalidHandleError handles the GetInvalid error response.
+func (client *datetimeOperations) getInvalidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetLocalNegativeOffsetLowercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00
@@ -132,11 +141,20 @@ func (client *datetimeOperations) getLocalNegativeOffsetLowercaseMaxDateTimeCrea
 // getLocalNegativeOffsetLowercaseMaxDateTimeHandleResponse handles the GetLocalNegativeOffsetLowercaseMaxDateTime response.
 func (client *datetimeOperations) getLocalNegativeOffsetLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getLocalNegativeOffsetLowercaseMaxDateTimeHandleError(resp)
 	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getLocalNegativeOffsetLowercaseMaxDateTimeHandleError handles the GetLocalNegativeOffsetLowercaseMaxDateTime error response.
+func (client *datetimeOperations) getLocalNegativeOffsetLowercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetLocalNegativeOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00-14:00
@@ -170,11 +188,20 @@ func (client *datetimeOperations) getLocalNegativeOffsetMinDateTimeCreateRequest
 // getLocalNegativeOffsetMinDateTimeHandleResponse handles the GetLocalNegativeOffsetMinDateTime response.
 func (client *datetimeOperations) getLocalNegativeOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getLocalNegativeOffsetMinDateTimeHandleError(resp)
 	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getLocalNegativeOffsetMinDateTimeHandleError handles the GetLocalNegativeOffsetMinDateTime error response.
+func (client *datetimeOperations) getLocalNegativeOffsetMinDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetLocalNegativeOffsetUppercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00
@@ -208,11 +235,20 @@ func (client *datetimeOperations) getLocalNegativeOffsetUppercaseMaxDateTimeCrea
 // getLocalNegativeOffsetUppercaseMaxDateTimeHandleResponse handles the GetLocalNegativeOffsetUppercaseMaxDateTime response.
 func (client *datetimeOperations) getLocalNegativeOffsetUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getLocalNegativeOffsetUppercaseMaxDateTimeHandleError(resp)
 	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getLocalNegativeOffsetUppercaseMaxDateTimeHandleError handles the GetLocalNegativeOffsetUppercaseMaxDateTime error response.
+func (client *datetimeOperations) getLocalNegativeOffsetUppercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetLocalPositiveOffsetLowercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00
@@ -246,11 +282,20 @@ func (client *datetimeOperations) getLocalPositiveOffsetLowercaseMaxDateTimeCrea
 // getLocalPositiveOffsetLowercaseMaxDateTimeHandleResponse handles the GetLocalPositiveOffsetLowercaseMaxDateTime response.
 func (client *datetimeOperations) getLocalPositiveOffsetLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getLocalPositiveOffsetLowercaseMaxDateTimeHandleError(resp)
 	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getLocalPositiveOffsetLowercaseMaxDateTimeHandleError handles the GetLocalPositiveOffsetLowercaseMaxDateTime error response.
+func (client *datetimeOperations) getLocalPositiveOffsetLowercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetLocalPositiveOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00+14:00
@@ -284,11 +329,20 @@ func (client *datetimeOperations) getLocalPositiveOffsetMinDateTimeCreateRequest
 // getLocalPositiveOffsetMinDateTimeHandleResponse handles the GetLocalPositiveOffsetMinDateTime response.
 func (client *datetimeOperations) getLocalPositiveOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getLocalPositiveOffsetMinDateTimeHandleError(resp)
 	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getLocalPositiveOffsetMinDateTimeHandleError handles the GetLocalPositiveOffsetMinDateTime error response.
+func (client *datetimeOperations) getLocalPositiveOffsetMinDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetLocalPositiveOffsetUppercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00
@@ -322,11 +376,20 @@ func (client *datetimeOperations) getLocalPositiveOffsetUppercaseMaxDateTimeCrea
 // getLocalPositiveOffsetUppercaseMaxDateTimeHandleResponse handles the GetLocalPositiveOffsetUppercaseMaxDateTime response.
 func (client *datetimeOperations) getLocalPositiveOffsetUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getLocalPositiveOffsetUppercaseMaxDateTimeHandleError(resp)
 	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getLocalPositiveOffsetUppercaseMaxDateTimeHandleError handles the GetLocalPositiveOffsetUppercaseMaxDateTime error response.
+func (client *datetimeOperations) getLocalPositiveOffsetUppercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNull - Get null datetime value
@@ -360,11 +423,20 @@ func (client *datetimeOperations) getNullCreateRequest() (*azcore.Request, error
 // getNullHandleResponse handles the GetNull response.
 func (client *datetimeOperations) getNullHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNullHandleError(resp)
 	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getNullHandleError handles the GetNull error response.
+func (client *datetimeOperations) getNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetOverflow - Get overflow datetime value
@@ -398,11 +470,20 @@ func (client *datetimeOperations) getOverflowCreateRequest() (*azcore.Request, e
 // getOverflowHandleResponse handles the GetOverflow response.
 func (client *datetimeOperations) getOverflowHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getOverflowHandleError(resp)
 	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getOverflowHandleError handles the GetOverflow error response.
+func (client *datetimeOperations) getOverflowHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetUTCLowercaseMaxDateTime - Get max datetime value 9999-12-31t23:59:59.999z
@@ -436,11 +517,20 @@ func (client *datetimeOperations) getUtcLowercaseMaxDateTimeCreateRequest() (*az
 // getUtcLowercaseMaxDateTimeHandleResponse handles the GetUTCLowercaseMaxDateTime response.
 func (client *datetimeOperations) getUtcLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getUtcLowercaseMaxDateTimeHandleError(resp)
 	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getUtcLowercaseMaxDateTimeHandleError handles the GetUTCLowercaseMaxDateTime error response.
+func (client *datetimeOperations) getUtcLowercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetUTCMinDateTime - Get min datetime value 0001-01-01T00:00:00Z
@@ -474,11 +564,20 @@ func (client *datetimeOperations) getUtcMinDateTimeCreateRequest() (*azcore.Requ
 // getUtcMinDateTimeHandleResponse handles the GetUTCMinDateTime response.
 func (client *datetimeOperations) getUtcMinDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getUtcMinDateTimeHandleError(resp)
 	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getUtcMinDateTimeHandleError handles the GetUTCMinDateTime error response.
+func (client *datetimeOperations) getUtcMinDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetUTCUppercaseMaxDateTime - Get max datetime value 9999-12-31T23:59:59.999Z
@@ -512,11 +611,20 @@ func (client *datetimeOperations) getUtcUppercaseMaxDateTimeCreateRequest() (*az
 // getUtcUppercaseMaxDateTimeHandleResponse handles the GetUTCUppercaseMaxDateTime response.
 func (client *datetimeOperations) getUtcUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getUtcUppercaseMaxDateTimeHandleError(resp)
 	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getUtcUppercaseMaxDateTimeHandleError handles the GetUTCUppercaseMaxDateTime error response.
+func (client *datetimeOperations) getUtcUppercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetUTCUppercaseMaxDateTime7Digits - Get max datetime value 9999-12-31T23:59:59.9999999Z
@@ -550,11 +658,20 @@ func (client *datetimeOperations) getUtcUppercaseMaxDateTime7DigitsCreateRequest
 // getUtcUppercaseMaxDateTime7DigitsHandleResponse handles the GetUTCUppercaseMaxDateTime7Digits response.
 func (client *datetimeOperations) getUtcUppercaseMaxDateTime7DigitsHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getUtcUppercaseMaxDateTime7DigitsHandleError(resp)
 	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getUtcUppercaseMaxDateTime7DigitsHandleError handles the GetUTCUppercaseMaxDateTime7Digits error response.
+func (client *datetimeOperations) getUtcUppercaseMaxDateTime7DigitsHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetUnderflow - Get underflow datetime value
@@ -588,11 +705,20 @@ func (client *datetimeOperations) getUnderflowCreateRequest() (*azcore.Request, 
 // getUnderflowHandleResponse handles the GetUnderflow response.
 func (client *datetimeOperations) getUnderflowHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getUnderflowHandleError(resp)
 	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getUnderflowHandleError handles the GetUnderflow error response.
+func (client *datetimeOperations) getUnderflowHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutLocalNegativeOffsetMaxDateTime - Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00
@@ -626,9 +752,18 @@ func (client *datetimeOperations) putLocalNegativeOffsetMaxDateTimeCreateRequest
 // putLocalNegativeOffsetMaxDateTimeHandleResponse handles the PutLocalNegativeOffsetMaxDateTime response.
 func (client *datetimeOperations) putLocalNegativeOffsetMaxDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putLocalNegativeOffsetMaxDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putLocalNegativeOffsetMaxDateTimeHandleError handles the PutLocalNegativeOffsetMaxDateTime error response.
+func (client *datetimeOperations) putLocalNegativeOffsetMaxDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutLocalNegativeOffsetMinDateTime - Put min datetime value 0001-01-01T00:00:00-14:00
@@ -662,9 +797,18 @@ func (client *datetimeOperations) putLocalNegativeOffsetMinDateTimeCreateRequest
 // putLocalNegativeOffsetMinDateTimeHandleResponse handles the PutLocalNegativeOffsetMinDateTime response.
 func (client *datetimeOperations) putLocalNegativeOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putLocalNegativeOffsetMinDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putLocalNegativeOffsetMinDateTimeHandleError handles the PutLocalNegativeOffsetMinDateTime error response.
+func (client *datetimeOperations) putLocalNegativeOffsetMinDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutLocalPositiveOffsetMaxDateTime - Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00
@@ -698,9 +842,18 @@ func (client *datetimeOperations) putLocalPositiveOffsetMaxDateTimeCreateRequest
 // putLocalPositiveOffsetMaxDateTimeHandleResponse handles the PutLocalPositiveOffsetMaxDateTime response.
 func (client *datetimeOperations) putLocalPositiveOffsetMaxDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putLocalPositiveOffsetMaxDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putLocalPositiveOffsetMaxDateTimeHandleError handles the PutLocalPositiveOffsetMaxDateTime error response.
+func (client *datetimeOperations) putLocalPositiveOffsetMaxDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutLocalPositiveOffsetMinDateTime - Put min datetime value 0001-01-01T00:00:00+14:00
@@ -734,9 +887,18 @@ func (client *datetimeOperations) putLocalPositiveOffsetMinDateTimeCreateRequest
 // putLocalPositiveOffsetMinDateTimeHandleResponse handles the PutLocalPositiveOffsetMinDateTime response.
 func (client *datetimeOperations) putLocalPositiveOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putLocalPositiveOffsetMinDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putLocalPositiveOffsetMinDateTimeHandleError handles the PutLocalPositiveOffsetMinDateTime error response.
+func (client *datetimeOperations) putLocalPositiveOffsetMinDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutUTCMaxDateTime - Put max datetime value 9999-12-31T23:59:59.999Z
@@ -770,9 +932,18 @@ func (client *datetimeOperations) putUtcMaxDateTimeCreateRequest(datetimeBody ti
 // putUtcMaxDateTimeHandleResponse handles the PutUTCMaxDateTime response.
 func (client *datetimeOperations) putUtcMaxDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putUtcMaxDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putUtcMaxDateTimeHandleError handles the PutUTCMaxDateTime error response.
+func (client *datetimeOperations) putUtcMaxDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutUTCMaxDateTime7Digits - Put max datetime value 9999-12-31T23:59:59.9999999Z
@@ -806,9 +977,18 @@ func (client *datetimeOperations) putUtcMaxDateTime7DigitsCreateRequest(datetime
 // putUtcMaxDateTime7DigitsHandleResponse handles the PutUTCMaxDateTime7Digits response.
 func (client *datetimeOperations) putUtcMaxDateTime7DigitsHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putUtcMaxDateTime7DigitsHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putUtcMaxDateTime7DigitsHandleError handles the PutUTCMaxDateTime7Digits error response.
+func (client *datetimeOperations) putUtcMaxDateTime7DigitsHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutUTCMinDateTime - Put min datetime value 0001-01-01T00:00:00Z
@@ -842,7 +1022,16 @@ func (client *datetimeOperations) putUtcMinDateTimeCreateRequest(datetimeBody ti
 // putUtcMinDateTimeHandleResponse handles the PutUTCMinDateTime response.
 func (client *datetimeOperations) putUtcMinDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putUtcMinDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putUtcMinDateTimeHandleError handles the PutUTCMinDateTime error response.
+func (client *datetimeOperations) putUtcMinDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/datetimegroup/models.go
+++ b/test/autorest/generated/datetimegroup/models.go
@@ -7,7 +7,6 @@ package datetimegroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"time"
 )
@@ -15,14 +14,6 @@ import (
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
+++ b/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
@@ -70,11 +70,20 @@ func (client *datetimerfc1123Operations) getInvalidCreateRequest() (*azcore.Requ
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *datetimerfc1123Operations) getInvalidHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getInvalidHandleError(resp)
 	}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getInvalidHandleError handles the GetInvalid error response.
+func (client *datetimerfc1123Operations) getInvalidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNull - Get null datetime value
@@ -108,11 +117,20 @@ func (client *datetimerfc1123Operations) getNullCreateRequest() (*azcore.Request
 // getNullHandleResponse handles the GetNull response.
 func (client *datetimerfc1123Operations) getNullHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNullHandleError(resp)
 	}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getNullHandleError handles the GetNull error response.
+func (client *datetimerfc1123Operations) getNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetOverflow - Get overflow datetime value
@@ -146,11 +164,20 @@ func (client *datetimerfc1123Operations) getOverflowCreateRequest() (*azcore.Req
 // getOverflowHandleResponse handles the GetOverflow response.
 func (client *datetimerfc1123Operations) getOverflowHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getOverflowHandleError(resp)
 	}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getOverflowHandleError handles the GetOverflow error response.
+func (client *datetimerfc1123Operations) getOverflowHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetUTCLowercaseMaxDateTime - Get max datetime value fri, 31 dec 9999 23:59:59 gmt
@@ -184,11 +211,20 @@ func (client *datetimerfc1123Operations) getUtcLowercaseMaxDateTimeCreateRequest
 // getUtcLowercaseMaxDateTimeHandleResponse handles the GetUTCLowercaseMaxDateTime response.
 func (client *datetimerfc1123Operations) getUtcLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getUtcLowercaseMaxDateTimeHandleError(resp)
 	}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getUtcLowercaseMaxDateTimeHandleError handles the GetUTCLowercaseMaxDateTime error response.
+func (client *datetimerfc1123Operations) getUtcLowercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetUTCMinDateTime - Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT
@@ -222,11 +258,20 @@ func (client *datetimerfc1123Operations) getUtcMinDateTimeCreateRequest() (*azco
 // getUtcMinDateTimeHandleResponse handles the GetUTCMinDateTime response.
 func (client *datetimerfc1123Operations) getUtcMinDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getUtcMinDateTimeHandleError(resp)
 	}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getUtcMinDateTimeHandleError handles the GetUTCMinDateTime error response.
+func (client *datetimerfc1123Operations) getUtcMinDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetUTCUppercaseMaxDateTime - Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT
@@ -260,11 +305,20 @@ func (client *datetimerfc1123Operations) getUtcUppercaseMaxDateTimeCreateRequest
 // getUtcUppercaseMaxDateTimeHandleResponse handles the GetUTCUppercaseMaxDateTime response.
 func (client *datetimerfc1123Operations) getUtcUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getUtcUppercaseMaxDateTimeHandleError(resp)
 	}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getUtcUppercaseMaxDateTimeHandleError handles the GetUTCUppercaseMaxDateTime error response.
+func (client *datetimerfc1123Operations) getUtcUppercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetUnderflow - Get underflow datetime value
@@ -298,11 +352,20 @@ func (client *datetimerfc1123Operations) getUnderflowCreateRequest() (*azcore.Re
 // getUnderflowHandleResponse handles the GetUnderflow response.
 func (client *datetimerfc1123Operations) getUnderflowHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getUnderflowHandleError(resp)
 	}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+}
+
+// getUnderflowHandleError handles the GetUnderflow error response.
+func (client *datetimerfc1123Operations) getUnderflowHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutUTCMaxDateTime - Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT
@@ -337,9 +400,18 @@ func (client *datetimerfc1123Operations) putUtcMaxDateTimeCreateRequest(datetime
 // putUtcMaxDateTimeHandleResponse handles the PutUTCMaxDateTime response.
 func (client *datetimerfc1123Operations) putUtcMaxDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putUtcMaxDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putUtcMaxDateTimeHandleError handles the PutUTCMaxDateTime error response.
+func (client *datetimerfc1123Operations) putUtcMaxDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutUTCMinDateTime - Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT
@@ -374,7 +446,16 @@ func (client *datetimerfc1123Operations) putUtcMinDateTimeCreateRequest(datetime
 // putUtcMinDateTimeHandleResponse handles the PutUTCMinDateTime response.
 func (client *datetimerfc1123Operations) putUtcMinDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putUtcMinDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putUtcMinDateTimeHandleError handles the PutUTCMinDateTime error response.
+func (client *datetimerfc1123Operations) putUtcMinDateTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/datetimerfc1123group/models.go
+++ b/test/autorest/generated/datetimerfc1123group/models.go
@@ -7,7 +7,6 @@ package datetimerfc1123group
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"time"
 )
@@ -15,14 +14,6 @@ import (
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/dictionarygroup/dictionary.go
+++ b/test/autorest/generated/dictionarygroup/dictionary.go
@@ -182,10 +182,19 @@ func (client *dictionaryOperations) getArrayEmptyCreateRequest() (*azcore.Reques
 // getArrayEmptyHandleResponse handles the GetArrayEmpty response.
 func (client *dictionaryOperations) getArrayEmptyHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getArrayEmptyHandleError(resp)
 	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getArrayEmptyHandleError handles the GetArrayEmpty error response.
+func (client *dictionaryOperations) getArrayEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetArrayItemEmpty - Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}
@@ -219,10 +228,19 @@ func (client *dictionaryOperations) getArrayItemEmptyCreateRequest() (*azcore.Re
 // getArrayItemEmptyHandleResponse handles the GetArrayItemEmpty response.
 func (client *dictionaryOperations) getArrayItemEmptyHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getArrayItemEmptyHandleError(resp)
 	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getArrayItemEmptyHandleError handles the GetArrayItemEmpty error response.
+func (client *dictionaryOperations) getArrayItemEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetArrayItemNull - Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}
@@ -256,10 +274,19 @@ func (client *dictionaryOperations) getArrayItemNullCreateRequest() (*azcore.Req
 // getArrayItemNullHandleResponse handles the GetArrayItemNull response.
 func (client *dictionaryOperations) getArrayItemNullHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getArrayItemNullHandleError(resp)
 	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getArrayItemNullHandleError handles the GetArrayItemNull error response.
+func (client *dictionaryOperations) getArrayItemNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetArrayNull - Get a null array
@@ -293,10 +320,19 @@ func (client *dictionaryOperations) getArrayNullCreateRequest() (*azcore.Request
 // getArrayNullHandleResponse handles the GetArrayNull response.
 func (client *dictionaryOperations) getArrayNullHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getArrayNullHandleError(resp)
 	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getArrayNullHandleError handles the GetArrayNull error response.
+func (client *dictionaryOperations) getArrayNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetArrayValid - Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
@@ -330,10 +366,19 @@ func (client *dictionaryOperations) getArrayValidCreateRequest() (*azcore.Reques
 // getArrayValidHandleResponse handles the GetArrayValid response.
 func (client *dictionaryOperations) getArrayValidHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getArrayValidHandleError(resp)
 	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getArrayValidHandleError handles the GetArrayValid error response.
+func (client *dictionaryOperations) getArrayValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBase64URL - Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}
@@ -367,10 +412,19 @@ func (client *dictionaryOperations) getBase64UrlCreateRequest() (*azcore.Request
 // getBase64UrlHandleResponse handles the GetBase64URL response.
 func (client *dictionaryOperations) getBase64UrlHandleResponse(resp *azcore.Response) (*MapOfByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBase64UrlHandleError(resp)
 	}
 	result := MapOfByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getBase64UrlHandleError handles the GetBase64URL error response.
+func (client *dictionaryOperations) getBase64UrlHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBooleanInvalidNull - Get boolean dictionary value {"0": true, "1": null, "2": false }
@@ -404,10 +458,19 @@ func (client *dictionaryOperations) getBooleanInvalidNullCreateRequest() (*azcor
 // getBooleanInvalidNullHandleResponse handles the GetBooleanInvalidNull response.
 func (client *dictionaryOperations) getBooleanInvalidNullHandleResponse(resp *azcore.Response) (*MapOfBoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBooleanInvalidNullHandleError(resp)
 	}
 	result := MapOfBoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getBooleanInvalidNullHandleError handles the GetBooleanInvalidNull error response.
+func (client *dictionaryOperations) getBooleanInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBooleanInvalidString - Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'
@@ -441,10 +504,19 @@ func (client *dictionaryOperations) getBooleanInvalidStringCreateRequest() (*azc
 // getBooleanInvalidStringHandleResponse handles the GetBooleanInvalidString response.
 func (client *dictionaryOperations) getBooleanInvalidStringHandleResponse(resp *azcore.Response) (*MapOfBoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBooleanInvalidStringHandleError(resp)
 	}
 	result := MapOfBoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getBooleanInvalidStringHandleError handles the GetBooleanInvalidString error response.
+func (client *dictionaryOperations) getBooleanInvalidStringHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBooleanTfft - Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }
@@ -478,10 +550,19 @@ func (client *dictionaryOperations) getBooleanTfftCreateRequest() (*azcore.Reque
 // getBooleanTfftHandleResponse handles the GetBooleanTfft response.
 func (client *dictionaryOperations) getBooleanTfftHandleResponse(resp *azcore.Response) (*MapOfBoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBooleanTfftHandleError(resp)
 	}
 	result := MapOfBoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getBooleanTfftHandleError handles the GetBooleanTfft error response.
+func (client *dictionaryOperations) getBooleanTfftHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetByteInvalidNull - Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded
@@ -515,10 +596,19 @@ func (client *dictionaryOperations) getByteInvalidNullCreateRequest() (*azcore.R
 // getByteInvalidNullHandleResponse handles the GetByteInvalidNull response.
 func (client *dictionaryOperations) getByteInvalidNullHandleResponse(resp *azcore.Response) (*MapOfByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getByteInvalidNullHandleError(resp)
 	}
 	result := MapOfByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getByteInvalidNullHandleError handles the GetByteInvalidNull error response.
+func (client *dictionaryOperations) getByteInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetByteValid - Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64
@@ -552,10 +642,19 @@ func (client *dictionaryOperations) getByteValidCreateRequest() (*azcore.Request
 // getByteValidHandleResponse handles the GetByteValid response.
 func (client *dictionaryOperations) getByteValidHandleResponse(resp *azcore.Response) (*MapOfByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getByteValidHandleError(resp)
 	}
 	result := MapOfByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getByteValidHandleError handles the GetByteValid error response.
+func (client *dictionaryOperations) getByteValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetComplexEmpty - Get empty dictionary of complex type {}
@@ -589,10 +688,19 @@ func (client *dictionaryOperations) getComplexEmptyCreateRequest() (*azcore.Requ
 // getComplexEmptyHandleResponse handles the GetComplexEmpty response.
 func (client *dictionaryOperations) getComplexEmptyHandleResponse(resp *azcore.Response) (*MapOfWidgetResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getComplexEmptyHandleError(resp)
 	}
 	result := MapOfWidgetResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getComplexEmptyHandleError handles the GetComplexEmpty error response.
+func (client *dictionaryOperations) getComplexEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetComplexItemEmpty - Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}
@@ -626,10 +734,19 @@ func (client *dictionaryOperations) getComplexItemEmptyCreateRequest() (*azcore.
 // getComplexItemEmptyHandleResponse handles the GetComplexItemEmpty response.
 func (client *dictionaryOperations) getComplexItemEmptyHandleResponse(resp *azcore.Response) (*MapOfWidgetResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getComplexItemEmptyHandleError(resp)
 	}
 	result := MapOfWidgetResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getComplexItemEmptyHandleError handles the GetComplexItemEmpty error response.
+func (client *dictionaryOperations) getComplexItemEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetComplexItemNull - Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}
@@ -663,10 +780,19 @@ func (client *dictionaryOperations) getComplexItemNullCreateRequest() (*azcore.R
 // getComplexItemNullHandleResponse handles the GetComplexItemNull response.
 func (client *dictionaryOperations) getComplexItemNullHandleResponse(resp *azcore.Response) (*MapOfWidgetResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getComplexItemNullHandleError(resp)
 	}
 	result := MapOfWidgetResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getComplexItemNullHandleError handles the GetComplexItemNull error response.
+func (client *dictionaryOperations) getComplexItemNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetComplexNull - Get dictionary of complex type null value
@@ -700,10 +826,19 @@ func (client *dictionaryOperations) getComplexNullCreateRequest() (*azcore.Reque
 // getComplexNullHandleResponse handles the GetComplexNull response.
 func (client *dictionaryOperations) getComplexNullHandleResponse(resp *azcore.Response) (*MapOfWidgetResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getComplexNullHandleError(resp)
 	}
 	result := MapOfWidgetResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getComplexNullHandleError handles the GetComplexNull error response.
+func (client *dictionaryOperations) getComplexNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetComplexValid - Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
@@ -737,10 +872,19 @@ func (client *dictionaryOperations) getComplexValidCreateRequest() (*azcore.Requ
 // getComplexValidHandleResponse handles the GetComplexValid response.
 func (client *dictionaryOperations) getComplexValidHandleResponse(resp *azcore.Response) (*MapOfWidgetResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getComplexValidHandleError(resp)
 	}
 	result := MapOfWidgetResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getComplexValidHandleError handles the GetComplexValid error response.
+func (client *dictionaryOperations) getComplexValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateInvalidChars - Get date dictionary value {"0": "2011-03-22", "1": "date"}
@@ -774,10 +918,19 @@ func (client *dictionaryOperations) getDateInvalidCharsCreateRequest() (*azcore.
 // getDateInvalidCharsHandleResponse handles the GetDateInvalidChars response.
 func (client *dictionaryOperations) getDateInvalidCharsHandleResponse(resp *azcore.Response) (*MapOfTimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateInvalidCharsHandleError(resp)
 	}
 	result := MapOfTimeResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getDateInvalidCharsHandleError handles the GetDateInvalidChars error response.
+func (client *dictionaryOperations) getDateInvalidCharsHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateInvalidNull - Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}
@@ -811,10 +964,19 @@ func (client *dictionaryOperations) getDateInvalidNullCreateRequest() (*azcore.R
 // getDateInvalidNullHandleResponse handles the GetDateInvalidNull response.
 func (client *dictionaryOperations) getDateInvalidNullHandleResponse(resp *azcore.Response) (*MapOfTimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateInvalidNullHandleError(resp)
 	}
 	result := MapOfTimeResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getDateInvalidNullHandleError handles the GetDateInvalidNull error response.
+func (client *dictionaryOperations) getDateInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateTimeInvalidChars - Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}
@@ -848,7 +1010,7 @@ func (client *dictionaryOperations) getDateTimeInvalidCharsCreateRequest() (*azc
 // getDateTimeInvalidCharsHandleResponse handles the GetDateTimeInvalidChars response.
 func (client *dictionaryOperations) getDateTimeInvalidCharsHandleResponse(resp *azcore.Response) (*MapOfTimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateTimeInvalidCharsHandleError(resp)
 	}
 	aux := map[string]timeRFC3339{}
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
@@ -859,6 +1021,15 @@ func (client *dictionaryOperations) getDateTimeInvalidCharsHandleResponse(resp *
 		cp[k] = time.Time(v)
 	}
 	return &MapOfTimeResponse{RawResponse: resp.Response, Value: &cp}, nil
+}
+
+// getDateTimeInvalidCharsHandleError handles the GetDateTimeInvalidChars error response.
+func (client *dictionaryOperations) getDateTimeInvalidCharsHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateTimeInvalidNull - Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}
@@ -892,7 +1063,7 @@ func (client *dictionaryOperations) getDateTimeInvalidNullCreateRequest() (*azco
 // getDateTimeInvalidNullHandleResponse handles the GetDateTimeInvalidNull response.
 func (client *dictionaryOperations) getDateTimeInvalidNullHandleResponse(resp *azcore.Response) (*MapOfTimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateTimeInvalidNullHandleError(resp)
 	}
 	aux := map[string]timeRFC3339{}
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
@@ -903,6 +1074,15 @@ func (client *dictionaryOperations) getDateTimeInvalidNullHandleResponse(resp *a
 		cp[k] = time.Time(v)
 	}
 	return &MapOfTimeResponse{RawResponse: resp.Response, Value: &cp}, nil
+}
+
+// getDateTimeInvalidNullHandleError handles the GetDateTimeInvalidNull error response.
+func (client *dictionaryOperations) getDateTimeInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateTimeRFC1123Valid - Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
@@ -936,7 +1116,7 @@ func (client *dictionaryOperations) getDateTimeRfc1123ValidCreateRequest() (*azc
 // getDateTimeRfc1123ValidHandleResponse handles the GetDateTimeRFC1123Valid response.
 func (client *dictionaryOperations) getDateTimeRfc1123ValidHandleResponse(resp *azcore.Response) (*MapOfTimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateTimeRfc1123ValidHandleError(resp)
 	}
 	aux := map[string]timeRFC1123{}
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
@@ -947,6 +1127,15 @@ func (client *dictionaryOperations) getDateTimeRfc1123ValidHandleResponse(resp *
 		cp[k] = time.Time(v)
 	}
 	return &MapOfTimeResponse{RawResponse: resp.Response, Value: &cp}, nil
+}
+
+// getDateTimeRfc1123ValidHandleError handles the GetDateTimeRFC1123Valid error response.
+func (client *dictionaryOperations) getDateTimeRfc1123ValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateTimeValid - Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
@@ -980,7 +1169,7 @@ func (client *dictionaryOperations) getDateTimeValidCreateRequest() (*azcore.Req
 // getDateTimeValidHandleResponse handles the GetDateTimeValid response.
 func (client *dictionaryOperations) getDateTimeValidHandleResponse(resp *azcore.Response) (*MapOfTimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateTimeValidHandleError(resp)
 	}
 	aux := map[string]timeRFC3339{}
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
@@ -991,6 +1180,15 @@ func (client *dictionaryOperations) getDateTimeValidHandleResponse(resp *azcore.
 		cp[k] = time.Time(v)
 	}
 	return &MapOfTimeResponse{RawResponse: resp.Response, Value: &cp}, nil
+}
+
+// getDateTimeValidHandleError handles the GetDateTimeValid error response.
+func (client *dictionaryOperations) getDateTimeValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDateValid - Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
@@ -1024,10 +1222,19 @@ func (client *dictionaryOperations) getDateValidCreateRequest() (*azcore.Request
 // getDateValidHandleResponse handles the GetDateValid response.
 func (client *dictionaryOperations) getDateValidHandleResponse(resp *azcore.Response) (*MapOfTimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDateValidHandleError(resp)
 	}
 	result := MapOfTimeResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getDateValidHandleError handles the GetDateValid error response.
+func (client *dictionaryOperations) getDateValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDictionaryEmpty - Get an dictionaries of dictionaries of type <string, string> with value {}
@@ -1061,10 +1268,19 @@ func (client *dictionaryOperations) getDictionaryEmptyCreateRequest() (*azcore.R
 // getDictionaryEmptyHandleResponse handles the GetDictionaryEmpty response.
 func (client *dictionaryOperations) getDictionaryEmptyHandleResponse(resp *azcore.Response) (*MapOfInterfaceResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDictionaryEmptyHandleError(resp)
 	}
 	result := MapOfInterfaceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getDictionaryEmptyHandleError handles the GetDictionaryEmpty error response.
+func (client *dictionaryOperations) getDictionaryEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDictionaryItemEmpty - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
@@ -1098,10 +1314,19 @@ func (client *dictionaryOperations) getDictionaryItemEmptyCreateRequest() (*azco
 // getDictionaryItemEmptyHandleResponse handles the GetDictionaryItemEmpty response.
 func (client *dictionaryOperations) getDictionaryItemEmptyHandleResponse(resp *azcore.Response) (*MapOfInterfaceResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDictionaryItemEmptyHandleError(resp)
 	}
 	result := MapOfInterfaceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getDictionaryItemEmptyHandleError handles the GetDictionaryItemEmpty error response.
+func (client *dictionaryOperations) getDictionaryItemEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDictionaryItemNull - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}
@@ -1135,10 +1360,19 @@ func (client *dictionaryOperations) getDictionaryItemNullCreateRequest() (*azcor
 // getDictionaryItemNullHandleResponse handles the GetDictionaryItemNull response.
 func (client *dictionaryOperations) getDictionaryItemNullHandleResponse(resp *azcore.Response) (*MapOfInterfaceResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDictionaryItemNullHandleError(resp)
 	}
 	result := MapOfInterfaceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getDictionaryItemNullHandleError handles the GetDictionaryItemNull error response.
+func (client *dictionaryOperations) getDictionaryItemNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDictionaryNull - Get an dictionaries of dictionaries with value null
@@ -1172,10 +1406,19 @@ func (client *dictionaryOperations) getDictionaryNullCreateRequest() (*azcore.Re
 // getDictionaryNullHandleResponse handles the GetDictionaryNull response.
 func (client *dictionaryOperations) getDictionaryNullHandleResponse(resp *azcore.Response) (*MapOfInterfaceResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDictionaryNullHandleError(resp)
 	}
 	result := MapOfInterfaceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getDictionaryNullHandleError handles the GetDictionaryNull error response.
+func (client *dictionaryOperations) getDictionaryNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDictionaryValid - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
@@ -1209,10 +1452,19 @@ func (client *dictionaryOperations) getDictionaryValidCreateRequest() (*azcore.R
 // getDictionaryValidHandleResponse handles the GetDictionaryValid response.
 func (client *dictionaryOperations) getDictionaryValidHandleResponse(resp *azcore.Response) (*MapOfInterfaceResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDictionaryValidHandleError(resp)
 	}
 	result := MapOfInterfaceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getDictionaryValidHandleError handles the GetDictionaryValid error response.
+func (client *dictionaryOperations) getDictionaryValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDoubleInvalidNull - Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
@@ -1246,10 +1498,19 @@ func (client *dictionaryOperations) getDoubleInvalidNullCreateRequest() (*azcore
 // getDoubleInvalidNullHandleResponse handles the GetDoubleInvalidNull response.
 func (client *dictionaryOperations) getDoubleInvalidNullHandleResponse(resp *azcore.Response) (*MapOfFloat64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDoubleInvalidNullHandleError(resp)
 	}
 	result := MapOfFloat64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getDoubleInvalidNullHandleError handles the GetDoubleInvalidNull error response.
+func (client *dictionaryOperations) getDoubleInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDoubleInvalidString - Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
@@ -1283,10 +1544,19 @@ func (client *dictionaryOperations) getDoubleInvalidStringCreateRequest() (*azco
 // getDoubleInvalidStringHandleResponse handles the GetDoubleInvalidString response.
 func (client *dictionaryOperations) getDoubleInvalidStringHandleResponse(resp *azcore.Response) (*MapOfFloat64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDoubleInvalidStringHandleError(resp)
 	}
 	result := MapOfFloat64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getDoubleInvalidStringHandleError handles the GetDoubleInvalidString error response.
+func (client *dictionaryOperations) getDoubleInvalidStringHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDoubleValid - Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
@@ -1320,10 +1590,19 @@ func (client *dictionaryOperations) getDoubleValidCreateRequest() (*azcore.Reque
 // getDoubleValidHandleResponse handles the GetDoubleValid response.
 func (client *dictionaryOperations) getDoubleValidHandleResponse(resp *azcore.Response) (*MapOfFloat64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDoubleValidHandleError(resp)
 	}
 	result := MapOfFloat64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getDoubleValidHandleError handles the GetDoubleValid error response.
+func (client *dictionaryOperations) getDoubleValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDurationValid - Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
@@ -1357,10 +1636,19 @@ func (client *dictionaryOperations) getDurationValidCreateRequest() (*azcore.Req
 // getDurationValidHandleResponse handles the GetDurationValid response.
 func (client *dictionaryOperations) getDurationValidHandleResponse(resp *azcore.Response) (*MapOfDurationResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getDurationValidHandleError(resp)
 	}
 	result := MapOfDurationResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getDurationValidHandleError handles the GetDurationValid error response.
+func (client *dictionaryOperations) getDurationValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetEmpty - Get empty dictionary value {}
@@ -1394,10 +1682,19 @@ func (client *dictionaryOperations) getEmptyCreateRequest() (*azcore.Request, er
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *dictionaryOperations) getEmptyHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getEmptyHandleError(resp)
 	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getEmptyHandleError handles the GetEmpty error response.
+func (client *dictionaryOperations) getEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetEmptyStringKey - Get Dictionary with key as empty string
@@ -1431,10 +1728,19 @@ func (client *dictionaryOperations) getEmptyStringKeyCreateRequest() (*azcore.Re
 // getEmptyStringKeyHandleResponse handles the GetEmptyStringKey response.
 func (client *dictionaryOperations) getEmptyStringKeyHandleResponse(resp *azcore.Response) (*MapOfStringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getEmptyStringKeyHandleError(resp)
 	}
 	result := MapOfStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getEmptyStringKeyHandleError handles the GetEmptyStringKey error response.
+func (client *dictionaryOperations) getEmptyStringKeyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetFloatInvalidNull - Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
@@ -1468,10 +1774,19 @@ func (client *dictionaryOperations) getFloatInvalidNullCreateRequest() (*azcore.
 // getFloatInvalidNullHandleResponse handles the GetFloatInvalidNull response.
 func (client *dictionaryOperations) getFloatInvalidNullHandleResponse(resp *azcore.Response) (*MapOfFloat32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getFloatInvalidNullHandleError(resp)
 	}
 	result := MapOfFloat32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getFloatInvalidNullHandleError handles the GetFloatInvalidNull error response.
+func (client *dictionaryOperations) getFloatInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetFloatInvalidString - Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
@@ -1505,10 +1820,19 @@ func (client *dictionaryOperations) getFloatInvalidStringCreateRequest() (*azcor
 // getFloatInvalidStringHandleResponse handles the GetFloatInvalidString response.
 func (client *dictionaryOperations) getFloatInvalidStringHandleResponse(resp *azcore.Response) (*MapOfFloat32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getFloatInvalidStringHandleError(resp)
 	}
 	result := MapOfFloat32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getFloatInvalidStringHandleError handles the GetFloatInvalidString error response.
+func (client *dictionaryOperations) getFloatInvalidStringHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetFloatValid - Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
@@ -1542,10 +1866,19 @@ func (client *dictionaryOperations) getFloatValidCreateRequest() (*azcore.Reques
 // getFloatValidHandleResponse handles the GetFloatValid response.
 func (client *dictionaryOperations) getFloatValidHandleResponse(resp *azcore.Response) (*MapOfFloat32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getFloatValidHandleError(resp)
 	}
 	result := MapOfFloat32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getFloatValidHandleError handles the GetFloatValid error response.
+func (client *dictionaryOperations) getFloatValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetIntInvalidNull - Get integer dictionary value {"0": 1, "1": null, "2": 0}
@@ -1579,10 +1912,19 @@ func (client *dictionaryOperations) getIntInvalidNullCreateRequest() (*azcore.Re
 // getIntInvalidNullHandleResponse handles the GetIntInvalidNull response.
 func (client *dictionaryOperations) getIntInvalidNullHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getIntInvalidNullHandleError(resp)
 	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getIntInvalidNullHandleError handles the GetIntInvalidNull error response.
+func (client *dictionaryOperations) getIntInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetIntInvalidString - Get integer dictionary value {"0": 1, "1": "integer", "2": 0}
@@ -1616,10 +1958,19 @@ func (client *dictionaryOperations) getIntInvalidStringCreateRequest() (*azcore.
 // getIntInvalidStringHandleResponse handles the GetIntInvalidString response.
 func (client *dictionaryOperations) getIntInvalidStringHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getIntInvalidStringHandleError(resp)
 	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getIntInvalidStringHandleError handles the GetIntInvalidString error response.
+func (client *dictionaryOperations) getIntInvalidStringHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetIntegerValid - Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
@@ -1653,10 +2004,19 @@ func (client *dictionaryOperations) getIntegerValidCreateRequest() (*azcore.Requ
 // getIntegerValidHandleResponse handles the GetIntegerValid response.
 func (client *dictionaryOperations) getIntegerValidHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getIntegerValidHandleError(resp)
 	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getIntegerValidHandleError handles the GetIntegerValid error response.
+func (client *dictionaryOperations) getIntegerValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetInvalid - Get invalid Dictionary value
@@ -1690,10 +2050,19 @@ func (client *dictionaryOperations) getInvalidCreateRequest() (*azcore.Request, 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *dictionaryOperations) getInvalidHandleResponse(resp *azcore.Response) (*MapOfStringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getInvalidHandleError(resp)
 	}
 	result := MapOfStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getInvalidHandleError handles the GetInvalid error response.
+func (client *dictionaryOperations) getInvalidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetLongInvalidNull - Get long dictionary value {"0": 1, "1": null, "2": 0}
@@ -1727,10 +2096,19 @@ func (client *dictionaryOperations) getLongInvalidNullCreateRequest() (*azcore.R
 // getLongInvalidNullHandleResponse handles the GetLongInvalidNull response.
 func (client *dictionaryOperations) getLongInvalidNullHandleResponse(resp *azcore.Response) (*MapOfInt64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getLongInvalidNullHandleError(resp)
 	}
 	result := MapOfInt64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getLongInvalidNullHandleError handles the GetLongInvalidNull error response.
+func (client *dictionaryOperations) getLongInvalidNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetLongInvalidString - Get long dictionary value {"0": 1, "1": "integer", "2": 0}
@@ -1764,10 +2142,19 @@ func (client *dictionaryOperations) getLongInvalidStringCreateRequest() (*azcore
 // getLongInvalidStringHandleResponse handles the GetLongInvalidString response.
 func (client *dictionaryOperations) getLongInvalidStringHandleResponse(resp *azcore.Response) (*MapOfInt64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getLongInvalidStringHandleError(resp)
 	}
 	result := MapOfInt64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getLongInvalidStringHandleError handles the GetLongInvalidString error response.
+func (client *dictionaryOperations) getLongInvalidStringHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetLongValid - Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
@@ -1801,10 +2188,19 @@ func (client *dictionaryOperations) getLongValidCreateRequest() (*azcore.Request
 // getLongValidHandleResponse handles the GetLongValid response.
 func (client *dictionaryOperations) getLongValidHandleResponse(resp *azcore.Response) (*MapOfInt64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getLongValidHandleError(resp)
 	}
 	result := MapOfInt64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getLongValidHandleError handles the GetLongValid error response.
+func (client *dictionaryOperations) getLongValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNull - Get null dictionary value
@@ -1838,10 +2234,19 @@ func (client *dictionaryOperations) getNullCreateRequest() (*azcore.Request, err
 // getNullHandleResponse handles the GetNull response.
 func (client *dictionaryOperations) getNullHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNullHandleError(resp)
 	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getNullHandleError handles the GetNull error response.
+func (client *dictionaryOperations) getNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNullKey - Get Dictionary with null key
@@ -1875,10 +2280,19 @@ func (client *dictionaryOperations) getNullKeyCreateRequest() (*azcore.Request, 
 // getNullKeyHandleResponse handles the GetNullKey response.
 func (client *dictionaryOperations) getNullKeyHandleResponse(resp *azcore.Response) (*MapOfStringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNullKeyHandleError(resp)
 	}
 	result := MapOfStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getNullKeyHandleError handles the GetNullKey error response.
+func (client *dictionaryOperations) getNullKeyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNullValue - Get Dictionary with null value
@@ -1912,10 +2326,19 @@ func (client *dictionaryOperations) getNullValueCreateRequest() (*azcore.Request
 // getNullValueHandleResponse handles the GetNullValue response.
 func (client *dictionaryOperations) getNullValueHandleResponse(resp *azcore.Response) (*MapOfStringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNullValueHandleError(resp)
 	}
 	result := MapOfStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getNullValueHandleError handles the GetNullValue error response.
+func (client *dictionaryOperations) getNullValueHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetStringValid - Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
@@ -1949,10 +2372,19 @@ func (client *dictionaryOperations) getStringValidCreateRequest() (*azcore.Reque
 // getStringValidHandleResponse handles the GetStringValid response.
 func (client *dictionaryOperations) getStringValidHandleResponse(resp *azcore.Response) (*MapOfStringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getStringValidHandleError(resp)
 	}
 	result := MapOfStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getStringValidHandleError handles the GetStringValid error response.
+func (client *dictionaryOperations) getStringValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetStringWithInvalid - Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}
@@ -1986,10 +2418,19 @@ func (client *dictionaryOperations) getStringWithInvalidCreateRequest() (*azcore
 // getStringWithInvalidHandleResponse handles the GetStringWithInvalid response.
 func (client *dictionaryOperations) getStringWithInvalidHandleResponse(resp *azcore.Response) (*MapOfStringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getStringWithInvalidHandleError(resp)
 	}
 	result := MapOfStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getStringWithInvalidHandleError handles the GetStringWithInvalid error response.
+func (client *dictionaryOperations) getStringWithInvalidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetStringWithNull - Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}
@@ -2023,10 +2464,19 @@ func (client *dictionaryOperations) getStringWithNullCreateRequest() (*azcore.Re
 // getStringWithNullHandleResponse handles the GetStringWithNull response.
 func (client *dictionaryOperations) getStringWithNullHandleResponse(resp *azcore.Response) (*MapOfStringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getStringWithNullHandleError(resp)
 	}
 	result := MapOfStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getStringWithNullHandleError handles the GetStringWithNull error response.
+func (client *dictionaryOperations) getStringWithNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutArrayValid - Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
@@ -2060,9 +2510,18 @@ func (client *dictionaryOperations) putArrayValidCreateRequest(arrayBody map[str
 // putArrayValidHandleResponse handles the PutArrayValid response.
 func (client *dictionaryOperations) putArrayValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putArrayValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putArrayValidHandleError handles the PutArrayValid error response.
+func (client *dictionaryOperations) putArrayValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutBooleanTfft - Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }
@@ -2096,9 +2555,18 @@ func (client *dictionaryOperations) putBooleanTfftCreateRequest(arrayBody map[st
 // putBooleanTfftHandleResponse handles the PutBooleanTfft response.
 func (client *dictionaryOperations) putBooleanTfftHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putBooleanTfftHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putBooleanTfftHandleError handles the PutBooleanTfft error response.
+func (client *dictionaryOperations) putBooleanTfftHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutByteValid - Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64
@@ -2132,9 +2600,18 @@ func (client *dictionaryOperations) putByteValidCreateRequest(arrayBody map[stri
 // putByteValidHandleResponse handles the PutByteValid response.
 func (client *dictionaryOperations) putByteValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putByteValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putByteValidHandleError handles the PutByteValid error response.
+func (client *dictionaryOperations) putByteValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutComplexValid - Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
@@ -2168,9 +2645,18 @@ func (client *dictionaryOperations) putComplexValidCreateRequest(arrayBody map[s
 // putComplexValidHandleResponse handles the PutComplexValid response.
 func (client *dictionaryOperations) putComplexValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putComplexValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putComplexValidHandleError handles the PutComplexValid error response.
+func (client *dictionaryOperations) putComplexValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDateTimeRFC1123Valid - Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
@@ -2208,9 +2694,18 @@ func (client *dictionaryOperations) putDateTimeRfc1123ValidCreateRequest(arrayBo
 // putDateTimeRfc1123ValidHandleResponse handles the PutDateTimeRFC1123Valid response.
 func (client *dictionaryOperations) putDateTimeRfc1123ValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDateTimeRfc1123ValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDateTimeRfc1123ValidHandleError handles the PutDateTimeRFC1123Valid error response.
+func (client *dictionaryOperations) putDateTimeRfc1123ValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDateTimeValid - Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
@@ -2248,9 +2743,18 @@ func (client *dictionaryOperations) putDateTimeValidCreateRequest(arrayBody map[
 // putDateTimeValidHandleResponse handles the PutDateTimeValid response.
 func (client *dictionaryOperations) putDateTimeValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDateTimeValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDateTimeValidHandleError handles the PutDateTimeValid error response.
+func (client *dictionaryOperations) putDateTimeValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDateValid - Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
@@ -2284,9 +2788,18 @@ func (client *dictionaryOperations) putDateValidCreateRequest(arrayBody map[stri
 // putDateValidHandleResponse handles the PutDateValid response.
 func (client *dictionaryOperations) putDateValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDateValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDateValidHandleError handles the PutDateValid error response.
+func (client *dictionaryOperations) putDateValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDictionaryValid - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
@@ -2320,9 +2833,18 @@ func (client *dictionaryOperations) putDictionaryValidCreateRequest(arrayBody ma
 // putDictionaryValidHandleResponse handles the PutDictionaryValid response.
 func (client *dictionaryOperations) putDictionaryValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDictionaryValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDictionaryValidHandleError handles the PutDictionaryValid error response.
+func (client *dictionaryOperations) putDictionaryValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDoubleValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
@@ -2356,9 +2878,18 @@ func (client *dictionaryOperations) putDoubleValidCreateRequest(arrayBody map[st
 // putDoubleValidHandleResponse handles the PutDoubleValid response.
 func (client *dictionaryOperations) putDoubleValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDoubleValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDoubleValidHandleError handles the PutDoubleValid error response.
+func (client *dictionaryOperations) putDoubleValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutDurationValid - Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
@@ -2392,9 +2923,18 @@ func (client *dictionaryOperations) putDurationValidCreateRequest(arrayBody map[
 // putDurationValidHandleResponse handles the PutDurationValid response.
 func (client *dictionaryOperations) putDurationValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putDurationValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putDurationValidHandleError handles the PutDurationValid error response.
+func (client *dictionaryOperations) putDurationValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutEmpty - Set dictionary value empty {}
@@ -2428,9 +2968,18 @@ func (client *dictionaryOperations) putEmptyCreateRequest(arrayBody map[string]s
 // putEmptyHandleResponse handles the PutEmpty response.
 func (client *dictionaryOperations) putEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putEmptyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putEmptyHandleError handles the PutEmpty error response.
+func (client *dictionaryOperations) putEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutFloatValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
@@ -2464,9 +3013,18 @@ func (client *dictionaryOperations) putFloatValidCreateRequest(arrayBody map[str
 // putFloatValidHandleResponse handles the PutFloatValid response.
 func (client *dictionaryOperations) putFloatValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putFloatValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putFloatValidHandleError handles the PutFloatValid error response.
+func (client *dictionaryOperations) putFloatValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutIntegerValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
@@ -2500,9 +3058,18 @@ func (client *dictionaryOperations) putIntegerValidCreateRequest(arrayBody map[s
 // putIntegerValidHandleResponse handles the PutIntegerValid response.
 func (client *dictionaryOperations) putIntegerValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putIntegerValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putIntegerValidHandleError handles the PutIntegerValid error response.
+func (client *dictionaryOperations) putIntegerValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutLongValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
@@ -2536,9 +3103,18 @@ func (client *dictionaryOperations) putLongValidCreateRequest(arrayBody map[stri
 // putLongValidHandleResponse handles the PutLongValid response.
 func (client *dictionaryOperations) putLongValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putLongValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putLongValidHandleError handles the PutLongValid error response.
+func (client *dictionaryOperations) putLongValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutStringValid - Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
@@ -2572,7 +3148,16 @@ func (client *dictionaryOperations) putStringValidCreateRequest(arrayBody map[st
 // putStringValidHandleResponse handles the PutStringValid response.
 func (client *dictionaryOperations) putStringValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putStringValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putStringValidHandleError handles the PutStringValid error response.
+func (client *dictionaryOperations) putStringValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/dictionarygroup/models.go
+++ b/test/autorest/generated/dictionarygroup/models.go
@@ -7,7 +7,6 @@ package dictionarygroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"time"
 )
@@ -15,14 +14,6 @@ import (
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/filegroup/files.go
+++ b/test/autorest/generated/filegroup/files.go
@@ -58,9 +58,18 @@ func (client *filesOperations) getEmptyFileCreateRequest() (*azcore.Request, err
 // getEmptyFileHandleResponse handles the GetEmptyFile response.
 func (client *filesOperations) getEmptyFileHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getEmptyFileHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getEmptyFileHandleError handles the GetEmptyFile error response.
+func (client *filesOperations) getEmptyFileHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetFile - Get file
@@ -95,9 +104,18 @@ func (client *filesOperations) getFileCreateRequest() (*azcore.Request, error) {
 // getFileHandleResponse handles the GetFile response.
 func (client *filesOperations) getFileHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getFileHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getFileHandleError handles the GetFile error response.
+func (client *filesOperations) getFileHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetFileLarge - Get a large file
@@ -132,7 +150,16 @@ func (client *filesOperations) getFileLargeCreateRequest() (*azcore.Request, err
 // getFileLargeHandleResponse handles the GetFileLarge response.
 func (client *filesOperations) getFileLargeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getFileLargeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getFileLargeHandleError handles the GetFileLarge error response.
+func (client *filesOperations) getFileLargeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/filegroup/models.go
+++ b/test/autorest/generated/filegroup/models.go
@@ -5,22 +5,11 @@
 
 package filegroup
 
-import (
-	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-)
+import "fmt"
 
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/headergroup/header.go
+++ b/test/autorest/generated/headergroup/header.go
@@ -112,9 +112,18 @@ func (client *headerOperations) customRequestIdCreateRequest() (*azcore.Request,
 // customRequestIdHandleResponse handles the CustomRequestID response.
 func (client *headerOperations) customRequestIdHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.customRequestIdHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// customRequestIdHandleError handles the CustomRequestID error response.
+func (client *headerOperations) customRequestIdHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ParamBool - Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false
@@ -150,9 +159,18 @@ func (client *headerOperations) paramBoolCreateRequest(scenario string, value bo
 // paramBoolHandleResponse handles the ParamBool response.
 func (client *headerOperations) paramBoolHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.paramBoolHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// paramBoolHandleError handles the ParamBool error response.
+func (client *headerOperations) paramBoolHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ParamByte - Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩"
@@ -188,9 +206,18 @@ func (client *headerOperations) paramByteCreateRequest(scenario string, value []
 // paramByteHandleResponse handles the ParamByte response.
 func (client *headerOperations) paramByteHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.paramByteHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// paramByteHandleError handles the ParamByte error response.
+func (client *headerOperations) paramByteHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ParamDate - Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01"
@@ -226,9 +253,18 @@ func (client *headerOperations) paramDateCreateRequest(scenario string, value ti
 // paramDateHandleResponse handles the ParamDate response.
 func (client *headerOperations) paramDateHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.paramDateHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// paramDateHandleError handles the ParamDate error response.
+func (client *headerOperations) paramDateHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ParamDatetime - Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z"
@@ -264,9 +300,18 @@ func (client *headerOperations) paramDatetimeCreateRequest(scenario string, valu
 // paramDatetimeHandleResponse handles the ParamDatetime response.
 func (client *headerOperations) paramDatetimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.paramDatetimeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// paramDatetimeHandleError handles the ParamDatetime error response.
+func (client *headerOperations) paramDatetimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ParamDatetimeRFC1123 - Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT"
@@ -304,9 +349,18 @@ func (client *headerOperations) paramDatetimeRfc1123CreateRequest(scenario strin
 // paramDatetimeRfc1123HandleResponse handles the ParamDatetimeRFC1123 response.
 func (client *headerOperations) paramDatetimeRfc1123HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.paramDatetimeRfc1123HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// paramDatetimeRfc1123HandleError handles the ParamDatetimeRFC1123 error response.
+func (client *headerOperations) paramDatetimeRfc1123HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ParamDouble - Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0
@@ -342,9 +396,18 @@ func (client *headerOperations) paramDoubleCreateRequest(scenario string, value 
 // paramDoubleHandleResponse handles the ParamDouble response.
 func (client *headerOperations) paramDoubleHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.paramDoubleHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// paramDoubleHandleError handles the ParamDouble error response.
+func (client *headerOperations) paramDoubleHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ParamDuration - Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S"
@@ -380,9 +443,18 @@ func (client *headerOperations) paramDurationCreateRequest(scenario string, valu
 // paramDurationHandleResponse handles the ParamDuration response.
 func (client *headerOperations) paramDurationHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.paramDurationHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// paramDurationHandleError handles the ParamDuration error response.
+func (client *headerOperations) paramDurationHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ParamEnum - Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null
@@ -420,9 +492,18 @@ func (client *headerOperations) paramEnumCreateRequest(scenario string, headerPa
 // paramEnumHandleResponse handles the ParamEnum response.
 func (client *headerOperations) paramEnumHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.paramEnumHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// paramEnumHandleError handles the ParamEnum error response.
+func (client *headerOperations) paramEnumHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ParamExistingKey - Send a post request with header value "User-Agent": "overwrite"
@@ -457,9 +538,18 @@ func (client *headerOperations) paramExistingKeyCreateRequest(userAgent string) 
 // paramExistingKeyHandleResponse handles the ParamExistingKey response.
 func (client *headerOperations) paramExistingKeyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.paramExistingKeyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// paramExistingKeyHandleError handles the ParamExistingKey error response.
+func (client *headerOperations) paramExistingKeyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ParamFloat - Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0
@@ -495,9 +585,18 @@ func (client *headerOperations) paramFloatCreateRequest(scenario string, value f
 // paramFloatHandleResponse handles the ParamFloat response.
 func (client *headerOperations) paramFloatHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.paramFloatHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// paramFloatHandleError handles the ParamFloat error response.
+func (client *headerOperations) paramFloatHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ParamInteger - Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2
@@ -533,9 +632,18 @@ func (client *headerOperations) paramIntegerCreateRequest(scenario string, value
 // paramIntegerHandleResponse handles the ParamInteger response.
 func (client *headerOperations) paramIntegerHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.paramIntegerHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// paramIntegerHandleError handles the ParamInteger error response.
+func (client *headerOperations) paramIntegerHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ParamLong - Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2
@@ -571,9 +679,18 @@ func (client *headerOperations) paramLongCreateRequest(scenario string, value in
 // paramLongHandleResponse handles the ParamLong response.
 func (client *headerOperations) paramLongHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.paramLongHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// paramLongHandleError handles the ParamLong error response.
+func (client *headerOperations) paramLongHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ParamProtectedKey - Send a post request with header value "Content-Type": "text/html"
@@ -608,9 +725,18 @@ func (client *headerOperations) paramProtectedKeyCreateRequest(contentType strin
 // paramProtectedKeyHandleResponse handles the ParamProtectedKey response.
 func (client *headerOperations) paramProtectedKeyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.paramProtectedKeyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// paramProtectedKeyHandleError handles the ParamProtectedKey error response.
+func (client *headerOperations) paramProtectedKeyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ParamString - Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": ""
@@ -648,9 +774,18 @@ func (client *headerOperations) paramStringCreateRequest(scenario string, header
 // paramStringHandleResponse handles the ParamString response.
 func (client *headerOperations) paramStringHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.paramStringHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// paramStringHandleError handles the ParamString error response.
+func (client *headerOperations) paramStringHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ResponseBool - Get a response with header value "value": true or false
@@ -685,7 +820,7 @@ func (client *headerOperations) responseBoolCreateRequest(scenario string) (*azc
 // responseBoolHandleResponse handles the ResponseBool response.
 func (client *headerOperations) responseBoolHandleResponse(resp *azcore.Response) (*HeaderResponseBoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.responseBoolHandleError(resp)
 	}
 	result := HeaderResponseBoolResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
@@ -696,6 +831,15 @@ func (client *headerOperations) responseBoolHandleResponse(resp *azcore.Response
 		result.Value = &value
 	}
 	return &result, nil
+}
+
+// responseBoolHandleError handles the ResponseBool error response.
+func (client *headerOperations) responseBoolHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ResponseByte - Get a response with header values "啊齄丂狛狜隣郎隣兀﨩"
@@ -730,7 +874,7 @@ func (client *headerOperations) responseByteCreateRequest(scenario string) (*azc
 // responseByteHandleResponse handles the ResponseByte response.
 func (client *headerOperations) responseByteHandleResponse(resp *azcore.Response) (*HeaderResponseByteResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.responseByteHandleError(resp)
 	}
 	result := HeaderResponseByteResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
@@ -741,6 +885,15 @@ func (client *headerOperations) responseByteHandleResponse(resp *azcore.Response
 		result.Value = &value
 	}
 	return &result, nil
+}
+
+// responseByteHandleError handles the ResponseByte error response.
+func (client *headerOperations) responseByteHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ResponseDate - Get a response with header values "2010-01-01" or "0001-01-01"
@@ -775,7 +928,7 @@ func (client *headerOperations) responseDateCreateRequest(scenario string) (*azc
 // responseDateHandleResponse handles the ResponseDate response.
 func (client *headerOperations) responseDateHandleResponse(resp *azcore.Response) (*HeaderResponseDateResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.responseDateHandleError(resp)
 	}
 	result := HeaderResponseDateResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
@@ -786,6 +939,15 @@ func (client *headerOperations) responseDateHandleResponse(resp *azcore.Response
 		result.Value = &value
 	}
 	return &result, nil
+}
+
+// responseDateHandleError handles the ResponseDate error response.
+func (client *headerOperations) responseDateHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ResponseDatetime - Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
@@ -820,7 +982,7 @@ func (client *headerOperations) responseDatetimeCreateRequest(scenario string) (
 // responseDatetimeHandleResponse handles the ResponseDatetime response.
 func (client *headerOperations) responseDatetimeHandleResponse(resp *azcore.Response) (*HeaderResponseDatetimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.responseDatetimeHandleError(resp)
 	}
 	result := HeaderResponseDatetimeResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
@@ -831,6 +993,15 @@ func (client *headerOperations) responseDatetimeHandleResponse(resp *azcore.Resp
 		result.Value = &value
 	}
 	return &result, nil
+}
+
+// responseDatetimeHandleError handles the ResponseDatetime error response.
+func (client *headerOperations) responseDatetimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ResponseDatetimeRFC1123 - Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
@@ -865,7 +1036,7 @@ func (client *headerOperations) responseDatetimeRfc1123CreateRequest(scenario st
 // responseDatetimeRfc1123HandleResponse handles the ResponseDatetimeRFC1123 response.
 func (client *headerOperations) responseDatetimeRfc1123HandleResponse(resp *azcore.Response) (*HeaderResponseDatetimeRFC1123Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.responseDatetimeRfc1123HandleError(resp)
 	}
 	result := HeaderResponseDatetimeRFC1123Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
@@ -876,6 +1047,15 @@ func (client *headerOperations) responseDatetimeRfc1123HandleResponse(resp *azco
 		result.Value = &value
 	}
 	return &result, nil
+}
+
+// responseDatetimeRfc1123HandleError handles the ResponseDatetimeRFC1123 error response.
+func (client *headerOperations) responseDatetimeRfc1123HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ResponseDouble - Get a response with header value "value": 7e120 or -3.0
@@ -910,7 +1090,7 @@ func (client *headerOperations) responseDoubleCreateRequest(scenario string) (*a
 // responseDoubleHandleResponse handles the ResponseDouble response.
 func (client *headerOperations) responseDoubleHandleResponse(resp *azcore.Response) (*HeaderResponseDoubleResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.responseDoubleHandleError(resp)
 	}
 	result := HeaderResponseDoubleResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
@@ -921,6 +1101,15 @@ func (client *headerOperations) responseDoubleHandleResponse(resp *azcore.Respon
 		result.Value = &value
 	}
 	return &result, nil
+}
+
+// responseDoubleHandleError handles the ResponseDouble error response.
+func (client *headerOperations) responseDoubleHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ResponseDuration - Get a response with header values "P123DT22H14M12.011S"
@@ -955,7 +1144,7 @@ func (client *headerOperations) responseDurationCreateRequest(scenario string) (
 // responseDurationHandleResponse handles the ResponseDuration response.
 func (client *headerOperations) responseDurationHandleResponse(resp *azcore.Response) (*HeaderResponseDurationResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.responseDurationHandleError(resp)
 	}
 	result := HeaderResponseDurationResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
@@ -966,6 +1155,15 @@ func (client *headerOperations) responseDurationHandleResponse(resp *azcore.Resp
 		result.Value = &value
 	}
 	return &result, nil
+}
+
+// responseDurationHandleError handles the ResponseDuration error response.
+func (client *headerOperations) responseDurationHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ResponseEnum - Get a response with header values "GREY" or null
@@ -1000,13 +1198,22 @@ func (client *headerOperations) responseEnumCreateRequest(scenario string) (*azc
 // responseEnumHandleResponse handles the ResponseEnum response.
 func (client *headerOperations) responseEnumHandleResponse(resp *azcore.Response) (*HeaderResponseEnumResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.responseEnumHandleError(resp)
 	}
 	result := HeaderResponseEnumResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
 		result.Value = (*GreyscaleColors)(&val)
 	}
 	return &result, nil
+}
+
+// responseEnumHandleError handles the ResponseEnum error response.
+func (client *headerOperations) responseEnumHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ResponseExistingKey - Get a response with header value "User-Agent": "overwrite"
@@ -1040,13 +1247,22 @@ func (client *headerOperations) responseExistingKeyCreateRequest() (*azcore.Requ
 // responseExistingKeyHandleResponse handles the ResponseExistingKey response.
 func (client *headerOperations) responseExistingKeyHandleResponse(resp *azcore.Response) (*HeaderResponseExistingKeyResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.responseExistingKeyHandleError(resp)
 	}
 	result := HeaderResponseExistingKeyResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("User-Agent"); val != "" {
 		result.UserAgent = &val
 	}
 	return &result, nil
+}
+
+// responseExistingKeyHandleError handles the ResponseExistingKey error response.
+func (client *headerOperations) responseExistingKeyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ResponseFloat - Get a response with header value "value": 0.07 or -3.0
@@ -1081,7 +1297,7 @@ func (client *headerOperations) responseFloatCreateRequest(scenario string) (*az
 // responseFloatHandleResponse handles the ResponseFloat response.
 func (client *headerOperations) responseFloatHandleResponse(resp *azcore.Response) (*HeaderResponseFloatResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.responseFloatHandleError(resp)
 	}
 	result := HeaderResponseFloatResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
@@ -1093,6 +1309,15 @@ func (client *headerOperations) responseFloatHandleResponse(resp *azcore.Respons
 		result.Value = &value
 	}
 	return &result, nil
+}
+
+// responseFloatHandleError handles the ResponseFloat error response.
+func (client *headerOperations) responseFloatHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ResponseInteger - Get a response with header value "value": 1 or -2
@@ -1127,7 +1352,7 @@ func (client *headerOperations) responseIntegerCreateRequest(scenario string) (*
 // responseIntegerHandleResponse handles the ResponseInteger response.
 func (client *headerOperations) responseIntegerHandleResponse(resp *azcore.Response) (*HeaderResponseIntegerResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.responseIntegerHandleError(resp)
 	}
 	result := HeaderResponseIntegerResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
@@ -1139,6 +1364,15 @@ func (client *headerOperations) responseIntegerHandleResponse(resp *azcore.Respo
 		result.Value = &value
 	}
 	return &result, nil
+}
+
+// responseIntegerHandleError handles the ResponseInteger error response.
+func (client *headerOperations) responseIntegerHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ResponseLong - Get a response with header value "value": 105 or -2
@@ -1173,7 +1407,7 @@ func (client *headerOperations) responseLongCreateRequest(scenario string) (*azc
 // responseLongHandleResponse handles the ResponseLong response.
 func (client *headerOperations) responseLongHandleResponse(resp *azcore.Response) (*HeaderResponseLongResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.responseLongHandleError(resp)
 	}
 	result := HeaderResponseLongResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
@@ -1184,6 +1418,15 @@ func (client *headerOperations) responseLongHandleResponse(resp *azcore.Response
 		result.Value = &value
 	}
 	return &result, nil
+}
+
+// responseLongHandleError handles the ResponseLong error response.
+func (client *headerOperations) responseLongHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ResponseProtectedKey - Get a response with header value "Content-Type": "text/html"
@@ -1217,13 +1460,22 @@ func (client *headerOperations) responseProtectedKeyCreateRequest() (*azcore.Req
 // responseProtectedKeyHandleResponse handles the ResponseProtectedKey response.
 func (client *headerOperations) responseProtectedKeyHandleResponse(resp *azcore.Response) (*HeaderResponseProtectedKeyResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.responseProtectedKeyHandleError(resp)
 	}
 	result := HeaderResponseProtectedKeyResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val
 	}
 	return &result, nil
+}
+
+// responseProtectedKeyHandleError handles the ResponseProtectedKey error response.
+func (client *headerOperations) responseProtectedKeyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ResponseString - Get a response with header values "The quick brown fox jumps over the lazy dog" or null or ""
@@ -1258,11 +1510,20 @@ func (client *headerOperations) responseStringCreateRequest(scenario string) (*a
 // responseStringHandleResponse handles the ResponseString response.
 func (client *headerOperations) responseStringHandleResponse(resp *azcore.Response) (*HeaderResponseStringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.responseStringHandleError(resp)
 	}
 	result := HeaderResponseStringResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
 		result.Value = &val
 	}
 	return &result, nil
+}
+
+// responseStringHandleError handles the ResponseString error response.
+func (client *headerOperations) responseStringHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/headergroup/models.go
+++ b/test/autorest/generated/headergroup/models.go
@@ -7,7 +7,6 @@ package headergroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"time"
 )
@@ -15,14 +14,6 @@ import (
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/httpinfrastructuregroup/httpclientfailure.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpclientfailure.go
@@ -102,7 +102,16 @@ func (client *httpClientFailureOperations) delete400CreateRequest() (*azcore.Req
 
 // delete400HandleResponse handles the Delete400 response.
 func (client *httpClientFailureOperations) delete400HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.delete400HandleError(resp)
+}
+
+// delete400HandleError handles the Delete400 error response.
+func (client *httpClientFailureOperations) delete400HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Delete407 - Return 407 status code - should be represented in the client as an error
@@ -135,7 +144,16 @@ func (client *httpClientFailureOperations) delete407CreateRequest() (*azcore.Req
 
 // delete407HandleResponse handles the Delete407 response.
 func (client *httpClientFailureOperations) delete407HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.delete407HandleError(resp)
+}
+
+// delete407HandleError handles the Delete407 error response.
+func (client *httpClientFailureOperations) delete407HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Delete417 - Return 417 status code - should be represented in the client as an error
@@ -168,7 +186,16 @@ func (client *httpClientFailureOperations) delete417CreateRequest() (*azcore.Req
 
 // delete417HandleResponse handles the Delete417 response.
 func (client *httpClientFailureOperations) delete417HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.delete417HandleError(resp)
+}
+
+// delete417HandleError handles the Delete417 error response.
+func (client *httpClientFailureOperations) delete417HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get400 - Return 400 status code - should be represented in the client as an error
@@ -201,7 +228,16 @@ func (client *httpClientFailureOperations) get400CreateRequest() (*azcore.Reques
 
 // get400HandleResponse handles the Get400 response.
 func (client *httpClientFailureOperations) get400HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.get400HandleError(resp)
+}
+
+// get400HandleError handles the Get400 error response.
+func (client *httpClientFailureOperations) get400HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get402 - Return 402 status code - should be represented in the client as an error
@@ -234,7 +270,16 @@ func (client *httpClientFailureOperations) get402CreateRequest() (*azcore.Reques
 
 // get402HandleResponse handles the Get402 response.
 func (client *httpClientFailureOperations) get402HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.get402HandleError(resp)
+}
+
+// get402HandleError handles the Get402 error response.
+func (client *httpClientFailureOperations) get402HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get403 - Return 403 status code - should be represented in the client as an error
@@ -267,7 +312,16 @@ func (client *httpClientFailureOperations) get403CreateRequest() (*azcore.Reques
 
 // get403HandleResponse handles the Get403 response.
 func (client *httpClientFailureOperations) get403HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.get403HandleError(resp)
+}
+
+// get403HandleError handles the Get403 error response.
+func (client *httpClientFailureOperations) get403HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get411 - Return 411 status code - should be represented in the client as an error
@@ -300,7 +354,16 @@ func (client *httpClientFailureOperations) get411CreateRequest() (*azcore.Reques
 
 // get411HandleResponse handles the Get411 response.
 func (client *httpClientFailureOperations) get411HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.get411HandleError(resp)
+}
+
+// get411HandleError handles the Get411 error response.
+func (client *httpClientFailureOperations) get411HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get412 - Return 412 status code - should be represented in the client as an error
@@ -333,7 +396,16 @@ func (client *httpClientFailureOperations) get412CreateRequest() (*azcore.Reques
 
 // get412HandleResponse handles the Get412 response.
 func (client *httpClientFailureOperations) get412HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.get412HandleError(resp)
+}
+
+// get412HandleError handles the Get412 error response.
+func (client *httpClientFailureOperations) get412HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get416 - Return 416 status code - should be represented in the client as an error
@@ -366,7 +438,16 @@ func (client *httpClientFailureOperations) get416CreateRequest() (*azcore.Reques
 
 // get416HandleResponse handles the Get416 response.
 func (client *httpClientFailureOperations) get416HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.get416HandleError(resp)
+}
+
+// get416HandleError handles the Get416 error response.
+func (client *httpClientFailureOperations) get416HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Head400 - Return 400 status code - should be represented in the client as an error
@@ -399,7 +480,16 @@ func (client *httpClientFailureOperations) head400CreateRequest() (*azcore.Reque
 
 // head400HandleResponse handles the Head400 response.
 func (client *httpClientFailureOperations) head400HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.head400HandleError(resp)
+}
+
+// head400HandleError handles the Head400 error response.
+func (client *httpClientFailureOperations) head400HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Head401 - Return 401 status code - should be represented in the client as an error
@@ -432,7 +522,16 @@ func (client *httpClientFailureOperations) head401CreateRequest() (*azcore.Reque
 
 // head401HandleResponse handles the Head401 response.
 func (client *httpClientFailureOperations) head401HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.head401HandleError(resp)
+}
+
+// head401HandleError handles the Head401 error response.
+func (client *httpClientFailureOperations) head401HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Head410 - Return 410 status code - should be represented in the client as an error
@@ -465,7 +564,16 @@ func (client *httpClientFailureOperations) head410CreateRequest() (*azcore.Reque
 
 // head410HandleResponse handles the Head410 response.
 func (client *httpClientFailureOperations) head410HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.head410HandleError(resp)
+}
+
+// head410HandleError handles the Head410 error response.
+func (client *httpClientFailureOperations) head410HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Head429 - Return 429 status code - should be represented in the client as an error
@@ -498,7 +606,16 @@ func (client *httpClientFailureOperations) head429CreateRequest() (*azcore.Reque
 
 // head429HandleResponse handles the Head429 response.
 func (client *httpClientFailureOperations) head429HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.head429HandleError(resp)
+}
+
+// head429HandleError handles the Head429 error response.
+func (client *httpClientFailureOperations) head429HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Options400 - Return 400 status code - should be represented in the client as an error
@@ -531,7 +648,16 @@ func (client *httpClientFailureOperations) options400CreateRequest() (*azcore.Re
 
 // options400HandleResponse handles the Options400 response.
 func (client *httpClientFailureOperations) options400HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.options400HandleError(resp)
+}
+
+// options400HandleError handles the Options400 error response.
+func (client *httpClientFailureOperations) options400HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Options403 - Return 403 status code - should be represented in the client as an error
@@ -564,7 +690,16 @@ func (client *httpClientFailureOperations) options403CreateRequest() (*azcore.Re
 
 // options403HandleResponse handles the Options403 response.
 func (client *httpClientFailureOperations) options403HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.options403HandleError(resp)
+}
+
+// options403HandleError handles the Options403 error response.
+func (client *httpClientFailureOperations) options403HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Options412 - Return 412 status code - should be represented in the client as an error
@@ -597,7 +732,16 @@ func (client *httpClientFailureOperations) options412CreateRequest() (*azcore.Re
 
 // options412HandleResponse handles the Options412 response.
 func (client *httpClientFailureOperations) options412HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.options412HandleError(resp)
+}
+
+// options412HandleError handles the Options412 error response.
+func (client *httpClientFailureOperations) options412HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Patch400 - Return 400 status code - should be represented in the client as an error
@@ -630,7 +774,16 @@ func (client *httpClientFailureOperations) patch400CreateRequest() (*azcore.Requ
 
 // patch400HandleResponse handles the Patch400 response.
 func (client *httpClientFailureOperations) patch400HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.patch400HandleError(resp)
+}
+
+// patch400HandleError handles the Patch400 error response.
+func (client *httpClientFailureOperations) patch400HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Patch405 - Return 405 status code - should be represented in the client as an error
@@ -663,7 +816,16 @@ func (client *httpClientFailureOperations) patch405CreateRequest() (*azcore.Requ
 
 // patch405HandleResponse handles the Patch405 response.
 func (client *httpClientFailureOperations) patch405HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.patch405HandleError(resp)
+}
+
+// patch405HandleError handles the Patch405 error response.
+func (client *httpClientFailureOperations) patch405HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Patch414 - Return 414 status code - should be represented in the client as an error
@@ -696,7 +858,16 @@ func (client *httpClientFailureOperations) patch414CreateRequest() (*azcore.Requ
 
 // patch414HandleResponse handles the Patch414 response.
 func (client *httpClientFailureOperations) patch414HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.patch414HandleError(resp)
+}
+
+// patch414HandleError handles the Patch414 error response.
+func (client *httpClientFailureOperations) patch414HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Post400 - Return 400 status code - should be represented in the client as an error
@@ -729,7 +900,16 @@ func (client *httpClientFailureOperations) post400CreateRequest() (*azcore.Reque
 
 // post400HandleResponse handles the Post400 response.
 func (client *httpClientFailureOperations) post400HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.post400HandleError(resp)
+}
+
+// post400HandleError handles the Post400 error response.
+func (client *httpClientFailureOperations) post400HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Post406 - Return 406 status code - should be represented in the client as an error
@@ -762,7 +942,16 @@ func (client *httpClientFailureOperations) post406CreateRequest() (*azcore.Reque
 
 // post406HandleResponse handles the Post406 response.
 func (client *httpClientFailureOperations) post406HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.post406HandleError(resp)
+}
+
+// post406HandleError handles the Post406 error response.
+func (client *httpClientFailureOperations) post406HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Post415 - Return 415 status code - should be represented in the client as an error
@@ -795,7 +984,16 @@ func (client *httpClientFailureOperations) post415CreateRequest() (*azcore.Reque
 
 // post415HandleResponse handles the Post415 response.
 func (client *httpClientFailureOperations) post415HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.post415HandleError(resp)
+}
+
+// post415HandleError handles the Post415 error response.
+func (client *httpClientFailureOperations) post415HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Put400 - Return 400 status code - should be represented in the client as an error
@@ -828,7 +1026,16 @@ func (client *httpClientFailureOperations) put400CreateRequest() (*azcore.Reques
 
 // put400HandleResponse handles the Put400 response.
 func (client *httpClientFailureOperations) put400HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.put400HandleError(resp)
+}
+
+// put400HandleError handles the Put400 error response.
+func (client *httpClientFailureOperations) put400HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Put404 - Return 404 status code - should be represented in the client as an error
@@ -861,7 +1068,16 @@ func (client *httpClientFailureOperations) put404CreateRequest() (*azcore.Reques
 
 // put404HandleResponse handles the Put404 response.
 func (client *httpClientFailureOperations) put404HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.put404HandleError(resp)
+}
+
+// put404HandleError handles the Put404 error response.
+func (client *httpClientFailureOperations) put404HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Put409 - Return 409 status code - should be represented in the client as an error
@@ -894,7 +1110,16 @@ func (client *httpClientFailureOperations) put409CreateRequest() (*azcore.Reques
 
 // put409HandleResponse handles the Put409 response.
 func (client *httpClientFailureOperations) put409HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.put409HandleError(resp)
+}
+
+// put409HandleError handles the Put409 error response.
+func (client *httpClientFailureOperations) put409HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Put413 - Return 413 status code - should be represented in the client as an error
@@ -927,5 +1152,14 @@ func (client *httpClientFailureOperations) put413CreateRequest() (*azcore.Reques
 
 // put413HandleResponse handles the Put413 response.
 func (client *httpClientFailureOperations) put413HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.put413HandleError(resp)
+}
+
+// put413HandleError handles the Put413 error response.
+func (client *httpClientFailureOperations) put413HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/httpinfrastructuregroup/httpfailure.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpfailure.go
@@ -58,10 +58,19 @@ func (client *httpFailureOperations) getEmptyErrorCreateRequest() (*azcore.Reque
 // getEmptyErrorHandleResponse handles the GetEmptyError response.
 func (client *httpFailureOperations) getEmptyErrorHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getEmptyErrorHandleError(resp)
 	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getEmptyErrorHandleError handles the GetEmptyError error response.
+func (client *httpFailureOperations) getEmptyErrorHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNoModelEmpty - Get empty response from server
@@ -95,10 +104,15 @@ func (client *httpFailureOperations) getNoModelEmptyCreateRequest() (*azcore.Req
 // getNoModelEmptyHandleResponse handles the GetNoModelEmpty response.
 func (client *httpFailureOperations) getNoModelEmptyHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getNoModelEmptyHandleError(resp)
 	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getNoModelEmptyHandleError handles the GetNoModelEmpty error response.
+func (client *httpFailureOperations) getNoModelEmptyHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetNoModelError - Get empty error form server
@@ -132,8 +146,13 @@ func (client *httpFailureOperations) getNoModelErrorCreateRequest() (*azcore.Req
 // getNoModelErrorHandleResponse handles the GetNoModelError response.
 func (client *httpFailureOperations) getNoModelErrorHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getNoModelErrorHandleError(resp)
 	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getNoModelErrorHandleError handles the GetNoModelError error response.
+func (client *httpFailureOperations) getNoModelErrorHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }

--- a/test/autorest/generated/httpinfrastructuregroup/httpredirects.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpredirects.go
@@ -83,13 +83,22 @@ func (client *httpRedirectsOperations) delete307CreateRequest() (*azcore.Request
 // delete307HandleResponse handles the Delete307 response.
 func (client *httpRedirectsOperations) delete307HandleResponse(resp *azcore.Response) (*HTTPRedirectsDelete307Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.delete307HandleError(resp)
 	}
 	result := HTTPRedirectsDelete307Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// delete307HandleError handles the Delete307 error response.
+func (client *httpRedirectsOperations) delete307HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get300 - Return 300 status code and redirect to /http/success/200
@@ -123,13 +132,22 @@ func (client *httpRedirectsOperations) get300CreateRequest() (*azcore.Request, e
 // get300HandleResponse handles the Get300 response.
 func (client *httpRedirectsOperations) get300HandleResponse(resp *azcore.Response) (*HTTPRedirectsGet300Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get300HandleError(resp)
 	}
 	result := HTTPRedirectsGet300Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// get300HandleError handles the Get300 error response.
+func (client *httpRedirectsOperations) get300HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get301 - Return 301 status code and redirect to /http/success/200
@@ -163,13 +181,22 @@ func (client *httpRedirectsOperations) get301CreateRequest() (*azcore.Request, e
 // get301HandleResponse handles the Get301 response.
 func (client *httpRedirectsOperations) get301HandleResponse(resp *azcore.Response) (*HTTPRedirectsGet301Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get301HandleError(resp)
 	}
 	result := HTTPRedirectsGet301Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// get301HandleError handles the Get301 error response.
+func (client *httpRedirectsOperations) get301HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get302 - Return 302 status code and redirect to /http/success/200
@@ -203,13 +230,22 @@ func (client *httpRedirectsOperations) get302CreateRequest() (*azcore.Request, e
 // get302HandleResponse handles the Get302 response.
 func (client *httpRedirectsOperations) get302HandleResponse(resp *azcore.Response) (*HTTPRedirectsGet302Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get302HandleError(resp)
 	}
 	result := HTTPRedirectsGet302Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// get302HandleError handles the Get302 error response.
+func (client *httpRedirectsOperations) get302HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get307 - Redirect get with 307, resulting in a 200 success
@@ -243,13 +279,22 @@ func (client *httpRedirectsOperations) get307CreateRequest() (*azcore.Request, e
 // get307HandleResponse handles the Get307 response.
 func (client *httpRedirectsOperations) get307HandleResponse(resp *azcore.Response) (*HTTPRedirectsGet307Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get307HandleError(resp)
 	}
 	result := HTTPRedirectsGet307Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// get307HandleError handles the Get307 error response.
+func (client *httpRedirectsOperations) get307HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Head300 - Return 300 status code and redirect to /http/success/200
@@ -283,13 +328,22 @@ func (client *httpRedirectsOperations) head300CreateRequest() (*azcore.Request, 
 // head300HandleResponse handles the Head300 response.
 func (client *httpRedirectsOperations) head300HandleResponse(resp *azcore.Response) (*HTTPRedirectsHead300Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.head300HandleError(resp)
 	}
 	result := HTTPRedirectsHead300Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// head300HandleError handles the Head300 error response.
+func (client *httpRedirectsOperations) head300HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Head301 - Return 301 status code and redirect to /http/success/200
@@ -323,13 +377,22 @@ func (client *httpRedirectsOperations) head301CreateRequest() (*azcore.Request, 
 // head301HandleResponse handles the Head301 response.
 func (client *httpRedirectsOperations) head301HandleResponse(resp *azcore.Response) (*HTTPRedirectsHead301Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.head301HandleError(resp)
 	}
 	result := HTTPRedirectsHead301Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// head301HandleError handles the Head301 error response.
+func (client *httpRedirectsOperations) head301HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Head302 - Return 302 status code and redirect to /http/success/200
@@ -363,13 +426,22 @@ func (client *httpRedirectsOperations) head302CreateRequest() (*azcore.Request, 
 // head302HandleResponse handles the Head302 response.
 func (client *httpRedirectsOperations) head302HandleResponse(resp *azcore.Response) (*HTTPRedirectsHead302Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.head302HandleError(resp)
 	}
 	result := HTTPRedirectsHead302Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// head302HandleError handles the Head302 error response.
+func (client *httpRedirectsOperations) head302HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Head307 - Redirect with 307, resulting in a 200 success
@@ -403,13 +475,22 @@ func (client *httpRedirectsOperations) head307CreateRequest() (*azcore.Request, 
 // head307HandleResponse handles the Head307 response.
 func (client *httpRedirectsOperations) head307HandleResponse(resp *azcore.Response) (*HTTPRedirectsHead307Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.head307HandleError(resp)
 	}
 	result := HTTPRedirectsHead307Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// head307HandleError handles the Head307 error response.
+func (client *httpRedirectsOperations) head307HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Options307 - options redirected with 307, resulting in a 200 after redirect
@@ -443,13 +524,22 @@ func (client *httpRedirectsOperations) options307CreateRequest() (*azcore.Reques
 // options307HandleResponse handles the Options307 response.
 func (client *httpRedirectsOperations) options307HandleResponse(resp *azcore.Response) (*HTTPRedirectsOptions307Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.options307HandleError(resp)
 	}
 	result := HTTPRedirectsOptions307Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// options307HandleError handles the Options307 error response.
+func (client *httpRedirectsOperations) options307HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Patch302 - Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation
@@ -483,13 +573,22 @@ func (client *httpRedirectsOperations) patch302CreateRequest() (*azcore.Request,
 // patch302HandleResponse handles the Patch302 response.
 func (client *httpRedirectsOperations) patch302HandleResponse(resp *azcore.Response) (*HTTPRedirectsPatch302Response, error) {
 	if !resp.HasStatusCode(http.StatusFound) {
-		return nil, newError(resp)
+		return nil, client.patch302HandleError(resp)
 	}
 	result := HTTPRedirectsPatch302Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// patch302HandleError handles the Patch302 error response.
+func (client *httpRedirectsOperations) patch302HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Patch307 - Patch redirected with 307, resulting in a 200 after redirect
@@ -523,13 +622,22 @@ func (client *httpRedirectsOperations) patch307CreateRequest() (*azcore.Request,
 // patch307HandleResponse handles the Patch307 response.
 func (client *httpRedirectsOperations) patch307HandleResponse(resp *azcore.Response) (*HTTPRedirectsPatch307Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.patch307HandleError(resp)
 	}
 	result := HTTPRedirectsPatch307Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// patch307HandleError handles the Patch307 error response.
+func (client *httpRedirectsOperations) patch307HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Post303 - Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code
@@ -563,13 +671,22 @@ func (client *httpRedirectsOperations) post303CreateRequest() (*azcore.Request, 
 // post303HandleResponse handles the Post303 response.
 func (client *httpRedirectsOperations) post303HandleResponse(resp *azcore.Response) (*HTTPRedirectsPost303Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.post303HandleError(resp)
 	}
 	result := HTTPRedirectsPost303Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// post303HandleError handles the Post303 error response.
+func (client *httpRedirectsOperations) post303HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Post307 - Post redirected with 307, resulting in a 200 after redirect
@@ -603,13 +720,22 @@ func (client *httpRedirectsOperations) post307CreateRequest() (*azcore.Request, 
 // post307HandleResponse handles the Post307 response.
 func (client *httpRedirectsOperations) post307HandleResponse(resp *azcore.Response) (*HTTPRedirectsPost307Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.post307HandleError(resp)
 	}
 	result := HTTPRedirectsPost307Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// post307HandleError handles the Post307 error response.
+func (client *httpRedirectsOperations) post307HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Put301 - Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation
@@ -643,13 +769,22 @@ func (client *httpRedirectsOperations) put301CreateRequest() (*azcore.Request, e
 // put301HandleResponse handles the Put301 response.
 func (client *httpRedirectsOperations) put301HandleResponse(resp *azcore.Response) (*HTTPRedirectsPut301Response, error) {
 	if !resp.HasStatusCode(http.StatusMovedPermanently) {
-		return nil, newError(resp)
+		return nil, client.put301HandleError(resp)
 	}
 	result := HTTPRedirectsPut301Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// put301HandleError handles the Put301 error response.
+func (client *httpRedirectsOperations) put301HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Put307 - Put redirected with 307, resulting in a 200 after redirect
@@ -683,11 +818,20 @@ func (client *httpRedirectsOperations) put307CreateRequest() (*azcore.Request, e
 // put307HandleResponse handles the Put307 response.
 func (client *httpRedirectsOperations) put307HandleResponse(resp *azcore.Response) (*HTTPRedirectsPut307Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.put307HandleError(resp)
 	}
 	result := HTTPRedirectsPut307Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
 	return &result, nil
+}
+
+// put307HandleError handles the Put307 error response.
+func (client *httpRedirectsOperations) put307HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/httpinfrastructuregroup/httpretry.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpretry.go
@@ -69,9 +69,18 @@ func (client *httpRetryOperations) delete503CreateRequest() (*azcore.Request, er
 // delete503HandleResponse handles the Delete503 response.
 func (client *httpRetryOperations) delete503HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.delete503HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// delete503HandleError handles the Delete503 error response.
+func (client *httpRetryOperations) delete503HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get502 - Return 502 status code, then 200 after retry
@@ -105,9 +114,18 @@ func (client *httpRetryOperations) get502CreateRequest() (*azcore.Request, error
 // get502HandleResponse handles the Get502 response.
 func (client *httpRetryOperations) get502HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get502HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// get502HandleError handles the Get502 error response.
+func (client *httpRetryOperations) get502HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Head408 - Return 408 status code, then 200 after retry
@@ -141,9 +159,18 @@ func (client *httpRetryOperations) head408CreateRequest() (*azcore.Request, erro
 // head408HandleResponse handles the Head408 response.
 func (client *httpRetryOperations) head408HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.head408HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// head408HandleError handles the Head408 error response.
+func (client *httpRetryOperations) head408HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Options502 - Return 502 status code, then 200 after retry
@@ -177,10 +204,19 @@ func (client *httpRetryOperations) options502CreateRequest() (*azcore.Request, e
 // options502HandleResponse handles the Options502 response.
 func (client *httpRetryOperations) options502HandleResponse(resp *azcore.Response) (*BoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.options502HandleError(resp)
 	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// options502HandleError handles the Options502 error response.
+func (client *httpRetryOperations) options502HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Patch500 - Return 500 status code, then 200 after retry
@@ -214,9 +250,18 @@ func (client *httpRetryOperations) patch500CreateRequest() (*azcore.Request, err
 // patch500HandleResponse handles the Patch500 response.
 func (client *httpRetryOperations) patch500HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.patch500HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// patch500HandleError handles the Patch500 error response.
+func (client *httpRetryOperations) patch500HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Patch504 - Return 504 status code, then 200 after retry
@@ -250,9 +295,18 @@ func (client *httpRetryOperations) patch504CreateRequest() (*azcore.Request, err
 // patch504HandleResponse handles the Patch504 response.
 func (client *httpRetryOperations) patch504HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.patch504HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// patch504HandleError handles the Patch504 error response.
+func (client *httpRetryOperations) patch504HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Post503 - Return 503 status code, then 200 after retry
@@ -286,9 +340,18 @@ func (client *httpRetryOperations) post503CreateRequest() (*azcore.Request, erro
 // post503HandleResponse handles the Post503 response.
 func (client *httpRetryOperations) post503HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.post503HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// post503HandleError handles the Post503 error response.
+func (client *httpRetryOperations) post503HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Put500 - Return 500 status code, then 200 after retry
@@ -322,9 +385,18 @@ func (client *httpRetryOperations) put500CreateRequest() (*azcore.Request, error
 // put500HandleResponse handles the Put500 response.
 func (client *httpRetryOperations) put500HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.put500HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// put500HandleError handles the Put500 error response.
+func (client *httpRetryOperations) put500HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Put504 - Return 504 status code, then 200 after retry
@@ -358,7 +430,16 @@ func (client *httpRetryOperations) put504CreateRequest() (*azcore.Request, error
 // put504HandleResponse handles the Put504 response.
 func (client *httpRetryOperations) put504HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.put504HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// put504HandleError handles the Put504 error response.
+func (client *httpRetryOperations) put504HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/httpinfrastructuregroup/httpserverfailure.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpserverfailure.go
@@ -58,7 +58,16 @@ func (client *httpServerFailureOperations) delete505CreateRequest() (*azcore.Req
 
 // delete505HandleResponse handles the Delete505 response.
 func (client *httpServerFailureOperations) delete505HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.delete505HandleError(resp)
+}
+
+// delete505HandleError handles the Delete505 error response.
+func (client *httpServerFailureOperations) delete505HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get501 - Return 501 status code - should be represented in the client as an error
@@ -91,7 +100,16 @@ func (client *httpServerFailureOperations) get501CreateRequest() (*azcore.Reques
 
 // get501HandleResponse handles the Get501 response.
 func (client *httpServerFailureOperations) get501HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.get501HandleError(resp)
+}
+
+// get501HandleError handles the Get501 error response.
+func (client *httpServerFailureOperations) get501HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Head501 - Return 501 status code - should be represented in the client as an error
@@ -124,7 +142,16 @@ func (client *httpServerFailureOperations) head501CreateRequest() (*azcore.Reque
 
 // head501HandleResponse handles the Head501 response.
 func (client *httpServerFailureOperations) head501HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.head501HandleError(resp)
+}
+
+// head501HandleError handles the Head501 error response.
+func (client *httpServerFailureOperations) head501HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Post505 - Return 505 status code - should be represented in the client as an error
@@ -157,5 +184,14 @@ func (client *httpServerFailureOperations) post505CreateRequest() (*azcore.Reque
 
 // post505HandleResponse handles the Post505 response.
 func (client *httpServerFailureOperations) post505HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, newError(resp)
+	return nil, client.post505HandleError(resp)
+}
+
+// post505HandleError handles the Post505 error response.
+func (client *httpServerFailureOperations) post505HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/httpinfrastructuregroup/httpsuccess.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpsuccess.go
@@ -89,9 +89,18 @@ func (client *httpSuccessOperations) delete200CreateRequest() (*azcore.Request, 
 // delete200HandleResponse handles the Delete200 response.
 func (client *httpSuccessOperations) delete200HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.delete200HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// delete200HandleError handles the Delete200 error response.
+func (client *httpSuccessOperations) delete200HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Delete202 - Delete true Boolean value in request returns 202 (accepted)
@@ -125,9 +134,18 @@ func (client *httpSuccessOperations) delete202CreateRequest() (*azcore.Request, 
 // delete202HandleResponse handles the Delete202 response.
 func (client *httpSuccessOperations) delete202HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, newError(resp)
+		return nil, client.delete202HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// delete202HandleError handles the Delete202 error response.
+func (client *httpSuccessOperations) delete202HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Delete204 - Delete true Boolean value in request returns 204 (no content)
@@ -161,9 +179,18 @@ func (client *httpSuccessOperations) delete204CreateRequest() (*azcore.Request, 
 // delete204HandleResponse handles the Delete204 response.
 func (client *httpSuccessOperations) delete204HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusNoContent) {
-		return nil, newError(resp)
+		return nil, client.delete204HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// delete204HandleError handles the Delete204 error response.
+func (client *httpSuccessOperations) delete204HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get200 - Get 200 success
@@ -197,10 +224,19 @@ func (client *httpSuccessOperations) get200CreateRequest() (*azcore.Request, err
 // get200HandleResponse handles the Get200 response.
 func (client *httpSuccessOperations) get200HandleResponse(resp *azcore.Response) (*BoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get200HandleError(resp)
 	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// get200HandleError handles the Get200 error response.
+func (client *httpSuccessOperations) get200HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Head200 - Return 200 status code if successful
@@ -234,9 +270,18 @@ func (client *httpSuccessOperations) head200CreateRequest() (*azcore.Request, er
 // head200HandleResponse handles the Head200 response.
 func (client *httpSuccessOperations) head200HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.head200HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// head200HandleError handles the Head200 error response.
+func (client *httpSuccessOperations) head200HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Head204 - Return 204 status code if successful
@@ -270,9 +315,18 @@ func (client *httpSuccessOperations) head204CreateRequest() (*azcore.Request, er
 // head204HandleResponse handles the Head204 response.
 func (client *httpSuccessOperations) head204HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusNoContent) {
-		return nil, newError(resp)
+		return nil, client.head204HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// head204HandleError handles the Head204 error response.
+func (client *httpSuccessOperations) head204HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Head404 - Return 404 status code
@@ -306,9 +360,18 @@ func (client *httpSuccessOperations) head404CreateRequest() (*azcore.Request, er
 // head404HandleResponse handles the Head404 response.
 func (client *httpSuccessOperations) head404HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusNoContent, http.StatusNotFound) {
-		return nil, newError(resp)
+		return nil, client.head404HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// head404HandleError handles the Head404 error response.
+func (client *httpSuccessOperations) head404HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Options200 - Options 200 success
@@ -342,10 +405,19 @@ func (client *httpSuccessOperations) options200CreateRequest() (*azcore.Request,
 // options200HandleResponse handles the Options200 response.
 func (client *httpSuccessOperations) options200HandleResponse(resp *azcore.Response) (*BoolResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.options200HandleError(resp)
 	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// options200HandleError handles the Options200 error response.
+func (client *httpSuccessOperations) options200HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Patch200 - Patch true Boolean value in request returning 200
@@ -379,9 +451,18 @@ func (client *httpSuccessOperations) patch200CreateRequest() (*azcore.Request, e
 // patch200HandleResponse handles the Patch200 response.
 func (client *httpSuccessOperations) patch200HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.patch200HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// patch200HandleError handles the Patch200 error response.
+func (client *httpSuccessOperations) patch200HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Patch202 - Patch true Boolean value in request returns 202
@@ -415,9 +496,18 @@ func (client *httpSuccessOperations) patch202CreateRequest() (*azcore.Request, e
 // patch202HandleResponse handles the Patch202 response.
 func (client *httpSuccessOperations) patch202HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, newError(resp)
+		return nil, client.patch202HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// patch202HandleError handles the Patch202 error response.
+func (client *httpSuccessOperations) patch202HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Patch204 - Patch true Boolean value in request returns 204 (no content)
@@ -451,9 +541,18 @@ func (client *httpSuccessOperations) patch204CreateRequest() (*azcore.Request, e
 // patch204HandleResponse handles the Patch204 response.
 func (client *httpSuccessOperations) patch204HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusNoContent) {
-		return nil, newError(resp)
+		return nil, client.patch204HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// patch204HandleError handles the Patch204 error response.
+func (client *httpSuccessOperations) patch204HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Post200 - Post bollean value true in request that returns a 200
@@ -487,9 +586,18 @@ func (client *httpSuccessOperations) post200CreateRequest() (*azcore.Request, er
 // post200HandleResponse handles the Post200 response.
 func (client *httpSuccessOperations) post200HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.post200HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// post200HandleError handles the Post200 error response.
+func (client *httpSuccessOperations) post200HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Post201 - Post true Boolean value in request returns 201 (Created)
@@ -523,9 +631,18 @@ func (client *httpSuccessOperations) post201CreateRequest() (*azcore.Request, er
 // post201HandleResponse handles the Post201 response.
 func (client *httpSuccessOperations) post201HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newError(resp)
+		return nil, client.post201HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// post201HandleError handles the Post201 error response.
+func (client *httpSuccessOperations) post201HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Post202 - Post true Boolean value in request returns 202 (Accepted)
@@ -559,9 +676,18 @@ func (client *httpSuccessOperations) post202CreateRequest() (*azcore.Request, er
 // post202HandleResponse handles the Post202 response.
 func (client *httpSuccessOperations) post202HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, newError(resp)
+		return nil, client.post202HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// post202HandleError handles the Post202 error response.
+func (client *httpSuccessOperations) post202HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Post204 - Post true Boolean value in request returns 204 (no content)
@@ -595,9 +721,18 @@ func (client *httpSuccessOperations) post204CreateRequest() (*azcore.Request, er
 // post204HandleResponse handles the Post204 response.
 func (client *httpSuccessOperations) post204HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusNoContent) {
-		return nil, newError(resp)
+		return nil, client.post204HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// post204HandleError handles the Post204 error response.
+func (client *httpSuccessOperations) post204HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Put200 - Put boolean value true returning 200 success
@@ -631,9 +766,18 @@ func (client *httpSuccessOperations) put200CreateRequest() (*azcore.Request, err
 // put200HandleResponse handles the Put200 response.
 func (client *httpSuccessOperations) put200HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.put200HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// put200HandleError handles the Put200 error response.
+func (client *httpSuccessOperations) put200HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Put201 - Put true Boolean value in request returns 201
@@ -667,9 +811,18 @@ func (client *httpSuccessOperations) put201CreateRequest() (*azcore.Request, err
 // put201HandleResponse handles the Put201 response.
 func (client *httpSuccessOperations) put201HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newError(resp)
+		return nil, client.put201HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// put201HandleError handles the Put201 error response.
+func (client *httpSuccessOperations) put201HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Put202 - Put true Boolean value in request returns 202 (Accepted)
@@ -703,9 +856,18 @@ func (client *httpSuccessOperations) put202CreateRequest() (*azcore.Request, err
 // put202HandleResponse handles the Put202 response.
 func (client *httpSuccessOperations) put202HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, newError(resp)
+		return nil, client.put202HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// put202HandleError handles the Put202 error response.
+func (client *httpSuccessOperations) put202HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Put204 - Put true Boolean value in request returns 204 (no content)
@@ -739,7 +901,16 @@ func (client *httpSuccessOperations) put204CreateRequest() (*azcore.Request, err
 // put204HandleResponse handles the Put204 response.
 func (client *httpSuccessOperations) put204HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusNoContent) {
-		return nil, newError(resp)
+		return nil, client.put204HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// put204HandleError handles the Put204 error response.
+func (client *httpSuccessOperations) put204HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/httpinfrastructuregroup/models.go
+++ b/test/autorest/generated/httpinfrastructuregroup/models.go
@@ -7,7 +7,6 @@ package httpinfrastructuregroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 )
 
@@ -36,14 +35,6 @@ type D struct {
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {
@@ -206,14 +197,6 @@ type HTTPRedirectsPut307Response struct {
 
 type MyException struct {
 	StatusCode *string `json:"statusCode,omitempty"`
-}
-
-func newMyException(resp *azcore.Response) error {
-	err := MyException{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e MyException) Error() string {

--- a/test/autorest/generated/httpinfrastructuregroup/multipleresponses.go
+++ b/test/autorest/generated/httpinfrastructuregroup/multipleresponses.go
@@ -120,10 +120,19 @@ func (client *multipleResponsesOperations) get200Model201ModelDefaultError200Val
 // get200Model201ModelDefaultError200ValidHandleResponse handles the Get200Model201ModelDefaultError200Valid response.
 func (client *multipleResponsesOperations) get200Model201ModelDefaultError200ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get200Model201ModelDefaultError200ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200Model201ModelDefaultError200ValidHandleError handles the Get200Model201ModelDefaultError200Valid error response.
+func (client *multipleResponsesOperations) get200Model201ModelDefaultError200ValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get200Model201ModelDefaultError201Valid - Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}
@@ -157,10 +166,19 @@ func (client *multipleResponsesOperations) get200Model201ModelDefaultError201Val
 // get200Model201ModelDefaultError201ValidHandleResponse handles the Get200Model201ModelDefaultError201Valid response.
 func (client *multipleResponsesOperations) get200Model201ModelDefaultError201ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get200Model201ModelDefaultError201ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200Model201ModelDefaultError201ValidHandleError handles the Get200Model201ModelDefaultError201Valid error response.
+func (client *multipleResponsesOperations) get200Model201ModelDefaultError201ValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get200Model201ModelDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
@@ -194,10 +212,19 @@ func (client *multipleResponsesOperations) get200Model201ModelDefaultError400Val
 // get200Model201ModelDefaultError400ValidHandleResponse handles the Get200Model201ModelDefaultError400Valid response.
 func (client *multipleResponsesOperations) get200Model201ModelDefaultError400ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get200Model201ModelDefaultError400ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200Model201ModelDefaultError400ValidHandleError handles the Get200Model201ModelDefaultError400Valid error response.
+func (client *multipleResponsesOperations) get200Model201ModelDefaultError400ValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get200Model204NoModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
@@ -231,10 +258,19 @@ func (client *multipleResponsesOperations) get200Model204NoModelDefaultError200V
 // get200Model204NoModelDefaultError200ValidHandleResponse handles the Get200Model204NoModelDefaultError200Valid response.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError200ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get200Model204NoModelDefaultError200ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200Model204NoModelDefaultError200ValidHandleError handles the Get200Model204NoModelDefaultError200Valid error response.
+func (client *multipleResponsesOperations) get200Model204NoModelDefaultError200ValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get200Model204NoModelDefaultError201Invalid - Send a 201 response with valid payload: {'statusCode': '201'}
@@ -268,10 +304,19 @@ func (client *multipleResponsesOperations) get200Model204NoModelDefaultError201I
 // get200Model204NoModelDefaultError201InvalidHandleResponse handles the Get200Model204NoModelDefaultError201Invalid response.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError201InvalidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get200Model204NoModelDefaultError201InvalidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200Model204NoModelDefaultError201InvalidHandleError handles the Get200Model204NoModelDefaultError201Invalid error response.
+func (client *multipleResponsesOperations) get200Model204NoModelDefaultError201InvalidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get200Model204NoModelDefaultError202None - Send a 202 response with no payload:
@@ -305,10 +350,19 @@ func (client *multipleResponsesOperations) get200Model204NoModelDefaultError202N
 // get200Model204NoModelDefaultError202NoneHandleResponse handles the Get200Model204NoModelDefaultError202None response.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError202NoneHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get200Model204NoModelDefaultError202NoneHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200Model204NoModelDefaultError202NoneHandleError handles the Get200Model204NoModelDefaultError202None error response.
+func (client *multipleResponsesOperations) get200Model204NoModelDefaultError202NoneHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get200Model204NoModelDefaultError204Valid - Send a 204 response with no payload
@@ -342,10 +396,19 @@ func (client *multipleResponsesOperations) get200Model204NoModelDefaultError204V
 // get200Model204NoModelDefaultError204ValidHandleResponse handles the Get200Model204NoModelDefaultError204Valid response.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError204ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get200Model204NoModelDefaultError204ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200Model204NoModelDefaultError204ValidHandleError handles the Get200Model204NoModelDefaultError204Valid error response.
+func (client *multipleResponsesOperations) get200Model204NoModelDefaultError204ValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get200Model204NoModelDefaultError400Valid - Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}
@@ -379,10 +442,19 @@ func (client *multipleResponsesOperations) get200Model204NoModelDefaultError400V
 // get200Model204NoModelDefaultError400ValidHandleResponse handles the Get200Model204NoModelDefaultError400Valid response.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError400ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get200Model204NoModelDefaultError400ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200Model204NoModelDefaultError400ValidHandleError handles the Get200Model204NoModelDefaultError400Valid error response.
+func (client *multipleResponsesOperations) get200Model204NoModelDefaultError400ValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get200ModelA200Invalid - Send a 200 response with invalid payload {'statusCodeInvalid': '200'}
@@ -416,10 +488,15 @@ func (client *multipleResponsesOperations) get200ModelA200InvalidCreateRequest()
 // get200ModelA200InvalidHandleResponse handles the Get200ModelA200Invalid response.
 func (client *multipleResponsesOperations) get200ModelA200InvalidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.get200ModelA200InvalidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200ModelA200InvalidHandleError handles the Get200ModelA200Invalid error response.
+func (client *multipleResponsesOperations) get200ModelA200InvalidHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // Get200ModelA200None - Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A
@@ -453,10 +530,15 @@ func (client *multipleResponsesOperations) get200ModelA200NoneCreateRequest() (*
 // get200ModelA200NoneHandleResponse handles the Get200ModelA200None response.
 func (client *multipleResponsesOperations) get200ModelA200NoneHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.get200ModelA200NoneHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200ModelA200NoneHandleError handles the Get200ModelA200None error response.
+func (client *multipleResponsesOperations) get200ModelA200NoneHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // Get200ModelA200Valid - Send a 200 response with payload {'statusCode': '200'}
@@ -490,10 +572,15 @@ func (client *multipleResponsesOperations) get200ModelA200ValidCreateRequest() (
 // get200ModelA200ValidHandleResponse handles the Get200ModelA200Valid response.
 func (client *multipleResponsesOperations) get200ModelA200ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.get200ModelA200ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200ModelA200ValidHandleError handles the Get200ModelA200Valid error response.
+func (client *multipleResponsesOperations) get200ModelA200ValidHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
@@ -527,10 +614,19 @@ func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefault
 // get200ModelA201ModelC404ModelDDefaultError200ValidHandleResponse handles the Get200ModelA201ModelC404ModelDDefaultError200Valid response.
 func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError200ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get200ModelA201ModelC404ModelDDefaultError200ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200ModelA201ModelC404ModelDDefaultError200ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError200Valid error response.
+func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError200ValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError201Valid - Send a 200 response with valid payload: {'httpCode': '201'}
@@ -564,10 +660,19 @@ func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefault
 // get200ModelA201ModelC404ModelDDefaultError201ValidHandleResponse handles the Get200ModelA201ModelC404ModelDDefaultError201Valid response.
 func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError201ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get200ModelA201ModelC404ModelDDefaultError201ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200ModelA201ModelC404ModelDDefaultError201ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError201Valid error response.
+func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError201ValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
@@ -601,10 +706,19 @@ func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefault
 // get200ModelA201ModelC404ModelDDefaultError400ValidHandleResponse handles the Get200ModelA201ModelC404ModelDDefaultError400Valid response.
 func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError400ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get200ModelA201ModelC404ModelDDefaultError400ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200ModelA201ModelC404ModelDDefaultError400ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError400Valid error response.
+func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError400ValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError404Valid - Send a 200 response with valid payload: {'httpStatusCode': '404'}
@@ -638,10 +752,19 @@ func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefault
 // get200ModelA201ModelC404ModelDDefaultError404ValidHandleResponse handles the Get200ModelA201ModelC404ModelDDefaultError404Valid response.
 func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError404ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.get200ModelA201ModelC404ModelDDefaultError404ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200ModelA201ModelC404ModelDDefaultError404ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError404Valid error response.
+func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError404ValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get200ModelA202Valid - Send a 202 response with payload {'statusCode': '202'}
@@ -675,10 +798,15 @@ func (client *multipleResponsesOperations) get200ModelA202ValidCreateRequest() (
 // get200ModelA202ValidHandleResponse handles the Get200ModelA202Valid response.
 func (client *multipleResponsesOperations) get200ModelA202ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.get200ModelA202ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200ModelA202ValidHandleError handles the Get200ModelA202Valid error response.
+func (client *multipleResponsesOperations) get200ModelA202ValidHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // Get200ModelA400Invalid - Send a 200 response with invalid payload {'statusCodeInvalid': '400'}
@@ -712,10 +840,15 @@ func (client *multipleResponsesOperations) get200ModelA400InvalidCreateRequest()
 // get200ModelA400InvalidHandleResponse handles the Get200ModelA400Invalid response.
 func (client *multipleResponsesOperations) get200ModelA400InvalidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.get200ModelA400InvalidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200ModelA400InvalidHandleError handles the Get200ModelA400Invalid error response.
+func (client *multipleResponsesOperations) get200ModelA400InvalidHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // Get200ModelA400None - Send a 400 response with no payload client should treat as an http error with no error model
@@ -749,10 +882,15 @@ func (client *multipleResponsesOperations) get200ModelA400NoneCreateRequest() (*
 // get200ModelA400NoneHandleResponse handles the Get200ModelA400None response.
 func (client *multipleResponsesOperations) get200ModelA400NoneHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.get200ModelA400NoneHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200ModelA400NoneHandleError handles the Get200ModelA400None error response.
+func (client *multipleResponsesOperations) get200ModelA400NoneHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // Get200ModelA400Valid - Send a 200 response with payload {'statusCode': '400'}
@@ -786,10 +924,15 @@ func (client *multipleResponsesOperations) get200ModelA400ValidCreateRequest() (
 // get200ModelA400ValidHandleResponse handles the Get200ModelA400Valid response.
 func (client *multipleResponsesOperations) get200ModelA400ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.get200ModelA400ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// get200ModelA400ValidHandleError handles the Get200ModelA400Valid error response.
+func (client *multipleResponsesOperations) get200ModelA400ValidHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // Get202None204NoneDefaultError202None - Send a 202 response with no payload
@@ -823,9 +966,18 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultError202NoneC
 // get202None204NoneDefaultError202NoneHandleResponse handles the Get202None204NoneDefaultError202None response.
 func (client *multipleResponsesOperations) get202None204NoneDefaultError202NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, newError(resp)
+		return nil, client.get202None204NoneDefaultError202NoneHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// get202None204NoneDefaultError202NoneHandleError handles the Get202None204NoneDefaultError202None error response.
+func (client *multipleResponsesOperations) get202None204NoneDefaultError202NoneHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get202None204NoneDefaultError204None - Send a 204 response with no payload
@@ -859,9 +1011,18 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultError204NoneC
 // get202None204NoneDefaultError204NoneHandleResponse handles the Get202None204NoneDefaultError204None response.
 func (client *multipleResponsesOperations) get202None204NoneDefaultError204NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, newError(resp)
+		return nil, client.get202None204NoneDefaultError204NoneHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// get202None204NoneDefaultError204NoneHandleError handles the Get202None204NoneDefaultError204None error response.
+func (client *multipleResponsesOperations) get202None204NoneDefaultError204NoneHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get202None204NoneDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
@@ -895,9 +1056,18 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultError400Valid
 // get202None204NoneDefaultError400ValidHandleResponse handles the Get202None204NoneDefaultError400Valid response.
 func (client *multipleResponsesOperations) get202None204NoneDefaultError400ValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, newError(resp)
+		return nil, client.get202None204NoneDefaultError400ValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// get202None204NoneDefaultError400ValidHandleError handles the Get202None204NoneDefaultError400Valid error response.
+func (client *multipleResponsesOperations) get202None204NoneDefaultError400ValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Get202None204NoneDefaultNone202Invalid - Send a 202 response with an unexpected payload {'property': 'value'}
@@ -931,9 +1101,14 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultNone202Invali
 // get202None204NoneDefaultNone202InvalidHandleResponse handles the Get202None204NoneDefaultNone202Invalid response.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone202InvalidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, errors.New(resp.Status)
+		return nil, client.get202None204NoneDefaultNone202InvalidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// get202None204NoneDefaultNone202InvalidHandleError handles the Get202None204NoneDefaultNone202Invalid error response.
+func (client *multipleResponsesOperations) get202None204NoneDefaultNone202InvalidHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // Get202None204NoneDefaultNone204None - Send a 204 response with no payload
@@ -967,9 +1142,14 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultNone204NoneCr
 // get202None204NoneDefaultNone204NoneHandleResponse handles the Get202None204NoneDefaultNone204None response.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone204NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, errors.New(resp.Status)
+		return nil, client.get202None204NoneDefaultNone204NoneHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// get202None204NoneDefaultNone204NoneHandleError handles the Get202None204NoneDefaultNone204None error response.
+func (client *multipleResponsesOperations) get202None204NoneDefaultNone204NoneHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // Get202None204NoneDefaultNone400Invalid - Send a 400 response with an unexpected payload {'property': 'value'}
@@ -1003,9 +1183,14 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultNone400Invali
 // get202None204NoneDefaultNone400InvalidHandleResponse handles the Get202None204NoneDefaultNone400Invalid response.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone400InvalidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, errors.New(resp.Status)
+		return nil, client.get202None204NoneDefaultNone400InvalidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// get202None204NoneDefaultNone400InvalidHandleError handles the Get202None204NoneDefaultNone400Invalid error response.
+func (client *multipleResponsesOperations) get202None204NoneDefaultNone400InvalidHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // Get202None204NoneDefaultNone400None - Send a 400 response with no payload
@@ -1039,9 +1224,14 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultNone400NoneCr
 // get202None204NoneDefaultNone400NoneHandleResponse handles the Get202None204NoneDefaultNone400None response.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone400NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, errors.New(resp.Status)
+		return nil, client.get202None204NoneDefaultNone400NoneHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// get202None204NoneDefaultNone400NoneHandleError handles the Get202None204NoneDefaultNone400None error response.
+func (client *multipleResponsesOperations) get202None204NoneDefaultNone400NoneHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetDefaultModelA200None - Send a 200 response with no payload
@@ -1075,10 +1265,15 @@ func (client *multipleResponsesOperations) getDefaultModelA200NoneCreateRequest(
 // getDefaultModelA200NoneHandleResponse handles the GetDefaultModelA200None response.
 func (client *multipleResponsesOperations) getDefaultModelA200NoneHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getDefaultModelA200NoneHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// getDefaultModelA200NoneHandleError handles the GetDefaultModelA200None error response.
+func (client *multipleResponsesOperations) getDefaultModelA200NoneHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetDefaultModelA200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
@@ -1112,10 +1307,15 @@ func (client *multipleResponsesOperations) getDefaultModelA200ValidCreateRequest
 // getDefaultModelA200ValidHandleResponse handles the GetDefaultModelA200Valid response.
 func (client *multipleResponsesOperations) getDefaultModelA200ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getDefaultModelA200ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
+}
+
+// getDefaultModelA200ValidHandleError handles the GetDefaultModelA200Valid error response.
+func (client *multipleResponsesOperations) getDefaultModelA200ValidHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetDefaultModelA400None - Send a 400 response with no payload
@@ -1149,9 +1349,18 @@ func (client *multipleResponsesOperations) getDefaultModelA400NoneCreateRequest(
 // getDefaultModelA400NoneHandleResponse handles the GetDefaultModelA400None response.
 func (client *multipleResponsesOperations) getDefaultModelA400NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newMyException(resp)
+		return nil, client.getDefaultModelA400NoneHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getDefaultModelA400NoneHandleError handles the GetDefaultModelA400None error response.
+func (client *multipleResponsesOperations) getDefaultModelA400NoneHandleError(resp *azcore.Response) error {
+	err := MyException{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDefaultModelA400Valid - Send a 400 response with valid payload: {'statusCode': '400'}
@@ -1185,9 +1394,18 @@ func (client *multipleResponsesOperations) getDefaultModelA400ValidCreateRequest
 // getDefaultModelA400ValidHandleResponse handles the GetDefaultModelA400Valid response.
 func (client *multipleResponsesOperations) getDefaultModelA400ValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newMyException(resp)
+		return nil, client.getDefaultModelA400ValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getDefaultModelA400ValidHandleError handles the GetDefaultModelA400Valid error response.
+func (client *multipleResponsesOperations) getDefaultModelA400ValidHandleError(resp *azcore.Response) error {
+	err := MyException{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetDefaultNone200Invalid - Send a 200 response with invalid payload: {'statusCode': '200'}
@@ -1221,9 +1439,14 @@ func (client *multipleResponsesOperations) getDefaultNone200InvalidCreateRequest
 // getDefaultNone200InvalidHandleResponse handles the GetDefaultNone200Invalid response.
 func (client *multipleResponsesOperations) getDefaultNone200InvalidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getDefaultNone200InvalidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getDefaultNone200InvalidHandleError handles the GetDefaultNone200Invalid error response.
+func (client *multipleResponsesOperations) getDefaultNone200InvalidHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetDefaultNone200None - Send a 200 response with no payload
@@ -1257,9 +1480,14 @@ func (client *multipleResponsesOperations) getDefaultNone200NoneCreateRequest() 
 // getDefaultNone200NoneHandleResponse handles the GetDefaultNone200None response.
 func (client *multipleResponsesOperations) getDefaultNone200NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getDefaultNone200NoneHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getDefaultNone200NoneHandleError handles the GetDefaultNone200None error response.
+func (client *multipleResponsesOperations) getDefaultNone200NoneHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetDefaultNone400Invalid - Send a 400 response with valid payload: {'statusCode': '400'}
@@ -1293,9 +1521,14 @@ func (client *multipleResponsesOperations) getDefaultNone400InvalidCreateRequest
 // getDefaultNone400InvalidHandleResponse handles the GetDefaultNone400Invalid response.
 func (client *multipleResponsesOperations) getDefaultNone400InvalidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getDefaultNone400InvalidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getDefaultNone400InvalidHandleError handles the GetDefaultNone400Invalid error response.
+func (client *multipleResponsesOperations) getDefaultNone400InvalidHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetDefaultNone400None - Send a 400 response with no payload
@@ -1329,7 +1562,12 @@ func (client *multipleResponsesOperations) getDefaultNone400NoneCreateRequest() 
 // getDefaultNone400NoneHandleResponse handles the GetDefaultNone400None response.
 func (client *multipleResponsesOperations) getDefaultNone400NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getDefaultNone400NoneHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getDefaultNone400NoneHandleError handles the GetDefaultNone400None error response.
+func (client *multipleResponsesOperations) getDefaultNone400NoneHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }

--- a/test/autorest/generated/integergroup/int.go
+++ b/test/autorest/generated/integergroup/int.go
@@ -80,10 +80,19 @@ func (client *intOperations) getInvalidCreateRequest() (*azcore.Request, error) 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *intOperations) getInvalidHandleResponse(resp *azcore.Response) (*Int32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getInvalidHandleError(resp)
 	}
 	result := Int32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getInvalidHandleError handles the GetInvalid error response.
+func (client *intOperations) getInvalidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetInvalidUnixTime - Get invalid Unix time value
@@ -117,10 +126,19 @@ func (client *intOperations) getInvalidUnixTimeCreateRequest() (*azcore.Request,
 // getInvalidUnixTimeHandleResponse handles the GetInvalidUnixTime response.
 func (client *intOperations) getInvalidUnixTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getInvalidUnixTimeHandleError(resp)
 	}
 	result := TimeResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getInvalidUnixTimeHandleError handles the GetInvalidUnixTime error response.
+func (client *intOperations) getInvalidUnixTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNull - Get null Int value
@@ -154,10 +172,19 @@ func (client *intOperations) getNullCreateRequest() (*azcore.Request, error) {
 // getNullHandleResponse handles the GetNull response.
 func (client *intOperations) getNullHandleResponse(resp *azcore.Response) (*Int32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNullHandleError(resp)
 	}
 	result := Int32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getNullHandleError handles the GetNull error response.
+func (client *intOperations) getNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNullUnixTime - Get null Unix time value
@@ -191,10 +218,19 @@ func (client *intOperations) getNullUnixTimeCreateRequest() (*azcore.Request, er
 // getNullUnixTimeHandleResponse handles the GetNullUnixTime response.
 func (client *intOperations) getNullUnixTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNullUnixTimeHandleError(resp)
 	}
 	result := TimeResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getNullUnixTimeHandleError handles the GetNullUnixTime error response.
+func (client *intOperations) getNullUnixTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetOverflowInt32 - Get overflow Int32 value
@@ -228,10 +264,19 @@ func (client *intOperations) getOverflowInt32CreateRequest() (*azcore.Request, e
 // getOverflowInt32HandleResponse handles the GetOverflowInt32 response.
 func (client *intOperations) getOverflowInt32HandleResponse(resp *azcore.Response) (*Int32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getOverflowInt32HandleError(resp)
 	}
 	result := Int32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getOverflowInt32HandleError handles the GetOverflowInt32 error response.
+func (client *intOperations) getOverflowInt32HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetOverflowInt64 - Get overflow Int64 value
@@ -265,10 +310,19 @@ func (client *intOperations) getOverflowInt64CreateRequest() (*azcore.Request, e
 // getOverflowInt64HandleResponse handles the GetOverflowInt64 response.
 func (client *intOperations) getOverflowInt64HandleResponse(resp *azcore.Response) (*Int64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getOverflowInt64HandleError(resp)
 	}
 	result := Int64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getOverflowInt64HandleError handles the GetOverflowInt64 error response.
+func (client *intOperations) getOverflowInt64HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetUnderflowInt32 - Get underflow Int32 value
@@ -302,10 +356,19 @@ func (client *intOperations) getUnderflowInt32CreateRequest() (*azcore.Request, 
 // getUnderflowInt32HandleResponse handles the GetUnderflowInt32 response.
 func (client *intOperations) getUnderflowInt32HandleResponse(resp *azcore.Response) (*Int32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getUnderflowInt32HandleError(resp)
 	}
 	result := Int32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getUnderflowInt32HandleError handles the GetUnderflowInt32 error response.
+func (client *intOperations) getUnderflowInt32HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetUnderflowInt64 - Get underflow Int64 value
@@ -339,10 +402,19 @@ func (client *intOperations) getUnderflowInt64CreateRequest() (*azcore.Request, 
 // getUnderflowInt64HandleResponse handles the GetUnderflowInt64 response.
 func (client *intOperations) getUnderflowInt64HandleResponse(resp *azcore.Response) (*Int64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getUnderflowInt64HandleError(resp)
 	}
 	result := Int64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getUnderflowInt64HandleError handles the GetUnderflowInt64 error response.
+func (client *intOperations) getUnderflowInt64HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetUnixTime - Get datetime encoded as Unix time value
@@ -376,10 +448,19 @@ func (client *intOperations) getUnixTimeCreateRequest() (*azcore.Request, error)
 // getUnixTimeHandleResponse handles the GetUnixTime response.
 func (client *intOperations) getUnixTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getUnixTimeHandleError(resp)
 	}
 	result := TimeResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getUnixTimeHandleError handles the GetUnixTime error response.
+func (client *intOperations) getUnixTimeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutMax32 - Put max int32 value
@@ -413,9 +494,18 @@ func (client *intOperations) putMax32CreateRequest(intBody int32) (*azcore.Reque
 // putMax32HandleResponse handles the PutMax32 response.
 func (client *intOperations) putMax32HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putMax32HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putMax32HandleError handles the PutMax32 error response.
+func (client *intOperations) putMax32HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutMax64 - Put max int64 value
@@ -449,9 +539,18 @@ func (client *intOperations) putMax64CreateRequest(intBody int64) (*azcore.Reque
 // putMax64HandleResponse handles the PutMax64 response.
 func (client *intOperations) putMax64HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putMax64HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putMax64HandleError handles the PutMax64 error response.
+func (client *intOperations) putMax64HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutMin32 - Put min int32 value
@@ -485,9 +584,18 @@ func (client *intOperations) putMin32CreateRequest(intBody int32) (*azcore.Reque
 // putMin32HandleResponse handles the PutMin32 response.
 func (client *intOperations) putMin32HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putMin32HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putMin32HandleError handles the PutMin32 error response.
+func (client *intOperations) putMin32HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutMin64 - Put min int64 value
@@ -521,9 +629,18 @@ func (client *intOperations) putMin64CreateRequest(intBody int64) (*azcore.Reque
 // putMin64HandleResponse handles the PutMin64 response.
 func (client *intOperations) putMin64HandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putMin64HandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putMin64HandleError handles the PutMin64 error response.
+func (client *intOperations) putMin64HandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutUnixTimeDate - Put datetime encoded as Unix time
@@ -557,7 +674,16 @@ func (client *intOperations) putUnixTimeDateCreateRequest(intBody time.Time) (*a
 // putUnixTimeDateHandleResponse handles the PutUnixTimeDate response.
 func (client *intOperations) putUnixTimeDateHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putUnixTimeDateHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putUnixTimeDateHandleError handles the PutUnixTimeDate error response.
+func (client *intOperations) putUnixTimeDateHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/integergroup/models.go
+++ b/test/autorest/generated/integergroup/models.go
@@ -7,7 +7,6 @@ package integergroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"time"
 )
@@ -15,14 +14,6 @@ import (
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/lrogroup/lroretrys.go
+++ b/test/autorest/generated/lrogroup/lroretrys.go
@@ -7,12 +7,9 @@ package lrogroup
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"strconv"
-	"strings"
 )
 
 // LroRetrysOperations contains the methods for the LroRetrys group.
@@ -63,7 +60,7 @@ func (client *lroRetrysOperations) BeginDelete202Retry200(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.delete202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -73,38 +70,15 @@ func (client *lroRetrysOperations) BeginDelete202Retry200(ctx context.Context) (
 	}, nil
 }
 
-func (client *lroRetrysOperations) ResumeLroRetrysDelete202Retry200Poller(id string) (LroRetrysDelete202Retry200Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lroRetrysOperations) ResumeLroRetrysDelete202Retry200Poller(token string) (LroRetrysDelete202Retry200Poller, error) {
+	pt, err := resumePollingTracker(token, client.delete202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLroRetrysDelete202Retry200Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lroRetrysDelete202Retry200Poller{
+	return &lroRetrysDelete202Retry200Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLroRetrysDelete202Retry200Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // delete202Retry200CreateRequest creates the Delete202Retry200 request.
@@ -135,6 +109,15 @@ func (client *lroRetrysOperations) delete202Retry200HandleResponse(resp *azcore.
 	return &result, nil
 }
 
+// delete202Retry200HandleError handles the Delete202Retry200 error response.
+func (client *lroRetrysOperations) delete202Retry200HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteAsyncRelativeRetrySucceeded - Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lroRetrysOperations) BeginDeleteAsyncRelativeRetrySucceeded(ctx context.Context) (LroRetrysDeleteAsyncRelativeRetrySucceededPoller, error) {
 	req, err := client.deleteAsyncRelativeRetrySucceededCreateRequest()
@@ -146,7 +129,7 @@ func (client *lroRetrysOperations) BeginDeleteAsyncRelativeRetrySucceeded(ctx co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -156,38 +139,15 @@ func (client *lroRetrysOperations) BeginDeleteAsyncRelativeRetrySucceeded(ctx co
 	}, nil
 }
 
-func (client *lroRetrysOperations) ResumeLroRetrysDeleteAsyncRelativeRetrySucceededPoller(id string) (LroRetrysDeleteAsyncRelativeRetrySucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lroRetrysOperations) ResumeLroRetrysDeleteAsyncRelativeRetrySucceededPoller(token string) (LroRetrysDeleteAsyncRelativeRetrySucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.deleteAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLroRetrysDeleteAsyncRelativeRetrySucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lroRetrysDeleteAsyncRelativeRetrySucceededPoller{
+	return &lroRetrysDeleteAsyncRelativeRetrySucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLroRetrysDeleteAsyncRelativeRetrySucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteAsyncRelativeRetrySucceededCreateRequest creates the DeleteAsyncRelativeRetrySucceeded request.
@@ -221,6 +181,15 @@ func (client *lroRetrysOperations) deleteAsyncRelativeRetrySucceededHandleRespon
 	return &result, nil
 }
 
+// deleteAsyncRelativeRetrySucceededHandleError handles the DeleteAsyncRelativeRetrySucceeded error response.
+func (client *lroRetrysOperations) deleteAsyncRelativeRetrySucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteProvisioning202Accepted200Succeeded - Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
 func (client *lroRetrysOperations) BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context) (LroRetrysDeleteProvisioning202Accepted200SucceededPoller, error) {
 	req, err := client.deleteProvisioning202Accepted200SucceededCreateRequest()
@@ -232,7 +201,7 @@ func (client *lroRetrysOperations) BeginDeleteProvisioning202Accepted200Succeede
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteProvisioning202Accepted200SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -242,38 +211,15 @@ func (client *lroRetrysOperations) BeginDeleteProvisioning202Accepted200Succeede
 	}, nil
 }
 
-func (client *lroRetrysOperations) ResumeLroRetrysDeleteProvisioning202Accepted200SucceededPoller(id string) (LroRetrysDeleteProvisioning202Accepted200SucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lroRetrysOperations) ResumeLroRetrysDeleteProvisioning202Accepted200SucceededPoller(token string) (LroRetrysDeleteProvisioning202Accepted200SucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.deleteProvisioning202Accepted200SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLroRetrysDeleteProvisioning202Accepted200SucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lroRetrysDeleteProvisioning202Accepted200SucceededPoller{
+	return &lroRetrysDeleteProvisioning202Accepted200SucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLroRetrysDeleteProvisioning202Accepted200SucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteProvisioning202Accepted200SucceededCreateRequest creates the DeleteProvisioning202Accepted200Succeeded request.
@@ -293,6 +239,15 @@ func (client *lroRetrysOperations) deleteProvisioning202Accepted200SucceededHand
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// deleteProvisioning202Accepted200SucceededHandleError handles the DeleteProvisioning202Accepted200Succeeded error response.
+func (client *lroRetrysOperations) deleteProvisioning202Accepted200SucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Post202Retry200 - Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
 func (client *lroRetrysOperations) BeginPost202Retry200(ctx context.Context, lroRetrysPost202Retry200Options *LroRetrysPost202Retry200Options) (LroRetrysPost202Retry200Poller, error) {
 	req, err := client.post202Retry200CreateRequest(lroRetrysPost202Retry200Options)
@@ -304,7 +259,7 @@ func (client *lroRetrysOperations) BeginPost202Retry200(ctx context.Context, lro
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.post202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -314,38 +269,15 @@ func (client *lroRetrysOperations) BeginPost202Retry200(ctx context.Context, lro
 	}, nil
 }
 
-func (client *lroRetrysOperations) ResumeLroRetrysPost202Retry200Poller(id string) (LroRetrysPost202Retry200Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lroRetrysOperations) ResumeLroRetrysPost202Retry200Poller(token string) (LroRetrysPost202Retry200Poller, error) {
+	pt, err := resumePollingTracker(token, client.post202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLroRetrysPost202Retry200Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lroRetrysPost202Retry200Poller{
+	return &lroRetrysPost202Retry200Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLroRetrysPost202Retry200Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // post202Retry200CreateRequest creates the Post202Retry200 request.
@@ -379,6 +311,15 @@ func (client *lroRetrysOperations) post202Retry200HandleResponse(resp *azcore.Re
 	return &result, nil
 }
 
+// post202Retry200HandleError handles the Post202Retry200 error response.
+func (client *lroRetrysOperations) post202Retry200HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PostAsyncRelativeRetrySucceeded - Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lroRetrysOperations) BeginPostAsyncRelativeRetrySucceeded(ctx context.Context, lroRetrysPostAsyncRelativeRetrySucceededOptions *LroRetrysPostAsyncRelativeRetrySucceededOptions) (LroRetrysPostAsyncRelativeRetrySucceededPoller, error) {
 	req, err := client.postAsyncRelativeRetrySucceededCreateRequest(lroRetrysPostAsyncRelativeRetrySucceededOptions)
@@ -390,7 +331,7 @@ func (client *lroRetrysOperations) BeginPostAsyncRelativeRetrySucceeded(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.postAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -400,38 +341,15 @@ func (client *lroRetrysOperations) BeginPostAsyncRelativeRetrySucceeded(ctx cont
 	}, nil
 }
 
-func (client *lroRetrysOperations) ResumeLroRetrysPostAsyncRelativeRetrySucceededPoller(id string) (LroRetrysPostAsyncRelativeRetrySucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lroRetrysOperations) ResumeLroRetrysPostAsyncRelativeRetrySucceededPoller(token string) (LroRetrysPostAsyncRelativeRetrySucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.postAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLroRetrysPostAsyncRelativeRetrySucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lroRetrysPostAsyncRelativeRetrySucceededPoller{
+	return &lroRetrysPostAsyncRelativeRetrySucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLroRetrysPostAsyncRelativeRetrySucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // postAsyncRelativeRetrySucceededCreateRequest creates the PostAsyncRelativeRetrySucceeded request.
@@ -468,6 +386,15 @@ func (client *lroRetrysOperations) postAsyncRelativeRetrySucceededHandleResponse
 	return &result, nil
 }
 
+// postAsyncRelativeRetrySucceededHandleError handles the PostAsyncRelativeRetrySucceeded error response.
+func (client *lroRetrysOperations) postAsyncRelativeRetrySucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Put201CreatingSucceeded200 - Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
 func (client *lroRetrysOperations) BeginPut201CreatingSucceeded200(ctx context.Context, lroRetrysPut201CreatingSucceeded200Options *LroRetrysPut201CreatingSucceeded200Options) (LroRetrysPut201CreatingSucceeded200Poller, error) {
 	req, err := client.put201CreatingSucceeded200CreateRequest(lroRetrysPut201CreatingSucceeded200Options)
@@ -479,7 +406,7 @@ func (client *lroRetrysOperations) BeginPut201CreatingSucceeded200(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -489,38 +416,15 @@ func (client *lroRetrysOperations) BeginPut201CreatingSucceeded200(ctx context.C
 	}, nil
 }
 
-func (client *lroRetrysOperations) ResumeLroRetrysPut201CreatingSucceeded200Poller(id string) (LroRetrysPut201CreatingSucceeded200Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lroRetrysOperations) ResumeLroRetrysPut201CreatingSucceeded200Poller(token string) (LroRetrysPut201CreatingSucceeded200Poller, error) {
+	pt, err := resumePollingTracker(token, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLroRetrysPut201CreatingSucceeded200Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lroRetrysPut201CreatingSucceeded200Poller{
+	return &lroRetrysPut201CreatingSucceeded200Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLroRetrysPut201CreatingSucceeded200Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // put201CreatingSucceeded200CreateRequest creates the Put201CreatingSucceeded200 request.
@@ -543,6 +447,15 @@ func (client *lroRetrysOperations) put201CreatingSucceeded200HandleResponse(resp
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// put201CreatingSucceeded200HandleError handles the Put201CreatingSucceeded200 error response.
+func (client *lroRetrysOperations) put201CreatingSucceeded200HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutAsyncRelativeRetrySucceeded - Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lroRetrysOperations) BeginPutAsyncRelativeRetrySucceeded(ctx context.Context, lroRetrysPutAsyncRelativeRetrySucceededOptions *LroRetrysPutAsyncRelativeRetrySucceededOptions) (LroRetrysPutAsyncRelativeRetrySucceededPoller, error) {
 	req, err := client.putAsyncRelativeRetrySucceededCreateRequest(lroRetrysPutAsyncRelativeRetrySucceededOptions)
@@ -554,7 +467,7 @@ func (client *lroRetrysOperations) BeginPutAsyncRelativeRetrySucceeded(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -564,38 +477,15 @@ func (client *lroRetrysOperations) BeginPutAsyncRelativeRetrySucceeded(ctx conte
 	}, nil
 }
 
-func (client *lroRetrysOperations) ResumeLroRetrysPutAsyncRelativeRetrySucceededPoller(id string) (LroRetrysPutAsyncRelativeRetrySucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lroRetrysOperations) ResumeLroRetrysPutAsyncRelativeRetrySucceededPoller(token string) (LroRetrysPutAsyncRelativeRetrySucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.putAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLroRetrysPutAsyncRelativeRetrySucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lroRetrysPutAsyncRelativeRetrySucceededPoller{
+	return &lroRetrysPutAsyncRelativeRetrySucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLroRetrysPutAsyncRelativeRetrySucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putAsyncRelativeRetrySucceededCreateRequest creates the PutAsyncRelativeRetrySucceeded request.
@@ -616,4 +506,13 @@ func (client *lroRetrysOperations) putAsyncRelativeRetrySucceededCreateRequest(l
 func (client *lroRetrysOperations) putAsyncRelativeRetrySucceededHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
 	result := ProductResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Product)
+}
+
+// putAsyncRelativeRetrySucceededHandleError handles the PutAsyncRelativeRetrySucceeded error response.
+func (client *lroRetrysOperations) putAsyncRelativeRetrySucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/lrogroup/lros.go
+++ b/test/autorest/generated/lrogroup/lros.go
@@ -7,12 +7,9 @@ package lrogroup
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"strconv"
-	"strings"
 )
 
 // LrOSOperations contains the methods for the LrOS group.
@@ -191,7 +188,7 @@ func (client *lrOSOperations) BeginDelete202NoRetry204(ctx context.Context) (LrO
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.delete202NoRetry204HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -201,38 +198,15 @@ func (client *lrOSOperations) BeginDelete202NoRetry204(ctx context.Context) (LrO
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSDelete202NoRetry204Poller(id string) (LrOSDelete202NoRetry204Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSDelete202NoRetry204Poller(token string) (LrOSDelete202NoRetry204Poller, error) {
+	pt, err := resumePollingTracker(token, client.delete202NoRetry204HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSDelete202NoRetry204Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSDelete202NoRetry204Poller{
+	return &lrOSDelete202NoRetry204Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSDelete202NoRetry204Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // delete202NoRetry204CreateRequest creates the Delete202NoRetry204 request.
@@ -252,6 +226,15 @@ func (client *lrOSOperations) delete202NoRetry204HandleResponse(resp *azcore.Res
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// delete202NoRetry204HandleError handles the Delete202NoRetry204 error response.
+func (client *lrOSOperations) delete202NoRetry204HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Delete202Retry200 - Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
 func (client *lrOSOperations) BeginDelete202Retry200(ctx context.Context) (LrOSDelete202Retry200Poller, error) {
 	req, err := client.delete202Retry200CreateRequest()
@@ -263,7 +246,7 @@ func (client *lrOSOperations) BeginDelete202Retry200(ctx context.Context) (LrOSD
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.delete202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -273,38 +256,15 @@ func (client *lrOSOperations) BeginDelete202Retry200(ctx context.Context) (LrOSD
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSDelete202Retry200Poller(id string) (LrOSDelete202Retry200Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSDelete202Retry200Poller(token string) (LrOSDelete202Retry200Poller, error) {
+	pt, err := resumePollingTracker(token, client.delete202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSDelete202Retry200Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSDelete202Retry200Poller{
+	return &lrOSDelete202Retry200Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSDelete202Retry200Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // delete202Retry200CreateRequest creates the Delete202Retry200 request.
@@ -324,6 +284,15 @@ func (client *lrOSOperations) delete202Retry200HandleResponse(resp *azcore.Respo
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// delete202Retry200HandleError handles the Delete202Retry200 error response.
+func (client *lrOSOperations) delete202Retry200HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Delete204Succeeded - Long running delete succeeds and returns right away
 func (client *lrOSOperations) BeginDelete204Succeeded(ctx context.Context) (LrOSDelete204SucceededPoller, error) {
 	req, err := client.delete204SucceededCreateRequest()
@@ -335,7 +304,7 @@ func (client *lrOSOperations) BeginDelete204Succeeded(ctx context.Context) (LrOS
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.delete204SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -345,38 +314,15 @@ func (client *lrOSOperations) BeginDelete204Succeeded(ctx context.Context) (LrOS
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSDelete204SucceededPoller(id string) (LrOSDelete204SucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSDelete204SucceededPoller(token string) (LrOSDelete204SucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.delete204SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSDelete204SucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSDelete204SucceededPoller{
+	return &lrOSDelete204SucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSDelete204SucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // delete204SucceededCreateRequest creates the Delete204Succeeded request.
@@ -395,6 +341,15 @@ func (client *lrOSOperations) delete204SucceededHandleResponse(resp *azcore.Resp
 	return resp.Response, nil
 }
 
+// delete204SucceededHandleError handles the Delete204Succeeded error response.
+func (client *lrOSOperations) delete204SucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteAsyncNoHeaderInRetry - Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
 func (client *lrOSOperations) BeginDeleteAsyncNoHeaderInRetry(ctx context.Context) (LrOSDeleteAsyncNoHeaderInRetryPoller, error) {
 	req, err := client.deleteAsyncNoHeaderInRetryCreateRequest()
@@ -406,7 +361,7 @@ func (client *lrOSOperations) BeginDeleteAsyncNoHeaderInRetry(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteAsyncNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -416,38 +371,15 @@ func (client *lrOSOperations) BeginDeleteAsyncNoHeaderInRetry(ctx context.Contex
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSDeleteAsyncNoHeaderInRetryPoller(id string) (LrOSDeleteAsyncNoHeaderInRetryPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSDeleteAsyncNoHeaderInRetryPoller(token string) (LrOSDeleteAsyncNoHeaderInRetryPoller, error) {
+	pt, err := resumePollingTracker(token, client.deleteAsyncNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSDeleteAsyncNoHeaderInRetryPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSDeleteAsyncNoHeaderInRetryPoller{
+	return &lrOSDeleteAsyncNoHeaderInRetryPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSDeleteAsyncNoHeaderInRetryPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteAsyncNoHeaderInRetryCreateRequest creates the DeleteAsyncNoHeaderInRetry request.
@@ -470,6 +402,15 @@ func (client *lrOSOperations) deleteAsyncNoHeaderInRetryHandleResponse(resp *azc
 	return &result, nil
 }
 
+// deleteAsyncNoHeaderInRetryHandleError handles the DeleteAsyncNoHeaderInRetry error response.
+func (client *lrOSOperations) deleteAsyncNoHeaderInRetryHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteAsyncNoRetrySucceeded - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrOSOperations) BeginDeleteAsyncNoRetrySucceeded(ctx context.Context) (LrOSDeleteAsyncNoRetrySucceededPoller, error) {
 	req, err := client.deleteAsyncNoRetrySucceededCreateRequest()
@@ -481,7 +422,7 @@ func (client *lrOSOperations) BeginDeleteAsyncNoRetrySucceeded(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteAsyncNoRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -491,38 +432,15 @@ func (client *lrOSOperations) BeginDeleteAsyncNoRetrySucceeded(ctx context.Conte
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSDeleteAsyncNoRetrySucceededPoller(id string) (LrOSDeleteAsyncNoRetrySucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSDeleteAsyncNoRetrySucceededPoller(token string) (LrOSDeleteAsyncNoRetrySucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.deleteAsyncNoRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSDeleteAsyncNoRetrySucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSDeleteAsyncNoRetrySucceededPoller{
+	return &lrOSDeleteAsyncNoRetrySucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSDeleteAsyncNoRetrySucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteAsyncNoRetrySucceededCreateRequest creates the DeleteAsyncNoRetrySucceeded request.
@@ -556,6 +474,15 @@ func (client *lrOSOperations) deleteAsyncNoRetrySucceededHandleResponse(resp *az
 	return &result, nil
 }
 
+// deleteAsyncNoRetrySucceededHandleError handles the DeleteAsyncNoRetrySucceeded error response.
+func (client *lrOSOperations) deleteAsyncNoRetrySucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteAsyncRetryFailed - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrOSOperations) BeginDeleteAsyncRetryFailed(ctx context.Context) (LrOSDeleteAsyncRetryFailedPoller, error) {
 	req, err := client.deleteAsyncRetryFailedCreateRequest()
@@ -567,7 +494,7 @@ func (client *lrOSOperations) BeginDeleteAsyncRetryFailed(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteAsyncRetryFailedHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -577,38 +504,15 @@ func (client *lrOSOperations) BeginDeleteAsyncRetryFailed(ctx context.Context) (
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSDeleteAsyncRetryFailedPoller(id string) (LrOSDeleteAsyncRetryFailedPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSDeleteAsyncRetryFailedPoller(token string) (LrOSDeleteAsyncRetryFailedPoller, error) {
+	pt, err := resumePollingTracker(token, client.deleteAsyncRetryFailedHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSDeleteAsyncRetryFailedPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSDeleteAsyncRetryFailedPoller{
+	return &lrOSDeleteAsyncRetryFailedPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSDeleteAsyncRetryFailedPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteAsyncRetryFailedCreateRequest creates the DeleteAsyncRetryFailed request.
@@ -642,6 +546,15 @@ func (client *lrOSOperations) deleteAsyncRetryFailedHandleResponse(resp *azcore.
 	return &result, nil
 }
 
+// deleteAsyncRetryFailedHandleError handles the DeleteAsyncRetryFailed error response.
+func (client *lrOSOperations) deleteAsyncRetryFailedHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteAsyncRetrySucceeded - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrOSOperations) BeginDeleteAsyncRetrySucceeded(ctx context.Context) (LrOSDeleteAsyncRetrySucceededPoller, error) {
 	req, err := client.deleteAsyncRetrySucceededCreateRequest()
@@ -653,7 +566,7 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrySucceeded(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -663,38 +576,15 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrySucceeded(ctx context.Context
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSDeleteAsyncRetrySucceededPoller(id string) (LrOSDeleteAsyncRetrySucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSDeleteAsyncRetrySucceededPoller(token string) (LrOSDeleteAsyncRetrySucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.deleteAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSDeleteAsyncRetrySucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSDeleteAsyncRetrySucceededPoller{
+	return &lrOSDeleteAsyncRetrySucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSDeleteAsyncRetrySucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteAsyncRetrySucceededCreateRequest creates the DeleteAsyncRetrySucceeded request.
@@ -728,6 +618,15 @@ func (client *lrOSOperations) deleteAsyncRetrySucceededHandleResponse(resp *azco
 	return &result, nil
 }
 
+// deleteAsyncRetrySucceededHandleError handles the DeleteAsyncRetrySucceeded error response.
+func (client *lrOSOperations) deleteAsyncRetrySucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteAsyncRetrycanceled - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrOSOperations) BeginDeleteAsyncRetrycanceled(ctx context.Context) (LrOSDeleteAsyncRetrycanceledPoller, error) {
 	req, err := client.deleteAsyncRetrycanceledCreateRequest()
@@ -739,7 +638,7 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrycanceled(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteAsyncRetrycanceledHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -749,38 +648,15 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrycanceled(ctx context.Context)
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSDeleteAsyncRetrycanceledPoller(id string) (LrOSDeleteAsyncRetrycanceledPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSDeleteAsyncRetrycanceledPoller(token string) (LrOSDeleteAsyncRetrycanceledPoller, error) {
+	pt, err := resumePollingTracker(token, client.deleteAsyncRetrycanceledHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSDeleteAsyncRetrycanceledPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSDeleteAsyncRetrycanceledPoller{
+	return &lrOSDeleteAsyncRetrycanceledPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSDeleteAsyncRetrycanceledPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteAsyncRetrycanceledCreateRequest creates the DeleteAsyncRetrycanceled request.
@@ -814,6 +690,15 @@ func (client *lrOSOperations) deleteAsyncRetrycanceledHandleResponse(resp *azcor
 	return &result, nil
 }
 
+// deleteAsyncRetrycanceledHandleError handles the DeleteAsyncRetrycanceled error response.
+func (client *lrOSOperations) deleteAsyncRetrycanceledHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteNoHeaderInRetry - Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
 func (client *lrOSOperations) BeginDeleteNoHeaderInRetry(ctx context.Context) (LrOSDeleteNoHeaderInRetryPoller, error) {
 	req, err := client.deleteNoHeaderInRetryCreateRequest()
@@ -825,7 +710,7 @@ func (client *lrOSOperations) BeginDeleteNoHeaderInRetry(ctx context.Context) (L
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -835,38 +720,15 @@ func (client *lrOSOperations) BeginDeleteNoHeaderInRetry(ctx context.Context) (L
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSDeleteNoHeaderInRetryPoller(id string) (LrOSDeleteNoHeaderInRetryPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSDeleteNoHeaderInRetryPoller(token string) (LrOSDeleteNoHeaderInRetryPoller, error) {
+	pt, err := resumePollingTracker(token, client.deleteNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSDeleteNoHeaderInRetryPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSDeleteNoHeaderInRetryPoller{
+	return &lrOSDeleteNoHeaderInRetryPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSDeleteNoHeaderInRetryPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteNoHeaderInRetryCreateRequest creates the DeleteNoHeaderInRetry request.
@@ -889,6 +751,15 @@ func (client *lrOSOperations) deleteNoHeaderInRetryHandleResponse(resp *azcore.R
 	return &result, nil
 }
 
+// deleteNoHeaderInRetryHandleError handles the DeleteNoHeaderInRetry error response.
+func (client *lrOSOperations) deleteNoHeaderInRetryHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteProvisioning202Accepted200Succeeded - Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
 func (client *lrOSOperations) BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context) (LrOSDeleteProvisioning202Accepted200SucceededPoller, error) {
 	req, err := client.deleteProvisioning202Accepted200SucceededCreateRequest()
@@ -900,7 +771,7 @@ func (client *lrOSOperations) BeginDeleteProvisioning202Accepted200Succeeded(ctx
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteProvisioning202Accepted200SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -910,38 +781,15 @@ func (client *lrOSOperations) BeginDeleteProvisioning202Accepted200Succeeded(ctx
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSDeleteProvisioning202Accepted200SucceededPoller(id string) (LrOSDeleteProvisioning202Accepted200SucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSDeleteProvisioning202Accepted200SucceededPoller(token string) (LrOSDeleteProvisioning202Accepted200SucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.deleteProvisioning202Accepted200SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSDeleteProvisioning202Accepted200SucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSDeleteProvisioning202Accepted200SucceededPoller{
+	return &lrOSDeleteProvisioning202Accepted200SucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSDeleteProvisioning202Accepted200SucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteProvisioning202Accepted200SucceededCreateRequest creates the DeleteProvisioning202Accepted200Succeeded request.
@@ -961,6 +809,15 @@ func (client *lrOSOperations) deleteProvisioning202Accepted200SucceededHandleRes
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// deleteProvisioning202Accepted200SucceededHandleError handles the DeleteProvisioning202Accepted200Succeeded error response.
+func (client *lrOSOperations) deleteProvisioning202Accepted200SucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteProvisioning202DeletingFailed200 - Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’
 func (client *lrOSOperations) BeginDeleteProvisioning202DeletingFailed200(ctx context.Context) (LrOSDeleteProvisioning202DeletingFailed200Poller, error) {
 	req, err := client.deleteProvisioning202DeletingFailed200CreateRequest()
@@ -972,7 +829,7 @@ func (client *lrOSOperations) BeginDeleteProvisioning202DeletingFailed200(ctx co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteProvisioning202DeletingFailed200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -982,38 +839,15 @@ func (client *lrOSOperations) BeginDeleteProvisioning202DeletingFailed200(ctx co
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSDeleteProvisioning202DeletingFailed200Poller(id string) (LrOSDeleteProvisioning202DeletingFailed200Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSDeleteProvisioning202DeletingFailed200Poller(token string) (LrOSDeleteProvisioning202DeletingFailed200Poller, error) {
+	pt, err := resumePollingTracker(token, client.deleteProvisioning202DeletingFailed200HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSDeleteProvisioning202DeletingFailed200Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSDeleteProvisioning202DeletingFailed200Poller{
+	return &lrOSDeleteProvisioning202DeletingFailed200Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSDeleteProvisioning202DeletingFailed200Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteProvisioning202DeletingFailed200CreateRequest creates the DeleteProvisioning202DeletingFailed200 request.
@@ -1033,6 +867,15 @@ func (client *lrOSOperations) deleteProvisioning202DeletingFailed200HandleRespon
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// deleteProvisioning202DeletingFailed200HandleError handles the DeleteProvisioning202DeletingFailed200 error response.
+func (client *lrOSOperations) deleteProvisioning202DeletingFailed200HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteProvisioning202Deletingcanceled200 - Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’
 func (client *lrOSOperations) BeginDeleteProvisioning202Deletingcanceled200(ctx context.Context) (LrOSDeleteProvisioning202Deletingcanceled200Poller, error) {
 	req, err := client.deleteProvisioning202Deletingcanceled200CreateRequest()
@@ -1044,7 +887,7 @@ func (client *lrOSOperations) BeginDeleteProvisioning202Deletingcanceled200(ctx 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteProvisioning202Deletingcanceled200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1054,38 +897,15 @@ func (client *lrOSOperations) BeginDeleteProvisioning202Deletingcanceled200(ctx 
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSDeleteProvisioning202Deletingcanceled200Poller(id string) (LrOSDeleteProvisioning202Deletingcanceled200Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSDeleteProvisioning202Deletingcanceled200Poller(token string) (LrOSDeleteProvisioning202Deletingcanceled200Poller, error) {
+	pt, err := resumePollingTracker(token, client.deleteProvisioning202Deletingcanceled200HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSDeleteProvisioning202Deletingcanceled200Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSDeleteProvisioning202Deletingcanceled200Poller{
+	return &lrOSDeleteProvisioning202Deletingcanceled200Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSDeleteProvisioning202Deletingcanceled200Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteProvisioning202Deletingcanceled200CreateRequest creates the DeleteProvisioning202Deletingcanceled200 request.
@@ -1105,6 +925,15 @@ func (client *lrOSOperations) deleteProvisioning202Deletingcanceled200HandleResp
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// deleteProvisioning202Deletingcanceled200HandleError handles the DeleteProvisioning202Deletingcanceled200 error response.
+func (client *lrOSOperations) deleteProvisioning202Deletingcanceled200HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Post200WithPayload - Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
 func (client *lrOSOperations) BeginPost200WithPayload(ctx context.Context) (LrOSPost200WithPayloadPoller, error) {
 	req, err := client.post200WithPayloadCreateRequest()
@@ -1116,7 +945,7 @@ func (client *lrOSOperations) BeginPost200WithPayload(ctx context.Context) (LrOS
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.post200WithPayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1126,38 +955,15 @@ func (client *lrOSOperations) BeginPost200WithPayload(ctx context.Context) (LrOS
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPost200WithPayloadPoller(id string) (LrOSPost200WithPayloadPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPost200WithPayloadPoller(token string) (LrOSPost200WithPayloadPoller, error) {
+	pt, err := resumePollingTracker(token, client.post200WithPayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPost200WithPayloadPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPost200WithPayloadPoller{
+	return &lrOSPost200WithPayloadPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPost200WithPayloadPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // post200WithPayloadCreateRequest creates the Post200WithPayload request.
@@ -1177,6 +983,15 @@ func (client *lrOSOperations) post200WithPayloadHandleResponse(resp *azcore.Resp
 	return &result, resp.UnmarshalAsJSON(&result.Sku)
 }
 
+// post200WithPayloadHandleError handles the Post200WithPayload error response.
+func (client *lrOSOperations) post200WithPayloadHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Post202NoRetry204 - Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success
 func (client *lrOSOperations) BeginPost202NoRetry204(ctx context.Context, lrOSPost202NoRetry204Options *LrOSPost202NoRetry204Options) (LrOSPost202NoRetry204Poller, error) {
 	req, err := client.post202NoRetry204CreateRequest(lrOSPost202NoRetry204Options)
@@ -1188,7 +1003,7 @@ func (client *lrOSOperations) BeginPost202NoRetry204(ctx context.Context, lrOSPo
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.post202NoRetry204HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1198,38 +1013,15 @@ func (client *lrOSOperations) BeginPost202NoRetry204(ctx context.Context, lrOSPo
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPost202NoRetry204Poller(id string) (LrOSPost202NoRetry204Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPost202NoRetry204Poller(token string) (LrOSPost202NoRetry204Poller, error) {
+	pt, err := resumePollingTracker(token, client.post202NoRetry204HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPost202NoRetry204Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPost202NoRetry204Poller{
+	return &lrOSPost202NoRetry204Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPost202NoRetry204Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // post202NoRetry204CreateRequest creates the Post202NoRetry204 request.
@@ -1252,6 +1044,15 @@ func (client *lrOSOperations) post202NoRetry204HandleResponse(resp *azcore.Respo
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// post202NoRetry204HandleError handles the Post202NoRetry204 error response.
+func (client *lrOSOperations) post202NoRetry204HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Post202Retry200 - Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
 func (client *lrOSOperations) BeginPost202Retry200(ctx context.Context, lrOSPost202Retry200Options *LrOSPost202Retry200Options) (LrOSPost202Retry200Poller, error) {
 	req, err := client.post202Retry200CreateRequest(lrOSPost202Retry200Options)
@@ -1263,7 +1064,7 @@ func (client *lrOSOperations) BeginPost202Retry200(ctx context.Context, lrOSPost
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.post202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1273,38 +1074,15 @@ func (client *lrOSOperations) BeginPost202Retry200(ctx context.Context, lrOSPost
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPost202Retry200Poller(id string) (LrOSPost202Retry200Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPost202Retry200Poller(token string) (LrOSPost202Retry200Poller, error) {
+	pt, err := resumePollingTracker(token, client.post202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPost202Retry200Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPost202Retry200Poller{
+	return &lrOSPost202Retry200Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPost202Retry200Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // post202Retry200CreateRequest creates the Post202Retry200 request.
@@ -1338,6 +1116,15 @@ func (client *lrOSOperations) post202Retry200HandleResponse(resp *azcore.Respons
 	return &result, nil
 }
 
+// post202Retry200HandleError handles the Post202Retry200 error response.
+func (client *lrOSOperations) post202Retry200HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PostAsyncNoRetrySucceeded - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrOSOperations) BeginPostAsyncNoRetrySucceeded(ctx context.Context, lrOSPostAsyncNoRetrySucceededOptions *LrOSPostAsyncNoRetrySucceededOptions) (LrOSPostAsyncNoRetrySucceededPoller, error) {
 	req, err := client.postAsyncNoRetrySucceededCreateRequest(lrOSPostAsyncNoRetrySucceededOptions)
@@ -1349,7 +1136,7 @@ func (client *lrOSOperations) BeginPostAsyncNoRetrySucceeded(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.postAsyncNoRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1359,38 +1146,15 @@ func (client *lrOSOperations) BeginPostAsyncNoRetrySucceeded(ctx context.Context
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPostAsyncNoRetrySucceededPoller(id string) (LrOSPostAsyncNoRetrySucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPostAsyncNoRetrySucceededPoller(token string) (LrOSPostAsyncNoRetrySucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.postAsyncNoRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPostAsyncNoRetrySucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPostAsyncNoRetrySucceededPoller{
+	return &lrOSPostAsyncNoRetrySucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPostAsyncNoRetrySucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // postAsyncNoRetrySucceededCreateRequest creates the PostAsyncNoRetrySucceeded request.
@@ -1413,6 +1177,15 @@ func (client *lrOSOperations) postAsyncNoRetrySucceededHandleResponse(resp *azco
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// postAsyncNoRetrySucceededHandleError handles the PostAsyncNoRetrySucceeded error response.
+func (client *lrOSOperations) postAsyncNoRetrySucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PostAsyncRetryFailed - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrOSOperations) BeginPostAsyncRetryFailed(ctx context.Context, lrOSPostAsyncRetryFailedOptions *LrOSPostAsyncRetryFailedOptions) (LrOSPostAsyncRetryFailedPoller, error) {
 	req, err := client.postAsyncRetryFailedCreateRequest(lrOSPostAsyncRetryFailedOptions)
@@ -1424,7 +1197,7 @@ func (client *lrOSOperations) BeginPostAsyncRetryFailed(ctx context.Context, lrO
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.postAsyncRetryFailedHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1434,38 +1207,15 @@ func (client *lrOSOperations) BeginPostAsyncRetryFailed(ctx context.Context, lrO
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPostAsyncRetryFailedPoller(id string) (LrOSPostAsyncRetryFailedPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPostAsyncRetryFailedPoller(token string) (LrOSPostAsyncRetryFailedPoller, error) {
+	pt, err := resumePollingTracker(token, client.postAsyncRetryFailedHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPostAsyncRetryFailedPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPostAsyncRetryFailedPoller{
+	return &lrOSPostAsyncRetryFailedPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPostAsyncRetryFailedPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // postAsyncRetryFailedCreateRequest creates the PostAsyncRetryFailed request.
@@ -1502,6 +1252,15 @@ func (client *lrOSOperations) postAsyncRetryFailedHandleResponse(resp *azcore.Re
 	return &result, nil
 }
 
+// postAsyncRetryFailedHandleError handles the PostAsyncRetryFailed error response.
+func (client *lrOSOperations) postAsyncRetryFailedHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PostAsyncRetrySucceeded - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrOSOperations) BeginPostAsyncRetrySucceeded(ctx context.Context, lrOSPostAsyncRetrySucceededOptions *LrOSPostAsyncRetrySucceededOptions) (LrOSPostAsyncRetrySucceededPoller, error) {
 	req, err := client.postAsyncRetrySucceededCreateRequest(lrOSPostAsyncRetrySucceededOptions)
@@ -1513,7 +1272,7 @@ func (client *lrOSOperations) BeginPostAsyncRetrySucceeded(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.postAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1523,38 +1282,15 @@ func (client *lrOSOperations) BeginPostAsyncRetrySucceeded(ctx context.Context, 
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPostAsyncRetrySucceededPoller(id string) (LrOSPostAsyncRetrySucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPostAsyncRetrySucceededPoller(token string) (LrOSPostAsyncRetrySucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.postAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPostAsyncRetrySucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPostAsyncRetrySucceededPoller{
+	return &lrOSPostAsyncRetrySucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPostAsyncRetrySucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // postAsyncRetrySucceededCreateRequest creates the PostAsyncRetrySucceeded request.
@@ -1577,6 +1313,15 @@ func (client *lrOSOperations) postAsyncRetrySucceededHandleResponse(resp *azcore
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// postAsyncRetrySucceededHandleError handles the PostAsyncRetrySucceeded error response.
+func (client *lrOSOperations) postAsyncRetrySucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PostAsyncRetrycanceled - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrOSOperations) BeginPostAsyncRetrycanceled(ctx context.Context, lrOSPostAsyncRetrycanceledOptions *LrOSPostAsyncRetrycanceledOptions) (LrOSPostAsyncRetrycanceledPoller, error) {
 	req, err := client.postAsyncRetrycanceledCreateRequest(lrOSPostAsyncRetrycanceledOptions)
@@ -1588,7 +1333,7 @@ func (client *lrOSOperations) BeginPostAsyncRetrycanceled(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.postAsyncRetrycanceledHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1598,38 +1343,15 @@ func (client *lrOSOperations) BeginPostAsyncRetrycanceled(ctx context.Context, l
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPostAsyncRetrycanceledPoller(id string) (LrOSPostAsyncRetrycanceledPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPostAsyncRetrycanceledPoller(token string) (LrOSPostAsyncRetrycanceledPoller, error) {
+	pt, err := resumePollingTracker(token, client.postAsyncRetrycanceledHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPostAsyncRetrycanceledPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPostAsyncRetrycanceledPoller{
+	return &lrOSPostAsyncRetrycanceledPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPostAsyncRetrycanceledPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // postAsyncRetrycanceledCreateRequest creates the PostAsyncRetrycanceled request.
@@ -1666,6 +1388,15 @@ func (client *lrOSOperations) postAsyncRetrycanceledHandleResponse(resp *azcore.
 	return &result, nil
 }
 
+// postAsyncRetrycanceledHandleError handles the PostAsyncRetrycanceled error response.
+func (client *lrOSOperations) postAsyncRetrycanceledHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PostDoubleHeadersFinalAzureHeaderGet - Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the final object
 func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx context.Context) (LrOSPostDoubleHeadersFinalAzureHeaderGetPoller, error) {
 	req, err := client.postDoubleHeadersFinalAzureHeaderGetCreateRequest()
@@ -1677,7 +1408,7 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.postDoubleHeadersFinalAzureHeaderGetHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1687,38 +1418,15 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx cont
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPostDoubleHeadersFinalAzureHeaderGetPoller(id string) (LrOSPostDoubleHeadersFinalAzureHeaderGetPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPostDoubleHeadersFinalAzureHeaderGetPoller(token string) (LrOSPostDoubleHeadersFinalAzureHeaderGetPoller, error) {
+	pt, err := resumePollingTracker(token, client.postDoubleHeadersFinalAzureHeaderGetHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPostDoubleHeadersFinalAzureHeaderGetPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPostDoubleHeadersFinalAzureHeaderGetPoller{
+	return &lrOSPostDoubleHeadersFinalAzureHeaderGetPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPostDoubleHeadersFinalAzureHeaderGetPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // postDoubleHeadersFinalAzureHeaderGetCreateRequest creates the PostDoubleHeadersFinalAzureHeaderGet request.
@@ -1738,6 +1446,15 @@ func (client *lrOSOperations) postDoubleHeadersFinalAzureHeaderGetHandleResponse
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// postDoubleHeadersFinalAzureHeaderGetHandleError handles the PostDoubleHeadersFinalAzureHeaderGet error response.
+func (client *lrOSOperations) postDoubleHeadersFinalAzureHeaderGetHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PostDoubleHeadersFinalAzureHeaderGetDefault - Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the final object if you support initial Autorest behavior.
 func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(ctx context.Context) (LrOSPostDoubleHeadersFinalAzureHeaderGetDefaultPoller, error) {
 	req, err := client.postDoubleHeadersFinalAzureHeaderGetDefaultCreateRequest()
@@ -1749,7 +1466,7 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(c
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.postDoubleHeadersFinalAzureHeaderGetDefaultHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1759,38 +1476,15 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(c
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPostDoubleHeadersFinalAzureHeaderGetDefaultPoller(id string) (LrOSPostDoubleHeadersFinalAzureHeaderGetDefaultPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPostDoubleHeadersFinalAzureHeaderGetDefaultPoller(token string) (LrOSPostDoubleHeadersFinalAzureHeaderGetDefaultPoller, error) {
+	pt, err := resumePollingTracker(token, client.postDoubleHeadersFinalAzureHeaderGetDefaultHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPostDoubleHeadersFinalAzureHeaderGetDefaultPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPostDoubleHeadersFinalAzureHeaderGetDefaultPoller{
+	return &lrOSPostDoubleHeadersFinalAzureHeaderGetDefaultPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPostDoubleHeadersFinalAzureHeaderGetDefaultPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // postDoubleHeadersFinalAzureHeaderGetDefaultCreateRequest creates the PostDoubleHeadersFinalAzureHeaderGetDefault request.
@@ -1810,6 +1504,15 @@ func (client *lrOSOperations) postDoubleHeadersFinalAzureHeaderGetDefaultHandleR
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// postDoubleHeadersFinalAzureHeaderGetDefaultHandleError handles the PostDoubleHeadersFinalAzureHeaderGetDefault error response.
+func (client *lrOSOperations) postDoubleHeadersFinalAzureHeaderGetDefaultHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PostDoubleHeadersFinalLocationGet - Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header. Poll Azure-Async and it's success. Should poll Location to get the final object
 func (client *lrOSOperations) BeginPostDoubleHeadersFinalLocationGet(ctx context.Context) (LrOSPostDoubleHeadersFinalLocationGetPoller, error) {
 	req, err := client.postDoubleHeadersFinalLocationGetCreateRequest()
@@ -1821,7 +1524,7 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalLocationGet(ctx context
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.postDoubleHeadersFinalLocationGetHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1831,38 +1534,15 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalLocationGet(ctx context
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPostDoubleHeadersFinalLocationGetPoller(id string) (LrOSPostDoubleHeadersFinalLocationGetPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPostDoubleHeadersFinalLocationGetPoller(token string) (LrOSPostDoubleHeadersFinalLocationGetPoller, error) {
+	pt, err := resumePollingTracker(token, client.postDoubleHeadersFinalLocationGetHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPostDoubleHeadersFinalLocationGetPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPostDoubleHeadersFinalLocationGetPoller{
+	return &lrOSPostDoubleHeadersFinalLocationGetPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPostDoubleHeadersFinalLocationGetPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // postDoubleHeadersFinalLocationGetCreateRequest creates the PostDoubleHeadersFinalLocationGet request.
@@ -1882,6 +1562,15 @@ func (client *lrOSOperations) postDoubleHeadersFinalLocationGetHandleResponse(re
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// postDoubleHeadersFinalLocationGetHandleError handles the PostDoubleHeadersFinalLocationGet error response.
+func (client *lrOSOperations) postDoubleHeadersFinalLocationGetHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Put200Acceptedcanceled200 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’
 func (client *lrOSOperations) BeginPut200Acceptedcanceled200(ctx context.Context, lrOSPut200Acceptedcanceled200Options *LrOSPut200Acceptedcanceled200Options) (LrOSPut200Acceptedcanceled200Poller, error) {
 	req, err := client.put200Acceptedcanceled200CreateRequest(lrOSPut200Acceptedcanceled200Options)
@@ -1893,7 +1582,7 @@ func (client *lrOSOperations) BeginPut200Acceptedcanceled200(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.put200Acceptedcanceled200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1903,38 +1592,15 @@ func (client *lrOSOperations) BeginPut200Acceptedcanceled200(ctx context.Context
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPut200Acceptedcanceled200Poller(id string) (LrOSPut200Acceptedcanceled200Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPut200Acceptedcanceled200Poller(token string) (LrOSPut200Acceptedcanceled200Poller, error) {
+	pt, err := resumePollingTracker(token, client.put200Acceptedcanceled200HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPut200Acceptedcanceled200Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPut200Acceptedcanceled200Poller{
+	return &lrOSPut200Acceptedcanceled200Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPut200Acceptedcanceled200Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // put200Acceptedcanceled200CreateRequest creates the Put200Acceptedcanceled200 request.
@@ -1957,6 +1623,15 @@ func (client *lrOSOperations) put200Acceptedcanceled200HandleResponse(resp *azco
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// put200Acceptedcanceled200HandleError handles the Put200Acceptedcanceled200 error response.
+func (client *lrOSOperations) put200Acceptedcanceled200HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Put200Succeeded - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
 func (client *lrOSOperations) BeginPut200Succeeded(ctx context.Context, lrOSPut200SucceededOptions *LrOSPut200SucceededOptions) (LrOSPut200SucceededPoller, error) {
 	req, err := client.put200SucceededCreateRequest(lrOSPut200SucceededOptions)
@@ -1968,7 +1643,7 @@ func (client *lrOSOperations) BeginPut200Succeeded(ctx context.Context, lrOSPut2
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.put200SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1978,38 +1653,15 @@ func (client *lrOSOperations) BeginPut200Succeeded(ctx context.Context, lrOSPut2
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPut200SucceededPoller(id string) (LrOSPut200SucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPut200SucceededPoller(token string) (LrOSPut200SucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.put200SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPut200SucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPut200SucceededPoller{
+	return &lrOSPut200SucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPut200SucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // put200SucceededCreateRequest creates the Put200Succeeded request.
@@ -2032,6 +1684,15 @@ func (client *lrOSOperations) put200SucceededHandleResponse(resp *azcore.Respons
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// put200SucceededHandleError handles the Put200Succeeded error response.
+func (client *lrOSOperations) put200SucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Put200SucceededNoState - Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
 func (client *lrOSOperations) BeginPut200SucceededNoState(ctx context.Context, lrOSPut200SucceededNoStateOptions *LrOSPut200SucceededNoStateOptions) (LrOSPut200SucceededNoStatePoller, error) {
 	req, err := client.put200SucceededNoStateCreateRequest(lrOSPut200SucceededNoStateOptions)
@@ -2043,7 +1704,7 @@ func (client *lrOSOperations) BeginPut200SucceededNoState(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.put200SucceededNoStateHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2053,38 +1714,15 @@ func (client *lrOSOperations) BeginPut200SucceededNoState(ctx context.Context, l
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPut200SucceededNoStatePoller(id string) (LrOSPut200SucceededNoStatePoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPut200SucceededNoStatePoller(token string) (LrOSPut200SucceededNoStatePoller, error) {
+	pt, err := resumePollingTracker(token, client.put200SucceededNoStateHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPut200SucceededNoStatePoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPut200SucceededNoStatePoller{
+	return &lrOSPut200SucceededNoStatePoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPut200SucceededNoStatePoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // put200SucceededNoStateCreateRequest creates the Put200SucceededNoState request.
@@ -2107,6 +1745,15 @@ func (client *lrOSOperations) put200SucceededNoStateHandleResponse(resp *azcore.
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// put200SucceededNoStateHandleError handles the Put200SucceededNoState error response.
+func (client *lrOSOperations) put200SucceededNoStateHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Put200UpdatingSucceeded204 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
 func (client *lrOSOperations) BeginPut200UpdatingSucceeded204(ctx context.Context, lrOSPut200UpdatingSucceeded204Options *LrOSPut200UpdatingSucceeded204Options) (LrOSPut200UpdatingSucceeded204Poller, error) {
 	req, err := client.put200UpdatingSucceeded204CreateRequest(lrOSPut200UpdatingSucceeded204Options)
@@ -2118,7 +1765,7 @@ func (client *lrOSOperations) BeginPut200UpdatingSucceeded204(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.put200UpdatingSucceeded204HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2128,38 +1775,15 @@ func (client *lrOSOperations) BeginPut200UpdatingSucceeded204(ctx context.Contex
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPut200UpdatingSucceeded204Poller(id string) (LrOSPut200UpdatingSucceeded204Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPut200UpdatingSucceeded204Poller(token string) (LrOSPut200UpdatingSucceeded204Poller, error) {
+	pt, err := resumePollingTracker(token, client.put200UpdatingSucceeded204HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPut200UpdatingSucceeded204Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPut200UpdatingSucceeded204Poller{
+	return &lrOSPut200UpdatingSucceeded204Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPut200UpdatingSucceeded204Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // put200UpdatingSucceeded204CreateRequest creates the Put200UpdatingSucceeded204 request.
@@ -2182,6 +1806,15 @@ func (client *lrOSOperations) put200UpdatingSucceeded204HandleResponse(resp *azc
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// put200UpdatingSucceeded204HandleError handles the Put200UpdatingSucceeded204 error response.
+func (client *lrOSOperations) put200UpdatingSucceeded204HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Put201CreatingFailed200 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’
 func (client *lrOSOperations) BeginPut201CreatingFailed200(ctx context.Context, lrOSPut201CreatingFailed200Options *LrOSPut201CreatingFailed200Options) (LrOSPut201CreatingFailed200Poller, error) {
 	req, err := client.put201CreatingFailed200CreateRequest(lrOSPut201CreatingFailed200Options)
@@ -2193,7 +1826,7 @@ func (client *lrOSOperations) BeginPut201CreatingFailed200(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.put201CreatingFailed200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2203,38 +1836,15 @@ func (client *lrOSOperations) BeginPut201CreatingFailed200(ctx context.Context, 
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPut201CreatingFailed200Poller(id string) (LrOSPut201CreatingFailed200Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPut201CreatingFailed200Poller(token string) (LrOSPut201CreatingFailed200Poller, error) {
+	pt, err := resumePollingTracker(token, client.put201CreatingFailed200HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPut201CreatingFailed200Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPut201CreatingFailed200Poller{
+	return &lrOSPut201CreatingFailed200Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPut201CreatingFailed200Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // put201CreatingFailed200CreateRequest creates the Put201CreatingFailed200 request.
@@ -2257,6 +1867,15 @@ func (client *lrOSOperations) put201CreatingFailed200HandleResponse(resp *azcore
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// put201CreatingFailed200HandleError handles the Put201CreatingFailed200 error response.
+func (client *lrOSOperations) put201CreatingFailed200HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Put201CreatingSucceeded200 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
 func (client *lrOSOperations) BeginPut201CreatingSucceeded200(ctx context.Context, lrOSPut201CreatingSucceeded200Options *LrOSPut201CreatingSucceeded200Options) (LrOSPut201CreatingSucceeded200Poller, error) {
 	req, err := client.put201CreatingSucceeded200CreateRequest(lrOSPut201CreatingSucceeded200Options)
@@ -2268,7 +1887,7 @@ func (client *lrOSOperations) BeginPut201CreatingSucceeded200(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2278,38 +1897,15 @@ func (client *lrOSOperations) BeginPut201CreatingSucceeded200(ctx context.Contex
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPut201CreatingSucceeded200Poller(id string) (LrOSPut201CreatingSucceeded200Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPut201CreatingSucceeded200Poller(token string) (LrOSPut201CreatingSucceeded200Poller, error) {
+	pt, err := resumePollingTracker(token, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPut201CreatingSucceeded200Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPut201CreatingSucceeded200Poller{
+	return &lrOSPut201CreatingSucceeded200Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPut201CreatingSucceeded200Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // put201CreatingSucceeded200CreateRequest creates the Put201CreatingSucceeded200 request.
@@ -2332,6 +1928,15 @@ func (client *lrOSOperations) put201CreatingSucceeded200HandleResponse(resp *azc
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// put201CreatingSucceeded200HandleError handles the Put201CreatingSucceeded200 error response.
+func (client *lrOSOperations) put201CreatingSucceeded200HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Put202Retry200 - Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState
 func (client *lrOSOperations) BeginPut202Retry200(ctx context.Context, lrOSPut202Retry200Options *LrOSPut202Retry200Options) (LrOSPut202Retry200Poller, error) {
 	req, err := client.put202Retry200CreateRequest(lrOSPut202Retry200Options)
@@ -2343,7 +1948,7 @@ func (client *lrOSOperations) BeginPut202Retry200(ctx context.Context, lrOSPut20
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.put202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2353,38 +1958,15 @@ func (client *lrOSOperations) BeginPut202Retry200(ctx context.Context, lrOSPut20
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPut202Retry200Poller(id string) (LrOSPut202Retry200Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPut202Retry200Poller(token string) (LrOSPut202Retry200Poller, error) {
+	pt, err := resumePollingTracker(token, client.put202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPut202Retry200Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPut202Retry200Poller{
+	return &lrOSPut202Retry200Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPut202Retry200Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // put202Retry200CreateRequest creates the Put202Retry200 request.
@@ -2407,6 +1989,15 @@ func (client *lrOSOperations) put202Retry200HandleResponse(resp *azcore.Response
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// put202Retry200HandleError handles the Put202Retry200 error response.
+func (client *lrOSOperations) put202Retry200HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutAsyncNoHeaderInRetry - Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
 func (client *lrOSOperations) BeginPutAsyncNoHeaderInRetry(ctx context.Context, lrOSPutAsyncNoHeaderInRetryOptions *LrOSPutAsyncNoHeaderInRetryOptions) (LrOSPutAsyncNoHeaderInRetryPoller, error) {
 	req, err := client.putAsyncNoHeaderInRetryCreateRequest(lrOSPutAsyncNoHeaderInRetryOptions)
@@ -2418,7 +2009,7 @@ func (client *lrOSOperations) BeginPutAsyncNoHeaderInRetry(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putAsyncNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2428,38 +2019,15 @@ func (client *lrOSOperations) BeginPutAsyncNoHeaderInRetry(ctx context.Context, 
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPutAsyncNoHeaderInRetryPoller(id string) (LrOSPutAsyncNoHeaderInRetryPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPutAsyncNoHeaderInRetryPoller(token string) (LrOSPutAsyncNoHeaderInRetryPoller, error) {
+	pt, err := resumePollingTracker(token, client.putAsyncNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPutAsyncNoHeaderInRetryPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPutAsyncNoHeaderInRetryPoller{
+	return &lrOSPutAsyncNoHeaderInRetryPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPutAsyncNoHeaderInRetryPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putAsyncNoHeaderInRetryCreateRequest creates the PutAsyncNoHeaderInRetry request.
@@ -2482,6 +2050,15 @@ func (client *lrOSOperations) putAsyncNoHeaderInRetryHandleResponse(resp *azcore
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// putAsyncNoHeaderInRetryHandleError handles the PutAsyncNoHeaderInRetry error response.
+func (client *lrOSOperations) putAsyncNoHeaderInRetryHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutAsyncNoRetrySucceeded - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrOSOperations) BeginPutAsyncNoRetrySucceeded(ctx context.Context, lrOSPutAsyncNoRetrySucceededOptions *LrOSPutAsyncNoRetrySucceededOptions) (LrOSPutAsyncNoRetrySucceededPoller, error) {
 	req, err := client.putAsyncNoRetrySucceededCreateRequest(lrOSPutAsyncNoRetrySucceededOptions)
@@ -2493,7 +2070,7 @@ func (client *lrOSOperations) BeginPutAsyncNoRetrySucceeded(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putAsyncNoRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2503,38 +2080,15 @@ func (client *lrOSOperations) BeginPutAsyncNoRetrySucceeded(ctx context.Context,
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPutAsyncNoRetrySucceededPoller(id string) (LrOSPutAsyncNoRetrySucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPutAsyncNoRetrySucceededPoller(token string) (LrOSPutAsyncNoRetrySucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.putAsyncNoRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPutAsyncNoRetrySucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPutAsyncNoRetrySucceededPoller{
+	return &lrOSPutAsyncNoRetrySucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPutAsyncNoRetrySucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putAsyncNoRetrySucceededCreateRequest creates the PutAsyncNoRetrySucceeded request.
@@ -2557,6 +2111,15 @@ func (client *lrOSOperations) putAsyncNoRetrySucceededHandleResponse(resp *azcor
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// putAsyncNoRetrySucceededHandleError handles the PutAsyncNoRetrySucceeded error response.
+func (client *lrOSOperations) putAsyncNoRetrySucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutAsyncNoRetrycanceled - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrOSOperations) BeginPutAsyncNoRetrycanceled(ctx context.Context, lrOSPutAsyncNoRetrycanceledOptions *LrOSPutAsyncNoRetrycanceledOptions) (LrOSPutAsyncNoRetrycanceledPoller, error) {
 	req, err := client.putAsyncNoRetrycanceledCreateRequest(lrOSPutAsyncNoRetrycanceledOptions)
@@ -2568,7 +2131,7 @@ func (client *lrOSOperations) BeginPutAsyncNoRetrycanceled(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putAsyncNoRetrycanceledHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2578,38 +2141,15 @@ func (client *lrOSOperations) BeginPutAsyncNoRetrycanceled(ctx context.Context, 
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPutAsyncNoRetrycanceledPoller(id string) (LrOSPutAsyncNoRetrycanceledPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPutAsyncNoRetrycanceledPoller(token string) (LrOSPutAsyncNoRetrycanceledPoller, error) {
+	pt, err := resumePollingTracker(token, client.putAsyncNoRetrycanceledHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPutAsyncNoRetrycanceledPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPutAsyncNoRetrycanceledPoller{
+	return &lrOSPutAsyncNoRetrycanceledPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPutAsyncNoRetrycanceledPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putAsyncNoRetrycanceledCreateRequest creates the PutAsyncNoRetrycanceled request.
@@ -2632,6 +2172,15 @@ func (client *lrOSOperations) putAsyncNoRetrycanceledHandleResponse(resp *azcore
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// putAsyncNoRetrycanceledHandleError handles the PutAsyncNoRetrycanceled error response.
+func (client *lrOSOperations) putAsyncNoRetrycanceledHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutAsyncNonResource - Long running put request with non resource.
 func (client *lrOSOperations) BeginPutAsyncNonResource(ctx context.Context, lrOSPutAsyncNonResourceOptions *LrOSPutAsyncNonResourceOptions) (LrOSPutAsyncNonResourcePoller, error) {
 	req, err := client.putAsyncNonResourceCreateRequest(lrOSPutAsyncNonResourceOptions)
@@ -2643,7 +2192,7 @@ func (client *lrOSOperations) BeginPutAsyncNonResource(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putAsyncNonResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2653,38 +2202,15 @@ func (client *lrOSOperations) BeginPutAsyncNonResource(ctx context.Context, lrOS
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPutAsyncNonResourcePoller(id string) (LrOSPutAsyncNonResourcePoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPutAsyncNonResourcePoller(token string) (LrOSPutAsyncNonResourcePoller, error) {
+	pt, err := resumePollingTracker(token, client.putAsyncNonResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPutAsyncNonResourcePoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPutAsyncNonResourcePoller{
+	return &lrOSPutAsyncNonResourcePoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPutAsyncNonResourcePoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putAsyncNonResourceCreateRequest creates the PutAsyncNonResource request.
@@ -2707,6 +2233,15 @@ func (client *lrOSOperations) putAsyncNonResourceHandleResponse(resp *azcore.Res
 	return &result, resp.UnmarshalAsJSON(&result.Sku)
 }
 
+// putAsyncNonResourceHandleError handles the PutAsyncNonResource error response.
+func (client *lrOSOperations) putAsyncNonResourceHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutAsyncRetryFailed - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrOSOperations) BeginPutAsyncRetryFailed(ctx context.Context, lrOSPutAsyncRetryFailedOptions *LrOSPutAsyncRetryFailedOptions) (LrOSPutAsyncRetryFailedPoller, error) {
 	req, err := client.putAsyncRetryFailedCreateRequest(lrOSPutAsyncRetryFailedOptions)
@@ -2718,7 +2253,7 @@ func (client *lrOSOperations) BeginPutAsyncRetryFailed(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putAsyncRetryFailedHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2728,38 +2263,15 @@ func (client *lrOSOperations) BeginPutAsyncRetryFailed(ctx context.Context, lrOS
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPutAsyncRetryFailedPoller(id string) (LrOSPutAsyncRetryFailedPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPutAsyncRetryFailedPoller(token string) (LrOSPutAsyncRetryFailedPoller, error) {
+	pt, err := resumePollingTracker(token, client.putAsyncRetryFailedHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPutAsyncRetryFailedPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPutAsyncRetryFailedPoller{
+	return &lrOSPutAsyncRetryFailedPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPutAsyncRetryFailedPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putAsyncRetryFailedCreateRequest creates the PutAsyncRetryFailed request.
@@ -2782,6 +2294,15 @@ func (client *lrOSOperations) putAsyncRetryFailedHandleResponse(resp *azcore.Res
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// putAsyncRetryFailedHandleError handles the PutAsyncRetryFailed error response.
+func (client *lrOSOperations) putAsyncRetryFailedHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutAsyncRetrySucceeded - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrOSOperations) BeginPutAsyncRetrySucceeded(ctx context.Context, lrOSPutAsyncRetrySucceededOptions *LrOSPutAsyncRetrySucceededOptions) (LrOSPutAsyncRetrySucceededPoller, error) {
 	req, err := client.putAsyncRetrySucceededCreateRequest(lrOSPutAsyncRetrySucceededOptions)
@@ -2793,7 +2314,7 @@ func (client *lrOSOperations) BeginPutAsyncRetrySucceeded(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2803,38 +2324,15 @@ func (client *lrOSOperations) BeginPutAsyncRetrySucceeded(ctx context.Context, l
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPutAsyncRetrySucceededPoller(id string) (LrOSPutAsyncRetrySucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPutAsyncRetrySucceededPoller(token string) (LrOSPutAsyncRetrySucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.putAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPutAsyncRetrySucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPutAsyncRetrySucceededPoller{
+	return &lrOSPutAsyncRetrySucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPutAsyncRetrySucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putAsyncRetrySucceededCreateRequest creates the PutAsyncRetrySucceeded request.
@@ -2857,6 +2355,15 @@ func (client *lrOSOperations) putAsyncRetrySucceededHandleResponse(resp *azcore.
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// putAsyncRetrySucceededHandleError handles the PutAsyncRetrySucceeded error response.
+func (client *lrOSOperations) putAsyncRetrySucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutAsyncSubResource - Long running put request with sub resource.
 func (client *lrOSOperations) BeginPutAsyncSubResource(ctx context.Context, lrOSPutAsyncSubResourceOptions *LrOSPutAsyncSubResourceOptions) (LrOSPutAsyncSubResourcePoller, error) {
 	req, err := client.putAsyncSubResourceCreateRequest(lrOSPutAsyncSubResourceOptions)
@@ -2868,7 +2375,7 @@ func (client *lrOSOperations) BeginPutAsyncSubResource(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putAsyncSubResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2878,38 +2385,15 @@ func (client *lrOSOperations) BeginPutAsyncSubResource(ctx context.Context, lrOS
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPutAsyncSubResourcePoller(id string) (LrOSPutAsyncSubResourcePoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPutAsyncSubResourcePoller(token string) (LrOSPutAsyncSubResourcePoller, error) {
+	pt, err := resumePollingTracker(token, client.putAsyncSubResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPutAsyncSubResourcePoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPutAsyncSubResourcePoller{
+	return &lrOSPutAsyncSubResourcePoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPutAsyncSubResourcePoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putAsyncSubResourceCreateRequest creates the PutAsyncSubResource request.
@@ -2932,6 +2416,15 @@ func (client *lrOSOperations) putAsyncSubResourceHandleResponse(resp *azcore.Res
 	return &result, resp.UnmarshalAsJSON(&result.SubProduct)
 }
 
+// putAsyncSubResourceHandleError handles the PutAsyncSubResource error response.
+func (client *lrOSOperations) putAsyncSubResourceHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutNoHeaderInRetry - Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
 func (client *lrOSOperations) BeginPutNoHeaderInRetry(ctx context.Context, lrOSPutNoHeaderInRetryOptions *LrOSPutNoHeaderInRetryOptions) (LrOSPutNoHeaderInRetryPoller, error) {
 	req, err := client.putNoHeaderInRetryCreateRequest(lrOSPutNoHeaderInRetryOptions)
@@ -2943,7 +2436,7 @@ func (client *lrOSOperations) BeginPutNoHeaderInRetry(ctx context.Context, lrOSP
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2953,38 +2446,15 @@ func (client *lrOSOperations) BeginPutNoHeaderInRetry(ctx context.Context, lrOSP
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPutNoHeaderInRetryPoller(id string) (LrOSPutNoHeaderInRetryPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPutNoHeaderInRetryPoller(token string) (LrOSPutNoHeaderInRetryPoller, error) {
+	pt, err := resumePollingTracker(token, client.putNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPutNoHeaderInRetryPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPutNoHeaderInRetryPoller{
+	return &lrOSPutNoHeaderInRetryPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPutNoHeaderInRetryPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putNoHeaderInRetryCreateRequest creates the PutNoHeaderInRetry request.
@@ -3007,6 +2477,15 @@ func (client *lrOSOperations) putNoHeaderInRetryHandleResponse(resp *azcore.Resp
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// putNoHeaderInRetryHandleError handles the PutNoHeaderInRetry error response.
+func (client *lrOSOperations) putNoHeaderInRetryHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutNonResource - Long running put request with non resource.
 func (client *lrOSOperations) BeginPutNonResource(ctx context.Context, lrOSPutNonResourceOptions *LrOSPutNonResourceOptions) (LrOSPutNonResourcePoller, error) {
 	req, err := client.putNonResourceCreateRequest(lrOSPutNonResourceOptions)
@@ -3018,7 +2497,7 @@ func (client *lrOSOperations) BeginPutNonResource(ctx context.Context, lrOSPutNo
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putNonResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -3028,38 +2507,15 @@ func (client *lrOSOperations) BeginPutNonResource(ctx context.Context, lrOSPutNo
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPutNonResourcePoller(id string) (LrOSPutNonResourcePoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPutNonResourcePoller(token string) (LrOSPutNonResourcePoller, error) {
+	pt, err := resumePollingTracker(token, client.putNonResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPutNonResourcePoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPutNonResourcePoller{
+	return &lrOSPutNonResourcePoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPutNonResourcePoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putNonResourceCreateRequest creates the PutNonResource request.
@@ -3082,6 +2538,15 @@ func (client *lrOSOperations) putNonResourceHandleResponse(resp *azcore.Response
 	return &result, resp.UnmarshalAsJSON(&result.Sku)
 }
 
+// putNonResourceHandleError handles the PutNonResource error response.
+func (client *lrOSOperations) putNonResourceHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutSubResource - Long running put request with sub resource.
 func (client *lrOSOperations) BeginPutSubResource(ctx context.Context, lrOSPutSubResourceOptions *LrOSPutSubResourceOptions) (LrOSPutSubResourcePoller, error) {
 	req, err := client.putSubResourceCreateRequest(lrOSPutSubResourceOptions)
@@ -3093,7 +2558,7 @@ func (client *lrOSOperations) BeginPutSubResource(ctx context.Context, lrOSPutSu
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putSubResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -3103,38 +2568,15 @@ func (client *lrOSOperations) BeginPutSubResource(ctx context.Context, lrOSPutSu
 	}, nil
 }
 
-func (client *lrOSOperations) ResumeLrOSPutSubResourcePoller(id string) (LrOSPutSubResourcePoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSOperations) ResumeLrOSPutSubResourcePoller(token string) (LrOSPutSubResourcePoller, error) {
+	pt, err := resumePollingTracker(token, client.putSubResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSPutSubResourcePoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSPutSubResourcePoller{
+	return &lrOSPutSubResourcePoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSPutSubResourcePoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putSubResourceCreateRequest creates the PutSubResource request.
@@ -3155,4 +2597,13 @@ func (client *lrOSOperations) putSubResourceCreateRequest(lrOSPutSubResourceOpti
 func (client *lrOSOperations) putSubResourceHandleResponse(resp *azcore.Response) (*SubProductResponse, error) {
 	result := SubProductResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.SubProduct)
+}
+
+// putSubResourceHandleError handles the PutSubResource error response.
+func (client *lrOSOperations) putSubResourceHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/lrogroup/lrosads.go
+++ b/test/autorest/generated/lrogroup/lrosads.go
@@ -7,12 +7,9 @@ package lrogroup
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"strconv"
-	"strings"
 )
 
 // LrosaDsOperations contains the methods for the LrosaDs group.
@@ -139,7 +136,7 @@ func (client *lrosaDsOperations) BeginDelete202NonRetry400(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.delete202NonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -149,38 +146,15 @@ func (client *lrosaDsOperations) BeginDelete202NonRetry400(ctx context.Context) 
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsDelete202NonRetry400Poller(id string) (LrosaDsDelete202NonRetry400Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsDelete202NonRetry400Poller(token string) (LrosaDsDelete202NonRetry400Poller, error) {
+	pt, err := resumePollingTracker(token, client.delete202NonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsDelete202NonRetry400Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsDelete202NonRetry400Poller{
+	return &lrosaDsDelete202NonRetry400Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsDelete202NonRetry400Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // delete202NonRetry400CreateRequest creates the Delete202NonRetry400 request.
@@ -211,6 +185,15 @@ func (client *lrosaDsOperations) delete202NonRetry400HandleResponse(resp *azcore
 	return &result, nil
 }
 
+// delete202NonRetry400HandleError handles the Delete202NonRetry400 error response.
+func (client *lrosaDsOperations) delete202NonRetry400HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Delete202RetryInvalidHeader - Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers
 func (client *lrosaDsOperations) BeginDelete202RetryInvalidHeader(ctx context.Context) (LrosaDsDelete202RetryInvalidHeaderPoller, error) {
 	req, err := client.delete202RetryInvalidHeaderCreateRequest()
@@ -222,7 +205,7 @@ func (client *lrosaDsOperations) BeginDelete202RetryInvalidHeader(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.delete202RetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -232,38 +215,15 @@ func (client *lrosaDsOperations) BeginDelete202RetryInvalidHeader(ctx context.Co
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsDelete202RetryInvalidHeaderPoller(id string) (LrosaDsDelete202RetryInvalidHeaderPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsDelete202RetryInvalidHeaderPoller(token string) (LrosaDsDelete202RetryInvalidHeaderPoller, error) {
+	pt, err := resumePollingTracker(token, client.delete202RetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsDelete202RetryInvalidHeaderPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsDelete202RetryInvalidHeaderPoller{
+	return &lrosaDsDelete202RetryInvalidHeaderPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsDelete202RetryInvalidHeaderPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // delete202RetryInvalidHeaderCreateRequest creates the Delete202RetryInvalidHeader request.
@@ -294,6 +254,15 @@ func (client *lrosaDsOperations) delete202RetryInvalidHeaderHandleResponse(resp 
 	return &result, nil
 }
 
+// delete202RetryInvalidHeaderHandleError handles the Delete202RetryInvalidHeader error response.
+func (client *lrosaDsOperations) delete202RetryInvalidHeaderHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Delete204Succeeded - Long running delete request, service returns a 204 to the initial request, indicating success.
 func (client *lrosaDsOperations) BeginDelete204Succeeded(ctx context.Context) (LrosaDsDelete204SucceededPoller, error) {
 	req, err := client.delete204SucceededCreateRequest()
@@ -305,7 +274,7 @@ func (client *lrosaDsOperations) BeginDelete204Succeeded(ctx context.Context) (L
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.delete204SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -315,38 +284,15 @@ func (client *lrosaDsOperations) BeginDelete204Succeeded(ctx context.Context) (L
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsDelete204SucceededPoller(id string) (LrosaDsDelete204SucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsDelete204SucceededPoller(token string) (LrosaDsDelete204SucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.delete204SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsDelete204SucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsDelete204SucceededPoller{
+	return &lrosaDsDelete204SucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsDelete204SucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // delete204SucceededCreateRequest creates the Delete204Succeeded request.
@@ -365,6 +311,15 @@ func (client *lrosaDsOperations) delete204SucceededHandleResponse(resp *azcore.R
 	return resp.Response, nil
 }
 
+// delete204SucceededHandleError handles the Delete204Succeeded error response.
+func (client *lrosaDsOperations) delete204SucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteAsyncRelativeRetry400 - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetry400(ctx context.Context) (LrosaDsDeleteAsyncRelativeRetry400Poller, error) {
 	req, err := client.deleteAsyncRelativeRetry400CreateRequest()
@@ -376,7 +331,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetry400(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteAsyncRelativeRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -386,38 +341,15 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetry400(ctx context.Co
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsDeleteAsyncRelativeRetry400Poller(id string) (LrosaDsDeleteAsyncRelativeRetry400Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsDeleteAsyncRelativeRetry400Poller(token string) (LrosaDsDeleteAsyncRelativeRetry400Poller, error) {
+	pt, err := resumePollingTracker(token, client.deleteAsyncRelativeRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsDeleteAsyncRelativeRetry400Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsDeleteAsyncRelativeRetry400Poller{
+	return &lrosaDsDeleteAsyncRelativeRetry400Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsDeleteAsyncRelativeRetry400Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteAsyncRelativeRetry400CreateRequest creates the DeleteAsyncRelativeRetry400 request.
@@ -451,6 +383,15 @@ func (client *lrosaDsOperations) deleteAsyncRelativeRetry400HandleResponse(resp 
 	return &result, nil
 }
 
+// deleteAsyncRelativeRetry400HandleError handles the DeleteAsyncRelativeRetry400 error response.
+func (client *lrosaDsOperations) deleteAsyncRelativeRetry400HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteAsyncRelativeRetryInvalidHeader - Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid
 func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx context.Context) (LrosaDsDeleteAsyncRelativeRetryInvalidHeaderPoller, error) {
 	req, err := client.deleteAsyncRelativeRetryInvalidHeaderCreateRequest()
@@ -462,7 +403,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -472,38 +413,15 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx 
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsDeleteAsyncRelativeRetryInvalidHeaderPoller(id string) (LrosaDsDeleteAsyncRelativeRetryInvalidHeaderPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsDeleteAsyncRelativeRetryInvalidHeaderPoller(token string) (LrosaDsDeleteAsyncRelativeRetryInvalidHeaderPoller, error) {
+	pt, err := resumePollingTracker(token, client.deleteAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsDeleteAsyncRelativeRetryInvalidHeaderPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsDeleteAsyncRelativeRetryInvalidHeaderPoller{
+	return &lrosaDsDeleteAsyncRelativeRetryInvalidHeaderPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsDeleteAsyncRelativeRetryInvalidHeaderPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteAsyncRelativeRetryInvalidHeaderCreateRequest creates the DeleteAsyncRelativeRetryInvalidHeader request.
@@ -537,6 +455,15 @@ func (client *lrosaDsOperations) deleteAsyncRelativeRetryInvalidHeaderHandleResp
 	return &result, nil
 }
 
+// deleteAsyncRelativeRetryInvalidHeaderHandleError handles the DeleteAsyncRelativeRetryInvalidHeader error response.
+func (client *lrosaDsOperations) deleteAsyncRelativeRetryInvalidHeaderHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteAsyncRelativeRetryInvalidJSONPolling - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidJSONPolling(ctx context.Context) (LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingPoller, error) {
 	req, err := client.deleteAsyncRelativeRetryInvalidJsonPollingCreateRequest()
@@ -548,7 +475,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidJSONPolling
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteAsyncRelativeRetryInvalidJsonPollingHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -558,38 +485,15 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidJSONPolling
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingPoller(id string) (LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingPoller(token string) (LrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingPoller, error) {
+	pt, err := resumePollingTracker(token, client.deleteAsyncRelativeRetryInvalidJsonPollingHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsDeleteAsyncRelativeRetryInvalidJSONPollingPoller{
+	return &lrosaDsDeleteAsyncRelativeRetryInvalidJSONPollingPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsDeleteAsyncRelativeRetryInvalidJsonPollingPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteAsyncRelativeRetryInvalidJsonPollingCreateRequest creates the DeleteAsyncRelativeRetryInvalidJSONPolling request.
@@ -623,6 +527,15 @@ func (client *lrosaDsOperations) deleteAsyncRelativeRetryInvalidJsonPollingHandl
 	return &result, nil
 }
 
+// deleteAsyncRelativeRetryInvalidJsonPollingHandleError handles the DeleteAsyncRelativeRetryInvalidJSONPolling error response.
+func (client *lrosaDsOperations) deleteAsyncRelativeRetryInvalidJsonPollingHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteAsyncRelativeRetryNoStatus - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryNoStatus(ctx context.Context) (LrosaDsDeleteAsyncRelativeRetryNoStatusPoller, error) {
 	req, err := client.deleteAsyncRelativeRetryNoStatusCreateRequest()
@@ -634,7 +547,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryNoStatus(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteAsyncRelativeRetryNoStatusHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -644,38 +557,15 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryNoStatus(ctx conte
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsDeleteAsyncRelativeRetryNoStatusPoller(id string) (LrosaDsDeleteAsyncRelativeRetryNoStatusPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsDeleteAsyncRelativeRetryNoStatusPoller(token string) (LrosaDsDeleteAsyncRelativeRetryNoStatusPoller, error) {
+	pt, err := resumePollingTracker(token, client.deleteAsyncRelativeRetryNoStatusHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsDeleteAsyncRelativeRetryNoStatusPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsDeleteAsyncRelativeRetryNoStatusPoller{
+	return &lrosaDsDeleteAsyncRelativeRetryNoStatusPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsDeleteAsyncRelativeRetryNoStatusPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteAsyncRelativeRetryNoStatusCreateRequest creates the DeleteAsyncRelativeRetryNoStatus request.
@@ -709,6 +599,15 @@ func (client *lrosaDsOperations) deleteAsyncRelativeRetryNoStatusHandleResponse(
 	return &result, nil
 }
 
+// deleteAsyncRelativeRetryNoStatusHandleError handles the DeleteAsyncRelativeRetryNoStatus error response.
+func (client *lrosaDsOperations) deleteAsyncRelativeRetryNoStatusHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // DeleteNonRetry400 - Long running delete request, service returns a 400 with an error body
 func (client *lrosaDsOperations) BeginDeleteNonRetry400(ctx context.Context) (LrosaDsDeleteNonRetry400Poller, error) {
 	req, err := client.deleteNonRetry400CreateRequest()
@@ -720,7 +619,7 @@ func (client *lrosaDsOperations) BeginDeleteNonRetry400(ctx context.Context) (Lr
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.deleteNonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -730,38 +629,15 @@ func (client *lrosaDsOperations) BeginDeleteNonRetry400(ctx context.Context) (Lr
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsDeleteNonRetry400Poller(id string) (LrosaDsDeleteNonRetry400Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsDeleteNonRetry400Poller(token string) (LrosaDsDeleteNonRetry400Poller, error) {
+	pt, err := resumePollingTracker(token, client.deleteNonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsDeleteNonRetry400Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsDeleteNonRetry400Poller{
+	return &lrosaDsDeleteNonRetry400Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsDeleteNonRetry400Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // deleteNonRetry400CreateRequest creates the DeleteNonRetry400 request.
@@ -792,6 +668,15 @@ func (client *lrosaDsOperations) deleteNonRetry400HandleResponse(resp *azcore.Re
 	return &result, nil
 }
 
+// deleteNonRetry400HandleError handles the DeleteNonRetry400 error response.
+func (client *lrosaDsOperations) deleteNonRetry400HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Post202NoLocation - Long running post request, service returns a 202 to the initial request, without a location header.
 func (client *lrosaDsOperations) BeginPost202NoLocation(ctx context.Context, lrosaDsPost202NoLocationOptions *LrosaDsPost202NoLocationOptions) (LrosaDsPost202NoLocationPoller, error) {
 	req, err := client.post202NoLocationCreateRequest(lrosaDsPost202NoLocationOptions)
@@ -803,7 +688,7 @@ func (client *lrosaDsOperations) BeginPost202NoLocation(ctx context.Context, lro
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.post202NoLocationHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -813,38 +698,15 @@ func (client *lrosaDsOperations) BeginPost202NoLocation(ctx context.Context, lro
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPost202NoLocationPoller(id string) (LrosaDsPost202NoLocationPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPost202NoLocationPoller(token string) (LrosaDsPost202NoLocationPoller, error) {
+	pt, err := resumePollingTracker(token, client.post202NoLocationHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPost202NoLocationPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPost202NoLocationPoller{
+	return &lrosaDsPost202NoLocationPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPost202NoLocationPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // post202NoLocationCreateRequest creates the Post202NoLocation request.
@@ -878,6 +740,15 @@ func (client *lrosaDsOperations) post202NoLocationHandleResponse(resp *azcore.Re
 	return &result, nil
 }
 
+// post202NoLocationHandleError handles the Post202NoLocation error response.
+func (client *lrosaDsOperations) post202NoLocationHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Post202NonRetry400 - Long running post request, service returns a 202 with a location header
 func (client *lrosaDsOperations) BeginPost202NonRetry400(ctx context.Context, lrosaDsPost202NonRetry400Options *LrosaDsPost202NonRetry400Options) (LrosaDsPost202NonRetry400Poller, error) {
 	req, err := client.post202NonRetry400CreateRequest(lrosaDsPost202NonRetry400Options)
@@ -889,7 +760,7 @@ func (client *lrosaDsOperations) BeginPost202NonRetry400(ctx context.Context, lr
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.post202NonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -899,38 +770,15 @@ func (client *lrosaDsOperations) BeginPost202NonRetry400(ctx context.Context, lr
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPost202NonRetry400Poller(id string) (LrosaDsPost202NonRetry400Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPost202NonRetry400Poller(token string) (LrosaDsPost202NonRetry400Poller, error) {
+	pt, err := resumePollingTracker(token, client.post202NonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPost202NonRetry400Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPost202NonRetry400Poller{
+	return &lrosaDsPost202NonRetry400Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPost202NonRetry400Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // post202NonRetry400CreateRequest creates the Post202NonRetry400 request.
@@ -964,6 +812,15 @@ func (client *lrosaDsOperations) post202NonRetry400HandleResponse(resp *azcore.R
 	return &result, nil
 }
 
+// post202NonRetry400HandleError handles the Post202NonRetry400 error response.
+func (client *lrosaDsOperations) post202NonRetry400HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Post202RetryInvalidHeader - Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
 func (client *lrosaDsOperations) BeginPost202RetryInvalidHeader(ctx context.Context, lrosaDsPost202RetryInvalidHeaderOptions *LrosaDsPost202RetryInvalidHeaderOptions) (LrosaDsPost202RetryInvalidHeaderPoller, error) {
 	req, err := client.post202RetryInvalidHeaderCreateRequest(lrosaDsPost202RetryInvalidHeaderOptions)
@@ -975,7 +832,7 @@ func (client *lrosaDsOperations) BeginPost202RetryInvalidHeader(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.post202RetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -985,38 +842,15 @@ func (client *lrosaDsOperations) BeginPost202RetryInvalidHeader(ctx context.Cont
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPost202RetryInvalidHeaderPoller(id string) (LrosaDsPost202RetryInvalidHeaderPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPost202RetryInvalidHeaderPoller(token string) (LrosaDsPost202RetryInvalidHeaderPoller, error) {
+	pt, err := resumePollingTracker(token, client.post202RetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPost202RetryInvalidHeaderPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPost202RetryInvalidHeaderPoller{
+	return &lrosaDsPost202RetryInvalidHeaderPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPost202RetryInvalidHeaderPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // post202RetryInvalidHeaderCreateRequest creates the Post202RetryInvalidHeader request.
@@ -1050,6 +884,15 @@ func (client *lrosaDsOperations) post202RetryInvalidHeaderHandleResponse(resp *a
 	return &result, nil
 }
 
+// post202RetryInvalidHeaderHandleError handles the Post202RetryInvalidHeader error response.
+func (client *lrosaDsOperations) post202RetryInvalidHeaderHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PostAsyncRelativeRetry400 - Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrosaDsOperations) BeginPostAsyncRelativeRetry400(ctx context.Context, lrosaDsPostAsyncRelativeRetry400Options *LrosaDsPostAsyncRelativeRetry400Options) (LrosaDsPostAsyncRelativeRetry400Poller, error) {
 	req, err := client.postAsyncRelativeRetry400CreateRequest(lrosaDsPostAsyncRelativeRetry400Options)
@@ -1061,7 +904,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetry400(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.postAsyncRelativeRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1071,38 +914,15 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetry400(ctx context.Cont
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPostAsyncRelativeRetry400Poller(id string) (LrosaDsPostAsyncRelativeRetry400Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPostAsyncRelativeRetry400Poller(token string) (LrosaDsPostAsyncRelativeRetry400Poller, error) {
+	pt, err := resumePollingTracker(token, client.postAsyncRelativeRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPostAsyncRelativeRetry400Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPostAsyncRelativeRetry400Poller{
+	return &lrosaDsPostAsyncRelativeRetry400Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPostAsyncRelativeRetry400Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // postAsyncRelativeRetry400CreateRequest creates the PostAsyncRelativeRetry400 request.
@@ -1139,6 +959,15 @@ func (client *lrosaDsOperations) postAsyncRelativeRetry400HandleResponse(resp *a
 	return &result, nil
 }
 
+// postAsyncRelativeRetry400HandleError handles the PostAsyncRelativeRetry400 error response.
+func (client *lrosaDsOperations) postAsyncRelativeRetry400HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PostAsyncRelativeRetryInvalidHeader - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
 func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidHeader(ctx context.Context, lrosaDsPostAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPostAsyncRelativeRetryInvalidHeaderOptions) (LrosaDsPostAsyncRelativeRetryInvalidHeaderPoller, error) {
 	req, err := client.postAsyncRelativeRetryInvalidHeaderCreateRequest(lrosaDsPostAsyncRelativeRetryInvalidHeaderOptions)
@@ -1150,7 +979,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidHeader(ctx co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.postAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1160,38 +989,15 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidHeader(ctx co
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPostAsyncRelativeRetryInvalidHeaderPoller(id string) (LrosaDsPostAsyncRelativeRetryInvalidHeaderPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPostAsyncRelativeRetryInvalidHeaderPoller(token string) (LrosaDsPostAsyncRelativeRetryInvalidHeaderPoller, error) {
+	pt, err := resumePollingTracker(token, client.postAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPostAsyncRelativeRetryInvalidHeaderPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPostAsyncRelativeRetryInvalidHeaderPoller{
+	return &lrosaDsPostAsyncRelativeRetryInvalidHeaderPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPostAsyncRelativeRetryInvalidHeaderPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // postAsyncRelativeRetryInvalidHeaderCreateRequest creates the PostAsyncRelativeRetryInvalidHeader request.
@@ -1228,6 +1034,15 @@ func (client *lrosaDsOperations) postAsyncRelativeRetryInvalidHeaderHandleRespon
 	return &result, nil
 }
 
+// postAsyncRelativeRetryInvalidHeaderHandleError handles the PostAsyncRelativeRetryInvalidHeader error response.
+func (client *lrosaDsOperations) postAsyncRelativeRetryInvalidHeaderHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PostAsyncRelativeRetryInvalidJSONPolling - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, lrosaDsPostAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPostAsyncRelativeRetryInvalidJSONPollingOptions) (LrosaDsPostAsyncRelativeRetryInvalidJsonPollingPoller, error) {
 	req, err := client.postAsyncRelativeRetryInvalidJsonPollingCreateRequest(lrosaDsPostAsyncRelativeRetryInvalidJsonPollingOptions)
@@ -1239,7 +1054,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidJSONPolling(c
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.postAsyncRelativeRetryInvalidJsonPollingHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1249,38 +1064,15 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidJSONPolling(c
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPostAsyncRelativeRetryInvalidJsonPollingPoller(id string) (LrosaDsPostAsyncRelativeRetryInvalidJsonPollingPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPostAsyncRelativeRetryInvalidJsonPollingPoller(token string) (LrosaDsPostAsyncRelativeRetryInvalidJsonPollingPoller, error) {
+	pt, err := resumePollingTracker(token, client.postAsyncRelativeRetryInvalidJsonPollingHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPostAsyncRelativeRetryInvalidJsonPollingPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPostAsyncRelativeRetryInvalidJSONPollingPoller{
+	return &lrosaDsPostAsyncRelativeRetryInvalidJSONPollingPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPostAsyncRelativeRetryInvalidJsonPollingPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // postAsyncRelativeRetryInvalidJsonPollingCreateRequest creates the PostAsyncRelativeRetryInvalidJSONPolling request.
@@ -1317,6 +1109,15 @@ func (client *lrosaDsOperations) postAsyncRelativeRetryInvalidJsonPollingHandleR
 	return &result, nil
 }
 
+// postAsyncRelativeRetryInvalidJsonPollingHandleError handles the PostAsyncRelativeRetryInvalidJSONPolling error response.
+func (client *lrosaDsOperations) postAsyncRelativeRetryInvalidJsonPollingHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PostAsyncRelativeRetryNoPayload - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryNoPayload(ctx context.Context, lrosaDsPostAsyncRelativeRetryNoPayloadOptions *LrosaDsPostAsyncRelativeRetryNoPayloadOptions) (LrosaDsPostAsyncRelativeRetryNoPayloadPoller, error) {
 	req, err := client.postAsyncRelativeRetryNoPayloadCreateRequest(lrosaDsPostAsyncRelativeRetryNoPayloadOptions)
@@ -1328,7 +1129,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryNoPayload(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.postAsyncRelativeRetryNoPayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1338,38 +1139,15 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryNoPayload(ctx contex
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPostAsyncRelativeRetryNoPayloadPoller(id string) (LrosaDsPostAsyncRelativeRetryNoPayloadPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPostAsyncRelativeRetryNoPayloadPoller(token string) (LrosaDsPostAsyncRelativeRetryNoPayloadPoller, error) {
+	pt, err := resumePollingTracker(token, client.postAsyncRelativeRetryNoPayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPostAsyncRelativeRetryNoPayloadPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPostAsyncRelativeRetryNoPayloadPoller{
+	return &lrosaDsPostAsyncRelativeRetryNoPayloadPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPostAsyncRelativeRetryNoPayloadPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // postAsyncRelativeRetryNoPayloadCreateRequest creates the PostAsyncRelativeRetryNoPayload request.
@@ -1406,6 +1184,15 @@ func (client *lrosaDsOperations) postAsyncRelativeRetryNoPayloadHandleResponse(r
 	return &result, nil
 }
 
+// postAsyncRelativeRetryNoPayloadHandleError handles the PostAsyncRelativeRetryNoPayload error response.
+func (client *lrosaDsOperations) postAsyncRelativeRetryNoPayloadHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PostNonRetry400 - Long running post request, service returns a 400 with no error body
 func (client *lrosaDsOperations) BeginPostNonRetry400(ctx context.Context, lrosaDsPostNonRetry400Options *LrosaDsPostNonRetry400Options) (LrosaDsPostNonRetry400Poller, error) {
 	req, err := client.postNonRetry400CreateRequest(lrosaDsPostNonRetry400Options)
@@ -1417,7 +1204,7 @@ func (client *lrosaDsOperations) BeginPostNonRetry400(ctx context.Context, lrosa
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.postNonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1427,38 +1214,15 @@ func (client *lrosaDsOperations) BeginPostNonRetry400(ctx context.Context, lrosa
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPostNonRetry400Poller(id string) (LrosaDsPostNonRetry400Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPostNonRetry400Poller(token string) (LrosaDsPostNonRetry400Poller, error) {
+	pt, err := resumePollingTracker(token, client.postNonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPostNonRetry400Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPostNonRetry400Poller{
+	return &lrosaDsPostNonRetry400Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPostNonRetry400Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // postNonRetry400CreateRequest creates the PostNonRetry400 request.
@@ -1492,6 +1256,15 @@ func (client *lrosaDsOperations) postNonRetry400HandleResponse(resp *azcore.Resp
 	return &result, nil
 }
 
+// postNonRetry400HandleError handles the PostNonRetry400 error response.
+func (client *lrosaDsOperations) postNonRetry400HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Put200InvalidJSON - Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json
 func (client *lrosaDsOperations) BeginPut200InvalidJSON(ctx context.Context, lrosaDsPut200InvalidJsonOptions *LrosaDsPut200InvalidJSONOptions) (LrosaDsPut200InvalidJsonPoller, error) {
 	req, err := client.put200InvalidJsonCreateRequest(lrosaDsPut200InvalidJsonOptions)
@@ -1503,7 +1276,7 @@ func (client *lrosaDsOperations) BeginPut200InvalidJSON(ctx context.Context, lro
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.put200InvalidJsonHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1513,38 +1286,15 @@ func (client *lrosaDsOperations) BeginPut200InvalidJSON(ctx context.Context, lro
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPut200InvalidJsonPoller(id string) (LrosaDsPut200InvalidJsonPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPut200InvalidJsonPoller(token string) (LrosaDsPut200InvalidJsonPoller, error) {
+	pt, err := resumePollingTracker(token, client.put200InvalidJsonHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPut200InvalidJsonPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPut200InvalidJSONPoller{
+	return &lrosaDsPut200InvalidJSONPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPut200InvalidJsonPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // put200InvalidJsonCreateRequest creates the Put200InvalidJSON request.
@@ -1567,6 +1317,15 @@ func (client *lrosaDsOperations) put200InvalidJsonHandleResponse(resp *azcore.Re
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// put200InvalidJsonHandleError handles the Put200InvalidJSON error response.
+func (client *lrosaDsOperations) put200InvalidJsonHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutAsyncRelativeRetry400 - Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrosaDsOperations) BeginPutAsyncRelativeRetry400(ctx context.Context, lrosaDsPutAsyncRelativeRetry400Options *LrosaDsPutAsyncRelativeRetry400Options) (LrosaDsPutAsyncRelativeRetry400Poller, error) {
 	req, err := client.putAsyncRelativeRetry400CreateRequest(lrosaDsPutAsyncRelativeRetry400Options)
@@ -1578,7 +1337,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetry400(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putAsyncRelativeRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1588,38 +1347,15 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetry400(ctx context.Conte
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPutAsyncRelativeRetry400Poller(id string) (LrosaDsPutAsyncRelativeRetry400Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPutAsyncRelativeRetry400Poller(token string) (LrosaDsPutAsyncRelativeRetry400Poller, error) {
+	pt, err := resumePollingTracker(token, client.putAsyncRelativeRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPutAsyncRelativeRetry400Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPutAsyncRelativeRetry400Poller{
+	return &lrosaDsPutAsyncRelativeRetry400Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPutAsyncRelativeRetry400Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putAsyncRelativeRetry400CreateRequest creates the PutAsyncRelativeRetry400 request.
@@ -1642,6 +1378,15 @@ func (client *lrosaDsOperations) putAsyncRelativeRetry400HandleResponse(resp *az
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// putAsyncRelativeRetry400HandleError handles the PutAsyncRelativeRetry400 error response.
+func (client *lrosaDsOperations) putAsyncRelativeRetry400HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutAsyncRelativeRetryInvalidHeader - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
 func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidHeader(ctx context.Context, lrosaDsPutAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPutAsyncRelativeRetryInvalidHeaderOptions) (LrosaDsPutAsyncRelativeRetryInvalidHeaderPoller, error) {
 	req, err := client.putAsyncRelativeRetryInvalidHeaderCreateRequest(lrosaDsPutAsyncRelativeRetryInvalidHeaderOptions)
@@ -1653,7 +1398,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidHeader(ctx con
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1663,38 +1408,15 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidHeader(ctx con
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPutAsyncRelativeRetryInvalidHeaderPoller(id string) (LrosaDsPutAsyncRelativeRetryInvalidHeaderPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPutAsyncRelativeRetryInvalidHeaderPoller(token string) (LrosaDsPutAsyncRelativeRetryInvalidHeaderPoller, error) {
+	pt, err := resumePollingTracker(token, client.putAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPutAsyncRelativeRetryInvalidHeaderPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPutAsyncRelativeRetryInvalidHeaderPoller{
+	return &lrosaDsPutAsyncRelativeRetryInvalidHeaderPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPutAsyncRelativeRetryInvalidHeaderPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putAsyncRelativeRetryInvalidHeaderCreateRequest creates the PutAsyncRelativeRetryInvalidHeader request.
@@ -1717,6 +1439,15 @@ func (client *lrosaDsOperations) putAsyncRelativeRetryInvalidHeaderHandleRespons
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// putAsyncRelativeRetryInvalidHeaderHandleError handles the PutAsyncRelativeRetryInvalidHeader error response.
+func (client *lrosaDsOperations) putAsyncRelativeRetryInvalidHeaderHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutAsyncRelativeRetryInvalidJSONPolling - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, lrosaDsPutAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPutAsyncRelativeRetryInvalidJSONPollingOptions) (LrosaDsPutAsyncRelativeRetryInvalidJsonPollingPoller, error) {
 	req, err := client.putAsyncRelativeRetryInvalidJsonPollingCreateRequest(lrosaDsPutAsyncRelativeRetryInvalidJsonPollingOptions)
@@ -1728,7 +1459,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidJSONPolling(ct
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putAsyncRelativeRetryInvalidJsonPollingHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1738,38 +1469,15 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidJSONPolling(ct
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPutAsyncRelativeRetryInvalidJsonPollingPoller(id string) (LrosaDsPutAsyncRelativeRetryInvalidJsonPollingPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPutAsyncRelativeRetryInvalidJsonPollingPoller(token string) (LrosaDsPutAsyncRelativeRetryInvalidJsonPollingPoller, error) {
+	pt, err := resumePollingTracker(token, client.putAsyncRelativeRetryInvalidJsonPollingHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPutAsyncRelativeRetryInvalidJsonPollingPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPutAsyncRelativeRetryInvalidJSONPollingPoller{
+	return &lrosaDsPutAsyncRelativeRetryInvalidJSONPollingPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPutAsyncRelativeRetryInvalidJsonPollingPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putAsyncRelativeRetryInvalidJsonPollingCreateRequest creates the PutAsyncRelativeRetryInvalidJSONPolling request.
@@ -1792,6 +1500,15 @@ func (client *lrosaDsOperations) putAsyncRelativeRetryInvalidJsonPollingHandleRe
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// putAsyncRelativeRetryInvalidJsonPollingHandleError handles the PutAsyncRelativeRetryInvalidJSONPolling error response.
+func (client *lrosaDsOperations) putAsyncRelativeRetryInvalidJsonPollingHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutAsyncRelativeRetryNoStatus - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatus(ctx context.Context, lrosaDsPutAsyncRelativeRetryNoStatusOptions *LrosaDsPutAsyncRelativeRetryNoStatusOptions) (LrosaDsPutAsyncRelativeRetryNoStatusPoller, error) {
 	req, err := client.putAsyncRelativeRetryNoStatusCreateRequest(lrosaDsPutAsyncRelativeRetryNoStatusOptions)
@@ -1803,7 +1520,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatus(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putAsyncRelativeRetryNoStatusHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1813,38 +1530,15 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatus(ctx context.
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPutAsyncRelativeRetryNoStatusPoller(id string) (LrosaDsPutAsyncRelativeRetryNoStatusPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPutAsyncRelativeRetryNoStatusPoller(token string) (LrosaDsPutAsyncRelativeRetryNoStatusPoller, error) {
+	pt, err := resumePollingTracker(token, client.putAsyncRelativeRetryNoStatusHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPutAsyncRelativeRetryNoStatusPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPutAsyncRelativeRetryNoStatusPoller{
+	return &lrosaDsPutAsyncRelativeRetryNoStatusPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPutAsyncRelativeRetryNoStatusPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putAsyncRelativeRetryNoStatusCreateRequest creates the PutAsyncRelativeRetryNoStatus request.
@@ -1867,6 +1561,15 @@ func (client *lrosaDsOperations) putAsyncRelativeRetryNoStatusHandleResponse(res
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// putAsyncRelativeRetryNoStatusHandleError handles the PutAsyncRelativeRetryNoStatus error response.
+func (client *lrosaDsOperations) putAsyncRelativeRetryNoStatusHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutAsyncRelativeRetryNoStatusPayload - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatusPayload(ctx context.Context, lrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions *LrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions) (LrosaDsPutAsyncRelativeRetryNoStatusPayloadPoller, error) {
 	req, err := client.putAsyncRelativeRetryNoStatusPayloadCreateRequest(lrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions)
@@ -1878,7 +1581,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatusPayload(ctx c
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putAsyncRelativeRetryNoStatusPayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1888,38 +1591,15 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatusPayload(ctx c
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPutAsyncRelativeRetryNoStatusPayloadPoller(id string) (LrosaDsPutAsyncRelativeRetryNoStatusPayloadPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPutAsyncRelativeRetryNoStatusPayloadPoller(token string) (LrosaDsPutAsyncRelativeRetryNoStatusPayloadPoller, error) {
+	pt, err := resumePollingTracker(token, client.putAsyncRelativeRetryNoStatusPayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPutAsyncRelativeRetryNoStatusPayloadPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPutAsyncRelativeRetryNoStatusPayloadPoller{
+	return &lrosaDsPutAsyncRelativeRetryNoStatusPayloadPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPutAsyncRelativeRetryNoStatusPayloadPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putAsyncRelativeRetryNoStatusPayloadCreateRequest creates the PutAsyncRelativeRetryNoStatusPayload request.
@@ -1942,6 +1622,15 @@ func (client *lrosaDsOperations) putAsyncRelativeRetryNoStatusPayloadHandleRespo
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// putAsyncRelativeRetryNoStatusPayloadHandleError handles the PutAsyncRelativeRetryNoStatusPayload error response.
+func (client *lrosaDsOperations) putAsyncRelativeRetryNoStatusPayloadHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutError201NoProvisioningStatePayload - Long running put request, service returns a 201 to the initial request with no payload
 func (client *lrosaDsOperations) BeginPutError201NoProvisioningStatePayload(ctx context.Context, lrosaDsPutError201NoProvisioningStatePayloadOptions *LrosaDsPutError201NoProvisioningStatePayloadOptions) (LrosaDsPutError201NoProvisioningStatePayloadPoller, error) {
 	req, err := client.putError201NoProvisioningStatePayloadCreateRequest(lrosaDsPutError201NoProvisioningStatePayloadOptions)
@@ -1953,7 +1642,7 @@ func (client *lrosaDsOperations) BeginPutError201NoProvisioningStatePayload(ctx 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putError201NoProvisioningStatePayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1963,38 +1652,15 @@ func (client *lrosaDsOperations) BeginPutError201NoProvisioningStatePayload(ctx 
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPutError201NoProvisioningStatePayloadPoller(id string) (LrosaDsPutError201NoProvisioningStatePayloadPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPutError201NoProvisioningStatePayloadPoller(token string) (LrosaDsPutError201NoProvisioningStatePayloadPoller, error) {
+	pt, err := resumePollingTracker(token, client.putError201NoProvisioningStatePayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPutError201NoProvisioningStatePayloadPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPutError201NoProvisioningStatePayloadPoller{
+	return &lrosaDsPutError201NoProvisioningStatePayloadPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPutError201NoProvisioningStatePayloadPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putError201NoProvisioningStatePayloadCreateRequest creates the PutError201NoProvisioningStatePayload request.
@@ -2017,6 +1683,15 @@ func (client *lrosaDsOperations) putError201NoProvisioningStatePayloadHandleResp
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// putError201NoProvisioningStatePayloadHandleError handles the PutError201NoProvisioningStatePayload error response.
+func (client *lrosaDsOperations) putError201NoProvisioningStatePayloadHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutNonRetry201Creating400 - Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code
 func (client *lrosaDsOperations) BeginPutNonRetry201Creating400(ctx context.Context, lrosaDsPutNonRetry201Creating400Options *LrosaDsPutNonRetry201Creating400Options) (LrosaDsPutNonRetry201Creating400Poller, error) {
 	req, err := client.putNonRetry201Creating400CreateRequest(lrosaDsPutNonRetry201Creating400Options)
@@ -2028,7 +1703,7 @@ func (client *lrosaDsOperations) BeginPutNonRetry201Creating400(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putNonRetry201Creating400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2038,38 +1713,15 @@ func (client *lrosaDsOperations) BeginPutNonRetry201Creating400(ctx context.Cont
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPutNonRetry201Creating400Poller(id string) (LrosaDsPutNonRetry201Creating400Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPutNonRetry201Creating400Poller(token string) (LrosaDsPutNonRetry201Creating400Poller, error) {
+	pt, err := resumePollingTracker(token, client.putNonRetry201Creating400HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPutNonRetry201Creating400Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPutNonRetry201Creating400Poller{
+	return &lrosaDsPutNonRetry201Creating400Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPutNonRetry201Creating400Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putNonRetry201Creating400CreateRequest creates the PutNonRetry201Creating400 request.
@@ -2092,6 +1744,15 @@ func (client *lrosaDsOperations) putNonRetry201Creating400HandleResponse(resp *a
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// putNonRetry201Creating400HandleError handles the PutNonRetry201Creating400 error response.
+func (client *lrosaDsOperations) putNonRetry201Creating400HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutNonRetry201Creating400InvalidJSON - Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code
 func (client *lrosaDsOperations) BeginPutNonRetry201Creating400InvalidJSON(ctx context.Context, lrosaDsPutNonRetry201Creating400InvalidJsonOptions *LrosaDsPutNonRetry201Creating400InvalidJSONOptions) (LrosaDsPutNonRetry201Creating400InvalidJsonPoller, error) {
 	req, err := client.putNonRetry201Creating400InvalidJsonCreateRequest(lrosaDsPutNonRetry201Creating400InvalidJsonOptions)
@@ -2103,7 +1764,7 @@ func (client *lrosaDsOperations) BeginPutNonRetry201Creating400InvalidJSON(ctx c
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putNonRetry201Creating400InvalidJsonHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2113,38 +1774,15 @@ func (client *lrosaDsOperations) BeginPutNonRetry201Creating400InvalidJSON(ctx c
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPutNonRetry201Creating400InvalidJsonPoller(id string) (LrosaDsPutNonRetry201Creating400InvalidJsonPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPutNonRetry201Creating400InvalidJsonPoller(token string) (LrosaDsPutNonRetry201Creating400InvalidJsonPoller, error) {
+	pt, err := resumePollingTracker(token, client.putNonRetry201Creating400InvalidJsonHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPutNonRetry201Creating400InvalidJsonPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPutNonRetry201Creating400InvalidJSONPoller{
+	return &lrosaDsPutNonRetry201Creating400InvalidJSONPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPutNonRetry201Creating400InvalidJsonPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putNonRetry201Creating400InvalidJsonCreateRequest creates the PutNonRetry201Creating400InvalidJSON request.
@@ -2167,6 +1805,15 @@ func (client *lrosaDsOperations) putNonRetry201Creating400InvalidJsonHandleRespo
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// putNonRetry201Creating400InvalidJsonHandleError handles the PutNonRetry201Creating400InvalidJSON error response.
+func (client *lrosaDsOperations) putNonRetry201Creating400InvalidJsonHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutNonRetry400 - Long running put request, service returns a 400 to the initial request
 func (client *lrosaDsOperations) BeginPutNonRetry400(ctx context.Context, lrosaDsPutNonRetry400Options *LrosaDsPutNonRetry400Options) (LrosaDsPutNonRetry400Poller, error) {
 	req, err := client.putNonRetry400CreateRequest(lrosaDsPutNonRetry400Options)
@@ -2178,7 +1825,7 @@ func (client *lrosaDsOperations) BeginPutNonRetry400(ctx context.Context, lrosaD
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putNonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2188,38 +1835,15 @@ func (client *lrosaDsOperations) BeginPutNonRetry400(ctx context.Context, lrosaD
 	}, nil
 }
 
-func (client *lrosaDsOperations) ResumeLrosaDsPutNonRetry400Poller(id string) (LrosaDsPutNonRetry400Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrosaDsOperations) ResumeLrosaDsPutNonRetry400Poller(token string) (LrosaDsPutNonRetry400Poller, error) {
+	pt, err := resumePollingTracker(token, client.putNonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrosaDsPutNonRetry400Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrosaDsPutNonRetry400Poller{
+	return &lrosaDsPutNonRetry400Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrosaDsPutNonRetry400Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putNonRetry400CreateRequest creates the PutNonRetry400 request.
@@ -2240,4 +1864,13 @@ func (client *lrosaDsOperations) putNonRetry400CreateRequest(lrosaDsPutNonRetry4
 func (client *lrosaDsOperations) putNonRetry400HandleResponse(resp *azcore.Response) (*ProductResponse, error) {
 	result := ProductResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Product)
+}
+
+// putNonRetry400HandleError handles the PutNonRetry400 error response.
+func (client *lrosaDsOperations) putNonRetry400HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/lrogroup/lroscustomheader.go
+++ b/test/autorest/generated/lrogroup/lroscustomheader.go
@@ -7,12 +7,9 @@ package lrogroup
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"strconv"
-	"strings"
 )
 
 // LrOSCustomHeaderOperations contains the methods for the LrOSCustomHeader group.
@@ -51,7 +48,7 @@ func (client *lrOSCustomHeaderOperations) BeginPost202Retry200(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.post202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -61,38 +58,15 @@ func (client *lrOSCustomHeaderOperations) BeginPost202Retry200(ctx context.Conte
 	}, nil
 }
 
-func (client *lrOSCustomHeaderOperations) ResumeLrOSCustomHeaderPost202Retry200Poller(id string) (LrOSCustomHeaderPost202Retry200Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSCustomHeaderOperations) ResumeLrOSCustomHeaderPost202Retry200Poller(token string) (LrOSCustomHeaderPost202Retry200Poller, error) {
+	pt, err := resumePollingTracker(token, client.post202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSCustomHeaderPost202Retry200Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSCustomHeaderPost202Retry200Poller{
+	return &lrOSCustomHeaderPost202Retry200Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSCustomHeaderPost202Retry200Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // post202Retry200CreateRequest creates the Post202Retry200 request.
@@ -126,6 +100,15 @@ func (client *lrOSCustomHeaderOperations) post202Retry200HandleResponse(resp *az
 	return &result, nil
 }
 
+// post202Retry200HandleError handles the Post202Retry200 error response.
+func (client *lrOSCustomHeaderOperations) post202Retry200HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PostAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrOSCustomHeaderOperations) BeginPostAsyncRetrySucceeded(ctx context.Context, lrOSCustomHeaderPostAsyncRetrySucceededOptions *LrOSCustomHeaderPostAsyncRetrySucceededOptions) (LrOSCustomHeaderPostAsyncRetrySucceededPoller, error) {
 	req, err := client.postAsyncRetrySucceededCreateRequest(lrOSCustomHeaderPostAsyncRetrySucceededOptions)
@@ -137,7 +120,7 @@ func (client *lrOSCustomHeaderOperations) BeginPostAsyncRetrySucceeded(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.postAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -147,38 +130,15 @@ func (client *lrOSCustomHeaderOperations) BeginPostAsyncRetrySucceeded(ctx conte
 	}, nil
 }
 
-func (client *lrOSCustomHeaderOperations) ResumeLrOSCustomHeaderPostAsyncRetrySucceededPoller(id string) (LrOSCustomHeaderPostAsyncRetrySucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSCustomHeaderOperations) ResumeLrOSCustomHeaderPostAsyncRetrySucceededPoller(token string) (LrOSCustomHeaderPostAsyncRetrySucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.postAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSCustomHeaderPostAsyncRetrySucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSCustomHeaderPostAsyncRetrySucceededPoller{
+	return &lrOSCustomHeaderPostAsyncRetrySucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSCustomHeaderPostAsyncRetrySucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // postAsyncRetrySucceededCreateRequest creates the PostAsyncRetrySucceeded request.
@@ -215,6 +175,15 @@ func (client *lrOSCustomHeaderOperations) postAsyncRetrySucceededHandleResponse(
 	return &result, nil
 }
 
+// postAsyncRetrySucceededHandleError handles the PostAsyncRetrySucceeded error response.
+func (client *lrOSCustomHeaderOperations) postAsyncRetrySucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // Put201CreatingSucceeded200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
 func (client *lrOSCustomHeaderOperations) BeginPut201CreatingSucceeded200(ctx context.Context, lrOSCustomHeaderPut201CreatingSucceeded200Options *LrOSCustomHeaderPut201CreatingSucceeded200Options) (LrOSCustomHeaderPut201CreatingSucceeded200Poller, error) {
 	req, err := client.put201CreatingSucceeded200CreateRequest(lrOSCustomHeaderPut201CreatingSucceeded200Options)
@@ -226,7 +195,7 @@ func (client *lrOSCustomHeaderOperations) BeginPut201CreatingSucceeded200(ctx co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -236,38 +205,15 @@ func (client *lrOSCustomHeaderOperations) BeginPut201CreatingSucceeded200(ctx co
 	}, nil
 }
 
-func (client *lrOSCustomHeaderOperations) ResumeLrOSCustomHeaderPut201CreatingSucceeded200Poller(id string) (LrOSCustomHeaderPut201CreatingSucceeded200Poller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSCustomHeaderOperations) ResumeLrOSCustomHeaderPut201CreatingSucceeded200Poller(token string) (LrOSCustomHeaderPut201CreatingSucceeded200Poller, error) {
+	pt, err := resumePollingTracker(token, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSCustomHeaderPut201CreatingSucceeded200Poller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSCustomHeaderPut201CreatingSucceeded200Poller{
+	return &lrOSCustomHeaderPut201CreatingSucceeded200Poller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSCustomHeaderPut201CreatingSucceeded200Poller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // put201CreatingSucceeded200CreateRequest creates the Put201CreatingSucceeded200 request.
@@ -290,6 +236,15 @@ func (client *lrOSCustomHeaderOperations) put201CreatingSucceeded200HandleRespon
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
+// put201CreatingSucceeded200HandleError handles the Put201CreatingSucceeded200 error response.
+func (client *lrOSCustomHeaderOperations) put201CreatingSucceeded200HandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // PutAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func (client *lrOSCustomHeaderOperations) BeginPutAsyncRetrySucceeded(ctx context.Context, lrOSCustomHeaderPutAsyncRetrySucceededOptions *LrOSCustomHeaderPutAsyncRetrySucceededOptions) (LrOSCustomHeaderPutAsyncRetrySucceededPoller, error) {
 	req, err := client.putAsyncRetrySucceededCreateRequest(lrOSCustomHeaderPutAsyncRetrySucceededOptions)
@@ -301,7 +256,7 @@ func (client *lrOSCustomHeaderOperations) BeginPutAsyncRetrySucceeded(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker(resp)
+	pt, err := createPollingTracker(resp, client.putAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -311,38 +266,15 @@ func (client *lrOSCustomHeaderOperations) BeginPutAsyncRetrySucceeded(ctx contex
 	}, nil
 }
 
-func (client *lrOSCustomHeaderOperations) ResumeLrOSCustomHeaderPutAsyncRetrySucceededPoller(id string) (LrOSCustomHeaderPutAsyncRetrySucceededPoller, error) {
-	// unmarshal into JSON object to determine the tracker type
-	obj := map[string]interface{}{}
-	err := json.Unmarshal([]byte(id), &obj)
+func (client *lrOSCustomHeaderOperations) ResumeLrOSCustomHeaderPutAsyncRetrySucceededPoller(token string) (LrOSCustomHeaderPutAsyncRetrySucceededPoller, error) {
+	pt, err := resumePollingTracker(token, client.putAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
-	if obj["method"] == nil {
-		return nil, fmt.Errorf("ResumeLrOSCustomHeaderPutAsyncRetrySucceededPoller: missing 'method' property")
-	}
-	method := obj["method"].(string)
-	poller := &lrOSCustomHeaderPutAsyncRetrySucceededPoller{
+	return &lrOSCustomHeaderPutAsyncRetrySucceededPoller{
 		client: client,
-	}
-	switch strings.ToUpper(method) {
-	case http.MethodDelete:
-		poller.pt = &pollingTrackerDelete{}
-	case http.MethodPatch:
-		poller.pt = &pollingTrackerPatch{}
-	case http.MethodPost:
-		poller.pt = &pollingTrackerPost{}
-	case http.MethodPut:
-		poller.pt = &pollingTrackerPut{}
-	default:
-		return nil, fmt.Errorf("ResumeLrOSCustomHeaderPutAsyncRetrySucceededPoller: unsupported method '%s'", method)
-	}
-	// now unmarshal into the tracker
-	err = json.Unmarshal([]byte(id), &poller.pt)
-	if err != nil {
-		return nil, err
-	}
-	return poller, nil
+		pt:     pt,
+	}, nil
 }
 
 // putAsyncRetrySucceededCreateRequest creates the PutAsyncRetrySucceeded request.
@@ -363,4 +295,13 @@ func (client *lrOSCustomHeaderOperations) putAsyncRetrySucceededCreateRequest(lr
 func (client *lrOSCustomHeaderOperations) putAsyncRetrySucceededHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
 	result := ProductResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Product)
+}
+
+// putAsyncRetrySucceededHandleError handles the PutAsyncRetrySucceeded error response.
+func (client *lrOSCustomHeaderOperations) putAsyncRetrySucceededHandleError(resp *azcore.Response) error {
+	err := CloudError{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/lrogroup/models.go
+++ b/test/autorest/generated/lrogroup/models.go
@@ -7,21 +7,12 @@ package lrogroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 )
 
 type CloudError struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newCloudError(resp *azcore.Response) error {
-	err := CloudError{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e CloudError) Error() string {

--- a/test/autorest/generated/lrogroup/pollers.go
+++ b/test/autorest/generated/lrogroup/pollers.go
@@ -31,11 +31,11 @@ type lrOSCustomHeaderPost202Retry200Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSCustomHeaderPost202Retry200Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -123,11 +123,11 @@ type lrOSCustomHeaderPostAsyncRetrySucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSCustomHeaderPostAsyncRetrySucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -215,11 +215,11 @@ type lrOSCustomHeaderPut201CreatingSucceeded200Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSCustomHeaderPut201CreatingSucceeded200Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -307,11 +307,11 @@ type lrOSCustomHeaderPutAsyncRetrySucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSCustomHeaderPutAsyncRetrySucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -399,11 +399,11 @@ type lrOSDelete202NoRetry204Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSDelete202NoRetry204Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -491,11 +491,11 @@ type lrOSDelete202Retry200Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSDelete202Retry200Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -583,11 +583,11 @@ type lrOSDelete204SucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSDelete204SucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -675,11 +675,11 @@ type lrOSDeleteAsyncNoHeaderInRetryPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSDeleteAsyncNoHeaderInRetryPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -767,11 +767,11 @@ type lrOSDeleteAsyncNoRetrySucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSDeleteAsyncNoRetrySucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -859,11 +859,11 @@ type lrOSDeleteAsyncRetryFailedPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSDeleteAsyncRetryFailedPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -951,11 +951,11 @@ type lrOSDeleteAsyncRetrySucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSDeleteAsyncRetrySucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -1043,11 +1043,11 @@ type lrOSDeleteAsyncRetrycanceledPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSDeleteAsyncRetrycanceledPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -1135,11 +1135,11 @@ type lrOSDeleteNoHeaderInRetryPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSDeleteNoHeaderInRetryPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -1227,11 +1227,11 @@ type lrOSDeleteProvisioning202Accepted200SucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSDeleteProvisioning202Accepted200SucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -1319,11 +1319,11 @@ type lrOSDeleteProvisioning202DeletingFailed200Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSDeleteProvisioning202DeletingFailed200Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -1411,11 +1411,11 @@ type lrOSDeleteProvisioning202Deletingcanceled200Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSDeleteProvisioning202Deletingcanceled200Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -1503,11 +1503,11 @@ type lrOSPost200WithPayloadPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPost200WithPayloadPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -1595,11 +1595,11 @@ type lrOSPost202NoRetry204Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPost202NoRetry204Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -1687,11 +1687,11 @@ type lrOSPost202Retry200Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPost202Retry200Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -1779,11 +1779,11 @@ type lrOSPostAsyncNoRetrySucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPostAsyncNoRetrySucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -1871,11 +1871,11 @@ type lrOSPostAsyncRetryFailedPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPostAsyncRetryFailedPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -1963,11 +1963,11 @@ type lrOSPostAsyncRetrySucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPostAsyncRetrySucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -2055,11 +2055,11 @@ type lrOSPostAsyncRetrycanceledPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPostAsyncRetrycanceledPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -2147,11 +2147,11 @@ type lrOSPostDoubleHeadersFinalAzureHeaderGetDefaultPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -2239,11 +2239,11 @@ type lrOSPostDoubleHeadersFinalAzureHeaderGetPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPostDoubleHeadersFinalAzureHeaderGetPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -2331,11 +2331,11 @@ type lrOSPostDoubleHeadersFinalLocationGetPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPostDoubleHeadersFinalLocationGetPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -2423,11 +2423,11 @@ type lrOSPut200Acceptedcanceled200Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPut200Acceptedcanceled200Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -2515,11 +2515,11 @@ type lrOSPut200SucceededNoStatePoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPut200SucceededNoStatePoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -2607,11 +2607,11 @@ type lrOSPut200SucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPut200SucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -2699,11 +2699,11 @@ type lrOSPut200UpdatingSucceeded204Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPut200UpdatingSucceeded204Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -2791,11 +2791,11 @@ type lrOSPut201CreatingFailed200Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPut201CreatingFailed200Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -2883,11 +2883,11 @@ type lrOSPut201CreatingSucceeded200Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPut201CreatingSucceeded200Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -2975,11 +2975,11 @@ type lrOSPut202Retry200Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPut202Retry200Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -3067,11 +3067,11 @@ type lrOSPutAsyncNoHeaderInRetryPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPutAsyncNoHeaderInRetryPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -3159,11 +3159,11 @@ type lrOSPutAsyncNoRetrySucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPutAsyncNoRetrySucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -3251,11 +3251,11 @@ type lrOSPutAsyncNoRetrycanceledPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPutAsyncNoRetrycanceledPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -3343,11 +3343,11 @@ type lrOSPutAsyncNonResourcePoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPutAsyncNonResourcePoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -3435,11 +3435,11 @@ type lrOSPutAsyncRetryFailedPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPutAsyncRetryFailedPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -3527,11 +3527,11 @@ type lrOSPutAsyncRetrySucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPutAsyncRetrySucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -3619,11 +3619,11 @@ type lrOSPutAsyncSubResourcePoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPutAsyncSubResourcePoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -3711,11 +3711,11 @@ type lrOSPutNoHeaderInRetryPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPutNoHeaderInRetryPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -3803,11 +3803,11 @@ type lrOSPutNonResourcePoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPutNonResourcePoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -3895,11 +3895,11 @@ type lrOSPutSubResourcePoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrOSPutSubResourcePoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -3987,11 +3987,11 @@ type lroRetrysDelete202Retry200Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lroRetrysDelete202Retry200Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -4079,11 +4079,11 @@ type lroRetrysDeleteAsyncRelativeRetrySucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lroRetrysDeleteAsyncRelativeRetrySucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -4171,11 +4171,11 @@ type lroRetrysDeleteProvisioning202Accepted200SucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lroRetrysDeleteProvisioning202Accepted200SucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -4263,11 +4263,11 @@ type lroRetrysPost202Retry200Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lroRetrysPost202Retry200Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -4355,11 +4355,11 @@ type lroRetrysPostAsyncRelativeRetrySucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lroRetrysPostAsyncRelativeRetrySucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -4447,11 +4447,11 @@ type lroRetrysPut201CreatingSucceeded200Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lroRetrysPut201CreatingSucceeded200Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -4539,11 +4539,11 @@ type lroRetrysPutAsyncRelativeRetrySucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lroRetrysPutAsyncRelativeRetrySucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -4631,11 +4631,11 @@ type lrosaDsDelete202NonRetry400Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsDelete202NonRetry400Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -4723,11 +4723,11 @@ type lrosaDsDelete202RetryInvalidHeaderPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsDelete202RetryInvalidHeaderPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -4815,11 +4815,11 @@ type lrosaDsDelete204SucceededPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsDelete204SucceededPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -4907,11 +4907,11 @@ type lrosaDsDeleteAsyncRelativeRetry400Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsDeleteAsyncRelativeRetry400Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -4999,11 +4999,11 @@ type lrosaDsDeleteAsyncRelativeRetryInvalidHeaderPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsDeleteAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -5091,11 +5091,11 @@ type lrosaDsDeleteAsyncRelativeRetryInvalidJSONPollingPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsDeleteAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -5183,11 +5183,11 @@ type lrosaDsDeleteAsyncRelativeRetryNoStatusPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsDeleteAsyncRelativeRetryNoStatusPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -5275,11 +5275,11 @@ type lrosaDsDeleteNonRetry400Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsDeleteNonRetry400Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -5367,11 +5367,11 @@ type lrosaDsPost202NoLocationPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPost202NoLocationPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -5459,11 +5459,11 @@ type lrosaDsPost202NonRetry400Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPost202NonRetry400Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -5551,11 +5551,11 @@ type lrosaDsPost202RetryInvalidHeaderPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPost202RetryInvalidHeaderPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -5643,11 +5643,11 @@ type lrosaDsPostAsyncRelativeRetry400Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPostAsyncRelativeRetry400Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -5735,11 +5735,11 @@ type lrosaDsPostAsyncRelativeRetryInvalidHeaderPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPostAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -5827,11 +5827,11 @@ type lrosaDsPostAsyncRelativeRetryInvalidJSONPollingPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPostAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -5919,11 +5919,11 @@ type lrosaDsPostAsyncRelativeRetryNoPayloadPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPostAsyncRelativeRetryNoPayloadPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -6011,11 +6011,11 @@ type lrosaDsPostNonRetry400Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPostNonRetry400Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -6103,11 +6103,11 @@ type lrosaDsPut200InvalidJSONPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPut200InvalidJSONPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -6195,11 +6195,11 @@ type lrosaDsPutAsyncRelativeRetry400Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPutAsyncRelativeRetry400Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -6287,11 +6287,11 @@ type lrosaDsPutAsyncRelativeRetryInvalidHeaderPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPutAsyncRelativeRetryInvalidHeaderPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -6379,11 +6379,11 @@ type lrosaDsPutAsyncRelativeRetryInvalidJSONPollingPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPutAsyncRelativeRetryInvalidJSONPollingPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -6471,11 +6471,11 @@ type lrosaDsPutAsyncRelativeRetryNoStatusPayloadPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPutAsyncRelativeRetryNoStatusPayloadPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -6563,11 +6563,11 @@ type lrosaDsPutAsyncRelativeRetryNoStatusPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPutAsyncRelativeRetryNoStatusPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -6655,11 +6655,11 @@ type lrosaDsPutError201NoProvisioningStatePayloadPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPutError201NoProvisioningStatePayloadPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -6747,11 +6747,11 @@ type lrosaDsPutNonRetry201Creating400InvalidJSONPoller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPutNonRetry201Creating400InvalidJSONPoller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -6839,11 +6839,11 @@ type lrosaDsPutNonRetry201Creating400Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPutNonRetry201Creating400Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation
@@ -6931,11 +6931,11 @@ type lrosaDsPutNonRetry400Poller struct {
 
 // Poll returns false if there was an error or polling has reached a terminal state
 func (p *lrosaDsPutNonRetry400Poller) Poll(ctx context.Context) bool {
-	if done, err := p.done(ctx); err != nil {
+	done, err := p.done(ctx)
+	if err != nil {
 		return false
-	} else {
-		return !done
 	}
+	return !done
 }
 
 // Response returns the latest response that is stored from the latest polling operation

--- a/test/autorest/generated/morecustombaseurigroup/models.go
+++ b/test/autorest/generated/morecustombaseurigroup/models.go
@@ -5,22 +5,11 @@
 
 package morecustombaseurigroup
 
-import (
-	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-)
+import "fmt"
 
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/morecustombaseurigroup/paths.go
+++ b/test/autorest/generated/morecustombaseurigroup/paths.go
@@ -64,7 +64,16 @@ func (client *pathsOperations) getEmptyCreateRequest(vault string, secret string
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *pathsOperations) getEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getEmptyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getEmptyHandleError handles the GetEmpty error response.
+func (client *pathsOperations) getEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/numbergroup/models.go
+++ b/test/autorest/generated/numbergroup/models.go
@@ -7,21 +7,12 @@ package numbergroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 )
 
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/numbergroup/number.go
+++ b/test/autorest/generated/numbergroup/number.go
@@ -99,10 +99,19 @@ func (client *numberOperations) getBigDecimalCreateRequest() (*azcore.Request, e
 // getBigDecimalHandleResponse handles the GetBigDecimal response.
 func (client *numberOperations) getBigDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBigDecimalHandleError(resp)
 	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getBigDecimalHandleError handles the GetBigDecimal error response.
+func (client *numberOperations) getBigDecimalHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBigDecimalNegativeDecimal - Get big decimal value -99999999.99
@@ -136,10 +145,19 @@ func (client *numberOperations) getBigDecimalNegativeDecimalCreateRequest() (*az
 // getBigDecimalNegativeDecimalHandleResponse handles the GetBigDecimalNegativeDecimal response.
 func (client *numberOperations) getBigDecimalNegativeDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBigDecimalNegativeDecimalHandleError(resp)
 	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getBigDecimalNegativeDecimalHandleError handles the GetBigDecimalNegativeDecimal error response.
+func (client *numberOperations) getBigDecimalNegativeDecimalHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBigDecimalPositiveDecimal - Get big decimal value 99999999.99
@@ -173,10 +191,19 @@ func (client *numberOperations) getBigDecimalPositiveDecimalCreateRequest() (*az
 // getBigDecimalPositiveDecimalHandleResponse handles the GetBigDecimalPositiveDecimal response.
 func (client *numberOperations) getBigDecimalPositiveDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBigDecimalPositiveDecimalHandleError(resp)
 	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getBigDecimalPositiveDecimalHandleError handles the GetBigDecimalPositiveDecimal error response.
+func (client *numberOperations) getBigDecimalPositiveDecimalHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBigDouble - Get big double value 2.5976931e+101
@@ -210,10 +237,19 @@ func (client *numberOperations) getBigDoubleCreateRequest() (*azcore.Request, er
 // getBigDoubleHandleResponse handles the GetBigDouble response.
 func (client *numberOperations) getBigDoubleHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBigDoubleHandleError(resp)
 	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getBigDoubleHandleError handles the GetBigDouble error response.
+func (client *numberOperations) getBigDoubleHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBigDoubleNegativeDecimal - Get big double value -99999999.99
@@ -247,10 +283,19 @@ func (client *numberOperations) getBigDoubleNegativeDecimalCreateRequest() (*azc
 // getBigDoubleNegativeDecimalHandleResponse handles the GetBigDoubleNegativeDecimal response.
 func (client *numberOperations) getBigDoubleNegativeDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBigDoubleNegativeDecimalHandleError(resp)
 	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getBigDoubleNegativeDecimalHandleError handles the GetBigDoubleNegativeDecimal error response.
+func (client *numberOperations) getBigDoubleNegativeDecimalHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBigDoublePositiveDecimal - Get big double value 99999999.99
@@ -284,10 +329,19 @@ func (client *numberOperations) getBigDoublePositiveDecimalCreateRequest() (*azc
 // getBigDoublePositiveDecimalHandleResponse handles the GetBigDoublePositiveDecimal response.
 func (client *numberOperations) getBigDoublePositiveDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBigDoublePositiveDecimalHandleError(resp)
 	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getBigDoublePositiveDecimalHandleError handles the GetBigDoublePositiveDecimal error response.
+func (client *numberOperations) getBigDoublePositiveDecimalHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBigFloat - Get big float value 3.402823e+20
@@ -321,10 +375,19 @@ func (client *numberOperations) getBigFloatCreateRequest() (*azcore.Request, err
 // getBigFloatHandleResponse handles the GetBigFloat response.
 func (client *numberOperations) getBigFloatHandleResponse(resp *azcore.Response) (*Float32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBigFloatHandleError(resp)
 	}
 	result := Float32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getBigFloatHandleError handles the GetBigFloat error response.
+func (client *numberOperations) getBigFloatHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetInvalidDecimal - Get invalid decimal Number value
@@ -358,10 +421,19 @@ func (client *numberOperations) getInvalidDecimalCreateRequest() (*azcore.Reques
 // getInvalidDecimalHandleResponse handles the GetInvalidDecimal response.
 func (client *numberOperations) getInvalidDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getInvalidDecimalHandleError(resp)
 	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getInvalidDecimalHandleError handles the GetInvalidDecimal error response.
+func (client *numberOperations) getInvalidDecimalHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetInvalidDouble - Get invalid double Number value
@@ -395,10 +467,19 @@ func (client *numberOperations) getInvalidDoubleCreateRequest() (*azcore.Request
 // getInvalidDoubleHandleResponse handles the GetInvalidDouble response.
 func (client *numberOperations) getInvalidDoubleHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getInvalidDoubleHandleError(resp)
 	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getInvalidDoubleHandleError handles the GetInvalidDouble error response.
+func (client *numberOperations) getInvalidDoubleHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetInvalidFloat - Get invalid float Number value
@@ -432,10 +513,19 @@ func (client *numberOperations) getInvalidFloatCreateRequest() (*azcore.Request,
 // getInvalidFloatHandleResponse handles the GetInvalidFloat response.
 func (client *numberOperations) getInvalidFloatHandleResponse(resp *azcore.Response) (*Float32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getInvalidFloatHandleError(resp)
 	}
 	result := Float32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getInvalidFloatHandleError handles the GetInvalidFloat error response.
+func (client *numberOperations) getInvalidFloatHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNull - Get null Number value
@@ -469,10 +559,19 @@ func (client *numberOperations) getNullCreateRequest() (*azcore.Request, error) 
 // getNullHandleResponse handles the GetNull response.
 func (client *numberOperations) getNullHandleResponse(resp *azcore.Response) (*Float32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNullHandleError(resp)
 	}
 	result := Float32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getNullHandleError handles the GetNull error response.
+func (client *numberOperations) getNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetSmallDecimal - Get small decimal value 2.5976931e-101
@@ -506,10 +605,19 @@ func (client *numberOperations) getSmallDecimalCreateRequest() (*azcore.Request,
 // getSmallDecimalHandleResponse handles the GetSmallDecimal response.
 func (client *numberOperations) getSmallDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getSmallDecimalHandleError(resp)
 	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getSmallDecimalHandleError handles the GetSmallDecimal error response.
+func (client *numberOperations) getSmallDecimalHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetSmallDouble - Get big double value 2.5976931e-101
@@ -543,10 +651,19 @@ func (client *numberOperations) getSmallDoubleCreateRequest() (*azcore.Request, 
 // getSmallDoubleHandleResponse handles the GetSmallDouble response.
 func (client *numberOperations) getSmallDoubleHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getSmallDoubleHandleError(resp)
 	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getSmallDoubleHandleError handles the GetSmallDouble error response.
+func (client *numberOperations) getSmallDoubleHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetSmallFloat - Get big double value 3.402823e-20
@@ -580,10 +697,19 @@ func (client *numberOperations) getSmallFloatCreateRequest() (*azcore.Request, e
 // getSmallFloatHandleResponse handles the GetSmallFloat response.
 func (client *numberOperations) getSmallFloatHandleResponse(resp *azcore.Response) (*Float64Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getSmallFloatHandleError(resp)
 	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getSmallFloatHandleError handles the GetSmallFloat error response.
+func (client *numberOperations) getSmallFloatHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutBigDecimal - Put big decimal value 2.5976931e+101
@@ -617,9 +743,18 @@ func (client *numberOperations) putBigDecimalCreateRequest(numberBody float64) (
 // putBigDecimalHandleResponse handles the PutBigDecimal response.
 func (client *numberOperations) putBigDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putBigDecimalHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putBigDecimalHandleError handles the PutBigDecimal error response.
+func (client *numberOperations) putBigDecimalHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutBigDecimalNegativeDecimal - Put big decimal value -99999999.99
@@ -653,9 +788,18 @@ func (client *numberOperations) putBigDecimalNegativeDecimalCreateRequest() (*az
 // putBigDecimalNegativeDecimalHandleResponse handles the PutBigDecimalNegativeDecimal response.
 func (client *numberOperations) putBigDecimalNegativeDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putBigDecimalNegativeDecimalHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putBigDecimalNegativeDecimalHandleError handles the PutBigDecimalNegativeDecimal error response.
+func (client *numberOperations) putBigDecimalNegativeDecimalHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutBigDecimalPositiveDecimal - Put big decimal value 99999999.99
@@ -689,9 +833,18 @@ func (client *numberOperations) putBigDecimalPositiveDecimalCreateRequest() (*az
 // putBigDecimalPositiveDecimalHandleResponse handles the PutBigDecimalPositiveDecimal response.
 func (client *numberOperations) putBigDecimalPositiveDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putBigDecimalPositiveDecimalHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putBigDecimalPositiveDecimalHandleError handles the PutBigDecimalPositiveDecimal error response.
+func (client *numberOperations) putBigDecimalPositiveDecimalHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutBigDouble - Put big double value 2.5976931e+101
@@ -725,9 +878,18 @@ func (client *numberOperations) putBigDoubleCreateRequest(numberBody float64) (*
 // putBigDoubleHandleResponse handles the PutBigDouble response.
 func (client *numberOperations) putBigDoubleHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putBigDoubleHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putBigDoubleHandleError handles the PutBigDouble error response.
+func (client *numberOperations) putBigDoubleHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutBigDoubleNegativeDecimal - Put big double value -99999999.99
@@ -761,9 +923,18 @@ func (client *numberOperations) putBigDoubleNegativeDecimalCreateRequest() (*azc
 // putBigDoubleNegativeDecimalHandleResponse handles the PutBigDoubleNegativeDecimal response.
 func (client *numberOperations) putBigDoubleNegativeDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putBigDoubleNegativeDecimalHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putBigDoubleNegativeDecimalHandleError handles the PutBigDoubleNegativeDecimal error response.
+func (client *numberOperations) putBigDoubleNegativeDecimalHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutBigDoublePositiveDecimal - Put big double value 99999999.99
@@ -797,9 +968,18 @@ func (client *numberOperations) putBigDoublePositiveDecimalCreateRequest() (*azc
 // putBigDoublePositiveDecimalHandleResponse handles the PutBigDoublePositiveDecimal response.
 func (client *numberOperations) putBigDoublePositiveDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putBigDoublePositiveDecimalHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putBigDoublePositiveDecimalHandleError handles the PutBigDoublePositiveDecimal error response.
+func (client *numberOperations) putBigDoublePositiveDecimalHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutBigFloat - Put big float value 3.402823e+20
@@ -833,9 +1013,18 @@ func (client *numberOperations) putBigFloatCreateRequest(numberBody float32) (*a
 // putBigFloatHandleResponse handles the PutBigFloat response.
 func (client *numberOperations) putBigFloatHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putBigFloatHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putBigFloatHandleError handles the PutBigFloat error response.
+func (client *numberOperations) putBigFloatHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutSmallDecimal - Put small decimal value 2.5976931e-101
@@ -869,9 +1058,18 @@ func (client *numberOperations) putSmallDecimalCreateRequest(numberBody float64)
 // putSmallDecimalHandleResponse handles the PutSmallDecimal response.
 func (client *numberOperations) putSmallDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putSmallDecimalHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putSmallDecimalHandleError handles the PutSmallDecimal error response.
+func (client *numberOperations) putSmallDecimalHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutSmallDouble - Put small double value 2.5976931e-101
@@ -905,9 +1103,18 @@ func (client *numberOperations) putSmallDoubleCreateRequest(numberBody float64) 
 // putSmallDoubleHandleResponse handles the PutSmallDouble response.
 func (client *numberOperations) putSmallDoubleHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putSmallDoubleHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putSmallDoubleHandleError handles the PutSmallDouble error response.
+func (client *numberOperations) putSmallDoubleHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutSmallFloat - Put small float value 3.402823e-20
@@ -941,7 +1148,16 @@ func (client *numberOperations) putSmallFloatCreateRequest(numberBody float32) (
 // putSmallFloatHandleResponse handles the PutSmallFloat response.
 func (client *numberOperations) putSmallFloatHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putSmallFloatHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putSmallFloatHandleError handles the PutSmallFloat error response.
+func (client *numberOperations) putSmallFloatHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/optionalgroup/explicit.go
+++ b/test/autorest/generated/optionalgroup/explicit.go
@@ -100,9 +100,18 @@ func (client *explicitOperations) postOptionalArrayHeaderCreateRequest(explicitP
 // postOptionalArrayHeaderHandleResponse handles the PostOptionalArrayHeader response.
 func (client *explicitOperations) postOptionalArrayHeaderHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postOptionalArrayHeaderHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postOptionalArrayHeaderHandleError handles the PostOptionalArrayHeader error response.
+func (client *explicitOperations) postOptionalArrayHeaderHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostOptionalArrayParameter - Test explicitly optional array. Please put null.
@@ -139,9 +148,18 @@ func (client *explicitOperations) postOptionalArrayParameterCreateRequest(explic
 // postOptionalArrayParameterHandleResponse handles the PostOptionalArrayParameter response.
 func (client *explicitOperations) postOptionalArrayParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postOptionalArrayParameterHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postOptionalArrayParameterHandleError handles the PostOptionalArrayParameter error response.
+func (client *explicitOperations) postOptionalArrayParameterHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostOptionalArrayProperty - Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
@@ -178,9 +196,18 @@ func (client *explicitOperations) postOptionalArrayPropertyCreateRequest(explici
 // postOptionalArrayPropertyHandleResponse handles the PostOptionalArrayProperty response.
 func (client *explicitOperations) postOptionalArrayPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postOptionalArrayPropertyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postOptionalArrayPropertyHandleError handles the PostOptionalArrayProperty error response.
+func (client *explicitOperations) postOptionalArrayPropertyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostOptionalClassParameter - Test explicitly optional complex object. Please put null.
@@ -217,9 +244,18 @@ func (client *explicitOperations) postOptionalClassParameterCreateRequest(explic
 // postOptionalClassParameterHandleResponse handles the PostOptionalClassParameter response.
 func (client *explicitOperations) postOptionalClassParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postOptionalClassParameterHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postOptionalClassParameterHandleError handles the PostOptionalClassParameter error response.
+func (client *explicitOperations) postOptionalClassParameterHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostOptionalClassProperty - Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
@@ -256,9 +292,18 @@ func (client *explicitOperations) postOptionalClassPropertyCreateRequest(explici
 // postOptionalClassPropertyHandleResponse handles the PostOptionalClassProperty response.
 func (client *explicitOperations) postOptionalClassPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postOptionalClassPropertyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postOptionalClassPropertyHandleError handles the PostOptionalClassProperty error response.
+func (client *explicitOperations) postOptionalClassPropertyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostOptionalIntegerHeader - Test explicitly optional integer. Please put a header 'headerParameter' => null.
@@ -295,9 +340,18 @@ func (client *explicitOperations) postOptionalIntegerHeaderCreateRequest(explici
 // postOptionalIntegerHeaderHandleResponse handles the PostOptionalIntegerHeader response.
 func (client *explicitOperations) postOptionalIntegerHeaderHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postOptionalIntegerHeaderHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postOptionalIntegerHeaderHandleError handles the PostOptionalIntegerHeader error response.
+func (client *explicitOperations) postOptionalIntegerHeaderHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostOptionalIntegerParameter - Test explicitly optional integer. Please put null.
@@ -334,9 +388,18 @@ func (client *explicitOperations) postOptionalIntegerParameterCreateRequest(expl
 // postOptionalIntegerParameterHandleResponse handles the PostOptionalIntegerParameter response.
 func (client *explicitOperations) postOptionalIntegerParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postOptionalIntegerParameterHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postOptionalIntegerParameterHandleError handles the PostOptionalIntegerParameter error response.
+func (client *explicitOperations) postOptionalIntegerParameterHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostOptionalIntegerProperty - Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
@@ -373,9 +436,18 @@ func (client *explicitOperations) postOptionalIntegerPropertyCreateRequest(expli
 // postOptionalIntegerPropertyHandleResponse handles the PostOptionalIntegerProperty response.
 func (client *explicitOperations) postOptionalIntegerPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postOptionalIntegerPropertyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postOptionalIntegerPropertyHandleError handles the PostOptionalIntegerProperty error response.
+func (client *explicitOperations) postOptionalIntegerPropertyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostOptionalStringHeader - Test explicitly optional string. Please put a header 'headerParameter' => null.
@@ -412,9 +484,18 @@ func (client *explicitOperations) postOptionalStringHeaderCreateRequest(explicit
 // postOptionalStringHeaderHandleResponse handles the PostOptionalStringHeader response.
 func (client *explicitOperations) postOptionalStringHeaderHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postOptionalStringHeaderHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postOptionalStringHeaderHandleError handles the PostOptionalStringHeader error response.
+func (client *explicitOperations) postOptionalStringHeaderHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostOptionalStringParameter - Test explicitly optional string. Please put null.
@@ -451,9 +532,18 @@ func (client *explicitOperations) postOptionalStringParameterCreateRequest(expli
 // postOptionalStringParameterHandleResponse handles the PostOptionalStringParameter response.
 func (client *explicitOperations) postOptionalStringParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postOptionalStringParameterHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postOptionalStringParameterHandleError handles the PostOptionalStringParameter error response.
+func (client *explicitOperations) postOptionalStringParameterHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostOptionalStringProperty - Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
@@ -490,9 +580,18 @@ func (client *explicitOperations) postOptionalStringPropertyCreateRequest(explic
 // postOptionalStringPropertyHandleResponse handles the PostOptionalStringProperty response.
 func (client *explicitOperations) postOptionalStringPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postOptionalStringPropertyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postOptionalStringPropertyHandleError handles the PostOptionalStringProperty error response.
+func (client *explicitOperations) postOptionalStringPropertyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostRequiredArrayHeader - Test explicitly required array. Please put a header 'headerParameter' => null and the client library should throw before the request is sent.
@@ -527,9 +626,18 @@ func (client *explicitOperations) postRequiredArrayHeaderCreateRequest(headerPar
 // postRequiredArrayHeaderHandleResponse handles the PostRequiredArrayHeader response.
 func (client *explicitOperations) postRequiredArrayHeaderHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postRequiredArrayHeaderHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postRequiredArrayHeaderHandleError handles the PostRequiredArrayHeader error response.
+func (client *explicitOperations) postRequiredArrayHeaderHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostRequiredArrayParameter - Test explicitly required array. Please put null and the client library should throw before the request is sent.
@@ -563,9 +671,18 @@ func (client *explicitOperations) postRequiredArrayParameterCreateRequest(bodyPa
 // postRequiredArrayParameterHandleResponse handles the PostRequiredArrayParameter response.
 func (client *explicitOperations) postRequiredArrayParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postRequiredArrayParameterHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postRequiredArrayParameterHandleError handles the PostRequiredArrayParameter error response.
+func (client *explicitOperations) postRequiredArrayParameterHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostRequiredArrayProperty - Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -599,9 +716,18 @@ func (client *explicitOperations) postRequiredArrayPropertyCreateRequest(bodyPar
 // postRequiredArrayPropertyHandleResponse handles the PostRequiredArrayProperty response.
 func (client *explicitOperations) postRequiredArrayPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postRequiredArrayPropertyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postRequiredArrayPropertyHandleError handles the PostRequiredArrayProperty error response.
+func (client *explicitOperations) postRequiredArrayPropertyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostRequiredClassParameter - Test explicitly required complex object. Please put null and the client library should throw before the request is sent.
@@ -635,9 +761,18 @@ func (client *explicitOperations) postRequiredClassParameterCreateRequest(bodyPa
 // postRequiredClassParameterHandleResponse handles the PostRequiredClassParameter response.
 func (client *explicitOperations) postRequiredClassParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postRequiredClassParameterHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postRequiredClassParameterHandleError handles the PostRequiredClassParameter error response.
+func (client *explicitOperations) postRequiredClassParameterHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostRequiredClassProperty - Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -671,9 +806,18 @@ func (client *explicitOperations) postRequiredClassPropertyCreateRequest(bodyPar
 // postRequiredClassPropertyHandleResponse handles the PostRequiredClassProperty response.
 func (client *explicitOperations) postRequiredClassPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postRequiredClassPropertyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postRequiredClassPropertyHandleError handles the PostRequiredClassProperty error response.
+func (client *explicitOperations) postRequiredClassPropertyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostRequiredIntegerHeader - Test explicitly required integer. Please put a header 'headerParameter' => null and the client library should throw before the request is sent.
@@ -708,9 +852,18 @@ func (client *explicitOperations) postRequiredIntegerHeaderCreateRequest(headerP
 // postRequiredIntegerHeaderHandleResponse handles the PostRequiredIntegerHeader response.
 func (client *explicitOperations) postRequiredIntegerHeaderHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postRequiredIntegerHeaderHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postRequiredIntegerHeaderHandleError handles the PostRequiredIntegerHeader error response.
+func (client *explicitOperations) postRequiredIntegerHeaderHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostRequiredIntegerParameter - Test explicitly required integer. Please put null and the client library should throw before the request is sent.
@@ -744,9 +897,18 @@ func (client *explicitOperations) postRequiredIntegerParameterCreateRequest(body
 // postRequiredIntegerParameterHandleResponse handles the PostRequiredIntegerParameter response.
 func (client *explicitOperations) postRequiredIntegerParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postRequiredIntegerParameterHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postRequiredIntegerParameterHandleError handles the PostRequiredIntegerParameter error response.
+func (client *explicitOperations) postRequiredIntegerParameterHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostRequiredIntegerProperty - Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -780,9 +942,18 @@ func (client *explicitOperations) postRequiredIntegerPropertyCreateRequest(bodyP
 // postRequiredIntegerPropertyHandleResponse handles the PostRequiredIntegerProperty response.
 func (client *explicitOperations) postRequiredIntegerPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postRequiredIntegerPropertyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postRequiredIntegerPropertyHandleError handles the PostRequiredIntegerProperty error response.
+func (client *explicitOperations) postRequiredIntegerPropertyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostRequiredStringHeader - Test explicitly required string. Please put a header 'headerParameter' => null and the client library should throw before the request is sent.
@@ -817,9 +988,18 @@ func (client *explicitOperations) postRequiredStringHeaderCreateRequest(headerPa
 // postRequiredStringHeaderHandleResponse handles the PostRequiredStringHeader response.
 func (client *explicitOperations) postRequiredStringHeaderHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postRequiredStringHeaderHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postRequiredStringHeaderHandleError handles the PostRequiredStringHeader error response.
+func (client *explicitOperations) postRequiredStringHeaderHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostRequiredStringParameter - Test explicitly required string. Please put null and the client library should throw before the request is sent.
@@ -853,9 +1033,18 @@ func (client *explicitOperations) postRequiredStringParameterCreateRequest(bodyP
 // postRequiredStringParameterHandleResponse handles the PostRequiredStringParameter response.
 func (client *explicitOperations) postRequiredStringParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postRequiredStringParameterHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postRequiredStringParameterHandleError handles the PostRequiredStringParameter error response.
+func (client *explicitOperations) postRequiredStringParameterHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostRequiredStringProperty - Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -889,7 +1078,16 @@ func (client *explicitOperations) postRequiredStringPropertyCreateRequest(bodyPa
 // postRequiredStringPropertyHandleResponse handles the PostRequiredStringProperty response.
 func (client *explicitOperations) postRequiredStringPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postRequiredStringPropertyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postRequiredStringPropertyHandleError handles the PostRequiredStringProperty error response.
+func (client *explicitOperations) postRequiredStringPropertyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/optionalgroup/implicit.go
+++ b/test/autorest/generated/optionalgroup/implicit.go
@@ -76,9 +76,18 @@ func (client *implicitOperations) getOptionalGlobalQueryCreateRequest() (*azcore
 // getOptionalGlobalQueryHandleResponse handles the GetOptionalGlobalQuery response.
 func (client *implicitOperations) getOptionalGlobalQueryHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getOptionalGlobalQueryHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getOptionalGlobalQueryHandleError handles the GetOptionalGlobalQuery error response.
+func (client *implicitOperations) getOptionalGlobalQueryHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetRequiredGlobalPath - Test implicitly required path parameter
@@ -113,9 +122,18 @@ func (client *implicitOperations) getRequiredGlobalPathCreateRequest() (*azcore.
 // getRequiredGlobalPathHandleResponse handles the GetRequiredGlobalPath response.
 func (client *implicitOperations) getRequiredGlobalPathHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getRequiredGlobalPathHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getRequiredGlobalPathHandleError handles the GetRequiredGlobalPath error response.
+func (client *implicitOperations) getRequiredGlobalPathHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetRequiredGlobalQuery - Test implicitly required query parameter
@@ -152,9 +170,18 @@ func (client *implicitOperations) getRequiredGlobalQueryCreateRequest() (*azcore
 // getRequiredGlobalQueryHandleResponse handles the GetRequiredGlobalQuery response.
 func (client *implicitOperations) getRequiredGlobalQueryHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getRequiredGlobalQueryHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getRequiredGlobalQueryHandleError handles the GetRequiredGlobalQuery error response.
+func (client *implicitOperations) getRequiredGlobalQueryHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetRequiredPath - Test implicitly required path parameter
@@ -189,9 +216,18 @@ func (client *implicitOperations) getRequiredPathCreateRequest(pathParameter str
 // getRequiredPathHandleResponse handles the GetRequiredPath response.
 func (client *implicitOperations) getRequiredPathHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getRequiredPathHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getRequiredPathHandleError handles the GetRequiredPath error response.
+func (client *implicitOperations) getRequiredPathHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutOptionalBody - Test implicitly optional body parameter
@@ -228,9 +264,18 @@ func (client *implicitOperations) putOptionalBodyCreateRequest(implicitPutOption
 // putOptionalBodyHandleResponse handles the PutOptionalBody response.
 func (client *implicitOperations) putOptionalBodyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putOptionalBodyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putOptionalBodyHandleError handles the PutOptionalBody error response.
+func (client *implicitOperations) putOptionalBodyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutOptionalHeader - Test implicitly optional header parameter
@@ -267,9 +312,18 @@ func (client *implicitOperations) putOptionalHeaderCreateRequest(implicitPutOpti
 // putOptionalHeaderHandleResponse handles the PutOptionalHeader response.
 func (client *implicitOperations) putOptionalHeaderHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putOptionalHeaderHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putOptionalHeaderHandleError handles the PutOptionalHeader error response.
+func (client *implicitOperations) putOptionalHeaderHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutOptionalQuery - Test implicitly optional query parameter
@@ -308,7 +362,16 @@ func (client *implicitOperations) putOptionalQueryCreateRequest(implicitPutOptio
 // putOptionalQueryHandleResponse handles the PutOptionalQuery response.
 func (client *implicitOperations) putOptionalQueryHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putOptionalQueryHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putOptionalQueryHandleError handles the PutOptionalQuery error response.
+func (client *implicitOperations) putOptionalQueryHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/optionalgroup/models.go
+++ b/test/autorest/generated/optionalgroup/models.go
@@ -5,10 +5,7 @@
 
 package optionalgroup
 
-import (
-	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-)
+import "fmt"
 
 type ArrayOptionalWrapper struct {
 	Value *[]string `json:"value,omitempty"`
@@ -29,14 +26,6 @@ type ClassWrapper struct {
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/paginggroup/paging.go
+++ b/test/autorest/generated/paginggroup/paging.go
@@ -99,10 +99,15 @@ func (client *pagingOperations) getMultiplePagesCreateRequest(pagingGetMultipleP
 // getMultiplePagesHandleResponse handles the GetMultiplePages response.
 func (client *pagingOperations) getMultiplePagesHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getMultiplePagesHandleError(resp)
 	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
+}
+
+// getMultiplePagesHandleError handles the GetMultiplePages error response.
+func (client *pagingOperations) getMultiplePagesHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetMultiplePagesFailure - A paging operation that receives a 400 on the second call
@@ -142,10 +147,15 @@ func (client *pagingOperations) getMultiplePagesFailureCreateRequest() (*azcore.
 // getMultiplePagesFailureHandleResponse handles the GetMultiplePagesFailure response.
 func (client *pagingOperations) getMultiplePagesFailureHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getMultiplePagesFailureHandleError(resp)
 	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
+}
+
+// getMultiplePagesFailureHandleError handles the GetMultiplePagesFailure error response.
+func (client *pagingOperations) getMultiplePagesFailureHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetMultiplePagesFailureURI - A paging operation that receives an invalid nextLink
@@ -185,10 +195,15 @@ func (client *pagingOperations) getMultiplePagesFailureUriCreateRequest() (*azco
 // getMultiplePagesFailureUriHandleResponse handles the GetMultiplePagesFailureURI response.
 func (client *pagingOperations) getMultiplePagesFailureUriHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getMultiplePagesFailureUriHandleError(resp)
 	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
+}
+
+// getMultiplePagesFailureUriHandleError handles the GetMultiplePagesFailureURI error response.
+func (client *pagingOperations) getMultiplePagesFailureUriHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetMultiplePagesFragmentNextLink - A paging operation that doesn't return a full URL, just a fragment
@@ -225,10 +240,15 @@ func (client *pagingOperations) getMultiplePagesFragmentNextLinkCreateRequest(ap
 // getMultiplePagesFragmentNextLinkHandleResponse handles the GetMultiplePagesFragmentNextLink response.
 func (client *pagingOperations) getMultiplePagesFragmentNextLinkHandleResponse(resp *azcore.Response) (*OdataProductResultResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getMultiplePagesFragmentNextLinkHandleError(resp)
 	}
 	result := OdataProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.OdataProductResult)
+}
+
+// getMultiplePagesFragmentNextLinkHandleError handles the GetMultiplePagesFragmentNextLink error response.
+func (client *pagingOperations) getMultiplePagesFragmentNextLinkHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetMultiplePagesFragmentWithGroupingNextLink - A paging operation that doesn't return a full URL, just a fragment with parameters grouped
@@ -265,10 +285,15 @@ func (client *pagingOperations) getMultiplePagesFragmentWithGroupingNextLinkCrea
 // getMultiplePagesFragmentWithGroupingNextLinkHandleResponse handles the GetMultiplePagesFragmentWithGroupingNextLink response.
 func (client *pagingOperations) getMultiplePagesFragmentWithGroupingNextLinkHandleResponse(resp *azcore.Response) (*OdataProductResultResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getMultiplePagesFragmentWithGroupingNextLinkHandleError(resp)
 	}
 	result := OdataProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.OdataProductResult)
+}
+
+// getMultiplePagesFragmentWithGroupingNextLinkHandleError handles the GetMultiplePagesFragmentWithGroupingNextLink error response.
+func (client *pagingOperations) getMultiplePagesFragmentWithGroupingNextLinkHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetMultiplePagesLro - A long-running paging operation that includes a nextLink that has 10 pages
@@ -300,6 +325,11 @@ func (client *pagingOperations) getMultiplePagesLroCreateRequest(pagingGetMultip
 func (client *pagingOperations) getMultiplePagesLroHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
+}
+
+// getMultiplePagesLroHandleError handles the GetMultiplePagesLro error response.
+func (client *pagingOperations) getMultiplePagesLroHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetMultiplePagesRetryFirst - A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages
@@ -339,10 +369,15 @@ func (client *pagingOperations) getMultiplePagesRetryFirstCreateRequest() (*azco
 // getMultiplePagesRetryFirstHandleResponse handles the GetMultiplePagesRetryFirst response.
 func (client *pagingOperations) getMultiplePagesRetryFirstHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getMultiplePagesRetryFirstHandleError(resp)
 	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
+}
+
+// getMultiplePagesRetryFirstHandleError handles the GetMultiplePagesRetryFirst error response.
+func (client *pagingOperations) getMultiplePagesRetryFirstHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetMultiplePagesRetrySecond - A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
@@ -382,10 +417,15 @@ func (client *pagingOperations) getMultiplePagesRetrySecondCreateRequest() (*azc
 // getMultiplePagesRetrySecondHandleResponse handles the GetMultiplePagesRetrySecond response.
 func (client *pagingOperations) getMultiplePagesRetrySecondHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getMultiplePagesRetrySecondHandleError(resp)
 	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
+}
+
+// getMultiplePagesRetrySecondHandleError handles the GetMultiplePagesRetrySecond error response.
+func (client *pagingOperations) getMultiplePagesRetrySecondHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetMultiplePagesWithOffset - A paging operation that includes a nextLink that has 10 pages
@@ -435,10 +475,15 @@ func (client *pagingOperations) getMultiplePagesWithOffsetCreateRequest(pagingGe
 // getMultiplePagesWithOffsetHandleResponse handles the GetMultiplePagesWithOffset response.
 func (client *pagingOperations) getMultiplePagesWithOffsetHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getMultiplePagesWithOffsetHandleError(resp)
 	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
+}
+
+// getMultiplePagesWithOffsetHandleError handles the GetMultiplePagesWithOffset error response.
+func (client *pagingOperations) getMultiplePagesWithOffsetHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetNoItemNamePages - A paging operation that must return result of the default 'value' node.
@@ -478,10 +523,15 @@ func (client *pagingOperations) getNoItemNamePagesCreateRequest() (*azcore.Reque
 // getNoItemNamePagesHandleResponse handles the GetNoItemNamePages response.
 func (client *pagingOperations) getNoItemNamePagesHandleResponse(resp *azcore.Response) (*ProductResultValueResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getNoItemNamePagesHandleError(resp)
 	}
 	result := ProductResultValueResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResultValue)
+}
+
+// getNoItemNamePagesHandleError handles the GetNoItemNamePages error response.
+func (client *pagingOperations) getNoItemNamePagesHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetNullNextLinkNamePages - A paging operation that must ignore any kind of nextLink, and stop after page 1.
@@ -515,10 +565,15 @@ func (client *pagingOperations) getNullNextLinkNamePagesCreateRequest() (*azcore
 // getNullNextLinkNamePagesHandleResponse handles the GetNullNextLinkNamePages response.
 func (client *pagingOperations) getNullNextLinkNamePagesHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getNullNextLinkNamePagesHandleError(resp)
 	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
+}
+
+// getNullNextLinkNamePagesHandleError handles the GetNullNextLinkNamePages error response.
+func (client *pagingOperations) getNullNextLinkNamePagesHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetOdataMultiplePages - A paging operation that includes a nextLink in odata format that has 10 pages
@@ -567,10 +622,15 @@ func (client *pagingOperations) getOdataMultiplePagesCreateRequest(pagingGetOdat
 // getOdataMultiplePagesHandleResponse handles the GetOdataMultiplePages response.
 func (client *pagingOperations) getOdataMultiplePagesHandleResponse(resp *azcore.Response) (*OdataProductResultResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getOdataMultiplePagesHandleError(resp)
 	}
 	result := OdataProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.OdataProductResult)
+}
+
+// getOdataMultiplePagesHandleError handles the GetOdataMultiplePages error response.
+func (client *pagingOperations) getOdataMultiplePagesHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetSinglePages - A paging operation that finishes on the first call without a nextlink
@@ -610,10 +670,15 @@ func (client *pagingOperations) getSinglePagesCreateRequest() (*azcore.Request, 
 // getSinglePagesHandleResponse handles the GetSinglePages response.
 func (client *pagingOperations) getSinglePagesHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getSinglePagesHandleError(resp)
 	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
+}
+
+// getSinglePagesHandleError handles the GetSinglePages error response.
+func (client *pagingOperations) getSinglePagesHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetSinglePagesFailure - A paging operation that receives a 400 on the first call
@@ -653,10 +718,15 @@ func (client *pagingOperations) getSinglePagesFailureCreateRequest() (*azcore.Re
 // getSinglePagesFailureHandleResponse handles the GetSinglePagesFailure response.
 func (client *pagingOperations) getSinglePagesFailureHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getSinglePagesFailureHandleError(resp)
 	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
+}
+
+// getSinglePagesFailureHandleError handles the GetSinglePagesFailure error response.
+func (client *pagingOperations) getSinglePagesFailureHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // nextFragmentCreateRequest creates the NextFragment request.
@@ -678,10 +748,15 @@ func (client *pagingOperations) nextFragmentCreateRequest(apiVersion string, ten
 // nextFragmentHandleResponse handles the NextFragment response.
 func (client *pagingOperations) nextFragmentHandleResponse(resp *azcore.Response) (*OdataProductResultResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.nextFragmentHandleError(resp)
 	}
 	result := OdataProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.OdataProductResult)
+}
+
+// nextFragmentHandleError handles the NextFragment error response.
+func (client *pagingOperations) nextFragmentHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // nextFragmentWithGroupingCreateRequest creates the NextFragmentWithGrouping request.
@@ -703,8 +778,13 @@ func (client *pagingOperations) nextFragmentWithGroupingCreateRequest(nextLink s
 // nextFragmentWithGroupingHandleResponse handles the NextFragmentWithGrouping response.
 func (client *pagingOperations) nextFragmentWithGroupingHandleResponse(resp *azcore.Response) (*OdataProductResultResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.nextFragmentWithGroupingHandleError(resp)
 	}
 	result := OdataProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.OdataProductResult)
+}
+
+// nextFragmentWithGroupingHandleError handles the NextFragmentWithGrouping error response.
+func (client *pagingOperations) nextFragmentWithGroupingHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }

--- a/test/autorest/generated/paramgroupinggroup/models.go
+++ b/test/autorest/generated/paramgroupinggroup/models.go
@@ -5,22 +5,11 @@
 
 package paramgroupinggroup
 
-import (
-	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-)
+import "fmt"
 
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/paramgroupinggroup/parametergrouping.go
+++ b/test/autorest/generated/paramgroupinggroup/parametergrouping.go
@@ -76,9 +76,18 @@ func (client *parameterGroupingOperations) postMultiParamGroupsCreateRequest(fir
 // postMultiParamGroupsHandleResponse handles the PostMultiParamGroups response.
 func (client *parameterGroupingOperations) postMultiParamGroupsHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postMultiParamGroupsHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postMultiParamGroupsHandleError handles the PostMultiParamGroups error response.
+func (client *parameterGroupingOperations) postMultiParamGroupsHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostOptional - Post a bunch of optional parameters grouped
@@ -120,9 +129,18 @@ func (client *parameterGroupingOperations) postOptionalCreateRequest(parameterGr
 // postOptionalHandleResponse handles the PostOptional response.
 func (client *parameterGroupingOperations) postOptionalHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postOptionalHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postOptionalHandleError handles the PostOptional error response.
+func (client *parameterGroupingOperations) postOptionalHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostRequired - Post a bunch of required parameters grouped
@@ -165,9 +183,18 @@ func (client *parameterGroupingOperations) postRequiredCreateRequest(parameterGr
 // postRequiredHandleResponse handles the PostRequired response.
 func (client *parameterGroupingOperations) postRequiredHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postRequiredHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postRequiredHandleError handles the PostRequired error response.
+func (client *parameterGroupingOperations) postRequiredHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PostSharedParameterGroupObject - Post parameters with a shared parameter group object
@@ -209,7 +236,16 @@ func (client *parameterGroupingOperations) postSharedParameterGroupObjectCreateR
 // postSharedParameterGroupObjectHandleResponse handles the PostSharedParameterGroupObject response.
 func (client *parameterGroupingOperations) postSharedParameterGroupObjectHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.postSharedParameterGroupObjectHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// postSharedParameterGroupObjectHandleError handles the PostSharedParameterGroupObject error response.
+func (client *parameterGroupingOperations) postSharedParameterGroupObjectHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/reportgroup/models.go
+++ b/test/autorest/generated/reportgroup/models.go
@@ -7,21 +7,12 @@ package reportgroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 )
 
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/reportgroup/operations.go
+++ b/test/autorest/generated/reportgroup/operations.go
@@ -60,10 +60,19 @@ func (client *operations) getOptionalReportCreateRequest(operationsGetOptionalRe
 // getOptionalReportHandleResponse handles the GetOptionalReport response.
 func (client *operations) getOptionalReportHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getOptionalReportHandleError(resp)
 	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getOptionalReportHandleError handles the GetOptionalReport error response.
+func (client *operations) getOptionalReportHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetReport - Get test coverage report
@@ -102,8 +111,17 @@ func (client *operations) getReportCreateRequest(operationsGetReportOptions *Ope
 // getReportHandleResponse handles the GetReport response.
 func (client *operations) getReportHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getReportHandleError(resp)
 	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getReportHandleError handles the GetReport error response.
+func (client *operations) getReportHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/stringgroup/enum.go
+++ b/test/autorest/generated/stringgroup/enum.go
@@ -63,10 +63,19 @@ func (client *enumOperations) getNotExpandableCreateRequest() (*azcore.Request, 
 // getNotExpandableHandleResponse handles the GetNotExpandable response.
 func (client *enumOperations) getNotExpandableHandleResponse(resp *azcore.Response) (*ColorsResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNotExpandableHandleError(resp)
 	}
 	result := ColorsResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getNotExpandableHandleError handles the GetNotExpandable error response.
+func (client *enumOperations) getNotExpandableHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetReferenced - Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -100,10 +109,19 @@ func (client *enumOperations) getReferencedCreateRequest() (*azcore.Request, err
 // getReferencedHandleResponse handles the GetReferenced response.
 func (client *enumOperations) getReferencedHandleResponse(resp *azcore.Response) (*ColorsResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getReferencedHandleError(resp)
 	}
 	result := ColorsResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getReferencedHandleError handles the GetReferenced error response.
+func (client *enumOperations) getReferencedHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetReferencedConstant - Get value 'green-color' from the constant.
@@ -137,10 +155,19 @@ func (client *enumOperations) getReferencedConstantCreateRequest() (*azcore.Requ
 // getReferencedConstantHandleResponse handles the GetReferencedConstant response.
 func (client *enumOperations) getReferencedConstantHandleResponse(resp *azcore.Response) (*RefColorConstantResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getReferencedConstantHandleError(resp)
 	}
 	result := RefColorConstantResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.RefColorConstant)
+}
+
+// getReferencedConstantHandleError handles the GetReferencedConstant error response.
+func (client *enumOperations) getReferencedConstantHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutNotExpandable - Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
@@ -174,9 +201,18 @@ func (client *enumOperations) putNotExpandableCreateRequest(stringBody Colors) (
 // putNotExpandableHandleResponse handles the PutNotExpandable response.
 func (client *enumOperations) putNotExpandableHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putNotExpandableHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putNotExpandableHandleError handles the PutNotExpandable error response.
+func (client *enumOperations) putNotExpandableHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutReferenced - Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
@@ -210,9 +246,18 @@ func (client *enumOperations) putReferencedCreateRequest(enumStringBody Colors) 
 // putReferencedHandleResponse handles the PutReferenced response.
 func (client *enumOperations) putReferencedHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putReferencedHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putReferencedHandleError handles the PutReferenced error response.
+func (client *enumOperations) putReferencedHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutReferencedConstant - Sends value 'green-color' from a constant
@@ -246,7 +291,16 @@ func (client *enumOperations) putReferencedConstantCreateRequest(enumStringBody 
 // putReferencedConstantHandleResponse handles the PutReferencedConstant response.
 func (client *enumOperations) putReferencedConstantHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putReferencedConstantHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putReferencedConstantHandleError handles the PutReferencedConstant error response.
+func (client *enumOperations) putReferencedConstantHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/stringgroup/models.go
+++ b/test/autorest/generated/stringgroup/models.go
@@ -7,7 +7,6 @@ package stringgroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 )
 
@@ -28,14 +27,6 @@ type ColorsResponse struct {
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/stringgroup/string.go
+++ b/test/autorest/generated/stringgroup/string.go
@@ -77,10 +77,19 @@ func (client *stringOperations) getBase64EncodedCreateRequest() (*azcore.Request
 // getBase64EncodedHandleResponse handles the GetBase64Encoded response.
 func (client *stringOperations) getBase64EncodedHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBase64EncodedHandleError(resp)
 	}
 	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getBase64EncodedHandleError handles the GetBase64Encoded error response.
+func (client *stringOperations) getBase64EncodedHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBase64URLEncoded - Get value that is base64url encoded
@@ -114,10 +123,19 @@ func (client *stringOperations) getBase64UrlEncodedCreateRequest() (*azcore.Requ
 // getBase64UrlEncodedHandleResponse handles the GetBase64URLEncoded response.
 func (client *stringOperations) getBase64UrlEncodedHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBase64UrlEncodedHandleError(resp)
 	}
 	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getBase64UrlEncodedHandleError handles the GetBase64URLEncoded error response.
+func (client *stringOperations) getBase64UrlEncodedHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetEmpty - Get empty string value value ''
@@ -151,10 +169,19 @@ func (client *stringOperations) getEmptyCreateRequest() (*azcore.Request, error)
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *stringOperations) getEmptyHandleResponse(resp *azcore.Response) (*StringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getEmptyHandleError(resp)
 	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getEmptyHandleError handles the GetEmpty error response.
+func (client *stringOperations) getEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetMBCS - Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
@@ -188,10 +215,19 @@ func (client *stringOperations) getMbcsCreateRequest() (*azcore.Request, error) 
 // getMbcsHandleResponse handles the GetMBCS response.
 func (client *stringOperations) getMbcsHandleResponse(resp *azcore.Response) (*StringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getMbcsHandleError(resp)
 	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getMbcsHandleError handles the GetMBCS error response.
+func (client *stringOperations) getMbcsHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNotProvided - Get String value when no string value is sent in response payload
@@ -225,10 +261,19 @@ func (client *stringOperations) getNotProvidedCreateRequest() (*azcore.Request, 
 // getNotProvidedHandleResponse handles the GetNotProvided response.
 func (client *stringOperations) getNotProvidedHandleResponse(resp *azcore.Response) (*StringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNotProvidedHandleError(resp)
 	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getNotProvidedHandleError handles the GetNotProvided error response.
+func (client *stringOperations) getNotProvidedHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNull - Get null string value value
@@ -262,10 +307,19 @@ func (client *stringOperations) getNullCreateRequest() (*azcore.Request, error) 
 // getNullHandleResponse handles the GetNull response.
 func (client *stringOperations) getNullHandleResponse(resp *azcore.Response) (*StringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNullHandleError(resp)
 	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getNullHandleError handles the GetNull error response.
+func (client *stringOperations) getNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNullBase64URLEncoded - Get null value that is expected to be base64url encoded
@@ -299,10 +353,19 @@ func (client *stringOperations) getNullBase64UrlEncodedCreateRequest() (*azcore.
 // getNullBase64UrlEncodedHandleResponse handles the GetNullBase64URLEncoded response.
 func (client *stringOperations) getNullBase64UrlEncodedHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNullBase64UrlEncodedHandleError(resp)
 	}
 	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getNullBase64UrlEncodedHandleError handles the GetNullBase64URLEncoded error response.
+func (client *stringOperations) getNullBase64UrlEncodedHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetWhitespace - Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
@@ -336,10 +399,19 @@ func (client *stringOperations) getWhitespaceCreateRequest() (*azcore.Request, e
 // getWhitespaceHandleResponse handles the GetWhitespace response.
 func (client *stringOperations) getWhitespaceHandleResponse(resp *azcore.Response) (*StringResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getWhitespaceHandleError(resp)
 	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
+}
+
+// getWhitespaceHandleError handles the GetWhitespace error response.
+func (client *stringOperations) getWhitespaceHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutBase64URLEncoded - Put value that is base64url encoded
@@ -373,9 +445,18 @@ func (client *stringOperations) putBase64UrlEncodedCreateRequest(stringBody []by
 // putBase64UrlEncodedHandleResponse handles the PutBase64URLEncoded response.
 func (client *stringOperations) putBase64UrlEncodedHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putBase64UrlEncodedHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putBase64UrlEncodedHandleError handles the PutBase64URLEncoded error response.
+func (client *stringOperations) putBase64UrlEncodedHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutEmpty - Set string value empty ''
@@ -409,9 +490,18 @@ func (client *stringOperations) putEmptyCreateRequest() (*azcore.Request, error)
 // putEmptyHandleResponse handles the PutEmpty response.
 func (client *stringOperations) putEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putEmptyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putEmptyHandleError handles the PutEmpty error response.
+func (client *stringOperations) putEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutMBCS - Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
@@ -445,9 +535,18 @@ func (client *stringOperations) putMbcsCreateRequest() (*azcore.Request, error) 
 // putMbcsHandleResponse handles the PutMBCS response.
 func (client *stringOperations) putMbcsHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putMbcsHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putMbcsHandleError handles the PutMBCS error response.
+func (client *stringOperations) putMbcsHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutNull - Set string value null
@@ -484,9 +583,18 @@ func (client *stringOperations) putNullCreateRequest(stringPutNullOptions *Strin
 // putNullHandleResponse handles the PutNull response.
 func (client *stringOperations) putNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putNullHandleError handles the PutNull error response.
+func (client *stringOperations) putNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutWhitespace - Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
@@ -520,7 +628,16 @@ func (client *stringOperations) putWhitespaceCreateRequest() (*azcore.Request, e
 // putWhitespaceHandleResponse handles the PutWhitespace response.
 func (client *stringOperations) putWhitespaceHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.putWhitespaceHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putWhitespaceHandleError handles the PutWhitespace error response.
+func (client *stringOperations) putWhitespaceHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/urlgroup/models.go
+++ b/test/autorest/generated/urlgroup/models.go
@@ -7,21 +7,12 @@ package urlgroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"time"
 )
 
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/urlgroup/pathitems.go
+++ b/test/autorest/generated/urlgroup/pathitems.go
@@ -77,9 +77,18 @@ func (client *pathItemsOperations) getAllWithValuesCreateRequest(pathItemStringP
 // getAllWithValuesHandleResponse handles the GetAllWithValues response.
 func (client *pathItemsOperations) getAllWithValuesHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getAllWithValuesHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getAllWithValuesHandleError handles the GetAllWithValues error response.
+func (client *pathItemsOperations) getAllWithValuesHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetGlobalAndLocalQueryNull - send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null
@@ -127,9 +136,18 @@ func (client *pathItemsOperations) getGlobalAndLocalQueryNullCreateRequest(pathI
 // getGlobalAndLocalQueryNullHandleResponse handles the GetGlobalAndLocalQueryNull response.
 func (client *pathItemsOperations) getGlobalAndLocalQueryNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getGlobalAndLocalQueryNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getGlobalAndLocalQueryNullHandleError handles the GetGlobalAndLocalQueryNull error response.
+func (client *pathItemsOperations) getGlobalAndLocalQueryNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetGlobalQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
@@ -177,9 +195,18 @@ func (client *pathItemsOperations) getGlobalQueryNullCreateRequest(pathItemStrin
 // getGlobalQueryNullHandleResponse handles the GetGlobalQueryNull response.
 func (client *pathItemsOperations) getGlobalQueryNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getGlobalQueryNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getGlobalQueryNullHandleError handles the GetGlobalQueryNull error response.
+func (client *pathItemsOperations) getGlobalQueryNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetLocalPathItemQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null
@@ -227,7 +254,16 @@ func (client *pathItemsOperations) getLocalPathItemQueryNullCreateRequest(pathIt
 // getLocalPathItemQueryNullHandleResponse handles the GetLocalPathItemQueryNull response.
 func (client *pathItemsOperations) getLocalPathItemQueryNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getLocalPathItemQueryNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getLocalPathItemQueryNullHandleError handles the GetLocalPathItemQueryNull error response.
+func (client *pathItemsOperations) getLocalPathItemQueryNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/urlgroup/paths.go
+++ b/test/autorest/generated/urlgroup/paths.go
@@ -110,9 +110,18 @@ func (client *pathsOperations) arrayCsvInPathCreateRequest(arrayPath []string) (
 // arrayCsvInPathHandleResponse handles the ArrayCSVInPath response.
 func (client *pathsOperations) arrayCsvInPathHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.arrayCsvInPathHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// arrayCsvInPathHandleError handles the ArrayCSVInPath error response.
+func (client *pathsOperations) arrayCsvInPathHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Base64URL - Get 'lorem' encoded value as 'bG9yZW0' (base64url)
@@ -147,9 +156,18 @@ func (client *pathsOperations) base64UrlCreateRequest(base64UrlPath []byte) (*az
 // base64UrlHandleResponse handles the Base64URL response.
 func (client *pathsOperations) base64UrlHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.base64UrlHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// base64UrlHandleError handles the Base64URL error response.
+func (client *pathsOperations) base64UrlHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ByteEmpty - Get '' as byte array
@@ -184,9 +202,18 @@ func (client *pathsOperations) byteEmptyCreateRequest() (*azcore.Request, error)
 // byteEmptyHandleResponse handles the ByteEmpty response.
 func (client *pathsOperations) byteEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.byteEmptyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// byteEmptyHandleError handles the ByteEmpty error response.
+func (client *pathsOperations) byteEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
@@ -221,9 +248,18 @@ func (client *pathsOperations) byteMultiByteCreateRequest(bytePath []byte) (*azc
 // byteMultiByteHandleResponse handles the ByteMultiByte response.
 func (client *pathsOperations) byteMultiByteHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.byteMultiByteHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// byteMultiByteHandleError handles the ByteMultiByte error response.
+func (client *pathsOperations) byteMultiByteHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ByteNull - Get null as byte array (should throw)
@@ -258,9 +294,18 @@ func (client *pathsOperations) byteNullCreateRequest(bytePath []byte) (*azcore.R
 // byteNullHandleResponse handles the ByteNull response.
 func (client *pathsOperations) byteNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusBadRequest) {
-		return nil, newError(resp)
+		return nil, client.byteNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// byteNullHandleError handles the ByteNull error response.
+func (client *pathsOperations) byteNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // DateNull - Get null as date - this should throw or be unusable on the client side, depending on date representation
@@ -295,9 +340,18 @@ func (client *pathsOperations) dateNullCreateRequest(datePath time.Time) (*azcor
 // dateNullHandleResponse handles the DateNull response.
 func (client *pathsOperations) dateNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusBadRequest) {
-		return nil, newError(resp)
+		return nil, client.dateNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// dateNullHandleError handles the DateNull error response.
+func (client *pathsOperations) dateNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // DateTimeNull - Get null as date-time, should be disallowed or throw depending on representation of date-time
@@ -332,9 +386,18 @@ func (client *pathsOperations) dateTimeNullCreateRequest(dateTimePath time.Time)
 // dateTimeNullHandleResponse handles the DateTimeNull response.
 func (client *pathsOperations) dateTimeNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusBadRequest) {
-		return nil, newError(resp)
+		return nil, client.dateTimeNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// dateTimeNullHandleError handles the DateTimeNull error response.
+func (client *pathsOperations) dateTimeNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
@@ -369,9 +432,18 @@ func (client *pathsOperations) dateTimeValidCreateRequest() (*azcore.Request, er
 // dateTimeValidHandleResponse handles the DateTimeValid response.
 func (client *pathsOperations) dateTimeValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.dateTimeValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// dateTimeValidHandleError handles the DateTimeValid error response.
+func (client *pathsOperations) dateTimeValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // DateValid - Get '2012-01-01' as date
@@ -406,9 +478,18 @@ func (client *pathsOperations) dateValidCreateRequest() (*azcore.Request, error)
 // dateValidHandleResponse handles the DateValid response.
 func (client *pathsOperations) dateValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.dateValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// dateValidHandleError handles the DateValid error response.
+func (client *pathsOperations) dateValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // DoubleDecimalNegative - Get '-9999999.999' numeric value
@@ -443,9 +524,18 @@ func (client *pathsOperations) doubleDecimalNegativeCreateRequest() (*azcore.Req
 // doubleDecimalNegativeHandleResponse handles the DoubleDecimalNegative response.
 func (client *pathsOperations) doubleDecimalNegativeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.doubleDecimalNegativeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// doubleDecimalNegativeHandleError handles the DoubleDecimalNegative error response.
+func (client *pathsOperations) doubleDecimalNegativeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // DoubleDecimalPositive - Get '9999999.999' numeric value
@@ -480,9 +570,18 @@ func (client *pathsOperations) doubleDecimalPositiveCreateRequest() (*azcore.Req
 // doubleDecimalPositiveHandleResponse handles the DoubleDecimalPositive response.
 func (client *pathsOperations) doubleDecimalPositiveHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.doubleDecimalPositiveHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// doubleDecimalPositiveHandleError handles the DoubleDecimalPositive error response.
+func (client *pathsOperations) doubleDecimalPositiveHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // EnumNull - Get null (should throw on the client before the request is sent on wire)
@@ -517,9 +616,18 @@ func (client *pathsOperations) enumNullCreateRequest(enumPath UriColor) (*azcore
 // enumNullHandleResponse handles the EnumNull response.
 func (client *pathsOperations) enumNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusBadRequest) {
-		return nil, newError(resp)
+		return nil, client.enumNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// enumNullHandleError handles the EnumNull error response.
+func (client *pathsOperations) enumNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // EnumValid - Get using uri with 'green color' in path parameter
@@ -554,9 +662,18 @@ func (client *pathsOperations) enumValidCreateRequest(enumPath UriColor) (*azcor
 // enumValidHandleResponse handles the EnumValid response.
 func (client *pathsOperations) enumValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.enumValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// enumValidHandleError handles the EnumValid error response.
+func (client *pathsOperations) enumValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // FloatScientificNegative - Get '-1.034E-20' numeric value
@@ -591,9 +708,18 @@ func (client *pathsOperations) floatScientificNegativeCreateRequest() (*azcore.R
 // floatScientificNegativeHandleResponse handles the FloatScientificNegative response.
 func (client *pathsOperations) floatScientificNegativeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.floatScientificNegativeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// floatScientificNegativeHandleError handles the FloatScientificNegative error response.
+func (client *pathsOperations) floatScientificNegativeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // FloatScientificPositive - Get '1.034E+20' numeric value
@@ -628,9 +754,18 @@ func (client *pathsOperations) floatScientificPositiveCreateRequest() (*azcore.R
 // floatScientificPositiveHandleResponse handles the FloatScientificPositive response.
 func (client *pathsOperations) floatScientificPositiveHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.floatScientificPositiveHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// floatScientificPositiveHandleError handles the FloatScientificPositive error response.
+func (client *pathsOperations) floatScientificPositiveHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBooleanFalse - Get false Boolean value on path
@@ -665,9 +800,18 @@ func (client *pathsOperations) getBooleanFalseCreateRequest() (*azcore.Request, 
 // getBooleanFalseHandleResponse handles the GetBooleanFalse response.
 func (client *pathsOperations) getBooleanFalseHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBooleanFalseHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getBooleanFalseHandleError handles the GetBooleanFalse error response.
+func (client *pathsOperations) getBooleanFalseHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBooleanTrue - Get true Boolean value on path
@@ -702,9 +846,18 @@ func (client *pathsOperations) getBooleanTrueCreateRequest() (*azcore.Request, e
 // getBooleanTrueHandleResponse handles the GetBooleanTrue response.
 func (client *pathsOperations) getBooleanTrueHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBooleanTrueHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getBooleanTrueHandleError handles the GetBooleanTrue error response.
+func (client *pathsOperations) getBooleanTrueHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetIntNegativeOneMillion - Get '-1000000' integer value
@@ -739,9 +892,18 @@ func (client *pathsOperations) getIntNegativeOneMillionCreateRequest() (*azcore.
 // getIntNegativeOneMillionHandleResponse handles the GetIntNegativeOneMillion response.
 func (client *pathsOperations) getIntNegativeOneMillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getIntNegativeOneMillionHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getIntNegativeOneMillionHandleError handles the GetIntNegativeOneMillion error response.
+func (client *pathsOperations) getIntNegativeOneMillionHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetIntOneMillion - Get '1000000' integer value
@@ -776,9 +938,18 @@ func (client *pathsOperations) getIntOneMillionCreateRequest() (*azcore.Request,
 // getIntOneMillionHandleResponse handles the GetIntOneMillion response.
 func (client *pathsOperations) getIntOneMillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getIntOneMillionHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getIntOneMillionHandleError handles the GetIntOneMillion error response.
+func (client *pathsOperations) getIntOneMillionHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
@@ -813,9 +984,18 @@ func (client *pathsOperations) getNegativeTenBillionCreateRequest() (*azcore.Req
 // getNegativeTenBillionHandleResponse handles the GetNegativeTenBillion response.
 func (client *pathsOperations) getNegativeTenBillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNegativeTenBillionHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getNegativeTenBillionHandleError handles the GetNegativeTenBillion error response.
+func (client *pathsOperations) getNegativeTenBillionHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetTenBillion - Get '10000000000' 64 bit integer value
@@ -850,9 +1030,18 @@ func (client *pathsOperations) getTenBillionCreateRequest() (*azcore.Request, er
 // getTenBillionHandleResponse handles the GetTenBillion response.
 func (client *pathsOperations) getTenBillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getTenBillionHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getTenBillionHandleError handles the GetTenBillion error response.
+func (client *pathsOperations) getTenBillionHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // StringEmpty - Get ''
@@ -887,9 +1076,18 @@ func (client *pathsOperations) stringEmptyCreateRequest() (*azcore.Request, erro
 // stringEmptyHandleResponse handles the StringEmpty response.
 func (client *pathsOperations) stringEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.stringEmptyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// stringEmptyHandleError handles the StringEmpty error response.
+func (client *pathsOperations) stringEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // StringNull - Get null (should throw)
@@ -924,9 +1122,18 @@ func (client *pathsOperations) stringNullCreateRequest(stringPath string) (*azco
 // stringNullHandleResponse handles the StringNull response.
 func (client *pathsOperations) stringNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusBadRequest) {
-		return nil, newError(resp)
+		return nil, client.stringNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// stringNullHandleError handles the StringNull error response.
+func (client *pathsOperations) stringNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
@@ -961,9 +1168,18 @@ func (client *pathsOperations) stringUrlEncodedCreateRequest() (*azcore.Request,
 // stringUrlEncodedHandleResponse handles the StringURLEncoded response.
 func (client *pathsOperations) stringUrlEncodedHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.stringUrlEncodedHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// stringUrlEncodedHandleError handles the StringURLEncoded error response.
+func (client *pathsOperations) stringUrlEncodedHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // StringURLNonEncoded - Get 'begin!*'();:@&=+$,end
@@ -998,9 +1214,18 @@ func (client *pathsOperations) stringUrlNonEncodedCreateRequest() (*azcore.Reque
 // stringUrlNonEncodedHandleResponse handles the StringURLNonEncoded response.
 func (client *pathsOperations) stringUrlNonEncodedHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.stringUrlNonEncodedHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// stringUrlNonEncodedHandleError handles the StringURLNonEncoded error response.
+func (client *pathsOperations) stringUrlNonEncodedHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
@@ -1035,9 +1260,18 @@ func (client *pathsOperations) stringUnicodeCreateRequest() (*azcore.Request, er
 // stringUnicodeHandleResponse handles the StringUnicode response.
 func (client *pathsOperations) stringUnicodeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.stringUnicodeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// stringUnicodeHandleError handles the StringUnicode error response.
+func (client *pathsOperations) stringUnicodeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // UnixTimeURL - Get the date 2016-04-13 encoded value as '1460505600' (Unix time)
@@ -1072,7 +1306,16 @@ func (client *pathsOperations) unixTimeUrlCreateRequest(unixTimeUrlPath time.Tim
 // unixTimeUrlHandleResponse handles the UnixTimeURL response.
 func (client *pathsOperations) unixTimeUrlHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.unixTimeUrlHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// unixTimeUrlHandleError handles the UnixTimeURL error response.
+func (client *pathsOperations) unixTimeUrlHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/urlgroup/queries.go
+++ b/test/autorest/generated/urlgroup/queries.go
@@ -128,9 +128,18 @@ func (client *queriesOperations) arrayStringCsvEmptyCreateRequest(queriesArraySt
 // arrayStringCsvEmptyHandleResponse handles the ArrayStringCSVEmpty response.
 func (client *queriesOperations) arrayStringCsvEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.arrayStringCsvEmptyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// arrayStringCsvEmptyHandleError handles the ArrayStringCSVEmpty error response.
+func (client *queriesOperations) arrayStringCsvEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ArrayStringCSVNull - Get a null array of string using the csv-array format
@@ -169,9 +178,18 @@ func (client *queriesOperations) arrayStringCsvNullCreateRequest(queriesArrayStr
 // arrayStringCsvNullHandleResponse handles the ArrayStringCSVNull response.
 func (client *queriesOperations) arrayStringCsvNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.arrayStringCsvNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// arrayStringCsvNullHandleError handles the ArrayStringCSVNull error response.
+func (client *queriesOperations) arrayStringCsvNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ArrayStringCSVValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
@@ -210,9 +228,18 @@ func (client *queriesOperations) arrayStringCsvValidCreateRequest(queriesArraySt
 // arrayStringCsvValidHandleResponse handles the ArrayStringCSVValid response.
 func (client *queriesOperations) arrayStringCsvValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.arrayStringCsvValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// arrayStringCsvValidHandleError handles the ArrayStringCSVValid error response.
+func (client *queriesOperations) arrayStringCsvValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ArrayStringPipesValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array format
@@ -251,9 +278,18 @@ func (client *queriesOperations) arrayStringPipesValidCreateRequest(queriesArray
 // arrayStringPipesValidHandleResponse handles the ArrayStringPipesValid response.
 func (client *queriesOperations) arrayStringPipesValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.arrayStringPipesValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// arrayStringPipesValidHandleError handles the ArrayStringPipesValid error response.
+func (client *queriesOperations) arrayStringPipesValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ArrayStringSsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format
@@ -292,9 +328,18 @@ func (client *queriesOperations) arrayStringSsvValidCreateRequest(queriesArraySt
 // arrayStringSsvValidHandleResponse handles the ArrayStringSsvValid response.
 func (client *queriesOperations) arrayStringSsvValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.arrayStringSsvValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// arrayStringSsvValidHandleError handles the ArrayStringSsvValid error response.
+func (client *queriesOperations) arrayStringSsvValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ArrayStringTsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array format
@@ -333,9 +378,18 @@ func (client *queriesOperations) arrayStringTsvValidCreateRequest(queriesArraySt
 // arrayStringTsvValidHandleResponse handles the ArrayStringTsvValid response.
 func (client *queriesOperations) arrayStringTsvValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.arrayStringTsvValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// arrayStringTsvValidHandleError handles the ArrayStringTsvValid error response.
+func (client *queriesOperations) arrayStringTsvValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ByteEmpty - Get '' as byte array
@@ -372,9 +426,18 @@ func (client *queriesOperations) byteEmptyCreateRequest() (*azcore.Request, erro
 // byteEmptyHandleResponse handles the ByteEmpty response.
 func (client *queriesOperations) byteEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.byteEmptyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// byteEmptyHandleError handles the ByteEmpty error response.
+func (client *queriesOperations) byteEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
@@ -413,9 +476,18 @@ func (client *queriesOperations) byteMultiByteCreateRequest(queriesByteMultiByte
 // byteMultiByteHandleResponse handles the ByteMultiByte response.
 func (client *queriesOperations) byteMultiByteHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.byteMultiByteHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// byteMultiByteHandleError handles the ByteMultiByte error response.
+func (client *queriesOperations) byteMultiByteHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ByteNull - Get null as byte array (no query parameters in uri)
@@ -454,9 +526,18 @@ func (client *queriesOperations) byteNullCreateRequest(queriesByteNullOptions *Q
 // byteNullHandleResponse handles the ByteNull response.
 func (client *queriesOperations) byteNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.byteNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// byteNullHandleError handles the ByteNull error response.
+func (client *queriesOperations) byteNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // DateNull - Get null as date - this should result in no query parameters in uri
@@ -495,9 +576,18 @@ func (client *queriesOperations) dateNullCreateRequest(queriesDateNullOptions *Q
 // dateNullHandleResponse handles the DateNull response.
 func (client *queriesOperations) dateNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.dateNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// dateNullHandleError handles the DateNull error response.
+func (client *queriesOperations) dateNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // DateTimeNull - Get null as date-time, should result in no query parameters in uri
@@ -536,9 +626,18 @@ func (client *queriesOperations) dateTimeNullCreateRequest(queriesDateTimeNullOp
 // dateTimeNullHandleResponse handles the DateTimeNull response.
 func (client *queriesOperations) dateTimeNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.dateTimeNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// dateTimeNullHandleError handles the DateTimeNull error response.
+func (client *queriesOperations) dateTimeNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
@@ -575,9 +674,18 @@ func (client *queriesOperations) dateTimeValidCreateRequest() (*azcore.Request, 
 // dateTimeValidHandleResponse handles the DateTimeValid response.
 func (client *queriesOperations) dateTimeValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.dateTimeValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// dateTimeValidHandleError handles the DateTimeValid error response.
+func (client *queriesOperations) dateTimeValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // DateValid - Get '2012-01-01' as date
@@ -614,9 +722,18 @@ func (client *queriesOperations) dateValidCreateRequest() (*azcore.Request, erro
 // dateValidHandleResponse handles the DateValid response.
 func (client *queriesOperations) dateValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.dateValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// dateValidHandleError handles the DateValid error response.
+func (client *queriesOperations) dateValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // DoubleDecimalNegative - Get '-9999999.999' numeric value
@@ -653,9 +770,18 @@ func (client *queriesOperations) doubleDecimalNegativeCreateRequest() (*azcore.R
 // doubleDecimalNegativeHandleResponse handles the DoubleDecimalNegative response.
 func (client *queriesOperations) doubleDecimalNegativeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.doubleDecimalNegativeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// doubleDecimalNegativeHandleError handles the DoubleDecimalNegative error response.
+func (client *queriesOperations) doubleDecimalNegativeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // DoubleDecimalPositive - Get '9999999.999' numeric value
@@ -692,9 +818,18 @@ func (client *queriesOperations) doubleDecimalPositiveCreateRequest() (*azcore.R
 // doubleDecimalPositiveHandleResponse handles the DoubleDecimalPositive response.
 func (client *queriesOperations) doubleDecimalPositiveHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.doubleDecimalPositiveHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// doubleDecimalPositiveHandleError handles the DoubleDecimalPositive error response.
+func (client *queriesOperations) doubleDecimalPositiveHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // DoubleNull - Get null numeric value (no query parameter)
@@ -733,9 +868,18 @@ func (client *queriesOperations) doubleNullCreateRequest(queriesDoubleNullOption
 // doubleNullHandleResponse handles the DoubleNull response.
 func (client *queriesOperations) doubleNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.doubleNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// doubleNullHandleError handles the DoubleNull error response.
+func (client *queriesOperations) doubleNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // EnumNull - Get null (no query parameter in url)
@@ -774,9 +918,18 @@ func (client *queriesOperations) enumNullCreateRequest(queriesEnumNullOptions *Q
 // enumNullHandleResponse handles the EnumNull response.
 func (client *queriesOperations) enumNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.enumNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// enumNullHandleError handles the EnumNull error response.
+func (client *queriesOperations) enumNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // EnumValid - Get using uri with query parameter 'green color'
@@ -815,9 +968,18 @@ func (client *queriesOperations) enumValidCreateRequest(queriesEnumValidOptions 
 // enumValidHandleResponse handles the EnumValid response.
 func (client *queriesOperations) enumValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.enumValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// enumValidHandleError handles the EnumValid error response.
+func (client *queriesOperations) enumValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // FloatNull - Get null numeric value (no query parameter)
@@ -856,9 +1018,18 @@ func (client *queriesOperations) floatNullCreateRequest(queriesFloatNullOptions 
 // floatNullHandleResponse handles the FloatNull response.
 func (client *queriesOperations) floatNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.floatNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// floatNullHandleError handles the FloatNull error response.
+func (client *queriesOperations) floatNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // FloatScientificNegative - Get '-1.034E-20' numeric value
@@ -895,9 +1066,18 @@ func (client *queriesOperations) floatScientificNegativeCreateRequest() (*azcore
 // floatScientificNegativeHandleResponse handles the FloatScientificNegative response.
 func (client *queriesOperations) floatScientificNegativeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.floatScientificNegativeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// floatScientificNegativeHandleError handles the FloatScientificNegative error response.
+func (client *queriesOperations) floatScientificNegativeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // FloatScientificPositive - Get '1.034E+20' numeric value
@@ -934,9 +1114,18 @@ func (client *queriesOperations) floatScientificPositiveCreateRequest() (*azcore
 // floatScientificPositiveHandleResponse handles the FloatScientificPositive response.
 func (client *queriesOperations) floatScientificPositiveHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.floatScientificPositiveHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// floatScientificPositiveHandleError handles the FloatScientificPositive error response.
+func (client *queriesOperations) floatScientificPositiveHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBooleanFalse - Get false Boolean value on path
@@ -973,9 +1162,18 @@ func (client *queriesOperations) getBooleanFalseCreateRequest() (*azcore.Request
 // getBooleanFalseHandleResponse handles the GetBooleanFalse response.
 func (client *queriesOperations) getBooleanFalseHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBooleanFalseHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getBooleanFalseHandleError handles the GetBooleanFalse error response.
+func (client *queriesOperations) getBooleanFalseHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBooleanNull - Get null Boolean value on query (query string should be absent)
@@ -1014,9 +1212,18 @@ func (client *queriesOperations) getBooleanNullCreateRequest(queriesGetBooleanNu
 // getBooleanNullHandleResponse handles the GetBooleanNull response.
 func (client *queriesOperations) getBooleanNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBooleanNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getBooleanNullHandleError handles the GetBooleanNull error response.
+func (client *queriesOperations) getBooleanNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetBooleanTrue - Get true Boolean value on path
@@ -1053,9 +1260,18 @@ func (client *queriesOperations) getBooleanTrueCreateRequest() (*azcore.Request,
 // getBooleanTrueHandleResponse handles the GetBooleanTrue response.
 func (client *queriesOperations) getBooleanTrueHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getBooleanTrueHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getBooleanTrueHandleError handles the GetBooleanTrue error response.
+func (client *queriesOperations) getBooleanTrueHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetIntNegativeOneMillion - Get '-1000000' integer value
@@ -1092,9 +1308,18 @@ func (client *queriesOperations) getIntNegativeOneMillionCreateRequest() (*azcor
 // getIntNegativeOneMillionHandleResponse handles the GetIntNegativeOneMillion response.
 func (client *queriesOperations) getIntNegativeOneMillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getIntNegativeOneMillionHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getIntNegativeOneMillionHandleError handles the GetIntNegativeOneMillion error response.
+func (client *queriesOperations) getIntNegativeOneMillionHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetIntNull - Get null integer value (no query parameter)
@@ -1133,9 +1358,18 @@ func (client *queriesOperations) getIntNullCreateRequest(queriesGetIntNullOption
 // getIntNullHandleResponse handles the GetIntNull response.
 func (client *queriesOperations) getIntNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getIntNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getIntNullHandleError handles the GetIntNull error response.
+func (client *queriesOperations) getIntNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetIntOneMillion - Get '1000000' integer value
@@ -1172,9 +1406,18 @@ func (client *queriesOperations) getIntOneMillionCreateRequest() (*azcore.Reques
 // getIntOneMillionHandleResponse handles the GetIntOneMillion response.
 func (client *queriesOperations) getIntOneMillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getIntOneMillionHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getIntOneMillionHandleError handles the GetIntOneMillion error response.
+func (client *queriesOperations) getIntOneMillionHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetLongNull - Get 'null 64 bit integer value (no query param in uri)
@@ -1213,9 +1456,18 @@ func (client *queriesOperations) getLongNullCreateRequest(queriesGetLongNullOpti
 // getLongNullHandleResponse handles the GetLongNull response.
 func (client *queriesOperations) getLongNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getLongNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getLongNullHandleError handles the GetLongNull error response.
+func (client *queriesOperations) getLongNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
@@ -1252,9 +1504,18 @@ func (client *queriesOperations) getNegativeTenBillionCreateRequest() (*azcore.R
 // getNegativeTenBillionHandleResponse handles the GetNegativeTenBillion response.
 func (client *queriesOperations) getNegativeTenBillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getNegativeTenBillionHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getNegativeTenBillionHandleError handles the GetNegativeTenBillion error response.
+func (client *queriesOperations) getNegativeTenBillionHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetTenBillion - Get '10000000000' 64 bit integer value
@@ -1291,9 +1552,18 @@ func (client *queriesOperations) getTenBillionCreateRequest() (*azcore.Request, 
 // getTenBillionHandleResponse handles the GetTenBillion response.
 func (client *queriesOperations) getTenBillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getTenBillionHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getTenBillionHandleError handles the GetTenBillion error response.
+func (client *queriesOperations) getTenBillionHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // StringEmpty - Get ''
@@ -1330,9 +1600,18 @@ func (client *queriesOperations) stringEmptyCreateRequest() (*azcore.Request, er
 // stringEmptyHandleResponse handles the StringEmpty response.
 func (client *queriesOperations) stringEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.stringEmptyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// stringEmptyHandleError handles the StringEmpty error response.
+func (client *queriesOperations) stringEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // StringNull - Get null (no query parameter in url)
@@ -1371,9 +1650,18 @@ func (client *queriesOperations) stringNullCreateRequest(queriesStringNullOption
 // stringNullHandleResponse handles the StringNull response.
 func (client *queriesOperations) stringNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.stringNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// stringNullHandleError handles the StringNull error response.
+func (client *queriesOperations) stringNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
@@ -1410,9 +1698,18 @@ func (client *queriesOperations) stringUrlEncodedCreateRequest() (*azcore.Reques
 // stringUrlEncodedHandleResponse handles the StringURLEncoded response.
 func (client *queriesOperations) stringUrlEncodedHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.stringUrlEncodedHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// stringUrlEncodedHandleError handles the StringURLEncoded error response.
+func (client *queriesOperations) stringUrlEncodedHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
@@ -1449,7 +1746,16 @@ func (client *queriesOperations) stringUnicodeCreateRequest() (*azcore.Request, 
 // stringUnicodeHandleResponse handles the StringUnicode response.
 func (client *queriesOperations) stringUnicodeHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.stringUnicodeHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// stringUnicodeHandleError handles the StringUnicode error response.
+func (client *queriesOperations) stringUnicodeHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/urlmultigroup/models.go
+++ b/test/autorest/generated/urlmultigroup/models.go
@@ -5,22 +5,11 @@
 
 package urlmultigroup
 
-import (
-	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-)
+import "fmt"
 
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/urlmultigroup/queries.go
+++ b/test/autorest/generated/urlmultigroup/queries.go
@@ -63,9 +63,18 @@ func (client *queriesOperations) arrayStringMultiEmptyCreateRequest(queriesArray
 // arrayStringMultiEmptyHandleResponse handles the ArrayStringMultiEmpty response.
 func (client *queriesOperations) arrayStringMultiEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.arrayStringMultiEmptyHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// arrayStringMultiEmptyHandleError handles the ArrayStringMultiEmpty error response.
+func (client *queriesOperations) arrayStringMultiEmptyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ArrayStringMultiNull - Get a null array of string using the multi-array format
@@ -104,9 +113,18 @@ func (client *queriesOperations) arrayStringMultiNullCreateRequest(queriesArrayS
 // arrayStringMultiNullHandleResponse handles the ArrayStringMultiNull response.
 func (client *queriesOperations) arrayStringMultiNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.arrayStringMultiNullHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// arrayStringMultiNullHandleError handles the ArrayStringMultiNull error response.
+func (client *queriesOperations) arrayStringMultiNullHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ArrayStringMultiValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the mult-array format
@@ -145,7 +163,16 @@ func (client *queriesOperations) arrayStringMultiValidCreateRequest(queriesArray
 // arrayStringMultiValidHandleResponse handles the ArrayStringMultiValid response.
 func (client *queriesOperations) arrayStringMultiValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.arrayStringMultiValidHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// arrayStringMultiValidHandleError handles the ArrayStringMultiValid error response.
+func (client *queriesOperations) arrayStringMultiValidHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/validationgroup/models.go
+++ b/test/autorest/generated/validationgroup/models.go
@@ -7,7 +7,6 @@ package validationgroup
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 )
 
@@ -33,14 +32,6 @@ type Error struct {
 	Code    *int32  `json:"code,omitempty"`
 	Fields  *string `json:"fields,omitempty"`
 	Message *string `json:"message,omitempty"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsJSON(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/validationgroup/operations.go
+++ b/test/autorest/generated/validationgroup/operations.go
@@ -62,9 +62,14 @@ func (client *operations) getWithConstantInPathCreateRequest() (*azcore.Request,
 // getWithConstantInPathHandleResponse handles the GetWithConstantInPath response.
 func (client *operations) getWithConstantInPathHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getWithConstantInPathHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// getWithConstantInPathHandleError handles the GetWithConstantInPath error response.
+func (client *operations) getWithConstantInPathHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 func (client *operations) PostWithConstantInBody(ctx context.Context, operationsPostWithConstantInBodyOptions *OperationsPostWithConstantInBodyOptions) (*ProductResponse, error) {
@@ -101,10 +106,15 @@ func (client *operations) postWithConstantInBodyCreateRequest(operationsPostWith
 // postWithConstantInBodyHandleResponse handles the PostWithConstantInBody response.
 func (client *operations) postWithConstantInBodyHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.postWithConstantInBodyHandleError(resp)
 	}
 	result := ProductResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Product)
+}
+
+// postWithConstantInBodyHandleError handles the PostWithConstantInBody error response.
+func (client *operations) postWithConstantInBodyHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // ValidationOfBody - Validates body parameters on the method. See swagger for details.
@@ -147,10 +157,19 @@ func (client *operations) validationOfBodyCreateRequest(resourceGroupName string
 // validationOfBodyHandleResponse handles the ValidationOfBody response.
 func (client *operations) validationOfBodyHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.validationOfBodyHandleError(resp)
 	}
 	result := ProductResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Product)
+}
+
+// validationOfBodyHandleError handles the ValidationOfBody error response.
+func (client *operations) validationOfBodyHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ValidationOfMethodParameters - Validates input parameters on the method. See swagger for details.
@@ -190,8 +209,17 @@ func (client *operations) validationOfMethodParametersCreateRequest(resourceGrou
 // validationOfMethodParametersHandleResponse handles the ValidationOfMethodParameters response.
 func (client *operations) validationOfMethodParametersHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.validationOfMethodParametersHandleError(resp)
 	}
 	result := ProductResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Product)
+}
+
+// validationOfMethodParametersHandleError handles the ValidationOfMethodParameters error response.
+func (client *operations) validationOfMethodParametersHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/autorest/generated/xmlgroup/models.go
+++ b/test/autorest/generated/xmlgroup/models.go
@@ -8,7 +8,6 @@ package xmlgroup
 import (
 	"encoding/xml"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"time"
 )
@@ -301,14 +300,6 @@ type CorsRule struct {
 type Error struct {
 	Message *string `xml:"message"`
 	Status  *int32  `xml:"status"`
-}
-
-func newError(resp *azcore.Response) error {
-	err := Error{}
-	if err := resp.UnmarshalAsXML(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e Error) Error() string {

--- a/test/autorest/generated/xmlgroup/xml.go
+++ b/test/autorest/generated/xmlgroup/xml.go
@@ -115,10 +115,15 @@ func (client *xmlOperations) getAcLsCreateRequest() (*azcore.Request, error) {
 // getAcLsHandleResponse handles the GetACLs response.
 func (client *xmlOperations) getAcLsHandleResponse(resp *azcore.Response) (*SignedIDentifierArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getAcLsHandleError(resp)
 	}
 	result := SignedIDentifierArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result)
+}
+
+// getAcLsHandleError handles the GetACLs error response.
+func (client *xmlOperations) getAcLsHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetComplexTypeRefNoMeta - Get a complex type that has a ref to a complex type with no XML node
@@ -152,10 +157,15 @@ func (client *xmlOperations) getComplexTypeRefNoMetaCreateRequest() (*azcore.Req
 // getComplexTypeRefNoMetaHandleResponse handles the GetComplexTypeRefNoMeta response.
 func (client *xmlOperations) getComplexTypeRefNoMetaHandleResponse(resp *azcore.Response) (*RootWithRefAndNoMetaResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getComplexTypeRefNoMetaHandleError(resp)
 	}
 	result := RootWithRefAndNoMetaResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.RootWithRefAndNoMeta)
+}
+
+// getComplexTypeRefNoMetaHandleError handles the GetComplexTypeRefNoMeta error response.
+func (client *xmlOperations) getComplexTypeRefNoMetaHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetComplexTypeRefWithMeta - Get a complex type that has a ref to a complex type with XML node
@@ -189,10 +199,15 @@ func (client *xmlOperations) getComplexTypeRefWithMetaCreateRequest() (*azcore.R
 // getComplexTypeRefWithMetaHandleResponse handles the GetComplexTypeRefWithMeta response.
 func (client *xmlOperations) getComplexTypeRefWithMetaHandleResponse(resp *azcore.Response) (*RootWithRefAndMetaResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getComplexTypeRefWithMetaHandleError(resp)
 	}
 	result := RootWithRefAndMetaResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.RootWithRefAndMeta)
+}
+
+// getComplexTypeRefWithMetaHandleError handles the GetComplexTypeRefWithMeta error response.
+func (client *xmlOperations) getComplexTypeRefWithMetaHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetEmptyChildElement - Gets an XML document with an empty child element.
@@ -226,10 +241,15 @@ func (client *xmlOperations) getEmptyChildElementCreateRequest() (*azcore.Reques
 // getEmptyChildElementHandleResponse handles the GetEmptyChildElement response.
 func (client *xmlOperations) getEmptyChildElementHandleResponse(resp *azcore.Response) (*BananaResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getEmptyChildElementHandleError(resp)
 	}
 	result := BananaResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.Banana)
+}
+
+// getEmptyChildElementHandleError handles the GetEmptyChildElement error response.
+func (client *xmlOperations) getEmptyChildElementHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetEmptyList - Get an empty list.
@@ -263,10 +283,15 @@ func (client *xmlOperations) getEmptyListCreateRequest() (*azcore.Request, error
 // getEmptyListHandleResponse handles the GetEmptyList response.
 func (client *xmlOperations) getEmptyListHandleResponse(resp *azcore.Response) (*SlideshowResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getEmptyListHandleError(resp)
 	}
 	result := SlideshowResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.Slideshow)
+}
+
+// getEmptyListHandleError handles the GetEmptyList error response.
+func (client *xmlOperations) getEmptyListHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetEmptyRootList - Gets an empty list as the root element.
@@ -300,10 +325,15 @@ func (client *xmlOperations) getEmptyRootListCreateRequest() (*azcore.Request, e
 // getEmptyRootListHandleResponse handles the GetEmptyRootList response.
 func (client *xmlOperations) getEmptyRootListHandleResponse(resp *azcore.Response) (*BananaArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getEmptyRootListHandleError(resp)
 	}
 	result := BananaArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result)
+}
+
+// getEmptyRootListHandleError handles the GetEmptyRootList error response.
+func (client *xmlOperations) getEmptyRootListHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetEmptyWrappedLists - Gets some empty wrapped lists.
@@ -337,10 +367,15 @@ func (client *xmlOperations) getEmptyWrappedListsCreateRequest() (*azcore.Reques
 // getEmptyWrappedListsHandleResponse handles the GetEmptyWrappedLists response.
 func (client *xmlOperations) getEmptyWrappedListsHandleResponse(resp *azcore.Response) (*AppleBarrelResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getEmptyWrappedListsHandleError(resp)
 	}
 	result := AppleBarrelResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.AppleBarrel)
+}
+
+// getEmptyWrappedListsHandleError handles the GetEmptyWrappedLists error response.
+func (client *xmlOperations) getEmptyWrappedListsHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetHeaders - Get strongly-typed response headers.
@@ -374,13 +409,18 @@ func (client *xmlOperations) getHeadersCreateRequest() (*azcore.Request, error) 
 // getHeadersHandleResponse handles the GetHeaders response.
 func (client *xmlOperations) getHeadersHandleResponse(resp *azcore.Response) (*XMLGetHeadersResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getHeadersHandleError(resp)
 	}
 	result := XMLGetHeadersResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Custom-Header"); val != "" {
 		result.CustomHeader = &val
 	}
 	return &result, nil
+}
+
+// getHeadersHandleError handles the GetHeaders error response.
+func (client *xmlOperations) getHeadersHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetRootList - Gets a list as the root element.
@@ -414,10 +454,15 @@ func (client *xmlOperations) getRootListCreateRequest() (*azcore.Request, error)
 // getRootListHandleResponse handles the GetRootList response.
 func (client *xmlOperations) getRootListHandleResponse(resp *azcore.Response) (*BananaArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getRootListHandleError(resp)
 	}
 	result := BananaArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result)
+}
+
+// getRootListHandleError handles the GetRootList error response.
+func (client *xmlOperations) getRootListHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetRootListSingleItem - Gets a list with a single item.
@@ -451,10 +496,15 @@ func (client *xmlOperations) getRootListSingleItemCreateRequest() (*azcore.Reque
 // getRootListSingleItemHandleResponse handles the GetRootListSingleItem response.
 func (client *xmlOperations) getRootListSingleItemHandleResponse(resp *azcore.Response) (*BananaArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getRootListSingleItemHandleError(resp)
 	}
 	result := BananaArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result)
+}
+
+// getRootListSingleItemHandleError handles the GetRootListSingleItem error response.
+func (client *xmlOperations) getRootListSingleItemHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetServiceProperties - Gets storage service properties.
@@ -492,10 +542,15 @@ func (client *xmlOperations) getServicePropertiesCreateRequest() (*azcore.Reques
 // getServicePropertiesHandleResponse handles the GetServiceProperties response.
 func (client *xmlOperations) getServicePropertiesHandleResponse(resp *azcore.Response) (*StorageServicePropertiesResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getServicePropertiesHandleError(resp)
 	}
 	result := StorageServicePropertiesResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.StorageServiceProperties)
+}
+
+// getServicePropertiesHandleError handles the GetServiceProperties error response.
+func (client *xmlOperations) getServicePropertiesHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // GetSimple - Get a simple XML document
@@ -529,10 +584,19 @@ func (client *xmlOperations) getSimpleCreateRequest() (*azcore.Request, error) {
 // getSimpleHandleResponse handles the GetSimple response.
 func (client *xmlOperations) getSimpleHandleResponse(resp *azcore.Response) (*SlideshowResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newError(resp)
+		return nil, client.getSimpleHandleError(resp)
 	}
 	result := SlideshowResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.Slideshow)
+}
+
+// getSimpleHandleError handles the GetSimple error response.
+func (client *xmlOperations) getSimpleHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetWrappedLists - Get an XML document with multiple wrapped lists
@@ -566,10 +630,15 @@ func (client *xmlOperations) getWrappedListsCreateRequest() (*azcore.Request, er
 // getWrappedListsHandleResponse handles the GetWrappedLists response.
 func (client *xmlOperations) getWrappedListsHandleResponse(resp *azcore.Response) (*AppleBarrelResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.getWrappedListsHandleError(resp)
 	}
 	result := AppleBarrelResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.AppleBarrel)
+}
+
+// getWrappedListsHandleError handles the GetWrappedLists error response.
+func (client *xmlOperations) getWrappedListsHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // JSONInput - A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42
@@ -603,9 +672,14 @@ func (client *xmlOperations) jsonInputCreateRequest(properties JSONInput) (*azco
 // jsonInputHandleResponse handles the JSONInput response.
 func (client *xmlOperations) jsonInputHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.jsonInputHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// jsonInputHandleError handles the JSONInput error response.
+func (client *xmlOperations) jsonInputHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // JSONOutput - A Swagger with XML that has one operation that returns JSON. ID number 42
@@ -639,10 +713,15 @@ func (client *xmlOperations) jsonOutputCreateRequest() (*azcore.Request, error) 
 // jsonOutputHandleResponse handles the JSONOutput response.
 func (client *xmlOperations) jsonOutputHandleResponse(resp *azcore.Response) (*JSONOutputResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.jsonOutputHandleError(resp)
 	}
 	result := JSONOutputResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.JSONOutput)
+}
+
+// jsonOutputHandleError handles the JSONOutput error response.
+func (client *xmlOperations) jsonOutputHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // ListBlobs - Lists blobs in a storage container.
@@ -680,10 +759,15 @@ func (client *xmlOperations) listBlobsCreateRequest() (*azcore.Request, error) {
 // listBlobsHandleResponse handles the ListBlobs response.
 func (client *xmlOperations) listBlobsHandleResponse(resp *azcore.Response) (*ListBlobsResponseResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.listBlobsHandleError(resp)
 	}
 	result := ListBlobsResponseResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.EnumerationResults)
+}
+
+// listBlobsHandleError handles the ListBlobs error response.
+func (client *xmlOperations) listBlobsHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // ListContainers - Lists containers in a storage account.
@@ -720,10 +804,15 @@ func (client *xmlOperations) listContainersCreateRequest() (*azcore.Request, err
 // listContainersHandleResponse handles the ListContainers response.
 func (client *xmlOperations) listContainersHandleResponse(resp *azcore.Response) (*ListContainersResponseResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, errors.New(resp.Status)
+		return nil, client.listContainersHandleError(resp)
 	}
 	result := ListContainersResponseResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.EnumerationResults)
+}
+
+// listContainersHandleError handles the ListContainers error response.
+func (client *xmlOperations) listContainersHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // PutACLs - Puts storage ACLs for a container.
@@ -765,9 +854,14 @@ func (client *xmlOperations) putAcLsCreateRequest(properties []SignedIDentifier)
 // putAcLsHandleResponse handles the PutACLs response.
 func (client *xmlOperations) putAcLsHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, errors.New(resp.Status)
+		return nil, client.putAcLsHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putAcLsHandleError handles the PutACLs error response.
+func (client *xmlOperations) putAcLsHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // PutComplexTypeRefNoMeta - Puts a complex type that has a ref to a complex type with no XML node
@@ -801,9 +895,14 @@ func (client *xmlOperations) putComplexTypeRefNoMetaCreateRequest(model RootWith
 // putComplexTypeRefNoMetaHandleResponse handles the PutComplexTypeRefNoMeta response.
 func (client *xmlOperations) putComplexTypeRefNoMetaHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, errors.New(resp.Status)
+		return nil, client.putComplexTypeRefNoMetaHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putComplexTypeRefNoMetaHandleError handles the PutComplexTypeRefNoMeta error response.
+func (client *xmlOperations) putComplexTypeRefNoMetaHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // PutComplexTypeRefWithMeta - Puts a complex type that has a ref to a complex type with XML node
@@ -837,9 +936,14 @@ func (client *xmlOperations) putComplexTypeRefWithMetaCreateRequest(model RootWi
 // putComplexTypeRefWithMetaHandleResponse handles the PutComplexTypeRefWithMeta response.
 func (client *xmlOperations) putComplexTypeRefWithMetaHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, errors.New(resp.Status)
+		return nil, client.putComplexTypeRefWithMetaHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putComplexTypeRefWithMetaHandleError handles the PutComplexTypeRefWithMeta error response.
+func (client *xmlOperations) putComplexTypeRefWithMetaHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // PutEmptyChildElement - Puts a value with an empty child element.
@@ -873,9 +977,14 @@ func (client *xmlOperations) putEmptyChildElementCreateRequest(banana Banana) (*
 // putEmptyChildElementHandleResponse handles the PutEmptyChildElement response.
 func (client *xmlOperations) putEmptyChildElementHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, errors.New(resp.Status)
+		return nil, client.putEmptyChildElementHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putEmptyChildElementHandleError handles the PutEmptyChildElement error response.
+func (client *xmlOperations) putEmptyChildElementHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // PutEmptyList - Puts an empty list.
@@ -909,9 +1018,14 @@ func (client *xmlOperations) putEmptyListCreateRequest(slideshow Slideshow) (*az
 // putEmptyListHandleResponse handles the PutEmptyList response.
 func (client *xmlOperations) putEmptyListHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, errors.New(resp.Status)
+		return nil, client.putEmptyListHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putEmptyListHandleError handles the PutEmptyList error response.
+func (client *xmlOperations) putEmptyListHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // PutEmptyRootList - Puts an empty list as the root element.
@@ -949,9 +1063,14 @@ func (client *xmlOperations) putEmptyRootListCreateRequest(bananas []Banana) (*a
 // putEmptyRootListHandleResponse handles the PutEmptyRootList response.
 func (client *xmlOperations) putEmptyRootListHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, errors.New(resp.Status)
+		return nil, client.putEmptyRootListHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putEmptyRootListHandleError handles the PutEmptyRootList error response.
+func (client *xmlOperations) putEmptyRootListHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // PutEmptyWrappedLists - Puts some empty wrapped lists.
@@ -985,9 +1104,14 @@ func (client *xmlOperations) putEmptyWrappedListsCreateRequest(appleBarrel Apple
 // putEmptyWrappedListsHandleResponse handles the PutEmptyWrappedLists response.
 func (client *xmlOperations) putEmptyWrappedListsHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, errors.New(resp.Status)
+		return nil, client.putEmptyWrappedListsHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putEmptyWrappedListsHandleError handles the PutEmptyWrappedLists error response.
+func (client *xmlOperations) putEmptyWrappedListsHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // PutRootList - Puts a list as the root element.
@@ -1025,9 +1149,14 @@ func (client *xmlOperations) putRootListCreateRequest(bananas []Banana) (*azcore
 // putRootListHandleResponse handles the PutRootList response.
 func (client *xmlOperations) putRootListHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, errors.New(resp.Status)
+		return nil, client.putRootListHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putRootListHandleError handles the PutRootList error response.
+func (client *xmlOperations) putRootListHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // PutRootListSingleItem - Puts a list with a single item.
@@ -1065,9 +1194,14 @@ func (client *xmlOperations) putRootListSingleItemCreateRequest(bananas []Banana
 // putRootListSingleItemHandleResponse handles the PutRootListSingleItem response.
 func (client *xmlOperations) putRootListSingleItemHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, errors.New(resp.Status)
+		return nil, client.putRootListSingleItemHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putRootListSingleItemHandleError handles the PutRootListSingleItem error response.
+func (client *xmlOperations) putRootListSingleItemHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // PutServiceProperties - Puts storage service properties.
@@ -1105,9 +1239,14 @@ func (client *xmlOperations) putServicePropertiesCreateRequest(properties Storag
 // putServicePropertiesHandleResponse handles the PutServiceProperties response.
 func (client *xmlOperations) putServicePropertiesHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, errors.New(resp.Status)
+		return nil, client.putServicePropertiesHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putServicePropertiesHandleError handles the PutServiceProperties error response.
+func (client *xmlOperations) putServicePropertiesHandleError(resp *azcore.Response) error {
+	return errors.New(resp.Status)
 }
 
 // PutSimple - Put a simple XML document
@@ -1141,9 +1280,18 @@ func (client *xmlOperations) putSimpleCreateRequest(slideshow Slideshow) (*azcor
 // putSimpleHandleResponse handles the PutSimple response.
 func (client *xmlOperations) putSimpleHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newError(resp)
+		return nil, client.putSimpleHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putSimpleHandleError handles the PutSimple error response.
+func (client *xmlOperations) putSimpleHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // PutWrappedLists - Put an XML document with multiple wrapped lists
@@ -1177,7 +1325,16 @@ func (client *xmlOperations) putWrappedListsCreateRequest(wrappedLists AppleBarr
 // putWrappedListsHandleResponse handles the PutWrappedLists response.
 func (client *xmlOperations) putWrappedListsHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newError(resp)
+		return nil, client.putWrappedListsHandleError(resp)
 	}
 	return resp.Response, nil
+}
+
+// putWrappedListsHandleError handles the PutWrappedLists error response.
+func (client *xmlOperations) putWrappedListsHandleError(resp *azcore.Response) error {
+	err := Error{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/storage/2019-07-07/azblob/appendblob.go
+++ b/test/storage/2019-07-07/azblob/appendblob.go
@@ -104,7 +104,7 @@ func (client *appendBlobOperations) appendBlockCreateRequest(contentLength int64
 // appendBlockHandleResponse handles the AppendBlock response.
 func (client *appendBlobOperations) appendBlockHandleResponse(resp *azcore.Response) (*AppendBlobAppendBlockResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newStorageError(resp)
+		return nil, client.appendBlockHandleError(resp)
 	}
 	result := AppendBlobAppendBlockResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -172,6 +172,15 @@ func (client *appendBlobOperations) appendBlockHandleResponse(resp *azcore.Respo
 		result.EncryptionScope = &val
 	}
 	return &result, nil
+}
+
+// appendBlockHandleError handles the AppendBlock error response.
+func (client *appendBlobOperations) appendBlockHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // AppendBlockFromURL - The Append Block operation commits a new block of data to the end of an existing append blob where the contents are read from a source url. The Append Block operation is permitted only if the blob was created with x-ms-blob-type set to AppendBlob. Append Block is supported only on version 2015-02-21 version or later.
@@ -267,7 +276,7 @@ func (client *appendBlobOperations) appendBlockFromUrlCreateRequest(sourceUrl ur
 // appendBlockFromUrlHandleResponse handles the AppendBlockFromURL response.
 func (client *appendBlobOperations) appendBlockFromUrlHandleResponse(resp *azcore.Response) (*AppendBlobAppendBlockFromURLResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newStorageError(resp)
+		return nil, client.appendBlockFromUrlHandleError(resp)
 	}
 	result := AppendBlobAppendBlockFromURLResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -332,6 +341,15 @@ func (client *appendBlobOperations) appendBlockFromUrlHandleResponse(resp *azcor
 		result.RequestServerEncrypted = &requestServerEncrypted
 	}
 	return &result, nil
+}
+
+// appendBlockFromUrlHandleError handles the AppendBlockFromURL error response.
+func (client *appendBlobOperations) appendBlockFromUrlHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Create - The Create Append Blob operation creates a new append blob.
@@ -417,7 +435,7 @@ func (client *appendBlobOperations) createCreateRequest(contentLength int64, app
 // createHandleResponse handles the Create response.
 func (client *appendBlobOperations) createHandleResponse(resp *azcore.Response) (*AppendBlobCreateResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newStorageError(resp)
+		return nil, client.createHandleError(resp)
 	}
 	result := AppendBlobCreateResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -467,4 +485,13 @@ func (client *appendBlobOperations) createHandleResponse(resp *azcore.Response) 
 		result.EncryptionScope = &val
 	}
 	return &result, nil
+}
+
+// createHandleError handles the Create error response.
+func (client *appendBlobOperations) createHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/storage/2019-07-07/azblob/blob.go
+++ b/test/storage/2019-07-07/azblob/blob.go
@@ -107,7 +107,7 @@ func (client *blobOperations) abortCopyFromUrlCreateRequest(copyId string, blobA
 // abortCopyFromUrlHandleResponse handles the AbortCopyFromURL response.
 func (client *blobOperations) abortCopyFromUrlHandleResponse(resp *azcore.Response) (*BlobAbortCopyFromURLResponse, error) {
 	if !resp.HasStatusCode(http.StatusNoContent) {
-		return nil, newStorageError(resp)
+		return nil, client.abortCopyFromUrlHandleError(resp)
 	}
 	result := BlobAbortCopyFromURLResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
@@ -127,6 +127,15 @@ func (client *blobOperations) abortCopyFromUrlHandleResponse(resp *azcore.Respon
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// abortCopyFromUrlHandleError handles the AbortCopyFromURL error response.
+func (client *blobOperations) abortCopyFromUrlHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // AcquireLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
@@ -185,7 +194,7 @@ func (client *blobOperations) acquireLeaseCreateRequest(blobAcquireLeaseOptions 
 // acquireLeaseHandleResponse handles the AcquireLease response.
 func (client *blobOperations) acquireLeaseHandleResponse(resp *azcore.Response) (*BlobAcquireLeaseResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newStorageError(resp)
+		return nil, client.acquireLeaseHandleError(resp)
 	}
 	result := BlobAcquireLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -218,6 +227,15 @@ func (client *blobOperations) acquireLeaseHandleResponse(resp *azcore.Response) 
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// acquireLeaseHandleError handles the AcquireLease error response.
+func (client *blobOperations) acquireLeaseHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // BreakLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
@@ -273,7 +291,7 @@ func (client *blobOperations) breakLeaseCreateRequest(blobBreakLeaseOptions *Blo
 // breakLeaseHandleResponse handles the BreakLease response.
 func (client *blobOperations) breakLeaseHandleResponse(resp *azcore.Response) (*BlobBreakLeaseResponse, error) {
 	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, newStorageError(resp)
+		return nil, client.breakLeaseHandleError(resp)
 	}
 	result := BlobBreakLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -311,6 +329,15 @@ func (client *blobOperations) breakLeaseHandleResponse(resp *azcore.Response) (*
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// breakLeaseHandleError handles the BreakLease error response.
+func (client *blobOperations) breakLeaseHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ChangeLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
@@ -365,7 +392,7 @@ func (client *blobOperations) changeLeaseCreateRequest(leaseId string, proposedL
 // changeLeaseHandleResponse handles the ChangeLease response.
 func (client *blobOperations) changeLeaseHandleResponse(resp *azcore.Response) (*BlobChangeLeaseResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.changeLeaseHandleError(resp)
 	}
 	result := BlobChangeLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -398,6 +425,15 @@ func (client *blobOperations) changeLeaseHandleResponse(resp *azcore.Response) (
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// changeLeaseHandleError handles the ChangeLease error response.
+func (client *blobOperations) changeLeaseHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // CopyFromURL - The Copy From URL operation copies a blob or an internet resource to a new blob. It will not return a response until the copy is complete.
@@ -474,7 +510,7 @@ func (client *blobOperations) copyFromUrlCreateRequest(copySource url.URL, blobC
 // copyFromUrlHandleResponse handles the CopyFromURL response.
 func (client *blobOperations) copyFromUrlHandleResponse(resp *azcore.Response) (*BlobCopyFromURLResponse, error) {
 	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, newStorageError(resp)
+		return nil, client.copyFromUrlHandleError(resp)
 	}
 	result := BlobCopyFromURLResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -524,6 +560,15 @@ func (client *blobOperations) copyFromUrlHandleResponse(resp *azcore.Response) (
 		result.ContentCrc64 = &contentCrc64
 	}
 	return &result, nil
+}
+
+// copyFromUrlHandleError handles the CopyFromURL error response.
+func (client *blobOperations) copyFromUrlHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // CreateSnapshot - The Create Snapshot operation creates a read-only snapshot of a blob
@@ -590,7 +635,7 @@ func (client *blobOperations) createSnapshotCreateRequest(blobCreateSnapshotOpti
 // createSnapshotHandleResponse handles the CreateSnapshot response.
 func (client *blobOperations) createSnapshotHandleResponse(resp *azcore.Response) (*BlobCreateSnapshotResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newStorageError(resp)
+		return nil, client.createSnapshotHandleError(resp)
 	}
 	result := BlobCreateSnapshotResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-snapshot"); val != "" {
@@ -630,6 +675,15 @@ func (client *blobOperations) createSnapshotHandleResponse(resp *azcore.Response
 		result.RequestServerEncrypted = &requestServerEncrypted
 	}
 	return &result, nil
+}
+
+// createSnapshotHandleError handles the CreateSnapshot error response.
+func (client *blobOperations) createSnapshotHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Delete - If the storage account's soft delete feature is disabled then, when a blob is deleted, it is permanently removed from the storage account. If the storage account's soft delete feature is enabled, then, when a blob is deleted, it is marked for deletion and becomes inaccessible immediately. However, the blob service retains the blob or snapshot for the number of days specified by the DeleteRetentionPolicy section of [Storage service properties] (Set-Blob-Service-Properties.md). After the specified number of days has passed, the blob's data is permanently removed from the storage account. Note that you continue to be charged for the soft-deleted blob's storage until it is permanently removed. Use the List Blobs API and specify the "include=deleted" query parameter to discover which blobs and snapshots have been soft deleted. You can then use the Undelete Blob API to restore a soft-deleted blob. All other operations on a soft-deleted blob or snapshot causes the service to return an HTTP status code of 404 (ResourceNotFound).
@@ -689,7 +743,7 @@ func (client *blobOperations) deleteCreateRequest(blobDeleteOptions *BlobDeleteO
 // deleteHandleResponse handles the Delete response.
 func (client *blobOperations) deleteHandleResponse(resp *azcore.Response) (*BlobDeleteResponse, error) {
 	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, newStorageError(resp)
+		return nil, client.deleteHandleError(resp)
 	}
 	result := BlobDeleteResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
@@ -709,6 +763,15 @@ func (client *blobOperations) deleteHandleResponse(resp *azcore.Response) (*Blob
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// deleteHandleError handles the Delete error response.
+func (client *blobOperations) deleteHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Download - The Download operation reads or downloads a blob from the system, including its metadata and properties. You can also call Download to read a snapshot.
@@ -781,7 +844,7 @@ func (client *blobOperations) downloadCreateRequest(blobDownloadOptions *BlobDow
 // downloadHandleResponse handles the Download response.
 func (client *blobOperations) downloadHandleResponse(resp *azcore.Response) (*BlobDownloadResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.downloadHandleError(resp)
 	}
 	result := BlobDownloadResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
@@ -927,6 +990,15 @@ func (client *blobOperations) downloadHandleResponse(resp *azcore.Response) (*Bl
 	return &result, nil
 }
 
+// downloadHandleError handles the Download error response.
+func (client *blobOperations) downloadHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // GetAccessControl - Get the owner, group, permissions, or access control list for a blob.
 func (client *blobOperations) GetAccessControl(ctx context.Context, blobGetAccessControlOptions *BlobGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*BlobGetAccessControlResponse, error) {
 	req, err := client.getAccessControlCreateRequest(blobGetAccessControlOptions, leaseAccessConditions, modifiedAccessConditions)
@@ -982,7 +1054,7 @@ func (client *blobOperations) getAccessControlCreateRequest(blobGetAccessControl
 // getAccessControlHandleResponse handles the GetAccessControl response.
 func (client *blobOperations) getAccessControlHandleResponse(resp *azcore.Response) (*BlobGetAccessControlResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newDataLakeStorageError(resp)
+		return nil, client.getAccessControlHandleError(resp)
 	}
 	result := BlobGetAccessControlResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Date"); val != "" {
@@ -1023,6 +1095,15 @@ func (client *blobOperations) getAccessControlHandleResponse(resp *azcore.Respon
 	return &result, nil
 }
 
+// getAccessControlHandleError handles the GetAccessControl error response.
+func (client *blobOperations) getAccessControlHandleError(resp *azcore.Response) error {
+	err := DataLakeStorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // GetAccountInfo - Returns the sku name and account kind
 func (client *blobOperations) GetAccountInfo(ctx context.Context) (*BlobGetAccountInfoResponse, error) {
 	req, err := client.getAccountInfoCreateRequest()
@@ -1055,7 +1136,7 @@ func (client *blobOperations) getAccountInfoCreateRequest() (*azcore.Request, er
 // getAccountInfoHandleResponse handles the GetAccountInfo response.
 func (client *blobOperations) getAccountInfoHandleResponse(resp *azcore.Response) (*BlobGetAccountInfoResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.getAccountInfoHandleError(resp)
 	}
 	result := BlobGetAccountInfoResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
@@ -1081,6 +1162,15 @@ func (client *blobOperations) getAccountInfoHandleResponse(resp *azcore.Response
 		result.AccountKind = (*AccountKind)(&val)
 	}
 	return &result, nil
+}
+
+// getAccountInfoHandleError handles the GetAccountInfo error response.
+func (client *blobOperations) getAccountInfoHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetProperties - The Get Properties operation returns all user-defined metadata, standard HTTP properties, and system properties for the blob. It does not return the content of the blob.
@@ -1143,7 +1233,7 @@ func (client *blobOperations) getPropertiesCreateRequest(blobGetPropertiesOption
 // getPropertiesHandleResponse handles the GetProperties response.
 func (client *blobOperations) getPropertiesHandleResponse(resp *azcore.Response) (*BlobGetPropertiesResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.getPropertiesHandleError(resp)
 	}
 	result := BlobGetPropertiesResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
@@ -1309,6 +1399,15 @@ func (client *blobOperations) getPropertiesHandleResponse(resp *azcore.Response)
 	return &result, nil
 }
 
+// getPropertiesHandleError handles the GetProperties error response.
+func (client *blobOperations) getPropertiesHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // ReleaseLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
 func (client *blobOperations) ReleaseLease(ctx context.Context, leaseId string, blobReleaseLeaseOptions *BlobReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*BlobReleaseLeaseResponse, error) {
 	req, err := client.releaseLeaseCreateRequest(leaseId, blobReleaseLeaseOptions, modifiedAccessConditions)
@@ -1360,7 +1459,7 @@ func (client *blobOperations) releaseLeaseCreateRequest(leaseId string, blobRele
 // releaseLeaseHandleResponse handles the ReleaseLease response.
 func (client *blobOperations) releaseLeaseHandleResponse(resp *azcore.Response) (*BlobReleaseLeaseResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.releaseLeaseHandleError(resp)
 	}
 	result := BlobReleaseLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -1390,6 +1489,15 @@ func (client *blobOperations) releaseLeaseHandleResponse(resp *azcore.Response) 
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// releaseLeaseHandleError handles the ReleaseLease error response.
+func (client *blobOperations) releaseLeaseHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Rename - Rename a blob/file.  By default, the destination is overwritten and if the destination already exists and has a lease the lease is broken.  This operation supports conditional HTTP requests.  For more information, see [Specifying Conditional Headers for Blob Service Operations](https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations).  To fail if the destination already exists, use a conditional request with If-None-Match: "*".
@@ -1486,7 +1594,7 @@ func (client *blobOperations) renameCreateRequest(renameSource string, blobRenam
 // renameHandleResponse handles the Rename response.
 func (client *blobOperations) renameHandleResponse(resp *azcore.Response) (*BlobRenameResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newDataLakeStorageError(resp)
+		return nil, client.renameHandleError(resp)
 	}
 	result := BlobRenameResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -1523,6 +1631,15 @@ func (client *blobOperations) renameHandleResponse(resp *azcore.Response) (*Blob
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// renameHandleError handles the Rename error response.
+func (client *blobOperations) renameHandleError(resp *azcore.Response) error {
+	err := DataLakeStorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // RenewLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
@@ -1576,7 +1693,7 @@ func (client *blobOperations) renewLeaseCreateRequest(leaseId string, blobRenewL
 // renewLeaseHandleResponse handles the RenewLease response.
 func (client *blobOperations) renewLeaseHandleResponse(resp *azcore.Response) (*BlobRenewLeaseResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.renewLeaseHandleError(resp)
 	}
 	result := BlobRenewLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -1609,6 +1726,15 @@ func (client *blobOperations) renewLeaseHandleResponse(resp *azcore.Response) (*
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// renewLeaseHandleError handles the RenewLease error response.
+func (client *blobOperations) renewLeaseHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // SetAccessControl - Set the owner, group, permissions, or access control list for a blob.
@@ -1675,7 +1801,7 @@ func (client *blobOperations) setAccessControlCreateRequest(blobSetAccessControl
 // setAccessControlHandleResponse handles the SetAccessControl response.
 func (client *blobOperations) setAccessControlHandleResponse(resp *azcore.Response) (*BlobSetAccessControlResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newDataLakeStorageError(resp)
+		return nil, client.setAccessControlHandleError(resp)
 	}
 	result := BlobSetAccessControlResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Date"); val != "" {
@@ -1702,6 +1828,15 @@ func (client *blobOperations) setAccessControlHandleResponse(resp *azcore.Respon
 		result.Version = &val
 	}
 	return &result, nil
+}
+
+// setAccessControlHandleError handles the SetAccessControl error response.
+func (client *blobOperations) setAccessControlHandleError(resp *azcore.Response) error {
+	err := DataLakeStorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // SetHTTPHeaders - The Set HTTP Headers operation sets system properties on the blob
@@ -1774,7 +1909,7 @@ func (client *blobOperations) setHttpHeadersCreateRequest(blobSetHttpHeadersOpti
 // setHttpHeadersHandleResponse handles the SetHTTPHeaders response.
 func (client *blobOperations) setHttpHeadersHandleResponse(resp *azcore.Response) (*BlobSetHTTPHeadersResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.setHttpHeadersHandleError(resp)
 	}
 	result := BlobSetHTTPHeadersResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -1811,6 +1946,15 @@ func (client *blobOperations) setHttpHeadersHandleResponse(resp *azcore.Response
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// setHttpHeadersHandleError handles the SetHTTPHeaders error response.
+func (client *blobOperations) setHttpHeadersHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // SetMetadata - The Set Blob Metadata operation sets user-defined metadata for the specified blob as one or more name-value pairs
@@ -1877,7 +2021,7 @@ func (client *blobOperations) setMetadataCreateRequest(blobSetMetadataOptions *B
 // setMetadataHandleResponse handles the SetMetadata response.
 func (client *blobOperations) setMetadataHandleResponse(resp *azcore.Response) (*BlobSetMetadataResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.setMetadataHandleError(resp)
 	}
 	result := BlobSetMetadataResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -1920,6 +2064,15 @@ func (client *blobOperations) setMetadataHandleResponse(resp *azcore.Response) (
 		result.EncryptionScope = &val
 	}
 	return &result, nil
+}
+
+// setMetadataHandleError handles the SetMetadata error response.
+func (client *blobOperations) setMetadataHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // SetTier - The Set Tier operation sets the tier on a blob. The operation is allowed on a page blob in a premium storage account and on a block blob in a blob storage account (locally redundant storage only). A premium page blob's tier determines the allowed size, IOPS, and bandwidth of the blob. A block blob's tier determines Hot/Cool/Archive storage type. This operation does not update the blob's ETag.
@@ -1966,7 +2119,7 @@ func (client *blobOperations) setTierCreateRequest(tier AccessTier, blobSetTierO
 // setTierHandleResponse handles the SetTier response.
 func (client *blobOperations) setTierHandleResponse(resp *azcore.Response) (*BlobSetTierResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.setTierHandleError(resp)
 	}
 	result := BlobSetTierResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
@@ -1979,6 +2132,15 @@ func (client *blobOperations) setTierHandleResponse(resp *azcore.Response) (*Blo
 		result.Version = &val
 	}
 	return &result, nil
+}
+
+// setTierHandleError handles the SetTier error response.
+func (client *blobOperations) setTierHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // StartCopyFromURL - The Start Copy From URL operation copies a blob or an internet resource to a new blob.
@@ -2054,7 +2216,7 @@ func (client *blobOperations) startCopyFromUrlCreateRequest(copySource url.URL, 
 // startCopyFromUrlHandleResponse handles the StartCopyFromURL response.
 func (client *blobOperations) startCopyFromUrlHandleResponse(resp *azcore.Response) (*BlobStartCopyFromURLResponse, error) {
 	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, newStorageError(resp)
+		return nil, client.startCopyFromUrlHandleError(resp)
 	}
 	result := BlobStartCopyFromURLResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -2090,6 +2252,15 @@ func (client *blobOperations) startCopyFromUrlHandleResponse(resp *azcore.Respon
 		result.CopyStatus = (*CopyStatusType)(&val)
 	}
 	return &result, nil
+}
+
+// startCopyFromUrlHandleError handles the StartCopyFromURL error response.
+func (client *blobOperations) startCopyFromUrlHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Undelete - Undelete a blob that was previously soft deleted
@@ -2129,7 +2300,7 @@ func (client *blobOperations) undeleteCreateRequest(blobUndeleteOptions *BlobUnd
 // undeleteHandleResponse handles the Undelete response.
 func (client *blobOperations) undeleteHandleResponse(resp *azcore.Response) (*BlobUndeleteResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.undeleteHandleError(resp)
 	}
 	result := BlobUndeleteResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
@@ -2149,4 +2320,13 @@ func (client *blobOperations) undeleteHandleResponse(resp *azcore.Response) (*Bl
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// undeleteHandleError handles the Undelete error response.
+func (client *blobOperations) undeleteHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/storage/2019-07-07/azblob/blockblob.go
+++ b/test/storage/2019-07-07/azblob/blockblob.go
@@ -125,7 +125,7 @@ func (client *blockBlobOperations) commitBlockListCreateRequest(blocks BlockLook
 // commitBlockListHandleResponse handles the CommitBlockList response.
 func (client *blockBlobOperations) commitBlockListHandleResponse(resp *azcore.Response) (*BlockBlobCommitBlockListResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newStorageError(resp)
+		return nil, client.commitBlockListHandleError(resp)
 	}
 	result := BlockBlobCommitBlockListResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -184,6 +184,15 @@ func (client *blockBlobOperations) commitBlockListHandleResponse(resp *azcore.Re
 	return &result, nil
 }
 
+// commitBlockListHandleError handles the CommitBlockList error response.
+func (client *blockBlobOperations) commitBlockListHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // GetBlockList - The Get Block List operation retrieves the list of blocks that have been uploaded as part of a block blob
 func (client *blockBlobOperations) GetBlockList(ctx context.Context, listType BlockListType, blockBlobGetBlockListOptions *BlockBlobGetBlockListOptions, leaseAccessConditions *LeaseAccessConditions) (*BlockListResponse, error) {
 	req, err := client.getBlockListCreateRequest(listType, blockBlobGetBlockListOptions, leaseAccessConditions)
@@ -228,7 +237,7 @@ func (client *blockBlobOperations) getBlockListCreateRequest(listType BlockListT
 // getBlockListHandleResponse handles the GetBlockList response.
 func (client *blockBlobOperations) getBlockListHandleResponse(resp *azcore.Response) (*BlockListResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.getBlockListHandleError(resp)
 	}
 	result := BlockListResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
@@ -268,6 +277,15 @@ func (client *blockBlobOperations) getBlockListHandleResponse(resp *azcore.Respo
 		result.Date = &date
 	}
 	return &result, resp.UnmarshalAsXML(&result.BlockList)
+}
+
+// getBlockListHandleError handles the GetBlockList error response.
+func (client *blockBlobOperations) getBlockListHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // StageBlock - The Stage Block operation creates a new block to be committed as part of a blob
@@ -327,7 +345,7 @@ func (client *blockBlobOperations) stageBlockCreateRequest(blockId string, conte
 // stageBlockHandleResponse handles the StageBlock response.
 func (client *blockBlobOperations) stageBlockHandleResponse(resp *azcore.Response) (*BlockBlobStageBlockResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newStorageError(resp)
+		return nil, client.stageBlockHandleError(resp)
 	}
 	result := BlockBlobStageBlockResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Content-MD5"); val != "" {
@@ -374,6 +392,15 @@ func (client *blockBlobOperations) stageBlockHandleResponse(resp *azcore.Respons
 		result.EncryptionScope = &val
 	}
 	return &result, nil
+}
+
+// stageBlockHandleError handles the StageBlock error response.
+func (client *blockBlobOperations) stageBlockHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // StageBlockFromURL - The Stage Block operation creates a new block to be committed as part of a blob where the contents are read from a URL.
@@ -449,7 +476,7 @@ func (client *blockBlobOperations) stageBlockFromUrlCreateRequest(blockId string
 // stageBlockFromUrlHandleResponse handles the StageBlockFromURL response.
 func (client *blockBlobOperations) stageBlockFromUrlHandleResponse(resp *azcore.Response) (*BlockBlobStageBlockFromURLResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newStorageError(resp)
+		return nil, client.stageBlockFromUrlHandleError(resp)
 	}
 	result := BlockBlobStageBlockFromURLResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Content-MD5"); val != "" {
@@ -496,6 +523,15 @@ func (client *blockBlobOperations) stageBlockFromUrlHandleResponse(resp *azcore.
 		result.EncryptionScope = &val
 	}
 	return &result, nil
+}
+
+// stageBlockFromUrlHandleError handles the StageBlockFromURL error response.
+func (client *blockBlobOperations) stageBlockFromUrlHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Upload - The Upload Block Blob operation updates the content of an existing block blob. Updating an existing block blob overwrites any existing metadata on the blob. Partial updates are not supported with Put Blob; the content of the existing blob is overwritten with the content of the new blob. To perform a partial update of the content of a block blob, use the Put Block List operation.
@@ -587,7 +623,7 @@ func (client *blockBlobOperations) uploadCreateRequest(contentLength int64, body
 // uploadHandleResponse handles the Upload response.
 func (client *blockBlobOperations) uploadHandleResponse(resp *azcore.Response) (*BlockBlobUploadResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newStorageError(resp)
+		return nil, client.uploadHandleError(resp)
 	}
 	result := BlockBlobUploadResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -637,4 +673,13 @@ func (client *blockBlobOperations) uploadHandleResponse(resp *azcore.Response) (
 		result.EncryptionScope = &val
 	}
 	return &result, nil
+}
+
+// uploadHandleError handles the Upload error response.
+func (client *blockBlobOperations) uploadHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/storage/2019-07-07/azblob/container.go
+++ b/test/storage/2019-07-07/azblob/container.go
@@ -105,7 +105,7 @@ func (client *containerOperations) acquireLeaseCreateRequest(containerAcquireLea
 // acquireLeaseHandleResponse handles the AcquireLease response.
 func (client *containerOperations) acquireLeaseHandleResponse(resp *azcore.Response) (*ContainerAcquireLeaseResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newStorageError(resp)
+		return nil, client.acquireLeaseHandleError(resp)
 	}
 	result := ContainerAcquireLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -138,6 +138,15 @@ func (client *containerOperations) acquireLeaseHandleResponse(resp *azcore.Respo
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// acquireLeaseHandleError handles the AcquireLease error response.
+func (client *containerOperations) acquireLeaseHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // BreakLease - [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite
@@ -188,7 +197,7 @@ func (client *containerOperations) breakLeaseCreateRequest(containerBreakLeaseOp
 // breakLeaseHandleResponse handles the BreakLease response.
 func (client *containerOperations) breakLeaseHandleResponse(resp *azcore.Response) (*ContainerBreakLeaseResponse, error) {
 	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, newStorageError(resp)
+		return nil, client.breakLeaseHandleError(resp)
 	}
 	result := ContainerBreakLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -226,6 +235,15 @@ func (client *containerOperations) breakLeaseHandleResponse(resp *azcore.Respons
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// breakLeaseHandleError handles the BreakLease error response.
+func (client *containerOperations) breakLeaseHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ChangeLease - [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite
@@ -275,7 +293,7 @@ func (client *containerOperations) changeLeaseCreateRequest(leaseId string, prop
 // changeLeaseHandleResponse handles the ChangeLease response.
 func (client *containerOperations) changeLeaseHandleResponse(resp *azcore.Response) (*ContainerChangeLeaseResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.changeLeaseHandleError(resp)
 	}
 	result := ContainerChangeLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -308,6 +326,15 @@ func (client *containerOperations) changeLeaseHandleResponse(resp *azcore.Respon
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// changeLeaseHandleError handles the ChangeLease error response.
+func (client *containerOperations) changeLeaseHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Create - creates a new container under the specified account. If the container with the same name already exists, the operation fails
@@ -359,7 +386,7 @@ func (client *containerOperations) createCreateRequest(containerCreateOptions *C
 // createHandleResponse handles the Create response.
 func (client *containerOperations) createHandleResponse(resp *azcore.Response) (*ContainerCreateResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newStorageError(resp)
+		return nil, client.createHandleError(resp)
 	}
 	result := ContainerCreateResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -389,6 +416,15 @@ func (client *containerOperations) createHandleResponse(resp *azcore.Response) (
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// createHandleError handles the Create error response.
+func (client *containerOperations) createHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Delete - operation marks the specified container for deletion. The container and any blobs contained within it are later deleted during garbage collection
@@ -437,7 +473,7 @@ func (client *containerOperations) deleteCreateRequest(containerDeleteOptions *C
 // deleteHandleResponse handles the Delete response.
 func (client *containerOperations) deleteHandleResponse(resp *azcore.Response) (*ContainerDeleteResponse, error) {
 	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, newStorageError(resp)
+		return nil, client.deleteHandleError(resp)
 	}
 	result := ContainerDeleteResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
@@ -457,6 +493,15 @@ func (client *containerOperations) deleteHandleResponse(resp *azcore.Response) (
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// deleteHandleError handles the Delete error response.
+func (client *containerOperations) deleteHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetAccessPolicy - gets the permissions for the specified container. The permissions indicate whether container data may be accessed publicly.
@@ -500,7 +545,7 @@ func (client *containerOperations) getAccessPolicyCreateRequest(containerGetAcce
 // getAccessPolicyHandleResponse handles the GetAccessPolicy response.
 func (client *containerOperations) getAccessPolicyHandleResponse(resp *azcore.Response) (*SignedIDentifierArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.getAccessPolicyHandleError(resp)
 	}
 	result := SignedIDentifierArrayResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-blob-public-access"); val != "" {
@@ -535,6 +580,15 @@ func (client *containerOperations) getAccessPolicyHandleResponse(resp *azcore.Re
 	return &result, resp.UnmarshalAsXML(&result)
 }
 
+// getAccessPolicyHandleError handles the GetAccessPolicy error response.
+func (client *containerOperations) getAccessPolicyHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // GetAccountInfo - Returns the sku name and account kind
 func (client *containerOperations) GetAccountInfo(ctx context.Context) (*ContainerGetAccountInfoResponse, error) {
 	req, err := client.getAccountInfoCreateRequest()
@@ -567,7 +621,7 @@ func (client *containerOperations) getAccountInfoCreateRequest() (*azcore.Reques
 // getAccountInfoHandleResponse handles the GetAccountInfo response.
 func (client *containerOperations) getAccountInfoHandleResponse(resp *azcore.Response) (*ContainerGetAccountInfoResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.getAccountInfoHandleError(resp)
 	}
 	result := ContainerGetAccountInfoResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
@@ -593,6 +647,15 @@ func (client *containerOperations) getAccountInfoHandleResponse(resp *azcore.Res
 		result.AccountKind = (*AccountKind)(&val)
 	}
 	return &result, nil
+}
+
+// getAccountInfoHandleError handles the GetAccountInfo error response.
+func (client *containerOperations) getAccountInfoHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetProperties - returns all user-defined metadata and system properties for the specified container. The data returned does not include the container's list of blobs
@@ -635,7 +698,7 @@ func (client *containerOperations) getPropertiesCreateRequest(containerGetProper
 // getPropertiesHandleResponse handles the GetProperties response.
 func (client *containerOperations) getPropertiesHandleResponse(resp *azcore.Response) (*ContainerGetPropertiesResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.getPropertiesHandleError(resp)
 	}
 	result := ContainerGetPropertiesResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-meta"); val != "" {
@@ -706,6 +769,15 @@ func (client *containerOperations) getPropertiesHandleResponse(resp *azcore.Resp
 	return &result, nil
 }
 
+// getPropertiesHandleError handles the GetProperties error response.
+func (client *containerOperations) getPropertiesHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // ListBlobFlatSegment - [Update] The List Blobs operation returns a list of the blobs under the specified container
 func (client *containerOperations) ListBlobFlatSegment(containerListBlobFlatSegmentOptions *ContainerListBlobFlatSegmentOptions) (ListBlobsFlatSegmentResponsePager, error) {
 	req, err := client.listBlobFlatSegmentCreateRequest(containerListBlobFlatSegmentOptions)
@@ -762,7 +834,7 @@ func (client *containerOperations) listBlobFlatSegmentCreateRequest(containerLis
 // listBlobFlatSegmentHandleResponse handles the ListBlobFlatSegment response.
 func (client *containerOperations) listBlobFlatSegmentHandleResponse(resp *azcore.Response) (*ListBlobsFlatSegmentResponseResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.listBlobFlatSegmentHandleError(resp)
 	}
 	result := ListBlobsFlatSegmentResponseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Content-Type"); val != "" {
@@ -785,6 +857,15 @@ func (client *containerOperations) listBlobFlatSegmentHandleResponse(resp *azcor
 		result.Date = &date
 	}
 	return &result, resp.UnmarshalAsXML(&result.EnumerationResults)
+}
+
+// listBlobFlatSegmentHandleError handles the ListBlobFlatSegment error response.
+func (client *containerOperations) listBlobFlatSegmentHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ListBlobHierarchySegment - [Update] The List Blobs operation returns a list of the blobs under the specified container
@@ -844,7 +925,7 @@ func (client *containerOperations) listBlobHierarchySegmentCreateRequest(delimit
 // listBlobHierarchySegmentHandleResponse handles the ListBlobHierarchySegment response.
 func (client *containerOperations) listBlobHierarchySegmentHandleResponse(resp *azcore.Response) (*ListBlobsHierarchySegmentResponseResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.listBlobHierarchySegmentHandleError(resp)
 	}
 	result := ListBlobsHierarchySegmentResponseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Content-Type"); val != "" {
@@ -867,6 +948,15 @@ func (client *containerOperations) listBlobHierarchySegmentHandleResponse(resp *
 		result.Date = &date
 	}
 	return &result, resp.UnmarshalAsXML(&result.EnumerationResults)
+}
+
+// listBlobHierarchySegmentHandleError handles the ListBlobHierarchySegment error response.
+func (client *containerOperations) listBlobHierarchySegmentHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ReleaseLease - [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite
@@ -915,7 +1005,7 @@ func (client *containerOperations) releaseLeaseCreateRequest(leaseId string, con
 // releaseLeaseHandleResponse handles the ReleaseLease response.
 func (client *containerOperations) releaseLeaseHandleResponse(resp *azcore.Response) (*ContainerReleaseLeaseResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.releaseLeaseHandleError(resp)
 	}
 	result := ContainerReleaseLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -945,6 +1035,15 @@ func (client *containerOperations) releaseLeaseHandleResponse(resp *azcore.Respo
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// releaseLeaseHandleError handles the ReleaseLease error response.
+func (client *containerOperations) releaseLeaseHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // RenewLease - [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite
@@ -993,7 +1092,7 @@ func (client *containerOperations) renewLeaseCreateRequest(leaseId string, conta
 // renewLeaseHandleResponse handles the RenewLease response.
 func (client *containerOperations) renewLeaseHandleResponse(resp *azcore.Response) (*ContainerRenewLeaseResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.renewLeaseHandleError(resp)
 	}
 	result := ContainerRenewLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -1026,6 +1125,15 @@ func (client *containerOperations) renewLeaseHandleResponse(resp *azcore.Respons
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// renewLeaseHandleError handles the RenewLease error response.
+func (client *containerOperations) renewLeaseHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // SetAccessPolicy - sets the permissions for the specified container. The permissions indicate whether blobs in a container may be accessed publicly.
@@ -1085,7 +1193,7 @@ func (client *containerOperations) setAccessPolicyCreateRequest(containerSetAcce
 // setAccessPolicyHandleResponse handles the SetAccessPolicy response.
 func (client *containerOperations) setAccessPolicyHandleResponse(resp *azcore.Response) (*ContainerSetAccessPolicyResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.setAccessPolicyHandleError(resp)
 	}
 	result := ContainerSetAccessPolicyResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -1115,6 +1223,15 @@ func (client *containerOperations) setAccessPolicyHandleResponse(resp *azcore.Re
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// setAccessPolicyHandleError handles the SetAccessPolicy error response.
+func (client *containerOperations) setAccessPolicyHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // SetMetadata - operation sets one or more user-defined name-value pairs for the specified container.
@@ -1164,7 +1281,7 @@ func (client *containerOperations) setMetadataCreateRequest(containerSetMetadata
 // setMetadataHandleResponse handles the SetMetadata response.
 func (client *containerOperations) setMetadataHandleResponse(resp *azcore.Response) (*ContainerSetMetadataResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.setMetadataHandleError(resp)
 	}
 	result := ContainerSetMetadataResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -1194,4 +1311,13 @@ func (client *containerOperations) setMetadataHandleResponse(resp *azcore.Respon
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// setMetadataHandleError handles the SetMetadata error response.
+func (client *containerOperations) setMetadataHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/storage/2019-07-07/azblob/directory.go
+++ b/test/storage/2019-07-07/azblob/directory.go
@@ -109,7 +109,7 @@ func (client *directoryOperations) createCreateRequest(directoryCreateOptions *D
 // createHandleResponse handles the Create response.
 func (client *directoryOperations) createHandleResponse(resp *azcore.Response) (*DirectoryCreateResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newDataLakeStorageError(resp)
+		return nil, client.createHandleError(resp)
 	}
 	result := DirectoryCreateResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -146,6 +146,15 @@ func (client *directoryOperations) createHandleResponse(resp *azcore.Response) (
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// createHandleError handles the Create error response.
+func (client *directoryOperations) createHandleError(resp *azcore.Response) error {
+	err := DataLakeStorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Delete - Deletes the directory
@@ -203,7 +212,7 @@ func (client *directoryOperations) deleteCreateRequest(recursiveDirectoryDelete 
 // deleteHandleResponse handles the Delete response.
 func (client *directoryOperations) deleteHandleResponse(resp *azcore.Response) (*DirectoryDeleteResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newDataLakeStorageError(resp)
+		return nil, client.deleteHandleError(resp)
 	}
 	result := DirectoryDeleteResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-continuation"); val != "" {
@@ -226,6 +235,15 @@ func (client *directoryOperations) deleteHandleResponse(resp *azcore.Response) (
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// deleteHandleError handles the Delete error response.
+func (client *directoryOperations) deleteHandleError(resp *azcore.Response) error {
+	err := DataLakeStorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetAccessControl - Get the owner, group, permissions, or access control list for a directory.
@@ -283,7 +301,7 @@ func (client *directoryOperations) getAccessControlCreateRequest(directoryGetAcc
 // getAccessControlHandleResponse handles the GetAccessControl response.
 func (client *directoryOperations) getAccessControlHandleResponse(resp *azcore.Response) (*DirectoryGetAccessControlResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newDataLakeStorageError(resp)
+		return nil, client.getAccessControlHandleError(resp)
 	}
 	result := DirectoryGetAccessControlResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Date"); val != "" {
@@ -322,6 +340,15 @@ func (client *directoryOperations) getAccessControlHandleResponse(resp *azcore.R
 		result.Version = &val
 	}
 	return &result, nil
+}
+
+// getAccessControlHandleError handles the GetAccessControl error response.
+func (client *directoryOperations) getAccessControlHandleError(resp *azcore.Response) error {
+	err := DataLakeStorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Rename - Rename a directory. By default, the destination is overwritten and if the destination already exists and has a lease the lease is broken. This operation supports conditional HTTP requests. For more information, see [Specifying Conditional Headers for Blob Service Operations](https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations). To fail if the destination already exists, use a conditional request with If-None-Match: "*".
@@ -421,7 +448,7 @@ func (client *directoryOperations) renameCreateRequest(renameSource string, dire
 // renameHandleResponse handles the Rename response.
 func (client *directoryOperations) renameHandleResponse(resp *azcore.Response) (*DirectoryRenameResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newDataLakeStorageError(resp)
+		return nil, client.renameHandleError(resp)
 	}
 	result := DirectoryRenameResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-continuation"); val != "" {
@@ -461,6 +488,15 @@ func (client *directoryOperations) renameHandleResponse(resp *azcore.Response) (
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// renameHandleError handles the Rename error response.
+func (client *directoryOperations) renameHandleError(resp *azcore.Response) error {
+	err := DataLakeStorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // SetAccessControl - Set the owner, group, permissions, or access control list for a directory.
@@ -527,7 +563,7 @@ func (client *directoryOperations) setAccessControlCreateRequest(directorySetAcc
 // setAccessControlHandleResponse handles the SetAccessControl response.
 func (client *directoryOperations) setAccessControlHandleResponse(resp *azcore.Response) (*DirectorySetAccessControlResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newDataLakeStorageError(resp)
+		return nil, client.setAccessControlHandleError(resp)
 	}
 	result := DirectorySetAccessControlResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Date"); val != "" {
@@ -554,4 +590,13 @@ func (client *directoryOperations) setAccessControlHandleResponse(resp *azcore.R
 		result.Version = &val
 	}
 	return &result, nil
+}
+
+// setAccessControlHandleError handles the SetAccessControl error response.
+func (client *directoryOperations) setAccessControlHandleError(resp *azcore.Response) error {
+	err := DataLakeStorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/storage/2019-07-07/azblob/models.go
+++ b/test/storage/2019-07-07/azblob/models.go
@@ -8,7 +8,6 @@ package azblob
 import (
 	"encoding/xml"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
 	"time"
@@ -2232,14 +2231,6 @@ type DataLakeStorageError struct {
 	DataLakeStorageErrorDetails *DataLakeStorageErrorDetails `xml:"error"`
 }
 
-func newDataLakeStorageError(resp *azcore.Response) error {
-	err := DataLakeStorageError{}
-	if err := resp.UnmarshalAsXML(&err); err != nil {
-		return err
-	}
-	return err
-}
-
 func (e DataLakeStorageError) Error() string {
 	msg := ""
 	if e.DataLakeStorageErrorDetails != nil {
@@ -3330,14 +3321,6 @@ type StaticWebsite struct {
 
 type StorageError struct {
 	Message *string `xml:"Message"`
-}
-
-func newStorageError(resp *azcore.Response) error {
-	err := StorageError{}
-	if err := resp.UnmarshalAsXML(&err); err != nil {
-		return err
-	}
-	return err
 }
 
 func (e StorageError) Error() string {

--- a/test/storage/2019-07-07/azblob/pageblob.go
+++ b/test/storage/2019-07-07/azblob/pageblob.go
@@ -117,7 +117,7 @@ func (client *pageBlobOperations) clearPagesCreateRequest(contentLength int64, p
 // clearPagesHandleResponse handles the ClearPages response.
 func (client *pageBlobOperations) clearPagesHandleResponse(resp *azcore.Response) (*PageBlobClearPagesResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newStorageError(resp)
+		return nil, client.clearPagesHandleError(resp)
 	}
 	result := PageBlobClearPagesResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -170,6 +170,15 @@ func (client *pageBlobOperations) clearPagesHandleResponse(resp *azcore.Response
 	return &result, nil
 }
 
+// clearPagesHandleError handles the ClearPages error response.
+func (client *pageBlobOperations) clearPagesHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
+}
+
 // CopyIncremental - The Copy Incremental operation copies a snapshot of the source page blob to a destination page blob. The snapshot is copied such that only the differential changes between the previously copied snapshot are transferred to the destination. The copied snapshots are complete copies of the original snapshot and can be read or copied from as usual. This API is supported since REST version 2016-05-31.
 func (client *pageBlobOperations) CopyIncremental(ctx context.Context, copySource url.URL, pageBlobCopyIncrementalOptions *PageBlobCopyIncrementalOptions, modifiedAccessConditions *ModifiedAccessConditions) (*PageBlobCopyIncrementalResponse, error) {
 	req, err := client.copyIncrementalCreateRequest(copySource, pageBlobCopyIncrementalOptions, modifiedAccessConditions)
@@ -220,7 +229,7 @@ func (client *pageBlobOperations) copyIncrementalCreateRequest(copySource url.UR
 // copyIncrementalHandleResponse handles the CopyIncremental response.
 func (client *pageBlobOperations) copyIncrementalHandleResponse(resp *azcore.Response) (*PageBlobCopyIncrementalResponse, error) {
 	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, newStorageError(resp)
+		return nil, client.copyIncrementalHandleError(resp)
 	}
 	result := PageBlobCopyIncrementalResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -256,6 +265,15 @@ func (client *pageBlobOperations) copyIncrementalHandleResponse(resp *azcore.Res
 		result.CopyStatus = (*CopyStatusType)(&val)
 	}
 	return &result, nil
+}
+
+// copyIncrementalHandleError handles the CopyIncremental error response.
+func (client *pageBlobOperations) copyIncrementalHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Create - The Create operation creates a new page blob.
@@ -348,7 +366,7 @@ func (client *pageBlobOperations) createCreateRequest(contentLength int64, blobC
 // createHandleResponse handles the Create response.
 func (client *pageBlobOperations) createHandleResponse(resp *azcore.Response) (*PageBlobCreateResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newStorageError(resp)
+		return nil, client.createHandleError(resp)
 	}
 	result := PageBlobCreateResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -398,6 +416,15 @@ func (client *pageBlobOperations) createHandleResponse(resp *azcore.Response) (*
 		result.EncryptionScope = &val
 	}
 	return &result, nil
+}
+
+// createHandleError handles the Create error response.
+func (client *pageBlobOperations) createHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetPageRanges - The Get Page Ranges operation returns the list of valid page ranges for a page blob or snapshot of a page blob
@@ -458,7 +485,7 @@ func (client *pageBlobOperations) getPageRangesCreateRequest(pageBlobGetPageRang
 // getPageRangesHandleResponse handles the GetPageRanges response.
 func (client *pageBlobOperations) getPageRangesHandleResponse(resp *azcore.Response) (*PageListResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.getPageRangesHandleError(resp)
 	}
 	result := PageListResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
@@ -495,6 +522,15 @@ func (client *pageBlobOperations) getPageRangesHandleResponse(resp *azcore.Respo
 		result.Date = &date
 	}
 	return &result, resp.UnmarshalAsXML(&result.PageList)
+}
+
+// getPageRangesHandleError handles the GetPageRanges error response.
+func (client *pageBlobOperations) getPageRangesHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetPageRangesDiff - The Get Page Ranges Diff operation returns the list of valid page ranges for a page blob that were changed between target blob and previous snapshot.
@@ -561,7 +597,7 @@ func (client *pageBlobOperations) getPageRangesDiffCreateRequest(pageBlobGetPage
 // getPageRangesDiffHandleResponse handles the GetPageRangesDiff response.
 func (client *pageBlobOperations) getPageRangesDiffHandleResponse(resp *azcore.Response) (*PageListResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.getPageRangesDiffHandleError(resp)
 	}
 	result := PageListResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
@@ -598,6 +634,15 @@ func (client *pageBlobOperations) getPageRangesDiffHandleResponse(resp *azcore.R
 		result.Date = &date
 	}
 	return &result, resp.UnmarshalAsXML(&result.PageList)
+}
+
+// getPageRangesDiffHandleError handles the GetPageRangesDiff error response.
+func (client *pageBlobOperations) getPageRangesDiffHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // Resize - Resize the Blob
@@ -662,7 +707,7 @@ func (client *pageBlobOperations) resizeCreateRequest(blobContentLength int64, p
 // resizeHandleResponse handles the Resize response.
 func (client *pageBlobOperations) resizeHandleResponse(resp *azcore.Response) (*PageBlobResizeResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.resizeHandleError(resp)
 	}
 	result := PageBlobResizeResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -699,6 +744,15 @@ func (client *pageBlobOperations) resizeHandleResponse(resp *azcore.Response) (*
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// resizeHandleError handles the Resize error response.
+func (client *pageBlobOperations) resizeHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // UpdateSequenceNumber - Update the sequence number of the blob
@@ -757,7 +811,7 @@ func (client *pageBlobOperations) updateSequenceNumberCreateRequest(sequenceNumb
 // updateSequenceNumberHandleResponse handles the UpdateSequenceNumber response.
 func (client *pageBlobOperations) updateSequenceNumberHandleResponse(resp *azcore.Response) (*PageBlobUpdateSequenceNumberResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.updateSequenceNumberHandleError(resp)
 	}
 	result := PageBlobUpdateSequenceNumberResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -794,6 +848,15 @@ func (client *pageBlobOperations) updateSequenceNumberHandleResponse(resp *azcor
 		result.Date = &date
 	}
 	return &result, nil
+}
+
+// updateSequenceNumberHandleError handles the UpdateSequenceNumber error response.
+func (client *pageBlobOperations) updateSequenceNumberHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // UploadPages - The Upload Pages operation writes a range of pages to a page blob
@@ -877,7 +940,7 @@ func (client *pageBlobOperations) uploadPagesCreateRequest(contentLength int64, 
 // uploadPagesHandleResponse handles the UploadPages response.
 func (client *pageBlobOperations) uploadPagesHandleResponse(resp *azcore.Response) (*PageBlobUploadPagesResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newStorageError(resp)
+		return nil, client.uploadPagesHandleError(resp)
 	}
 	result := PageBlobUploadPagesResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -941,6 +1004,15 @@ func (client *pageBlobOperations) uploadPagesHandleResponse(resp *azcore.Respons
 		result.EncryptionScope = &val
 	}
 	return &result, nil
+}
+
+// uploadPagesHandleError handles the UploadPages error response.
+func (client *pageBlobOperations) uploadPagesHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // UploadPagesFromURL - The Upload Pages operation writes a range of pages to a page blob where the contents are read from a URL
@@ -1036,7 +1108,7 @@ func (client *pageBlobOperations) uploadPagesFromUrlCreateRequest(sourceUrl url.
 // uploadPagesFromUrlHandleResponse handles the UploadPagesFromURL response.
 func (client *pageBlobOperations) uploadPagesFromUrlHandleResponse(resp *azcore.Response) (*PageBlobUploadPagesFromURLResponse, error) {
 	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, newStorageError(resp)
+		return nil, client.uploadPagesFromUrlHandleError(resp)
 	}
 	result := PageBlobUploadPagesFromURLResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
@@ -1097,4 +1169,13 @@ func (client *pageBlobOperations) uploadPagesFromUrlHandleResponse(resp *azcore.
 		result.EncryptionScope = &val
 	}
 	return &result, nil
+}
+
+// uploadPagesFromUrlHandleError handles the UploadPagesFromURL error response.
+func (client *pageBlobOperations) uploadPagesFromUrlHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }

--- a/test/storage/2019-07-07/azblob/service.go
+++ b/test/storage/2019-07-07/azblob/service.go
@@ -70,7 +70,7 @@ func (client *serviceOperations) getAccountInfoCreateRequest() (*azcore.Request,
 // getAccountInfoHandleResponse handles the GetAccountInfo response.
 func (client *serviceOperations) getAccountInfoHandleResponse(resp *azcore.Response) (*ServiceGetAccountInfoResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.getAccountInfoHandleError(resp)
 	}
 	result := ServiceGetAccountInfoResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
@@ -96,6 +96,15 @@ func (client *serviceOperations) getAccountInfoHandleResponse(resp *azcore.Respo
 		result.AccountKind = (*AccountKind)(&val)
 	}
 	return &result, nil
+}
+
+// getAccountInfoHandleError handles the GetAccountInfo error response.
+func (client *serviceOperations) getAccountInfoHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetProperties - gets the properties of a storage account's Blob service, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
@@ -136,7 +145,7 @@ func (client *serviceOperations) getPropertiesCreateRequest(serviceGetProperties
 // getPropertiesHandleResponse handles the GetProperties response.
 func (client *serviceOperations) getPropertiesHandleResponse(resp *azcore.Response) (*StorageServicePropertiesResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.getPropertiesHandleError(resp)
 	}
 	result := StorageServicePropertiesResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
@@ -149,6 +158,15 @@ func (client *serviceOperations) getPropertiesHandleResponse(resp *azcore.Respon
 		result.Version = &val
 	}
 	return &result, resp.UnmarshalAsXML(&result.StorageServiceProperties)
+}
+
+// getPropertiesHandleError handles the GetProperties error response.
+func (client *serviceOperations) getPropertiesHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetStatistics - Retrieves statistics related to replication for the Blob service. It is only available on the secondary location endpoint when read-access geo-redundant replication is enabled for the storage account.
@@ -189,7 +207,7 @@ func (client *serviceOperations) getStatisticsCreateRequest(serviceGetStatistics
 // getStatisticsHandleResponse handles the GetStatistics response.
 func (client *serviceOperations) getStatisticsHandleResponse(resp *azcore.Response) (*StorageServiceStatsResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.getStatisticsHandleError(resp)
 	}
 	result := StorageServiceStatsResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
@@ -209,6 +227,15 @@ func (client *serviceOperations) getStatisticsHandleResponse(resp *azcore.Respon
 		result.Date = &date
 	}
 	return &result, resp.UnmarshalAsXML(&result.StorageServiceStats)
+}
+
+// getStatisticsHandleError handles the GetStatistics error response.
+func (client *serviceOperations) getStatisticsHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // GetUserDelegationKey - Retrieves a user delegation key for the Blob service. This is only a valid operation when using bearer token authentication.
@@ -249,7 +276,7 @@ func (client *serviceOperations) getUserDelegationKeyCreateRequest(keyInfo KeyIn
 // getUserDelegationKeyHandleResponse handles the GetUserDelegationKey response.
 func (client *serviceOperations) getUserDelegationKeyHandleResponse(resp *azcore.Response) (*UserDelegationKeyResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.getUserDelegationKeyHandleError(resp)
 	}
 	result := UserDelegationKeyResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
@@ -269,6 +296,15 @@ func (client *serviceOperations) getUserDelegationKeyHandleResponse(resp *azcore
 		result.Date = &date
 	}
 	return &result, resp.UnmarshalAsXML(&result.UserDelegationKey)
+}
+
+// getUserDelegationKeyHandleError handles the GetUserDelegationKey error response.
+func (client *serviceOperations) getUserDelegationKeyHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // ListContainersSegment - The List Containers Segment operation returns a list of the containers under the specified account
@@ -323,7 +359,7 @@ func (client *serviceOperations) listContainersSegmentCreateRequest(serviceListC
 // listContainersSegmentHandleResponse handles the ListContainersSegment response.
 func (client *serviceOperations) listContainersSegmentHandleResponse(resp *azcore.Response) (*ListContainersSegmentResponseResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.listContainersSegmentHandleError(resp)
 	}
 	result := ListContainersSegmentResponseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
@@ -336,6 +372,15 @@ func (client *serviceOperations) listContainersSegmentHandleResponse(resp *azcor
 		result.Version = &val
 	}
 	return &result, resp.UnmarshalAsXML(&result.EnumerationResults)
+}
+
+// listContainersSegmentHandleError handles the ListContainersSegment error response.
+func (client *serviceOperations) listContainersSegmentHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // SetProperties - Sets properties for a storage account's Blob service endpoint, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules
@@ -376,7 +421,7 @@ func (client *serviceOperations) setPropertiesCreateRequest(storageServiceProper
 // setPropertiesHandleResponse handles the SetProperties response.
 func (client *serviceOperations) setPropertiesHandleResponse(resp *azcore.Response) (*ServiceSetPropertiesResponse, error) {
 	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, newStorageError(resp)
+		return nil, client.setPropertiesHandleError(resp)
 	}
 	result := ServiceSetPropertiesResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
@@ -389,6 +434,15 @@ func (client *serviceOperations) setPropertiesHandleResponse(resp *azcore.Respon
 		result.Version = &val
 	}
 	return &result, nil
+}
+
+// setPropertiesHandleError handles the SetProperties error response.
+func (client *serviceOperations) setPropertiesHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }
 
 // SubmitBatch - The Batch operation allows multiple API calls to be embedded into a single HTTP request.
@@ -431,7 +485,7 @@ func (client *serviceOperations) submitBatchCreateRequest(contentLength int64, m
 // submitBatchHandleResponse handles the SubmitBatch response.
 func (client *serviceOperations) submitBatchHandleResponse(resp *azcore.Response) (*ServiceSubmitBatchResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, newStorageError(resp)
+		return nil, client.submitBatchHandleError(resp)
 	}
 	result := ServiceSubmitBatchResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Content-Type"); val != "" {
@@ -444,4 +498,13 @@ func (client *serviceOperations) submitBatchHandleResponse(resp *azcore.Response
 		result.Version = &val
 	}
 	return &result, nil
+}
+
+// submitBatchHandleError handles the SubmitBatch error response.
+func (client *serviceOperations) submitBatchHandleError(resp *azcore.Response) error {
+	err := StorageError{}
+	if err := resp.UnmarshalAsXML(&err); err != nil {
+		return err
+	}
+	return err
 }


### PR DESCRIPTION
Generate a '<operation>HandleError' method that unmarshalls the error
payload, and wired up the handler into the LRO polling tracker.
Removed constructors for error types.
Moved resuming pollers common code into helpers.
Refactored body of Poll() method to avoid 'go vet' complaining.