### PR TITLE
Fix operation groups with no name

### DIFF
--- a/src/autorest-configuration.md
+++ b/src/autorest-configuration.md
@@ -10,7 +10,7 @@ AutoRest needs the below config to pick this up as a plug-in - see https://githu
 
 ``` yaml !isLoaded('@autorest/remodeler') 
 use-extension:
-  "@autorest/modelerfour" : "4.13.309" 
+  "@autorest/modelerfour" : "4.13.348" 
 
 # will use highest 4.0.x 
 ```

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -32,9 +32,7 @@ export function isSchemaResponse(resp?: Response): resp is SchemaResponse {
 
 export interface PagerInfo {
   name: string;
-  schema: Schema;
-  client: string;
-  nextLink: string;
+  op: Operation;
 }
 
 // returns true if the operation is pageable
@@ -44,9 +42,7 @@ export function isPageableOperation(op: Operation): boolean {
 
 export interface PollerInfo {
   name: string;
-  operationName: string;
-  schema: Schema;
-  client: string;
+  op: Operation;
 }
 
 // returns true if the operation is a long-running operation

--- a/src/generator/client.ts
+++ b/src/generator/client.ts
@@ -114,7 +114,7 @@ export async function generateClient(session: Session<CodeModel>): Promise<strin
     }
     text += `// ${group.language.go!.clientName} returns the ${group.language.go!.clientName} associated with this client.\n`;
     text += `func (client *Client) ${group.language.go!.clientName}(${methodParams.join(', ')}) ${group.language.go!.clientName} {\n`;
-    text += `\treturn &${camelCase(group.language.go!.clientName)}{${clientLiterals.join(', ')}}\n`;
+    text += `\treturn &${group.operations[0].language.go!.clientName}{${clientLiterals.join(', ')}}\n`;
     text += '}\n\n';
   }
 

--- a/src/generator/pagers.ts
+++ b/src/generator/pagers.ts
@@ -5,11 +5,12 @@
 
 import { Session } from '@azure-tools/autorest-extension-base';
 import { camelCase } from '@azure-tools/codegen';
-import { CodeModel } from '@azure-tools/codemodel';
+import { CodeModel, SchemaResponse } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';
 import { PagerInfo } from '../common/helpers';
 import { contentPreamble, sortAscending } from './helpers';
 import { ImportManager } from './imports';
+import { open } from 'fs';
 
 // Creates the content in pagers.go
 export async function generatePagers(session: Session<CodeModel>): Promise<string> {
@@ -28,12 +29,13 @@ export async function generatePagers(session: Session<CodeModel>): Promise<strin
   pagers.sort((a: PagerInfo, b: PagerInfo) => { return sortAscending(a.name, b.name) });
   for (const pager of values(pagers)) {
     const pagerType = camelCase(pager.name);
-    const responseType = pager.schema.language.go!.responseType.name;
-    const resultType = pager.schema.language.go!.name;
+    const schemaResponse = <SchemaResponse>pager.op.responses![0];
+    const responseType = schemaResponse.schema.language.go!.responseType.name;
+    const resultType = schemaResponse.schema.language.go!.name;
     let resultTypeName = resultType;
-    if (pager.schema.serialization?.xml?.name) {
+    if (schemaResponse.schema.serialization?.xml?.name) {
       // xml can specifiy its own name, prefer that if available
-      resultTypeName = pager.schema.serialization.xml.name;
+      resultTypeName = schemaResponse.schema.serialization.xml.name;
     }
     const responderType = `${camelCase(resultType)}HandleResponse`;
     const advanceType = `${camelCase(resultType)}AdvancePage`;
@@ -56,7 +58,7 @@ type ${advanceType} func(*${responseType}) (*azcore.Request, error)
 
 type ${pagerType} struct {
 	// the client for making the request
-	client *${pager.client}
+	client *${pager.op.language.go!.clientName}
 	// contains the pending request
 	request *azcore.Request
 	// callback for handling the HTTP response
@@ -75,7 +77,7 @@ func (p *${pagerType}) Err() error {
 
 func (p *${pagerType}) NextPage(ctx context.Context) bool {
 	if p.current != nil {
-		if p.current.${resultTypeName}.${pager.nextLink} == nil || len(*p.current.${resultTypeName}.${pager.nextLink}) == 0 {
+		if p.current.${resultTypeName}.${pager.op.language.go!.paging.nextLinkName} == nil || len(*p.current.${resultTypeName}.${pager.op.language.go!.paging.nextLinkName}) == 0 {
 			return false
 		}
 		req, err := p.advancer(p.current)

--- a/src/generator/pagers.ts
+++ b/src/generator/pagers.ts
@@ -10,7 +10,6 @@ import { values } from '@azure-tools/linq';
 import { PagerInfo } from '../common/helpers';
 import { contentPreamble, sortAscending } from './helpers';
 import { ImportManager } from './imports';
-import { open } from 'fs';
 
 // Creates the content in pagers.go
 export async function generatePagers(session: Session<CodeModel>): Promise<string> {

--- a/src/transform/namer.ts
+++ b/src/transform/namer.ts
@@ -70,13 +70,13 @@ export async function namer(session: Session<CodeModel>) {
     const groupDetails = <Language>group.language.go;
     // use the swagger title as the default name for operation groups that don't specify a group name
     if (groupDetails.name.length === 0) {
-      groupDetails.name = pascalCase(session.model.info.title);
+      groupDetails.name = session.model.info.title;
     }
     groupDetails.name = capitalizeAcronyms(pascalCase(groupDetails.name));
     groupDetails.clientName = `${groupDetails.name}Operations`;
     if (groupDetails.name === 'Operations') {
       // if the group name is 'Operations' don't name it 'OperationsOperations'
-      groupDetails.clientName = groupDetails.clientName;
+      groupDetails.clientName = groupDetails.name;
     }
     for (const op of values(group.operations)) {
       const details = <OperationNaming>op.language.go;

--- a/src/transform/namer.ts
+++ b/src/transform/namer.ts
@@ -67,17 +67,22 @@ export async function namer(session: Session<CodeModel>) {
 
   // pascal-case and capitzalize acronym operation groups and their operations
   for (const group of values(model.operationGroups)) {
-    const details = <Language>group.language.go;
-    details.name = capitalizeAcronyms(pascalCase(details.name));
-    // we don't call GetEscapedReservedName here since any operation group that uses a reserved word will have 'Operations' attached to it
-    details.clientName = `${details.name}Operations`;
-    // this sets Operations as the default name for operation groups that don't specify a group name
-    if (length(details.name) === 0) {
-      details.name = `Operations`;
+    const groupDetails = <Language>group.language.go;
+    // use the swagger title as the default name for operation groups that don't specify a group name
+    if (groupDetails.name.length === 0) {
+      groupDetails.name = pascalCase(session.model.info.title);
+    }
+    groupDetails.name = capitalizeAcronyms(pascalCase(groupDetails.name));
+    groupDetails.clientName = `${groupDetails.name}Operations`;
+    if (groupDetails.name === 'Operations') {
+      // if the group name is 'Operations' don't name it 'OperationsOperations'
+      groupDetails.clientName = groupDetails.clientName;
     }
     for (const op of values(group.operations)) {
       const details = <OperationNaming>op.language.go;
       details.name = getEscapedReservedName(capitalizeAcronyms(pascalCase(details.name)), 'Method');
+      // add the client name to the operation as it's needed all over the place
+      details.clientName = camelCase(groupDetails.clientName);
       if (isLROOperation(op)) {
         op.language.go!.methodPrefix = 'Begin';
       }

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -473,9 +473,7 @@ function createResponseType(codeModel: CodeModel, group: OperationGroup, op: Ope
     // create a new one, add to global list and assign to method
     const pager = {
       name: name,
-      schema: (<SchemaResponse>firstResp).schema,
-      client: camelCase(group.language.go!.clientName),
-      nextLink: op.language.go!.paging.nextLinkName,
+      op: op,
     };
     pagers.push(pager);
     op.language.go!.pageableType = pager;
@@ -490,9 +488,7 @@ function createResponseType(codeModel: CodeModel, group: OperationGroup, op: Ope
     // create a new one, add to global list and assign to method
     const poller = {
       name: name,
-      operationName: camelCase(op.language.go!.name),
-      schema: (<SchemaResponse>firstResp).schema,
-      client: camelCase(group.language.go!.clientName),
+      op: op,
     };
     const pollers = <Array<PollerInfo>>codeModel.language.go!.pollerTypes;
     pollers.push(poller);

--- a/test/autorest/complexmodelgroup/complexmodelgroup_test.go
+++ b/test/autorest/complexmodelgroup/complexmodelgroup_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 )
 
-func getOperations(t *testing.T) complexmodelgroup.Operations {
+func getOperations(t *testing.T) complexmodelgroup.ComplexModelClientOperations {
 	client, err := complexmodelgroup.NewDefaultClient(nil)
 	if err != nil {
 		t.Fatalf("failed to create complex client: %v", err)
 	}
-	return client.Operations()
+	return client.ComplexModelClientOperations()
 }
 
 func TestCreate(t *testing.T) {

--- a/test/autorest/covreport/main.go
+++ b/test/autorest/covreport/main.go
@@ -17,7 +17,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	vanillaReport, err := vanillaClient.Operations().GetReport(context.Background(), nil)
+	vanillaReport, err := vanillaClient.AutoRestReportServiceOperations().GetReport(context.Background(), nil)
 	if err != nil {
 		panic(err)
 	}
@@ -25,7 +25,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	azureReport, err := azureClient.Operations("").GetReport(context.Background(), nil)
+	azureReport, err := azureClient.AutoRestReportServiceForAzureOperations("").GetReport(context.Background(), nil)
 	if err != nil {
 		panic(err)
 	}

--- a/test/autorest/generated/azurereportgroup/autorestreportserviceforazure.go
+++ b/test/autorest/generated/azurereportgroup/autorestreportserviceforazure.go
@@ -11,21 +11,21 @@ import (
 	"net/http"
 )
 
-// Operations contains the methods for the Operations group.
-type Operations interface {
+// AutoRestReportServiceForAzureOperations contains the methods for the AutoRestReportServiceForAzure group.
+type AutoRestReportServiceForAzureOperations interface {
 	// GetReport - Get test coverage report
-	GetReport(ctx context.Context, operationsGetReportOptions *OperationsGetReportOptions) (*MapOfInt32Response, error)
+	GetReport(ctx context.Context, autoRestReportServiceForAzureGetReportOptions *AutoRestReportServiceForAzureGetReportOptions) (*MapOfInt32Response, error)
 }
 
-// operations implements the Operations interface.
-type operations struct {
+// autoRestReportServiceForAzureOperations implements the AutoRestReportServiceForAzureOperations interface.
+type autoRestReportServiceForAzureOperations struct {
 	*Client
 	Host string
 }
 
 // GetReport - Get test coverage report
-func (client *operations) GetReport(ctx context.Context, operationsGetReportOptions *OperationsGetReportOptions) (*MapOfInt32Response, error) {
-	req, err := client.getReportCreateRequest(operationsGetReportOptions)
+func (client *autoRestReportServiceForAzureOperations) GetReport(ctx context.Context, autoRestReportServiceForAzureGetReportOptions *AutoRestReportServiceForAzureGetReportOptions) (*MapOfInt32Response, error) {
+	req, err := client.getReportCreateRequest(autoRestReportServiceForAzureGetReportOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -41,15 +41,15 @@ func (client *operations) GetReport(ctx context.Context, operationsGetReportOpti
 }
 
 // getReportCreateRequest creates the GetReport request.
-func (client *operations) getReportCreateRequest(operationsGetReportOptions *OperationsGetReportOptions) (*azcore.Request, error) {
+func (client *autoRestReportServiceForAzureOperations) getReportCreateRequest(autoRestReportServiceForAzureGetReportOptions *AutoRestReportServiceForAzureGetReportOptions) (*azcore.Request, error) {
 	urlPath := "/report/azure"
 	u, err := client.u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
 	query := u.Query()
-	if operationsGetReportOptions != nil && operationsGetReportOptions.Qualifier != nil {
-		query.Set("qualifier", *operationsGetReportOptions.Qualifier)
+	if autoRestReportServiceForAzureGetReportOptions != nil && autoRestReportServiceForAzureGetReportOptions.Qualifier != nil {
+		query.Set("qualifier", *autoRestReportServiceForAzureGetReportOptions.Qualifier)
 	}
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodGet, *u)
@@ -57,7 +57,7 @@ func (client *operations) getReportCreateRequest(operationsGetReportOptions *Ope
 }
 
 // getReportHandleResponse handles the GetReport response.
-func (client *operations) getReportHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
+func (client *autoRestReportServiceForAzureOperations) getReportHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, client.getReportHandleError(resp)
 	}
@@ -66,7 +66,7 @@ func (client *operations) getReportHandleResponse(resp *azcore.Response) (*MapOf
 }
 
 // getReportHandleError handles the GetReport error response.
-func (client *operations) getReportHandleError(resp *azcore.Response) error {
+func (client *autoRestReportServiceForAzureOperations) getReportHandleError(resp *azcore.Response) error {
 	err := Error{}
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/generated/azurereportgroup/client.go
+++ b/test/autorest/generated/azurereportgroup/client.go
@@ -63,7 +63,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	return &Client{u: u, p: p}, nil
 }
 
-// Operations returns the Operations associated with this client.
-func (client *Client) Operations(Host string) Operations {
-	return &operations{Client: client, Host: Host}
+// AutoRestReportServiceForAzureOperations returns the AutoRestReportServiceForAzureOperations associated with this client.
+func (client *Client) AutoRestReportServiceForAzureOperations(Host string) AutoRestReportServiceForAzureOperations {
+	return &autoRestReportServiceForAzureOperations{Client: client, Host: Host}
 }

--- a/test/autorest/generated/azurereportgroup/models.go
+++ b/test/autorest/generated/azurereportgroup/models.go
@@ -10,6 +10,14 @@ import (
 	"net/http"
 )
 
+// AutoRestReportServiceForAzureGetReportOptions contains the optional parameters for the AutoRestReportServiceForAzure.GetReport
+// method.
+type AutoRestReportServiceForAzureGetReportOptions struct {
+	// If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The only effect is, that generators
+	// that run all tests several times, can distinguish the generated reports.
+	Qualifier *string
+}
+
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
@@ -36,11 +44,4 @@ type MapOfInt32Response struct {
 
 	// Dictionary of <integer>
 	Value *map[string]int32
-}
-
-// OperationsGetReportOptions contains the optional parameters for the Operations.GetReport method.
-type OperationsGetReportOptions struct {
-	// If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The only effect is, that generators
-	// that run all tests several times, can distinguish the generated reports.
-	Qualifier *string
 }

--- a/test/autorest/generated/complexmodelgroup/client.go
+++ b/test/autorest/generated/complexmodelgroup/client.go
@@ -71,7 +71,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	return &Client{u: u, p: p}, nil
 }
 
-// Operations returns the Operations associated with this client.
-func (client *Client) Operations() Operations {
-	return &operations{Client: client}
+// ComplexModelClientOperations returns the ComplexModelClientOperations associated with this client.
+func (client *Client) ComplexModelClientOperations() ComplexModelClientOperations {
+	return &complexModelClientOperations{Client: client}
 }

--- a/test/autorest/generated/complexmodelgroup/complexmodelclient.go
+++ b/test/autorest/generated/complexmodelgroup/complexmodelclient.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 )
 
-// Operations contains the methods for the Operations group.
-type Operations interface {
+// ComplexModelClientOperations contains the methods for the ComplexModelClient group.
+type ComplexModelClientOperations interface {
 	// Create - Resets products.
 	Create(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*CatalogDictionaryResponse, error)
 	// List - The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.
@@ -23,13 +23,13 @@ type Operations interface {
 	Update(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*CatalogArrayResponse, error)
 }
 
-// operations implements the Operations interface.
-type operations struct {
+// complexModelClientOperations implements the ComplexModelClientOperations interface.
+type complexModelClientOperations struct {
 	*Client
 }
 
 // Create - Resets products.
-func (client *operations) Create(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*CatalogDictionaryResponse, error) {
+func (client *complexModelClientOperations) Create(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*CatalogDictionaryResponse, error) {
 	req, err := client.createCreateRequest(subscriptionId, resourceGroupName, bodyParameter)
 	if err != nil {
 		return nil, err
@@ -46,7 +46,7 @@ func (client *operations) Create(ctx context.Context, subscriptionId string, res
 }
 
 // createCreateRequest creates the Create request.
-func (client *operations) createCreateRequest(subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*azcore.Request, error) {
+func (client *complexModelClientOperations) createCreateRequest(subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -62,7 +62,7 @@ func (client *operations) createCreateRequest(subscriptionId string, resourceGro
 }
 
 // createHandleResponse handles the Create response.
-func (client *operations) createHandleResponse(resp *azcore.Response) (*CatalogDictionaryResponse, error) {
+func (client *complexModelClientOperations) createHandleResponse(resp *azcore.Response) (*CatalogDictionaryResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, client.createHandleError(resp)
 	}
@@ -71,7 +71,7 @@ func (client *operations) createHandleResponse(resp *azcore.Response) (*CatalogD
 }
 
 // createHandleError handles the Create error response.
-func (client *operations) createHandleError(resp *azcore.Response) error {
+func (client *complexModelClientOperations) createHandleError(resp *azcore.Response) error {
 	err := Error{}
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -80,7 +80,7 @@ func (client *operations) createHandleError(resp *azcore.Response) error {
 }
 
 // List - The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.
-func (client *operations) List(ctx context.Context, resourceGroupName string) (*CatalogArrayResponse, error) {
+func (client *complexModelClientOperations) List(ctx context.Context, resourceGroupName string) (*CatalogArrayResponse, error) {
 	req, err := client.listCreateRequest(resourceGroupName)
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func (client *operations) List(ctx context.Context, resourceGroupName string) (*
 }
 
 // listCreateRequest creates the List request.
-func (client *operations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+func (client *complexModelClientOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape("123456"))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -113,7 +113,7 @@ func (client *operations) listCreateRequest(resourceGroupName string) (*azcore.R
 }
 
 // listHandleResponse handles the List response.
-func (client *operations) listHandleResponse(resp *azcore.Response) (*CatalogArrayResponse, error) {
+func (client *complexModelClientOperations) listHandleResponse(resp *azcore.Response) (*CatalogArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, client.listHandleError(resp)
 	}
@@ -122,7 +122,7 @@ func (client *operations) listHandleResponse(resp *azcore.Response) (*CatalogArr
 }
 
 // listHandleError handles the List error response.
-func (client *operations) listHandleError(resp *azcore.Response) error {
+func (client *complexModelClientOperations) listHandleError(resp *azcore.Response) error {
 	err := Error{}
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -131,7 +131,7 @@ func (client *operations) listHandleError(resp *azcore.Response) error {
 }
 
 // Update - Resets products.
-func (client *operations) Update(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*CatalogArrayResponse, error) {
+func (client *complexModelClientOperations) Update(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*CatalogArrayResponse, error) {
 	req, err := client.updateCreateRequest(subscriptionId, resourceGroupName, bodyParameter)
 	if err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ func (client *operations) Update(ctx context.Context, subscriptionId string, res
 }
 
 // updateCreateRequest creates the Update request.
-func (client *operations) updateCreateRequest(subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*azcore.Request, error) {
+func (client *complexModelClientOperations) updateCreateRequest(subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -164,7 +164,7 @@ func (client *operations) updateCreateRequest(subscriptionId string, resourceGro
 }
 
 // updateHandleResponse handles the Update response.
-func (client *operations) updateHandleResponse(resp *azcore.Response) (*CatalogArrayResponse, error) {
+func (client *complexModelClientOperations) updateHandleResponse(resp *azcore.Response) (*CatalogArrayResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, client.updateHandleError(resp)
 	}
@@ -173,7 +173,7 @@ func (client *operations) updateHandleResponse(resp *azcore.Response) (*CatalogA
 }
 
 // updateHandleError handles the Update error response.
-func (client *operations) updateHandleError(resp *azcore.Response) error {
+func (client *complexModelClientOperations) updateHandleError(resp *azcore.Response) error {
 	err := Error{}
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/generated/lrogroup/pollers.go
+++ b/test/autorest/generated/lrogroup/pollers.go
@@ -67,7 +67,7 @@ func (p *lrOSCustomHeaderPost202Retry200Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSCustomHeaderPost202Retry200Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrOSCustomHeaderPost202Retry200Response, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -135,7 +135,7 @@ func (p *lrOSCustomHeaderPostAsyncRetrySucceededPoller) ResumeToken() (string, e
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSCustomHeaderPostAsyncRetrySucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrOSCustomHeaderPostAsyncRetrySucceededResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -203,7 +203,7 @@ func (p *lrOSCustomHeaderPut201CreatingSucceeded200Poller) ResumeToken() (string
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSCustomHeaderPut201CreatingSucceeded200Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -271,7 +271,7 @@ func (p *lrOSCustomHeaderPutAsyncRetrySucceededPoller) ResumeToken() (string, er
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSCustomHeaderPutAsyncRetrySucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -339,7 +339,7 @@ func (p *lrOSDelete202NoRetry204Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSDelete202NoRetry204Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -407,7 +407,7 @@ func (p *lrOSDelete202Retry200Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSDelete202Retry200Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -475,7 +475,7 @@ func (p *lrOSDelete204SucceededPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSDelete204SucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*http.Response, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -543,7 +543,7 @@ func (p *lrOSDeleteAsyncNoHeaderInRetryPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSDeleteAsyncNoHeaderInRetryPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrOSDeleteAsyncNoHeaderInRetryResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -611,7 +611,7 @@ func (p *lrOSDeleteAsyncNoRetrySucceededPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSDeleteAsyncNoRetrySucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrOSDeleteAsyncNoRetrySucceededResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -679,7 +679,7 @@ func (p *lrOSDeleteAsyncRetryFailedPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSDeleteAsyncRetryFailedPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrOSDeleteAsyncRetryFailedResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -747,7 +747,7 @@ func (p *lrOSDeleteAsyncRetrySucceededPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSDeleteAsyncRetrySucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrOSDeleteAsyncRetrySucceededResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -815,7 +815,7 @@ func (p *lrOSDeleteAsyncRetrycanceledPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSDeleteAsyncRetrycanceledPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrOSDeleteAsyncRetrycanceledResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -883,7 +883,7 @@ func (p *lrOSDeleteNoHeaderInRetryPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSDeleteNoHeaderInRetryPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrOSDeleteNoHeaderInRetryResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -951,7 +951,7 @@ func (p *lrOSDeleteProvisioning202Accepted200SucceededPoller) ResumeToken() (str
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSDeleteProvisioning202Accepted200SucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -1019,7 +1019,7 @@ func (p *lrOSDeleteProvisioning202DeletingFailed200Poller) ResumeToken() (string
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSDeleteProvisioning202DeletingFailed200Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -1087,7 +1087,7 @@ func (p *lrOSDeleteProvisioning202Deletingcanceled200Poller) ResumeToken() (stri
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSDeleteProvisioning202Deletingcanceled200Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -1155,7 +1155,7 @@ func (p *lrOSPost200WithPayloadPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPost200WithPayloadPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*SkuResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -1223,7 +1223,7 @@ func (p *lrOSPost202NoRetry204Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPost202NoRetry204Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -1291,7 +1291,7 @@ func (p *lrOSPost202Retry200Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPost202Retry200Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrOSPost202Retry200Response, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -1359,7 +1359,7 @@ func (p *lrOSPostAsyncNoRetrySucceededPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPostAsyncNoRetrySucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -1427,7 +1427,7 @@ func (p *lrOSPostAsyncRetryFailedPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPostAsyncRetryFailedPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrOSPostAsyncRetryFailedResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -1495,7 +1495,7 @@ func (p *lrOSPostAsyncRetrySucceededPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPostAsyncRetrySucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -1563,7 +1563,7 @@ func (p *lrOSPostAsyncRetrycanceledPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPostAsyncRetrycanceledPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrOSPostAsyncRetrycanceledResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -1631,7 +1631,7 @@ func (p *lrOSPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) ResumeToken() (s
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPostDoubleHeadersFinalAzureHeaderGetDefaultPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -1699,7 +1699,7 @@ func (p *lrOSPostDoubleHeadersFinalAzureHeaderGetPoller) ResumeToken() (string, 
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPostDoubleHeadersFinalAzureHeaderGetPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -1767,7 +1767,7 @@ func (p *lrOSPostDoubleHeadersFinalLocationGetPoller) ResumeToken() (string, err
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPostDoubleHeadersFinalLocationGetPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -1835,7 +1835,7 @@ func (p *lrOSPut200Acceptedcanceled200Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPut200Acceptedcanceled200Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -1903,7 +1903,7 @@ func (p *lrOSPut200SucceededNoStatePoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPut200SucceededNoStatePoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -1971,7 +1971,7 @@ func (p *lrOSPut200SucceededPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPut200SucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -2039,7 +2039,7 @@ func (p *lrOSPut200UpdatingSucceeded204Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPut200UpdatingSucceeded204Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -2107,7 +2107,7 @@ func (p *lrOSPut201CreatingFailed200Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPut201CreatingFailed200Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -2175,7 +2175,7 @@ func (p *lrOSPut201CreatingSucceeded200Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPut201CreatingSucceeded200Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -2243,7 +2243,7 @@ func (p *lrOSPut202Retry200Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPut202Retry200Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -2311,7 +2311,7 @@ func (p *lrOSPutAsyncNoHeaderInRetryPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPutAsyncNoHeaderInRetryPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -2379,7 +2379,7 @@ func (p *lrOSPutAsyncNoRetrySucceededPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPutAsyncNoRetrySucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -2447,7 +2447,7 @@ func (p *lrOSPutAsyncNoRetrycanceledPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPutAsyncNoRetrycanceledPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -2515,7 +2515,7 @@ func (p *lrOSPutAsyncNonResourcePoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPutAsyncNonResourcePoller) Wait(ctx context.Context, pollingInterval time.Duration) (*SkuResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -2583,7 +2583,7 @@ func (p *lrOSPutAsyncRetryFailedPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPutAsyncRetryFailedPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -2651,7 +2651,7 @@ func (p *lrOSPutAsyncRetrySucceededPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPutAsyncRetrySucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -2719,7 +2719,7 @@ func (p *lrOSPutAsyncSubResourcePoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPutAsyncSubResourcePoller) Wait(ctx context.Context, pollingInterval time.Duration) (*SubProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -2787,7 +2787,7 @@ func (p *lrOSPutNoHeaderInRetryPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPutNoHeaderInRetryPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -2855,7 +2855,7 @@ func (p *lrOSPutNonResourcePoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPutNonResourcePoller) Wait(ctx context.Context, pollingInterval time.Duration) (*SkuResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -2923,7 +2923,7 @@ func (p *lrOSPutSubResourcePoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrOSPutSubResourcePoller) Wait(ctx context.Context, pollingInterval time.Duration) (*SubProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -2991,7 +2991,7 @@ func (p *lroRetrysDelete202Retry200Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lroRetrysDelete202Retry200Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*LroRetrysDelete202Retry200Response, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -3059,7 +3059,7 @@ func (p *lroRetrysDeleteAsyncRelativeRetrySucceededPoller) ResumeToken() (string
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lroRetrysDeleteAsyncRelativeRetrySucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LroRetrysDeleteAsyncRelativeRetrySucceededResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -3127,7 +3127,7 @@ func (p *lroRetrysDeleteProvisioning202Accepted200SucceededPoller) ResumeToken()
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lroRetrysDeleteProvisioning202Accepted200SucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -3195,7 +3195,7 @@ func (p *lroRetrysPost202Retry200Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lroRetrysPost202Retry200Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*LroRetrysPost202Retry200Response, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -3263,7 +3263,7 @@ func (p *lroRetrysPostAsyncRelativeRetrySucceededPoller) ResumeToken() (string, 
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lroRetrysPostAsyncRelativeRetrySucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LroRetrysPostAsyncRelativeRetrySucceededResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -3331,7 +3331,7 @@ func (p *lroRetrysPut201CreatingSucceeded200Poller) ResumeToken() (string, error
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lroRetrysPut201CreatingSucceeded200Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -3399,7 +3399,7 @@ func (p *lroRetrysPutAsyncRelativeRetrySucceededPoller) ResumeToken() (string, e
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lroRetrysPutAsyncRelativeRetrySucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -3467,7 +3467,7 @@ func (p *lrosaDsDelete202NonRetry400Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsDelete202NonRetry400Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrosaDsDelete202NonRetry400Response, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -3535,7 +3535,7 @@ func (p *lrosaDsDelete202RetryInvalidHeaderPoller) ResumeToken() (string, error)
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsDelete202RetryInvalidHeaderPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrosaDsDelete202RetryInvalidHeaderResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -3603,7 +3603,7 @@ func (p *lrosaDsDelete204SucceededPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsDelete204SucceededPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*http.Response, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -3671,7 +3671,7 @@ func (p *lrosaDsDeleteAsyncRelativeRetry400Poller) ResumeToken() (string, error)
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsDeleteAsyncRelativeRetry400Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrosaDsDeleteAsyncRelativeRetry400Response, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -3739,7 +3739,7 @@ func (p *lrosaDsDeleteAsyncRelativeRetryInvalidHeaderPoller) ResumeToken() (stri
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsDeleteAsyncRelativeRetryInvalidHeaderPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrosaDsDeleteAsyncRelativeRetryInvalidHeaderResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -3807,7 +3807,7 @@ func (p *lrosaDsDeleteAsyncRelativeRetryInvalidJSONPollingPoller) ResumeToken() 
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsDeleteAsyncRelativeRetryInvalidJSONPollingPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrosaDsDeleteAsyncRelativeRetryInvalidJSONPollingResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -3875,7 +3875,7 @@ func (p *lrosaDsDeleteAsyncRelativeRetryNoStatusPoller) ResumeToken() (string, e
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsDeleteAsyncRelativeRetryNoStatusPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrosaDsDeleteAsyncRelativeRetryNoStatusResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -3943,7 +3943,7 @@ func (p *lrosaDsDeleteNonRetry400Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsDeleteNonRetry400Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrosaDsDeleteNonRetry400Response, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -4011,7 +4011,7 @@ func (p *lrosaDsPost202NoLocationPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPost202NoLocationPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrosaDsPost202NoLocationResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -4079,7 +4079,7 @@ func (p *lrosaDsPost202NonRetry400Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPost202NonRetry400Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrosaDsPost202NonRetry400Response, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -4147,7 +4147,7 @@ func (p *lrosaDsPost202RetryInvalidHeaderPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPost202RetryInvalidHeaderPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrosaDsPost202RetryInvalidHeaderResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -4215,7 +4215,7 @@ func (p *lrosaDsPostAsyncRelativeRetry400Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPostAsyncRelativeRetry400Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrosaDsPostAsyncRelativeRetry400Response, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -4283,7 +4283,7 @@ func (p *lrosaDsPostAsyncRelativeRetryInvalidHeaderPoller) ResumeToken() (string
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPostAsyncRelativeRetryInvalidHeaderPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrosaDsPostAsyncRelativeRetryInvalidHeaderResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -4351,7 +4351,7 @@ func (p *lrosaDsPostAsyncRelativeRetryInvalidJSONPollingPoller) ResumeToken() (s
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPostAsyncRelativeRetryInvalidJSONPollingPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrosaDsPostAsyncRelativeRetryInvalidJSONPollingResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -4419,7 +4419,7 @@ func (p *lrosaDsPostAsyncRelativeRetryNoPayloadPoller) ResumeToken() (string, er
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPostAsyncRelativeRetryNoPayloadPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrosaDsPostAsyncRelativeRetryNoPayloadResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -4487,7 +4487,7 @@ func (p *lrosaDsPostNonRetry400Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPostNonRetry400Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*LrosaDsPostNonRetry400Response, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -4555,7 +4555,7 @@ func (p *lrosaDsPut200InvalidJSONPoller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPut200InvalidJSONPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -4623,7 +4623,7 @@ func (p *lrosaDsPutAsyncRelativeRetry400Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPutAsyncRelativeRetry400Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -4691,7 +4691,7 @@ func (p *lrosaDsPutAsyncRelativeRetryInvalidHeaderPoller) ResumeToken() (string,
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPutAsyncRelativeRetryInvalidHeaderPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -4759,7 +4759,7 @@ func (p *lrosaDsPutAsyncRelativeRetryInvalidJSONPollingPoller) ResumeToken() (st
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPutAsyncRelativeRetryInvalidJSONPollingPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -4827,7 +4827,7 @@ func (p *lrosaDsPutAsyncRelativeRetryNoStatusPayloadPoller) ResumeToken() (strin
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPutAsyncRelativeRetryNoStatusPayloadPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -4895,7 +4895,7 @@ func (p *lrosaDsPutAsyncRelativeRetryNoStatusPoller) ResumeToken() (string, erro
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPutAsyncRelativeRetryNoStatusPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -4963,7 +4963,7 @@ func (p *lrosaDsPutError201NoProvisioningStatePayloadPoller) ResumeToken() (stri
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPutError201NoProvisioningStatePayloadPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -5031,7 +5031,7 @@ func (p *lrosaDsPutNonRetry201Creating400InvalidJSONPoller) ResumeToken() (strin
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPutNonRetry201Creating400InvalidJSONPoller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -5099,7 +5099,7 @@ func (p *lrosaDsPutNonRetry201Creating400Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPutNonRetry201Creating400Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {
@@ -5167,7 +5167,7 @@ func (p *lrosaDsPutNonRetry400Poller) ResumeToken() (string, error) {
 // duration specified in the retry-after header, if the header is not specified then the pollingInterval that
 // is specified will be used to wait between polling requests.
 func (p *lrosaDsPutNonRetry400Poller) Wait(ctx context.Context, pollingInterval time.Duration) (*ProductResponse, error) {
-	for p.Poll(context.Background()) {
+	for p.Poll(ctx) {
 		if delay := p.response().RetryAfter(); delay > 0 {
 			time.Sleep(delay)
 		} else {

--- a/test/autorest/generated/reportgroup/autorestreportservice.go
+++ b/test/autorest/generated/reportgroup/autorestreportservice.go
@@ -11,22 +11,22 @@ import (
 	"net/http"
 )
 
-// Operations contains the methods for the Operations group.
-type Operations interface {
+// AutoRestReportServiceOperations contains the methods for the AutoRestReportService group.
+type AutoRestReportServiceOperations interface {
 	// GetOptionalReport - Get optional test coverage report
-	GetOptionalReport(ctx context.Context, operationsGetOptionalReportOptions *OperationsGetOptionalReportOptions) (*MapOfInt32Response, error)
+	GetOptionalReport(ctx context.Context, autoRestReportServiceGetOptionalReportOptions *AutoRestReportServiceGetOptionalReportOptions) (*MapOfInt32Response, error)
 	// GetReport - Get test coverage report
-	GetReport(ctx context.Context, operationsGetReportOptions *OperationsGetReportOptions) (*MapOfInt32Response, error)
+	GetReport(ctx context.Context, autoRestReportServiceGetReportOptions *AutoRestReportServiceGetReportOptions) (*MapOfInt32Response, error)
 }
 
-// operations implements the Operations interface.
-type operations struct {
+// autoRestReportServiceOperations implements the AutoRestReportServiceOperations interface.
+type autoRestReportServiceOperations struct {
 	*Client
 }
 
 // GetOptionalReport - Get optional test coverage report
-func (client *operations) GetOptionalReport(ctx context.Context, operationsGetOptionalReportOptions *OperationsGetOptionalReportOptions) (*MapOfInt32Response, error) {
-	req, err := client.getOptionalReportCreateRequest(operationsGetOptionalReportOptions)
+func (client *autoRestReportServiceOperations) GetOptionalReport(ctx context.Context, autoRestReportServiceGetOptionalReportOptions *AutoRestReportServiceGetOptionalReportOptions) (*MapOfInt32Response, error) {
+	req, err := client.getOptionalReportCreateRequest(autoRestReportServiceGetOptionalReportOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -42,15 +42,15 @@ func (client *operations) GetOptionalReport(ctx context.Context, operationsGetOp
 }
 
 // getOptionalReportCreateRequest creates the GetOptionalReport request.
-func (client *operations) getOptionalReportCreateRequest(operationsGetOptionalReportOptions *OperationsGetOptionalReportOptions) (*azcore.Request, error) {
+func (client *autoRestReportServiceOperations) getOptionalReportCreateRequest(autoRestReportServiceGetOptionalReportOptions *AutoRestReportServiceGetOptionalReportOptions) (*azcore.Request, error) {
 	urlPath := "/report/optional"
 	u, err := client.u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
 	query := u.Query()
-	if operationsGetOptionalReportOptions != nil && operationsGetOptionalReportOptions.Qualifier != nil {
-		query.Set("qualifier", *operationsGetOptionalReportOptions.Qualifier)
+	if autoRestReportServiceGetOptionalReportOptions != nil && autoRestReportServiceGetOptionalReportOptions.Qualifier != nil {
+		query.Set("qualifier", *autoRestReportServiceGetOptionalReportOptions.Qualifier)
 	}
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodGet, *u)
@@ -58,7 +58,7 @@ func (client *operations) getOptionalReportCreateRequest(operationsGetOptionalRe
 }
 
 // getOptionalReportHandleResponse handles the GetOptionalReport response.
-func (client *operations) getOptionalReportHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
+func (client *autoRestReportServiceOperations) getOptionalReportHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, client.getOptionalReportHandleError(resp)
 	}
@@ -67,7 +67,7 @@ func (client *operations) getOptionalReportHandleResponse(resp *azcore.Response)
 }
 
 // getOptionalReportHandleError handles the GetOptionalReport error response.
-func (client *operations) getOptionalReportHandleError(resp *azcore.Response) error {
+func (client *autoRestReportServiceOperations) getOptionalReportHandleError(resp *azcore.Response) error {
 	err := Error{}
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -76,8 +76,8 @@ func (client *operations) getOptionalReportHandleError(resp *azcore.Response) er
 }
 
 // GetReport - Get test coverage report
-func (client *operations) GetReport(ctx context.Context, operationsGetReportOptions *OperationsGetReportOptions) (*MapOfInt32Response, error) {
-	req, err := client.getReportCreateRequest(operationsGetReportOptions)
+func (client *autoRestReportServiceOperations) GetReport(ctx context.Context, autoRestReportServiceGetReportOptions *AutoRestReportServiceGetReportOptions) (*MapOfInt32Response, error) {
+	req, err := client.getReportCreateRequest(autoRestReportServiceGetReportOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -93,15 +93,15 @@ func (client *operations) GetReport(ctx context.Context, operationsGetReportOpti
 }
 
 // getReportCreateRequest creates the GetReport request.
-func (client *operations) getReportCreateRequest(operationsGetReportOptions *OperationsGetReportOptions) (*azcore.Request, error) {
+func (client *autoRestReportServiceOperations) getReportCreateRequest(autoRestReportServiceGetReportOptions *AutoRestReportServiceGetReportOptions) (*azcore.Request, error) {
 	urlPath := "/report"
 	u, err := client.u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
 	query := u.Query()
-	if operationsGetReportOptions != nil && operationsGetReportOptions.Qualifier != nil {
-		query.Set("qualifier", *operationsGetReportOptions.Qualifier)
+	if autoRestReportServiceGetReportOptions != nil && autoRestReportServiceGetReportOptions.Qualifier != nil {
+		query.Set("qualifier", *autoRestReportServiceGetReportOptions.Qualifier)
 	}
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodGet, *u)
@@ -109,7 +109,7 @@ func (client *operations) getReportCreateRequest(operationsGetReportOptions *Ope
 }
 
 // getReportHandleResponse handles the GetReport response.
-func (client *operations) getReportHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
+func (client *autoRestReportServiceOperations) getReportHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, client.getReportHandleError(resp)
 	}
@@ -118,7 +118,7 @@ func (client *operations) getReportHandleResponse(resp *azcore.Response) (*MapOf
 }
 
 // getReportHandleError handles the GetReport error response.
-func (client *operations) getReportHandleError(resp *azcore.Response) error {
+func (client *autoRestReportServiceOperations) getReportHandleError(resp *azcore.Response) error {
 	err := Error{}
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/generated/reportgroup/client.go
+++ b/test/autorest/generated/reportgroup/client.go
@@ -71,7 +71,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	return &Client{u: u, p: p}, nil
 }
 
-// Operations returns the Operations associated with this client.
-func (client *Client) Operations() Operations {
-	return &operations{Client: client}
+// AutoRestReportServiceOperations returns the AutoRestReportServiceOperations associated with this client.
+func (client *Client) AutoRestReportServiceOperations() AutoRestReportServiceOperations {
+	return &autoRestReportServiceOperations{Client: client}
 }

--- a/test/autorest/generated/reportgroup/models.go
+++ b/test/autorest/generated/reportgroup/models.go
@@ -10,6 +10,21 @@ import (
 	"net/http"
 )
 
+// AutoRestReportServiceGetOptionalReportOptions contains the optional parameters for the AutoRestReportService.GetOptionalReport
+// method.
+type AutoRestReportServiceGetOptionalReportOptions struct {
+	// If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The only effect is, that generators
+	// that run all tests several times, can distinguish the generated reports.
+	Qualifier *string
+}
+
+// AutoRestReportServiceGetReportOptions contains the optional parameters for the AutoRestReportService.GetReport method.
+type AutoRestReportServiceGetReportOptions struct {
+	// If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The only effect is, that generators
+	// that run all tests several times, can distinguish the generated reports.
+	Qualifier *string
+}
+
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
@@ -36,18 +51,4 @@ type MapOfInt32Response struct {
 
 	// Dictionary of <integer>
 	Value *map[string]int32
-}
-
-// OperationsGetOptionalReportOptions contains the optional parameters for the Operations.GetOptionalReport method.
-type OperationsGetOptionalReportOptions struct {
-	// If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The only effect is, that generators
-	// that run all tests several times, can distinguish the generated reports.
-	Qualifier *string
-}
-
-// OperationsGetReportOptions contains the optional parameters for the Operations.GetReport method.
-type OperationsGetReportOptions struct {
-	// If specified, qualifies the generated report further (e.g. '2.7' vs '3.5' in for Python). The only effect is, that generators
-	// that run all tests several times, can distinguish the generated reports.
-	Qualifier *string
 }

--- a/test/autorest/generated/validationgroup/autorestvalidationtest.go
+++ b/test/autorest/generated/validationgroup/autorestvalidationtest.go
@@ -15,23 +15,23 @@ import (
 	"strings"
 )
 
-// Operations contains the methods for the Operations group.
-type Operations interface {
+// AutoRestValidationTestOperations contains the methods for the AutoRestValidationTest group.
+type AutoRestValidationTestOperations interface {
 	GetWithConstantInPath(ctx context.Context) (*http.Response, error)
-	PostWithConstantInBody(ctx context.Context, operationsPostWithConstantInBodyOptions *OperationsPostWithConstantInBodyOptions) (*ProductResponse, error)
+	PostWithConstantInBody(ctx context.Context, autoRestValidationTestPostWithConstantInBodyOptions *AutoRestValidationTestPostWithConstantInBodyOptions) (*ProductResponse, error)
 	// ValidationOfBody - Validates body parameters on the method. See swagger for details.
-	ValidationOfBody(ctx context.Context, resourceGroupName string, id int32, operationsValidationOfBodyOptions *OperationsValidationOfBodyOptions) (*ProductResponse, error)
+	ValidationOfBody(ctx context.Context, resourceGroupName string, id int32, autoRestValidationTestValidationOfBodyOptions *AutoRestValidationTestValidationOfBodyOptions) (*ProductResponse, error)
 	// ValidationOfMethodParameters - Validates input parameters on the method. See swagger for details.
 	ValidationOfMethodParameters(ctx context.Context, resourceGroupName string, id int32) (*ProductResponse, error)
 }
 
-// operations implements the Operations interface.
-type operations struct {
+// autoRestValidationTestOperations implements the AutoRestValidationTestOperations interface.
+type autoRestValidationTestOperations struct {
 	*Client
 	subscriptionID string
 }
 
-func (client *operations) GetWithConstantInPath(ctx context.Context) (*http.Response, error) {
+func (client *autoRestValidationTestOperations) GetWithConstantInPath(ctx context.Context) (*http.Response, error) {
 	req, err := client.getWithConstantInPathCreateRequest()
 	if err != nil {
 		return nil, err
@@ -48,7 +48,7 @@ func (client *operations) GetWithConstantInPath(ctx context.Context) (*http.Resp
 }
 
 // getWithConstantInPathCreateRequest creates the GetWithConstantInPath request.
-func (client *operations) getWithConstantInPathCreateRequest() (*azcore.Request, error) {
+func (client *autoRestValidationTestOperations) getWithConstantInPathCreateRequest() (*azcore.Request, error) {
 	urlPath := "/validation/constantsInPath/{constantParam}/value"
 	urlPath = strings.ReplaceAll(urlPath, "{constantParam}", url.PathEscape("constant"))
 	u, err := client.u.Parse(urlPath)
@@ -60,7 +60,7 @@ func (client *operations) getWithConstantInPathCreateRequest() (*azcore.Request,
 }
 
 // getWithConstantInPathHandleResponse handles the GetWithConstantInPath response.
-func (client *operations) getWithConstantInPathHandleResponse(resp *azcore.Response) (*http.Response, error) {
+func (client *autoRestValidationTestOperations) getWithConstantInPathHandleResponse(resp *azcore.Response) (*http.Response, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, client.getWithConstantInPathHandleError(resp)
 	}
@@ -68,12 +68,12 @@ func (client *operations) getWithConstantInPathHandleResponse(resp *azcore.Respo
 }
 
 // getWithConstantInPathHandleError handles the GetWithConstantInPath error response.
-func (client *operations) getWithConstantInPathHandleError(resp *azcore.Response) error {
+func (client *autoRestValidationTestOperations) getWithConstantInPathHandleError(resp *azcore.Response) error {
 	return errors.New(resp.Status)
 }
 
-func (client *operations) PostWithConstantInBody(ctx context.Context, operationsPostWithConstantInBodyOptions *OperationsPostWithConstantInBodyOptions) (*ProductResponse, error) {
-	req, err := client.postWithConstantInBodyCreateRequest(operationsPostWithConstantInBodyOptions)
+func (client *autoRestValidationTestOperations) PostWithConstantInBody(ctx context.Context, autoRestValidationTestPostWithConstantInBodyOptions *AutoRestValidationTestPostWithConstantInBodyOptions) (*ProductResponse, error) {
+	req, err := client.postWithConstantInBodyCreateRequest(autoRestValidationTestPostWithConstantInBodyOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (client *operations) PostWithConstantInBody(ctx context.Context, operations
 }
 
 // postWithConstantInBodyCreateRequest creates the PostWithConstantInBody request.
-func (client *operations) postWithConstantInBodyCreateRequest(operationsPostWithConstantInBodyOptions *OperationsPostWithConstantInBodyOptions) (*azcore.Request, error) {
+func (client *autoRestValidationTestOperations) postWithConstantInBodyCreateRequest(autoRestValidationTestPostWithConstantInBodyOptions *AutoRestValidationTestPostWithConstantInBodyOptions) (*azcore.Request, error) {
 	urlPath := "/validation/constantsInPath/{constantParam}/value"
 	urlPath = strings.ReplaceAll(urlPath, "{constantParam}", url.PathEscape("constant"))
 	u, err := client.u.Parse(urlPath)
@@ -97,14 +97,14 @@ func (client *operations) postWithConstantInBodyCreateRequest(operationsPostWith
 		return nil, err
 	}
 	req := azcore.NewRequest(http.MethodPost, *u)
-	if operationsPostWithConstantInBodyOptions != nil {
-		return req, req.MarshalAsJSON(operationsPostWithConstantInBodyOptions.Body)
+	if autoRestValidationTestPostWithConstantInBodyOptions != nil {
+		return req, req.MarshalAsJSON(autoRestValidationTestPostWithConstantInBodyOptions.Body)
 	}
 	return req, nil
 }
 
 // postWithConstantInBodyHandleResponse handles the PostWithConstantInBody response.
-func (client *operations) postWithConstantInBodyHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
+func (client *autoRestValidationTestOperations) postWithConstantInBodyHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, client.postWithConstantInBodyHandleError(resp)
 	}
@@ -113,13 +113,13 @@ func (client *operations) postWithConstantInBodyHandleResponse(resp *azcore.Resp
 }
 
 // postWithConstantInBodyHandleError handles the PostWithConstantInBody error response.
-func (client *operations) postWithConstantInBodyHandleError(resp *azcore.Response) error {
+func (client *autoRestValidationTestOperations) postWithConstantInBodyHandleError(resp *azcore.Response) error {
 	return errors.New(resp.Status)
 }
 
 // ValidationOfBody - Validates body parameters on the method. See swagger for details.
-func (client *operations) ValidationOfBody(ctx context.Context, resourceGroupName string, id int32, operationsValidationOfBodyOptions *OperationsValidationOfBodyOptions) (*ProductResponse, error) {
-	req, err := client.validationOfBodyCreateRequest(resourceGroupName, id, operationsValidationOfBodyOptions)
+func (client *autoRestValidationTestOperations) ValidationOfBody(ctx context.Context, resourceGroupName string, id int32, autoRestValidationTestValidationOfBodyOptions *AutoRestValidationTestValidationOfBodyOptions) (*ProductResponse, error) {
+	req, err := client.validationOfBodyCreateRequest(resourceGroupName, id, autoRestValidationTestValidationOfBodyOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (client *operations) ValidationOfBody(ctx context.Context, resourceGroupNam
 }
 
 // validationOfBodyCreateRequest creates the ValidationOfBody request.
-func (client *operations) validationOfBodyCreateRequest(resourceGroupName string, id int32, operationsValidationOfBodyOptions *OperationsValidationOfBodyOptions) (*azcore.Request, error) {
+func (client *autoRestValidationTestOperations) validationOfBodyCreateRequest(resourceGroupName string, id int32, autoRestValidationTestValidationOfBodyOptions *AutoRestValidationTestValidationOfBodyOptions) (*azcore.Request, error) {
 	urlPath := "/fakepath/{subscriptionId}/{resourceGroupName}/{id}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -148,14 +148,14 @@ func (client *operations) validationOfBodyCreateRequest(resourceGroupName string
 	query.Set("apiVersion", "1.0.0")
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodPut, *u)
-	if operationsValidationOfBodyOptions != nil {
-		return req, req.MarshalAsJSON(operationsValidationOfBodyOptions.Body)
+	if autoRestValidationTestValidationOfBodyOptions != nil {
+		return req, req.MarshalAsJSON(autoRestValidationTestValidationOfBodyOptions.Body)
 	}
 	return req, nil
 }
 
 // validationOfBodyHandleResponse handles the ValidationOfBody response.
-func (client *operations) validationOfBodyHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
+func (client *autoRestValidationTestOperations) validationOfBodyHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, client.validationOfBodyHandleError(resp)
 	}
@@ -164,7 +164,7 @@ func (client *operations) validationOfBodyHandleResponse(resp *azcore.Response) 
 }
 
 // validationOfBodyHandleError handles the ValidationOfBody error response.
-func (client *operations) validationOfBodyHandleError(resp *azcore.Response) error {
+func (client *autoRestValidationTestOperations) validationOfBodyHandleError(resp *azcore.Response) error {
 	err := Error{}
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -173,7 +173,7 @@ func (client *operations) validationOfBodyHandleError(resp *azcore.Response) err
 }
 
 // ValidationOfMethodParameters - Validates input parameters on the method. See swagger for details.
-func (client *operations) ValidationOfMethodParameters(ctx context.Context, resourceGroupName string, id int32) (*ProductResponse, error) {
+func (client *autoRestValidationTestOperations) ValidationOfMethodParameters(ctx context.Context, resourceGroupName string, id int32) (*ProductResponse, error) {
 	req, err := client.validationOfMethodParametersCreateRequest(resourceGroupName, id)
 	if err != nil {
 		return nil, err
@@ -190,7 +190,7 @@ func (client *operations) ValidationOfMethodParameters(ctx context.Context, reso
 }
 
 // validationOfMethodParametersCreateRequest creates the ValidationOfMethodParameters request.
-func (client *operations) validationOfMethodParametersCreateRequest(resourceGroupName string, id int32) (*azcore.Request, error) {
+func (client *autoRestValidationTestOperations) validationOfMethodParametersCreateRequest(resourceGroupName string, id int32) (*azcore.Request, error) {
 	urlPath := "/fakepath/{subscriptionId}/{resourceGroupName}/{id}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -207,7 +207,7 @@ func (client *operations) validationOfMethodParametersCreateRequest(resourceGrou
 }
 
 // validationOfMethodParametersHandleResponse handles the ValidationOfMethodParameters response.
-func (client *operations) validationOfMethodParametersHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
+func (client *autoRestValidationTestOperations) validationOfMethodParametersHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
 	if !resp.HasStatusCode(http.StatusOK) {
 		return nil, client.validationOfMethodParametersHandleError(resp)
 	}
@@ -216,7 +216,7 @@ func (client *operations) validationOfMethodParametersHandleResponse(resp *azcor
 }
 
 // validationOfMethodParametersHandleError handles the ValidationOfMethodParameters error response.
-func (client *operations) validationOfMethodParametersHandleError(resp *azcore.Response) error {
+func (client *autoRestValidationTestOperations) validationOfMethodParametersHandleError(resp *azcore.Response) error {
 	err := Error{}
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/generated/validationgroup/client.go
+++ b/test/autorest/generated/validationgroup/client.go
@@ -71,7 +71,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	return &Client{u: u, p: p}, nil
 }
 
-// Operations returns the Operations associated with this client.
-func (client *Client) Operations(subscriptionID string) Operations {
-	return &operations{Client: client, subscriptionID: subscriptionID}
+// AutoRestValidationTestOperations returns the AutoRestValidationTestOperations associated with this client.
+func (client *Client) AutoRestValidationTestOperations(subscriptionID string) AutoRestValidationTestOperations {
+	return &autoRestValidationTestOperations{Client: client, subscriptionID: subscriptionID}
 }

--- a/test/autorest/generated/validationgroup/models.go
+++ b/test/autorest/generated/validationgroup/models.go
@@ -10,6 +10,18 @@ import (
 	"net/http"
 )
 
+// AutoRestValidationTestPostWithConstantInBodyOptions contains the optional parameters for the AutoRestValidationTest.PostWithConstantInBody
+// method.
+type AutoRestValidationTestPostWithConstantInBodyOptions struct {
+	Body *Product
+}
+
+// AutoRestValidationTestValidationOfBodyOptions contains the optional parameters for the AutoRestValidationTest.ValidationOfBody
+// method.
+type AutoRestValidationTestValidationOfBodyOptions struct {
+	Body *Product
+}
+
 // The product documentation.
 type ChildProduct struct {
 	// Constant string
@@ -49,16 +61,6 @@ func (e Error) Error() string {
 		msg = "missing error info"
 	}
 	return msg
-}
-
-// OperationsPostWithConstantInBodyOptions contains the optional parameters for the Operations.PostWithConstantInBody method.
-type OperationsPostWithConstantInBodyOptions struct {
-	Body *Product
-}
-
-// OperationsValidationOfBodyOptions contains the optional parameters for the Operations.ValidationOfBody method.
-type OperationsValidationOfBodyOptions struct {
-	Body *Product
 }
 
 // The product documentation.

--- a/test/autorest/validationgroup/validationgroup_test.go
+++ b/test/autorest/validationgroup/validationgroup_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getValidationOperations(t *testing.T) validationgroup.Operations {
+func getValidationOperations(t *testing.T) validationgroup.AutoRestValidationTestOperations {
 	client, err := validationgroup.NewDefaultClient(nil)
 	if err != nil {
 		t.Fatalf("failed to create validation client: %v", err)
 	}
-	return client.Operations("")
+	return client.AutoRestValidationTestOperations("")
 }
 
 func TestValidationGetWithConstantInPath(t *testing.T) {
@@ -32,7 +32,7 @@ func TestValidationGetWithConstantInPath(t *testing.T) {
 
 func TestValidationPostWithConstantInBody(t *testing.T) {
 	client := getValidationOperations(t)
-	result, err := client.PostWithConstantInBody(context.Background(), &validationgroup.OperationsPostWithConstantInBodyOptions{Body: &validationgroup.Product{
+	result, err := client.PostWithConstantInBody(context.Background(), &validationgroup.AutoRestValidationTestPostWithConstantInBodyOptions{Body: &validationgroup.Product{
 		Child: &validationgroup.ChildProduct{
 			ConstProperty: to.StringPtr("constant")},
 		ConstString: to.StringPtr("constant"),
@@ -49,7 +49,7 @@ func TestValidationPostWithConstantInBody(t *testing.T) {
 func TestValidationValidationOfBody(t *testing.T) {
 	t.Skip("need to confirm if this test will remain in the testserver and what values it's expecting")
 	client := getValidationOperations(t)
-	result, err := client.ValidationOfBody(context.Background(), "123", 150, &validationgroup.OperationsValidationOfBodyOptions{
+	result, err := client.ValidationOfBody(context.Background(), "123", 150, &validationgroup.AutoRestValidationTestValidationOfBodyOptions{
 		Body: &validationgroup.Product{
 			DisplayNames: &[]string{
 				"displayname1",


### PR DESCRIPTION
For operations without a group name, use the pascal-cased swagger title.
Consolidated params in PagerInfo and PollerInfo.
Added clientName field to operations and consolidated its usage.
Fixed tests where operation group names changed.
Fixed a bug in poller's Wait() method to use the caller-supplied
context.
Updated to the latest M4 which includes the deduplication switch.