### PR TITLE
Slight refactor of discriminated types

### DIFF
--- a/src/autorest-configuration.md
+++ b/src/autorest-configuration.md
@@ -10,7 +10,7 @@ AutoRest needs the below config to pick this up as a plug-in - see https://githu
 
 ``` yaml !isLoaded('@autorest/remodeler') 
 use-extension:
-  "@autorest/modelerfour" : "4.13.348" 
+  "@autorest/modelerfour" : "4.13.351" 
 
 # will use highest 4.0.x 
 ```

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -191,7 +191,12 @@ class StructDef {
       // find the discriminator property
       for (const prop of values(this.Properties)) {
         if (prop.isDiscriminator) {
-          text += `\t${receiver}.${prop.language.go!.name} = strptr(${this.Language.discriminatorEnum})\n`;
+          text += `\t${receiver}.${prop.language.go!.name} = `;
+          if (this.Language.discriminatorRealEnum) {
+            text += `${this.Language.discriminatorEnum}.ToPtr()\n`;
+          } else {
+            text += `strptr(${this.Language.discriminatorEnum})\n`;
+          }
           break;
         }
       }

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -303,7 +303,7 @@ function generateOperation(clientName: string, op: Operation, imports: ImportMan
   text += `\t}\n`;
   if (isPageableOperation(op)) {
     text += `\treturn &${camelCase(op.language.go!.pageableType.name)}{\n`;
-    text += `\t\tclient: client,\n`;
+    text += `\t\tpipeline: client.p,\n`;
     text += `\t\trequest: req,\n`;
     text += `\t\tresponder: client.${info.protocolNaming.responseMethod},\n`;
     const pager = <PagerInfo>op.language.go!.pageableType;

--- a/src/generator/pagers.ts
+++ b/src/generator/pagers.ts
@@ -56,8 +56,8 @@ type ${responderType} func(*azcore.Response) (*${responseType}, error)
 type ${advanceType} func(*${responseType}) (*azcore.Request, error)
 
 type ${pagerType} struct {
-	// the client for making the request
-	client *${pager.op.language.go!.clientName}
+	// the pipeline for making the request
+	pipeline azcore.Pipeline
 	// contains the pending request
 	request *azcore.Request
 	// callback for handling the HTTP response
@@ -86,7 +86,7 @@ func (p *${pagerType}) NextPage(ctx context.Context) bool {
 		}
 		p.request = req
 	}
-	resp, err := p.client.p.Do(ctx, p.request)
+	resp, err := p.pipeline.Do(ctx, p.request)
 	if err != nil {
 		p.err = err
 		return false

--- a/src/transform/namer.ts
+++ b/src/transform/namer.ts
@@ -57,7 +57,7 @@ export async function namer(session: Session<CodeModel>) {
     details.name = getEscapedReservedName(capitalizeAcronyms(pascalCase(details.name)), 'Model');
     if (obj.discriminator) {
       // if this is a discriminator add the interface name
-      details.discriminator = `${details.name}Type`;
+      details.discriminator = createPolymorphicInterfaceName(details.name);
     }
     for (const prop of values(obj.properties)) {
       const details = <Language>prop.language.go;
@@ -172,4 +172,8 @@ export function removePrefix(name: string, prefix: string): string {
   }
 
   return name.slice(prefix.length);
+}
+
+export function createPolymorphicInterfaceName(base: string): string {
+  return base + 'Classification';
 }

--- a/test/autorest/complexgroup/polymorphicrecursive_test.go
+++ b/test/autorest/complexgroup/polymorphicrecursive_test.go
@@ -36,19 +36,19 @@ func TestGetValid(t *testing.T) {
 		Iswild:   to.BoolPtr(true),
 		Length:   to.Float32Ptr(1),
 		Location: to.StringPtr("alaska"),
-		Siblings: &[]complexgroup.FishType{
+		Siblings: &[]complexgroup.FishClassification{
 			&complexgroup.Shark{
 				Age:      to.Int32Ptr(6),
 				Birthday: &sharkBday,
 				Fishtype: to.StringPtr("shark"),
 				Length:   to.Float32Ptr(20),
-				Siblings: &[]complexgroup.FishType{
+				Siblings: &[]complexgroup.FishClassification{
 					&complexgroup.Salmon{
 						Fishtype: to.StringPtr("salmon"),
 						Iswild:   to.BoolPtr(true),
 						Length:   to.Float32Ptr(2),
 						Location: to.StringPtr("atlantic"),
-						Siblings: &[]complexgroup.FishType{
+						Siblings: &[]complexgroup.FishClassification{
 							&complexgroup.Shark{
 								Age:      to.Int32Ptr(6),
 								Birthday: &sharkBday,
@@ -73,7 +73,7 @@ func TestGetValid(t *testing.T) {
 						Fishtype: to.StringPtr("sawshark"),
 						Length:   to.Float32Ptr(10),
 						Picture:  &[]byte{255, 255, 255, 255, 254},
-						Siblings: &[]complexgroup.FishType{},
+						Siblings: &[]complexgroup.FishClassification{},
 						Species:  to.StringPtr("dangerous"),
 					},
 				},
@@ -85,7 +85,7 @@ func TestGetValid(t *testing.T) {
 				Fishtype: to.StringPtr("sawshark"),
 				Length:   to.Float32Ptr(10),
 				Picture:  &[]byte{255, 255, 255, 255, 254},
-				Siblings: &[]complexgroup.FishType{},
+				Siblings: &[]complexgroup.FishClassification{},
 				Species:  to.StringPtr("dangerous"),
 			},
 		},
@@ -103,19 +103,19 @@ func TestPutValid(t *testing.T) {
 		Iswild:   to.BoolPtr(true),
 		Length:   to.Float32Ptr(1),
 		Location: to.StringPtr("alaska"),
-		Siblings: &[]complexgroup.FishType{
+		Siblings: &[]complexgroup.FishClassification{
 			&complexgroup.Shark{
 				Age:      to.Int32Ptr(6),
 				Birthday: &sharkBday,
 				Fishtype: to.StringPtr("shark"),
 				Length:   to.Float32Ptr(20),
-				Siblings: &[]complexgroup.FishType{
+				Siblings: &[]complexgroup.FishClassification{
 					&complexgroup.Salmon{
 						Fishtype: to.StringPtr("salmon"),
 						Iswild:   to.BoolPtr(true),
 						Length:   to.Float32Ptr(2),
 						Location: to.StringPtr("atlantic"),
-						Siblings: &[]complexgroup.FishType{
+						Siblings: &[]complexgroup.FishClassification{
 							&complexgroup.Shark{
 								Age:      to.Int32Ptr(6),
 								Birthday: &sharkBday,
@@ -140,7 +140,7 @@ func TestPutValid(t *testing.T) {
 						Fishtype: to.StringPtr("sawshark"),
 						Length:   to.Float32Ptr(10),
 						Picture:  &[]byte{255, 255, 255, 255, 254},
-						Siblings: &[]complexgroup.FishType{},
+						Siblings: &[]complexgroup.FishClassification{},
 						Species:  to.StringPtr("dangerous"),
 					},
 				},
@@ -152,7 +152,7 @@ func TestPutValid(t *testing.T) {
 				Fishtype: to.StringPtr("sawshark"),
 				Length:   to.Float32Ptr(10),
 				Picture:  &[]byte{255, 255, 255, 255, 254},
-				Siblings: &[]complexgroup.FishType{},
+				Siblings: &[]complexgroup.FishClassification{},
 				Species:  to.StringPtr("dangerous"),
 			},
 		},

--- a/test/autorest/complexgroup/polymorphism_test.go
+++ b/test/autorest/complexgroup/polymorphism_test.go
@@ -41,7 +41,7 @@ func TestPolymorphismGetComplicated(t *testing.T) {
 		Iswild:   to.BoolPtr(true),
 		Length:   to.Float32Ptr(1),
 		Location: to.StringPtr("alaska"),
-		Siblings: &[]complexgroup.FishType{
+		Siblings: &[]complexgroup.FishClassification{
 			&complexgroup.Shark{
 				Age:      to.Int32Ptr(6),
 				Birthday: &sharkBday,
@@ -79,7 +79,7 @@ func TestPolymorphismGetComposedWithDiscriminator(t *testing.T) {
 		t.Fatal(err)
 	}
 	helpers.DeepEqualOrFatal(t, result.DotFishMarket, &complexgroup.DotFishMarket{
-		Fishes: &[]complexgroup.DotFishType{
+		Fishes: &[]complexgroup.DotFishClassification{
 			&complexgroup.DotSalmon{
 				FishType: to.StringPtr("DotSalmon"),
 				Location: to.StringPtr("australia"),
@@ -130,7 +130,7 @@ func TestPolymorphismGetComposedWithoutDiscriminator(t *testing.T) {
 		t.Fatal(err)
 	}
 	helpers.DeepEqualOrFatal(t, result.DotFishMarket, &complexgroup.DotFishMarket{
-		Fishes: &[]complexgroup.DotFishType{
+		Fishes: &[]complexgroup.DotFishClassification{
 			&complexgroup.DotFish{
 				Species: to.StringPtr("king"),
 			},
@@ -195,7 +195,7 @@ func TestPolymorphismGetValid(t *testing.T) {
 		Iswild:   to.BoolPtr(true),
 		Length:   to.Float32Ptr(1),
 		Location: to.StringPtr("alaska"),
-		Siblings: &[]complexgroup.FishType{
+		Siblings: &[]complexgroup.FishClassification{
 			&complexgroup.Shark{
 				Age:      to.Int32Ptr(6),
 				Birthday: &sharkBday,
@@ -240,7 +240,7 @@ func TestPolymorphismPutMissingDiscriminator(t *testing.T) {
 		Iswild:   to.BoolPtr(true),
 		Length:   to.Float32Ptr(1),
 		Location: to.StringPtr("alaska"),
-		Siblings: &[]complexgroup.FishType{
+		Siblings: &[]complexgroup.FishClassification{
 			&complexgroup.Shark{
 				Age:      to.Int32Ptr(6),
 				Birthday: &sharkBday,
@@ -281,7 +281,7 @@ func TestPolymorphismPutValid(t *testing.T) {
 		Iswild:   to.BoolPtr(true),
 		Length:   to.Float32Ptr(1),
 		Location: to.StringPtr("alaska"),
-		Siblings: &[]complexgroup.FishType{
+		Siblings: &[]complexgroup.FishClassification{
 			&complexgroup.Shark{
 				Age:      to.Int32Ptr(6),
 				Birthday: &sharkBday,

--- a/test/autorest/generated/complexgroup/models.go
+++ b/test/autorest/generated/complexgroup/models.go
@@ -75,16 +75,16 @@ type Cat struct {
 }
 
 type Cookiecuttershark struct {
-	Age      *int32      `json:"age,omitempty"`
-	Birthday *time.Time  `json:"birthday,omitempty"`
-	Fishtype *string     `json:"fishtype,omitempty"`
-	Length   *float32    `json:"length,omitempty"`
-	Siblings *[]FishType `json:"siblings,omitempty"`
-	Species  *string     `json:"species,omitempty"`
+	Age      *int32                `json:"age,omitempty"`
+	Birthday *time.Time            `json:"birthday,omitempty"`
+	Fishtype *string               `json:"fishtype,omitempty"`
+	Length   *float32              `json:"length,omitempty"`
+	Siblings *[]FishClassification `json:"siblings,omitempty"`
+	Species  *string               `json:"species,omitempty"`
 }
 
 func (c Cookiecuttershark) MarshalJSON() ([]byte, error) {
-	c.Fishtype = strptr(fishTypeCookiecuttershark)
+	c.Fishtype = strptr(fishClassificationCookiecuttershark)
 	type alias Cookiecuttershark
 	aux := &struct {
 		*alias
@@ -124,7 +124,7 @@ func (c *Cookiecuttershark) UnmarshalJSON(data []byte) error {
 			}
 		case "siblings":
 			if v != nil {
-				c.Siblings, err = unmarshalFishTypeArray(*v)
+				c.Siblings, err = unmarshalFishClassificationArray(*v)
 			}
 		case "species":
 			if v != nil {
@@ -138,9 +138,9 @@ func (c *Cookiecuttershark) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (*Cookiecuttershark) fishType() {}
+func (*Cookiecuttershark) fishClassification() {}
 
-func (*Cookiecuttershark) sharkType() {}
+func (*Cookiecuttershark) sharkClassification() {}
 
 type DateWrapper struct {
 	Field *time.Time `json:"field,omitempty"`
@@ -262,9 +262,9 @@ type Dog struct {
 	Name *string `json:"name,omitempty"`
 }
 
-// DotFishType provides polymorphic access to related types.
-type DotFishType interface {
-	dotFishType()
+// DotFishClassification provides polymorphic access to related types.
+type DotFishClassification interface {
+	dotFishClassification()
 }
 
 type DotFish struct {
@@ -272,13 +272,13 @@ type DotFish struct {
 	Species  *string `json:"species,omitempty"`
 }
 
-func (*DotFish) dotFishType() {}
+func (*DotFish) dotFishClassification() {}
 
 type DotFishMarket struct {
-	Fishes       *[]DotFishType `json:"fishes,omitempty"`
-	Salmons      *[]DotSalmon   `json:"salmons,omitempty"`
-	SampleFish   DotFishType    `json:"sampleFish,omitempty"`
-	SampleSalmon *DotSalmon     `json:"sampleSalmon,omitempty"`
+	Fishes       *[]DotFishClassification `json:"fishes,omitempty"`
+	Salmons      *[]DotSalmon             `json:"salmons,omitempty"`
+	SampleFish   DotFishClassification    `json:"sampleFish,omitempty"`
+	SampleSalmon *DotSalmon               `json:"sampleSalmon,omitempty"`
 }
 
 func (d *DotFishMarket) UnmarshalJSON(data []byte) error {
@@ -291,7 +291,7 @@ func (d *DotFishMarket) UnmarshalJSON(data []byte) error {
 		switch k {
 		case "fishes":
 			if v != nil {
-				d.Fishes, err = unmarshalDotFishTypeArray(*v)
+				d.Fishes, err = unmarshalDotFishClassificationArray(*v)
 			}
 		case "salmons":
 			if v != nil {
@@ -299,7 +299,7 @@ func (d *DotFishMarket) UnmarshalJSON(data []byte) error {
 			}
 		case "sampleFish":
 			if v != nil {
-				d.SampleFish, err = unmarshalDotFishType(*v)
+				d.SampleFish, err = unmarshalDotFishClassification(*v)
 			}
 		case "sampleSalmon":
 			if v != nil {
@@ -323,14 +323,14 @@ type DotFishMarketResponse struct {
 
 // DotFishResponse is the response envelope for operations that return a DotFish type.
 type DotFishResponse struct {
-	DotFish DotFishType
+	DotFish DotFishClassification
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
 func (d *DotFishResponse) UnmarshalJSON(data []byte) error {
-	t, err := unmarshalDotFishType(data)
+	t, err := unmarshalDotFishClassification(data)
 	if err != nil {
 		return err
 	}
@@ -346,7 +346,7 @@ type DotSalmon struct {
 }
 
 func (d DotSalmon) MarshalJSON() ([]byte, error) {
-	d.FishType = strptr(dotFishTypeDotSalmon)
+	d.FishType = strptr(dotFishClassificationDotSalmon)
 	type alias DotSalmon
 	aux := &struct {
 		*alias
@@ -388,7 +388,7 @@ func (d *DotSalmon) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (*DotSalmon) dotFishType() {}
+func (*DotSalmon) dotFishClassification() {}
 
 type DoubleWrapper struct {
 	Field1                                                                          *float64 `json:"field1,omitempty"`
@@ -434,30 +434,30 @@ func (e Error) Error() string {
 	return msg
 }
 
-// FishType provides polymorphic access to related types.
-type FishType interface {
-	fishType()
+// FishClassification provides polymorphic access to related types.
+type FishClassification interface {
+	fishClassification()
 }
 
 type Fish struct {
-	Fishtype *string     `json:"fishtype,omitempty"`
-	Length   *float32    `json:"length,omitempty"`
-	Siblings *[]FishType `json:"siblings,omitempty"`
-	Species  *string     `json:"species,omitempty"`
+	Fishtype *string               `json:"fishtype,omitempty"`
+	Length   *float32              `json:"length,omitempty"`
+	Siblings *[]FishClassification `json:"siblings,omitempty"`
+	Species  *string               `json:"species,omitempty"`
 }
 
-func (*Fish) fishType() {}
+func (*Fish) fishClassification() {}
 
 // FishResponse is the response envelope for operations that return a Fish type.
 type FishResponse struct {
-	Fish FishType
+	Fish FishClassification
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
 func (f *FishResponse) UnmarshalJSON(data []byte) error {
-	t, err := unmarshalFishType(data)
+	t, err := unmarshalFishClassification(data)
 	if err != nil {
 		return err
 	}
@@ -483,16 +483,16 @@ type Goblinshark struct {
 	Birthday *time.Time `json:"birthday,omitempty"`
 
 	// Colors possible
-	Color    *GoblinSharkColor `json:"color,omitempty"`
-	Fishtype *string           `json:"fishtype,omitempty"`
-	Jawsize  *int32            `json:"jawsize,omitempty"`
-	Length   *float32          `json:"length,omitempty"`
-	Siblings *[]FishType       `json:"siblings,omitempty"`
-	Species  *string           `json:"species,omitempty"`
+	Color    *GoblinSharkColor     `json:"color,omitempty"`
+	Fishtype *string               `json:"fishtype,omitempty"`
+	Jawsize  *int32                `json:"jawsize,omitempty"`
+	Length   *float32              `json:"length,omitempty"`
+	Siblings *[]FishClassification `json:"siblings,omitempty"`
+	Species  *string               `json:"species,omitempty"`
 }
 
 func (g Goblinshark) MarshalJSON() ([]byte, error) {
-	g.Fishtype = strptr(fishTypeGoblin)
+	g.Fishtype = strptr(fishClassificationGoblin)
 	type alias Goblinshark
 	aux := &struct {
 		*alias
@@ -540,7 +540,7 @@ func (g *Goblinshark) UnmarshalJSON(data []byte) error {
 			}
 		case "siblings":
 			if v != nil {
-				g.Siblings, err = unmarshalFishTypeArray(*v)
+				g.Siblings, err = unmarshalFishClassificationArray(*v)
 			}
 		case "species":
 			if v != nil {
@@ -554,9 +554,9 @@ func (g *Goblinshark) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (*Goblinshark) fishType() {}
+func (*Goblinshark) fishClassification() {}
 
-func (*Goblinshark) sharkType() {}
+func (*Goblinshark) sharkClassification() {}
 
 type IntWrapper struct {
 	Field1 *int32 `json:"field1,omitempty"`
@@ -588,9 +588,9 @@ type MyBaseHelperType struct {
 	PropBh1 *string `json:"propBH1,omitempty"`
 }
 
-// MyBaseTypeType provides polymorphic access to related types.
-type MyBaseTypeType interface {
-	myBaseType()
+// MyBaseTypeClassification provides polymorphic access to related types.
+type MyBaseTypeClassification interface {
+	myBaseTypeClassification()
 }
 
 type MyBaseType struct {
@@ -599,18 +599,18 @@ type MyBaseType struct {
 	PropB1 *string           `json:"propB1,omitempty"`
 }
 
-func (*MyBaseType) myBaseType() {}
+func (*MyBaseType) myBaseTypeClassification() {}
 
 // MyBaseTypeResponse is the response envelope for operations that return a MyBaseType type.
 type MyBaseTypeResponse struct {
-	MyBaseType MyBaseTypeType
+	MyBaseType MyBaseTypeClassification
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
 func (m *MyBaseTypeResponse) UnmarshalJSON(data []byte) error {
-	t, err := unmarshalMyBaseTypeType(data)
+	t, err := unmarshalMyBaseTypeClassification(data)
 	if err != nil {
 		return err
 	}
@@ -626,7 +626,7 @@ type MyDerivedType struct {
 }
 
 func (m MyDerivedType) MarshalJSON() ([]byte, error) {
-	m.Kind = strptr(myBaseTypeKind1)
+	m.Kind = strptr(myBaseTypeClassificationKind1)
 	type alias MyDerivedType
 	aux := &struct {
 		*alias
@@ -668,7 +668,7 @@ func (m *MyDerivedType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (*MyDerivedType) myBaseType() {}
+func (*MyDerivedType) myBaseTypeClassification() {}
 
 type Pet struct {
 	ID   *int32  `json:"id,omitempty"`
@@ -687,23 +687,23 @@ type ReadonlyObjResponse struct {
 	ReadonlyObj *ReadonlyObj
 }
 
-// SalmonType provides polymorphic access to related types.
-type SalmonType interface {
-	FishType
-	salmonType()
+// SalmonClassification provides polymorphic access to related types.
+type SalmonClassification interface {
+	FishClassification
+	salmonClassification()
 }
 
 type Salmon struct {
-	Fishtype *string     `json:"fishtype,omitempty"`
-	Iswild   *bool       `json:"iswild,omitempty"`
-	Length   *float32    `json:"length,omitempty"`
-	Location *string     `json:"location,omitempty"`
-	Siblings *[]FishType `json:"siblings,omitempty"`
-	Species  *string     `json:"species,omitempty"`
+	Fishtype *string               `json:"fishtype,omitempty"`
+	Iswild   *bool                 `json:"iswild,omitempty"`
+	Length   *float32              `json:"length,omitempty"`
+	Location *string               `json:"location,omitempty"`
+	Siblings *[]FishClassification `json:"siblings,omitempty"`
+	Species  *string               `json:"species,omitempty"`
 }
 
 func (s Salmon) MarshalJSON() ([]byte, error) {
-	s.Fishtype = strptr(fishTypeSalmon)
+	s.Fishtype = strptr(fishClassificationSalmon)
 	type alias Salmon
 	aux := &struct {
 		*alias
@@ -739,7 +739,7 @@ func (s *Salmon) UnmarshalJSON(data []byte) error {
 			}
 		case "siblings":
 			if v != nil {
-				s.Siblings, err = unmarshalFishTypeArray(*v)
+				s.Siblings, err = unmarshalFishClassificationArray(*v)
 			}
 		case "species":
 			if v != nil {
@@ -753,19 +753,19 @@ func (s *Salmon) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (*Salmon) fishType() {}
+func (*Salmon) fishClassification() {}
 
-func (*Salmon) salmonType() {}
+func (*Salmon) salmonClassification() {}
 
 // SalmonResponse is the response envelope for operations that return a Salmon type.
 type SalmonResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-	Salmon      SalmonType
+	Salmon      SalmonClassification
 }
 
 func (s *SalmonResponse) UnmarshalJSON(data []byte) error {
-	t, err := unmarshalSalmonType(data)
+	t, err := unmarshalSalmonClassification(data)
 	if err != nil {
 		return err
 	}
@@ -774,17 +774,17 @@ func (s *SalmonResponse) UnmarshalJSON(data []byte) error {
 }
 
 type Sawshark struct {
-	Age      *int32      `json:"age,omitempty"`
-	Birthday *time.Time  `json:"birthday,omitempty"`
-	Fishtype *string     `json:"fishtype,omitempty"`
-	Length   *float32    `json:"length,omitempty"`
-	Picture  *[]byte     `json:"picture,omitempty"`
-	Siblings *[]FishType `json:"siblings,omitempty"`
-	Species  *string     `json:"species,omitempty"`
+	Age      *int32                `json:"age,omitempty"`
+	Birthday *time.Time            `json:"birthday,omitempty"`
+	Fishtype *string               `json:"fishtype,omitempty"`
+	Length   *float32              `json:"length,omitempty"`
+	Picture  *[]byte               `json:"picture,omitempty"`
+	Siblings *[]FishClassification `json:"siblings,omitempty"`
+	Species  *string               `json:"species,omitempty"`
 }
 
 func (s Sawshark) MarshalJSON() ([]byte, error) {
-	s.Fishtype = strptr(fishTypeSawshark)
+	s.Fishtype = strptr(fishClassificationSawshark)
 	type alias Sawshark
 	aux := &struct {
 		*alias
@@ -828,7 +828,7 @@ func (s *Sawshark) UnmarshalJSON(data []byte) error {
 			}
 		case "siblings":
 			if v != nil {
-				s.Siblings, err = unmarshalFishTypeArray(*v)
+				s.Siblings, err = unmarshalFishClassificationArray(*v)
 			}
 		case "species":
 			if v != nil {
@@ -842,27 +842,27 @@ func (s *Sawshark) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (*Sawshark) fishType() {}
+func (*Sawshark) fishClassification() {}
 
-func (*Sawshark) sharkType() {}
+func (*Sawshark) sharkClassification() {}
 
-// SharkType provides polymorphic access to related types.
-type SharkType interface {
-	FishType
-	sharkType()
+// SharkClassification provides polymorphic access to related types.
+type SharkClassification interface {
+	FishClassification
+	sharkClassification()
 }
 
 type Shark struct {
-	Age      *int32      `json:"age,omitempty"`
-	Birthday *time.Time  `json:"birthday,omitempty"`
-	Fishtype *string     `json:"fishtype,omitempty"`
-	Length   *float32    `json:"length,omitempty"`
-	Siblings *[]FishType `json:"siblings,omitempty"`
-	Species  *string     `json:"species,omitempty"`
+	Age      *int32                `json:"age,omitempty"`
+	Birthday *time.Time            `json:"birthday,omitempty"`
+	Fishtype *string               `json:"fishtype,omitempty"`
+	Length   *float32              `json:"length,omitempty"`
+	Siblings *[]FishClassification `json:"siblings,omitempty"`
+	Species  *string               `json:"species,omitempty"`
 }
 
 func (s Shark) MarshalJSON() ([]byte, error) {
-	s.Fishtype = strptr(fishTypeShark)
+	s.Fishtype = strptr(fishClassificationShark)
 	type alias Shark
 	aux := &struct {
 		*alias
@@ -902,7 +902,7 @@ func (s *Shark) UnmarshalJSON(data []byte) error {
 			}
 		case "siblings":
 			if v != nil {
-				s.Siblings, err = unmarshalFishTypeArray(*v)
+				s.Siblings, err = unmarshalFishClassificationArray(*v)
 			}
 		case "species":
 			if v != nil {
@@ -916,9 +916,9 @@ func (s *Shark) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (*Shark) fishType() {}
+func (*Shark) fishClassification() {}
 
-func (*Shark) sharkType() {}
+func (*Shark) sharkClassification() {}
 
 type Siamese struct {
 	Breed *string `json:"breed,omitempty"`
@@ -936,17 +936,17 @@ type SiameseResponse struct {
 }
 
 type SmartSalmon struct {
-	CollegeDegree *string     `json:"college_degree,omitempty"`
-	Fishtype      *string     `json:"fishtype,omitempty"`
-	Iswild        *bool       `json:"iswild,omitempty"`
-	Length        *float32    `json:"length,omitempty"`
-	Location      *string     `json:"location,omitempty"`
-	Siblings      *[]FishType `json:"siblings,omitempty"`
-	Species       *string     `json:"species,omitempty"`
+	CollegeDegree *string               `json:"college_degree,omitempty"`
+	Fishtype      *string               `json:"fishtype,omitempty"`
+	Iswild        *bool                 `json:"iswild,omitempty"`
+	Length        *float32              `json:"length,omitempty"`
+	Location      *string               `json:"location,omitempty"`
+	Siblings      *[]FishClassification `json:"siblings,omitempty"`
+	Species       *string               `json:"species,omitempty"`
 }
 
 func (s SmartSalmon) MarshalJSON() ([]byte, error) {
-	s.Fishtype = strptr(fishTypeSmartSalmon)
+	s.Fishtype = strptr(fishClassificationSmartSalmon)
 	type alias SmartSalmon
 	aux := &struct {
 		*alias
@@ -986,7 +986,7 @@ func (s *SmartSalmon) UnmarshalJSON(data []byte) error {
 			}
 		case "siblings":
 			if v != nil {
-				s.Siblings, err = unmarshalFishTypeArray(*v)
+				s.Siblings, err = unmarshalFishClassificationArray(*v)
 			}
 		case "species":
 			if v != nil {
@@ -1000,9 +1000,9 @@ func (s *SmartSalmon) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (*SmartSalmon) fishType() {}
+func (*SmartSalmon) fishClassification() {}
 
-func (*SmartSalmon) salmonType() {}
+func (*SmartSalmon) salmonClassification() {}
 
 type StringWrapper struct {
 	Empty *string `json:"empty,omitempty"`

--- a/test/autorest/generated/complexgroup/polymorphic_helpers.go
+++ b/test/autorest/generated/complexgroup/polymorphic_helpers.go
@@ -8,17 +8,17 @@ package complexgroup
 import "encoding/json"
 
 const (
-	dotFishTypeDotSalmon = "DotSalmon"
+	dotFishClassificationDotSalmon = "DotSalmon"
 )
 
-func unmarshalDotFishType(body []byte) (DotFishType, error) {
+func unmarshalDotFishClassification(body []byte) (DotFishClassification, error) {
 	var m map[string]interface{}
 	if err := json.Unmarshal(body, &m); err != nil {
 		return nil, err
 	}
-	var b DotFishType
+	var b DotFishClassification
 	switch m["fish.type"] {
-	case dotFishTypeDotSalmon:
+	case dotFishClassificationDotSalmon:
 		b = &DotSalmon{}
 	default:
 		b = &DotFish{}
@@ -26,14 +26,14 @@ func unmarshalDotFishType(body []byte) (DotFishType, error) {
 	return b, json.Unmarshal(body, &b)
 }
 
-func unmarshalDotFishTypeArray(body []byte) (*[]DotFishType, error) {
+func unmarshalDotFishClassificationArray(body []byte) (*[]DotFishClassification, error) {
 	var rawMessages []*json.RawMessage
 	if err := json.Unmarshal(body, &rawMessages); err != nil {
 		return nil, err
 	}
-	fArray := make([]DotFishType, len(rawMessages))
+	fArray := make([]DotFishClassification, len(rawMessages))
 	for index, rawMessage := range rawMessages {
-		f, err := unmarshalDotFishType(*rawMessage)
+		f, err := unmarshalDotFishClassification(*rawMessage)
 		if err != nil {
 			return nil, err
 		}
@@ -43,32 +43,32 @@ func unmarshalDotFishTypeArray(body []byte) (*[]DotFishType, error) {
 }
 
 const (
-	fishTypeCookiecuttershark = "cookiecuttershark"
-	fishTypeGoblin            = "goblin"
-	fishTypeSalmon            = "salmon"
-	fishTypeSawshark          = "sawshark"
-	fishTypeShark             = "shark"
-	fishTypeSmartSalmon       = "smart_salmon"
+	fishClassificationCookiecuttershark = "cookiecuttershark"
+	fishClassificationGoblin            = "goblin"
+	fishClassificationSalmon            = "salmon"
+	fishClassificationSawshark          = "sawshark"
+	fishClassificationShark             = "shark"
+	fishClassificationSmartSalmon       = "smart_salmon"
 )
 
-func unmarshalFishType(body []byte) (FishType, error) {
+func unmarshalFishClassification(body []byte) (FishClassification, error) {
 	var m map[string]interface{}
 	if err := json.Unmarshal(body, &m); err != nil {
 		return nil, err
 	}
-	var b FishType
+	var b FishClassification
 	switch m["fishtype"] {
-	case fishTypeCookiecuttershark:
+	case fishClassificationCookiecuttershark:
 		b = &Cookiecuttershark{}
-	case fishTypeGoblin:
+	case fishClassificationGoblin:
 		b = &Goblinshark{}
-	case fishTypeSalmon:
+	case fishClassificationSalmon:
 		b = &Salmon{}
-	case fishTypeSawshark:
+	case fishClassificationSawshark:
 		b = &Sawshark{}
-	case fishTypeShark:
+	case fishClassificationShark:
 		b = &Shark{}
-	case fishTypeSmartSalmon:
+	case fishClassificationSmartSalmon:
 		b = &SmartSalmon{}
 	default:
 		b = &Fish{}
@@ -76,14 +76,14 @@ func unmarshalFishType(body []byte) (FishType, error) {
 	return b, json.Unmarshal(body, &b)
 }
 
-func unmarshalFishTypeArray(body []byte) (*[]FishType, error) {
+func unmarshalFishClassificationArray(body []byte) (*[]FishClassification, error) {
 	var rawMessages []*json.RawMessage
 	if err := json.Unmarshal(body, &rawMessages); err != nil {
 		return nil, err
 	}
-	fArray := make([]FishType, len(rawMessages))
+	fArray := make([]FishClassification, len(rawMessages))
 	for index, rawMessage := range rawMessages {
-		f, err := unmarshalFishType(*rawMessage)
+		f, err := unmarshalFishClassification(*rawMessage)
 		if err != nil {
 			return nil, err
 		}
@@ -92,14 +92,14 @@ func unmarshalFishTypeArray(body []byte) (*[]FishType, error) {
 	return &fArray, nil
 }
 
-func unmarshalSalmonType(body []byte) (SalmonType, error) {
+func unmarshalSalmonClassification(body []byte) (SalmonClassification, error) {
 	var m map[string]interface{}
 	if err := json.Unmarshal(body, &m); err != nil {
 		return nil, err
 	}
-	var b SalmonType
+	var b SalmonClassification
 	switch m["fishtype"] {
-	case fishTypeSmartSalmon:
+	case fishClassificationSmartSalmon:
 		b = &SmartSalmon{}
 	default:
 		b = &Salmon{}
@@ -107,14 +107,14 @@ func unmarshalSalmonType(body []byte) (SalmonType, error) {
 	return b, json.Unmarshal(body, &b)
 }
 
-func unmarshalSalmonTypeArray(body []byte) (*[]SalmonType, error) {
+func unmarshalSalmonClassificationArray(body []byte) (*[]SalmonClassification, error) {
 	var rawMessages []*json.RawMessage
 	if err := json.Unmarshal(body, &rawMessages); err != nil {
 		return nil, err
 	}
-	fArray := make([]SalmonType, len(rawMessages))
+	fArray := make([]SalmonClassification, len(rawMessages))
 	for index, rawMessage := range rawMessages {
-		f, err := unmarshalSalmonType(*rawMessage)
+		f, err := unmarshalSalmonClassification(*rawMessage)
 		if err != nil {
 			return nil, err
 		}
@@ -123,18 +123,18 @@ func unmarshalSalmonTypeArray(body []byte) (*[]SalmonType, error) {
 	return &fArray, nil
 }
 
-func unmarshalSharkType(body []byte) (SharkType, error) {
+func unmarshalSharkClassification(body []byte) (SharkClassification, error) {
 	var m map[string]interface{}
 	if err := json.Unmarshal(body, &m); err != nil {
 		return nil, err
 	}
-	var b SharkType
+	var b SharkClassification
 	switch m["fishtype"] {
-	case fishTypeCookiecuttershark:
+	case fishClassificationCookiecuttershark:
 		b = &Cookiecuttershark{}
-	case fishTypeGoblin:
+	case fishClassificationGoblin:
 		b = &Goblinshark{}
-	case fishTypeSawshark:
+	case fishClassificationSawshark:
 		b = &Sawshark{}
 	default:
 		b = &Shark{}
@@ -142,14 +142,14 @@ func unmarshalSharkType(body []byte) (SharkType, error) {
 	return b, json.Unmarshal(body, &b)
 }
 
-func unmarshalSharkTypeArray(body []byte) (*[]SharkType, error) {
+func unmarshalSharkClassificationArray(body []byte) (*[]SharkClassification, error) {
 	var rawMessages []*json.RawMessage
 	if err := json.Unmarshal(body, &rawMessages); err != nil {
 		return nil, err
 	}
-	fArray := make([]SharkType, len(rawMessages))
+	fArray := make([]SharkClassification, len(rawMessages))
 	for index, rawMessage := range rawMessages {
-		f, err := unmarshalSharkType(*rawMessage)
+		f, err := unmarshalSharkClassification(*rawMessage)
 		if err != nil {
 			return nil, err
 		}
@@ -159,17 +159,17 @@ func unmarshalSharkTypeArray(body []byte) (*[]SharkType, error) {
 }
 
 const (
-	myBaseTypeKind1 = "Kind1"
+	myBaseTypeClassificationKind1 = "Kind1"
 )
 
-func unmarshalMyBaseTypeType(body []byte) (MyBaseTypeType, error) {
+func unmarshalMyBaseTypeClassification(body []byte) (MyBaseTypeClassification, error) {
 	var m map[string]interface{}
 	if err := json.Unmarshal(body, &m); err != nil {
 		return nil, err
 	}
-	var b MyBaseTypeType
+	var b MyBaseTypeClassification
 	switch m["kind"] {
-	case myBaseTypeKind1:
+	case myBaseTypeClassificationKind1:
 		b = &MyDerivedType{}
 	default:
 		b = &MyBaseType{}
@@ -177,14 +177,14 @@ func unmarshalMyBaseTypeType(body []byte) (MyBaseTypeType, error) {
 	return b, json.Unmarshal(body, &b)
 }
 
-func unmarshalMyBaseTypeTypeArray(body []byte) (*[]MyBaseTypeType, error) {
+func unmarshalMyBaseTypeClassificationArray(body []byte) (*[]MyBaseTypeClassification, error) {
 	var rawMessages []*json.RawMessage
 	if err := json.Unmarshal(body, &rawMessages); err != nil {
 		return nil, err
 	}
-	fArray := make([]MyBaseTypeType, len(rawMessages))
+	fArray := make([]MyBaseTypeClassification, len(rawMessages))
 	for index, rawMessage := range rawMessages {
-		f, err := unmarshalMyBaseTypeType(*rawMessage)
+		f, err := unmarshalMyBaseTypeClassification(*rawMessage)
 		if err != nil {
 			return nil, err
 		}

--- a/test/autorest/generated/complexgroup/polymorphicrecursive.go
+++ b/test/autorest/generated/complexgroup/polymorphicrecursive.go
@@ -16,7 +16,7 @@ type PolymorphicrecursiveOperations interface {
 	// GetValid - Get complex types that are polymorphic and have recursive references
 	GetValid(ctx context.Context) (*FishResponse, error)
 	// PutValid - Put complex types that are polymorphic and have recursive references
-	PutValid(ctx context.Context, complexBody FishType) (*http.Response, error)
+	PutValid(ctx context.Context, complexBody FishClassification) (*http.Response, error)
 }
 
 // polymorphicrecursiveOperations implements the PolymorphicrecursiveOperations interface.
@@ -71,7 +71,7 @@ func (client *polymorphicrecursiveOperations) getValidHandleError(resp *azcore.R
 }
 
 // PutValid - Put complex types that are polymorphic and have recursive references
-func (client *polymorphicrecursiveOperations) PutValid(ctx context.Context, complexBody FishType) (*http.Response, error) {
+func (client *polymorphicrecursiveOperations) PutValid(ctx context.Context, complexBody FishClassification) (*http.Response, error) {
 	req, err := client.putValidCreateRequest(complexBody)
 	if err != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func (client *polymorphicrecursiveOperations) PutValid(ctx context.Context, comp
 }
 
 // putValidCreateRequest creates the PutValid request.
-func (client *polymorphicrecursiveOperations) putValidCreateRequest(complexBody FishType) (*azcore.Request, error) {
+func (client *polymorphicrecursiveOperations) putValidCreateRequest(complexBody FishClassification) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphicrecursive/valid"
 	u, err := client.u.Parse(urlPath)
 	if err != nil {

--- a/test/autorest/generated/complexgroup/polymorphism.go
+++ b/test/autorest/generated/complexgroup/polymorphism.go
@@ -24,13 +24,13 @@ type PolymorphismOperations interface {
 	// GetValid - Get complex types that are polymorphic
 	GetValid(ctx context.Context) (*FishResponse, error)
 	// PutComplicated - Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
-	PutComplicated(ctx context.Context, complexBody SalmonType) (*http.Response, error)
+	PutComplicated(ctx context.Context, complexBody SalmonClassification) (*http.Response, error)
 	// PutMissingDiscriminator - Put complex types that are polymorphic, omitting the discriminator
-	PutMissingDiscriminator(ctx context.Context, complexBody SalmonType) (*SalmonResponse, error)
+	PutMissingDiscriminator(ctx context.Context, complexBody SalmonClassification) (*SalmonResponse, error)
 	// PutValid - Put complex types that are polymorphic
-	PutValid(ctx context.Context, complexBody FishType) (*http.Response, error)
+	PutValid(ctx context.Context, complexBody FishClassification) (*http.Response, error)
 	// PutValidMissingRequired - Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client
-	PutValidMissingRequired(ctx context.Context, complexBody FishType) (*http.Response, error)
+	PutValidMissingRequired(ctx context.Context, complexBody FishClassification) (*http.Response, error)
 }
 
 // polymorphismOperations implements the PolymorphismOperations interface.
@@ -269,7 +269,7 @@ func (client *polymorphismOperations) getValidHandleError(resp *azcore.Response)
 }
 
 // PutComplicated - Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
-func (client *polymorphismOperations) PutComplicated(ctx context.Context, complexBody SalmonType) (*http.Response, error) {
+func (client *polymorphismOperations) PutComplicated(ctx context.Context, complexBody SalmonClassification) (*http.Response, error) {
 	req, err := client.putComplicatedCreateRequest(complexBody)
 	if err != nil {
 		return nil, err
@@ -286,7 +286,7 @@ func (client *polymorphismOperations) PutComplicated(ctx context.Context, comple
 }
 
 // putComplicatedCreateRequest creates the PutComplicated request.
-func (client *polymorphismOperations) putComplicatedCreateRequest(complexBody SalmonType) (*azcore.Request, error) {
+func (client *polymorphismOperations) putComplicatedCreateRequest(complexBody SalmonClassification) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/complicated"
 	u, err := client.u.Parse(urlPath)
 	if err != nil {
@@ -314,7 +314,7 @@ func (client *polymorphismOperations) putComplicatedHandleError(resp *azcore.Res
 }
 
 // PutMissingDiscriminator - Put complex types that are polymorphic, omitting the discriminator
-func (client *polymorphismOperations) PutMissingDiscriminator(ctx context.Context, complexBody SalmonType) (*SalmonResponse, error) {
+func (client *polymorphismOperations) PutMissingDiscriminator(ctx context.Context, complexBody SalmonClassification) (*SalmonResponse, error) {
 	req, err := client.putMissingDiscriminatorCreateRequest(complexBody)
 	if err != nil {
 		return nil, err
@@ -331,7 +331,7 @@ func (client *polymorphismOperations) PutMissingDiscriminator(ctx context.Contex
 }
 
 // putMissingDiscriminatorCreateRequest creates the PutMissingDiscriminator request.
-func (client *polymorphismOperations) putMissingDiscriminatorCreateRequest(complexBody SalmonType) (*azcore.Request, error) {
+func (client *polymorphismOperations) putMissingDiscriminatorCreateRequest(complexBody SalmonClassification) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/missingdiscriminator"
 	u, err := client.u.Parse(urlPath)
 	if err != nil {
@@ -360,7 +360,7 @@ func (client *polymorphismOperations) putMissingDiscriminatorHandleError(resp *a
 }
 
 // PutValid - Put complex types that are polymorphic
-func (client *polymorphismOperations) PutValid(ctx context.Context, complexBody FishType) (*http.Response, error) {
+func (client *polymorphismOperations) PutValid(ctx context.Context, complexBody FishClassification) (*http.Response, error) {
 	req, err := client.putValidCreateRequest(complexBody)
 	if err != nil {
 		return nil, err
@@ -377,7 +377,7 @@ func (client *polymorphismOperations) PutValid(ctx context.Context, complexBody 
 }
 
 // putValidCreateRequest creates the PutValid request.
-func (client *polymorphismOperations) putValidCreateRequest(complexBody FishType) (*azcore.Request, error) {
+func (client *polymorphismOperations) putValidCreateRequest(complexBody FishClassification) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/valid"
 	u, err := client.u.Parse(urlPath)
 	if err != nil {
@@ -405,7 +405,7 @@ func (client *polymorphismOperations) putValidHandleError(resp *azcore.Response)
 }
 
 // PutValidMissingRequired - Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client
-func (client *polymorphismOperations) PutValidMissingRequired(ctx context.Context, complexBody FishType) (*http.Response, error) {
+func (client *polymorphismOperations) PutValidMissingRequired(ctx context.Context, complexBody FishClassification) (*http.Response, error) {
 	req, err := client.putValidMissingRequiredCreateRequest(complexBody)
 	if err != nil {
 		return nil, err
@@ -422,7 +422,7 @@ func (client *polymorphismOperations) PutValidMissingRequired(ctx context.Contex
 }
 
 // putValidMissingRequiredCreateRequest creates the PutValidMissingRequired request.
-func (client *polymorphismOperations) putValidMissingRequiredCreateRequest(complexBody FishType) (*azcore.Request, error) {
+func (client *polymorphismOperations) putValidMissingRequiredCreateRequest(complexBody FishClassification) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/missingrequired/invalid"
 	u, err := client.u.Parse(urlPath)
 	if err != nil {

--- a/test/autorest/generated/paginggroup/pagers.go
+++ b/test/autorest/generated/paginggroup/pagers.go
@@ -28,8 +28,8 @@ type odataProductResultHandleResponse func(*azcore.Response) (*OdataProductResul
 type odataProductResultAdvancePage func(*OdataProductResultResponse) (*azcore.Request, error)
 
 type odataProductResultPager struct {
-	// the client for making the request
-	client *pagingOperations
+	// the pipeline for making the request
+	pipeline azcore.Pipeline
 	// contains the pending request
 	request *azcore.Request
 	// callback for handling the HTTP response
@@ -58,7 +58,7 @@ func (p *odataProductResultPager) NextPage(ctx context.Context) bool {
 		}
 		p.request = req
 	}
-	resp, err := p.client.p.Do(ctx, p.request)
+	resp, err := p.pipeline.Do(ctx, p.request)
 	if err != nil {
 		p.err = err
 		return false
@@ -94,8 +94,8 @@ type productResultHandleResponse func(*azcore.Response) (*ProductResultResponse,
 type productResultAdvancePage func(*ProductResultResponse) (*azcore.Request, error)
 
 type productResultPager struct {
-	// the client for making the request
-	client *pagingOperations
+	// the pipeline for making the request
+	pipeline azcore.Pipeline
 	// contains the pending request
 	request *azcore.Request
 	// callback for handling the HTTP response
@@ -124,7 +124,7 @@ func (p *productResultPager) NextPage(ctx context.Context) bool {
 		}
 		p.request = req
 	}
-	resp, err := p.client.p.Do(ctx, p.request)
+	resp, err := p.pipeline.Do(ctx, p.request)
 	if err != nil {
 		p.err = err
 		return false
@@ -160,8 +160,8 @@ type productResultValueHandleResponse func(*azcore.Response) (*ProductResultValu
 type productResultValueAdvancePage func(*ProductResultValueResponse) (*azcore.Request, error)
 
 type productResultValuePager struct {
-	// the client for making the request
-	client *pagingOperations
+	// the pipeline for making the request
+	pipeline azcore.Pipeline
 	// contains the pending request
 	request *azcore.Request
 	// callback for handling the HTTP response
@@ -190,7 +190,7 @@ func (p *productResultValuePager) NextPage(ctx context.Context) bool {
 		}
 		p.request = req
 	}
-	resp, err := p.client.p.Do(ctx, p.request)
+	resp, err := p.pipeline.Do(ctx, p.request)
 	if err != nil {
 		p.err = err
 		return false

--- a/test/autorest/generated/paginggroup/paging.go
+++ b/test/autorest/generated/paginggroup/paging.go
@@ -60,7 +60,7 @@ func (client *pagingOperations) GetMultiplePages(pagingGetMultiplePagesOptions *
 		return nil, err
 	}
 	return &productResultPager{
-		client:    client,
+		pipeline:  client.p,
 		request:   req,
 		responder: client.getMultiplePagesHandleResponse,
 		advancer: func(resp *ProductResultResponse) (*azcore.Request, error) {
@@ -117,7 +117,7 @@ func (client *pagingOperations) GetMultiplePagesFailure() (ProductResultPager, e
 		return nil, err
 	}
 	return &productResultPager{
-		client:    client,
+		pipeline:  client.p,
 		request:   req,
 		responder: client.getMultiplePagesFailureHandleResponse,
 		advancer: func(resp *ProductResultResponse) (*azcore.Request, error) {
@@ -165,7 +165,7 @@ func (client *pagingOperations) GetMultiplePagesFailureURI() (ProductResultPager
 		return nil, err
 	}
 	return &productResultPager{
-		client:    client,
+		pipeline:  client.p,
 		request:   req,
 		responder: client.getMultiplePagesFailureUriHandleResponse,
 		advancer: func(resp *ProductResultResponse) (*azcore.Request, error) {
@@ -213,7 +213,7 @@ func (client *pagingOperations) GetMultiplePagesFragmentNextLink(apiVersion stri
 		return nil, err
 	}
 	return &odataProductResultPager{
-		client:    client,
+		pipeline:  client.p,
 		request:   req,
 		responder: client.getMultiplePagesFragmentNextLinkHandleResponse,
 		advancer: func(resp *OdataProductResultResponse) (*azcore.Request, error) {
@@ -258,7 +258,7 @@ func (client *pagingOperations) GetMultiplePagesFragmentWithGroupingNextLink(cus
 		return nil, err
 	}
 	return &odataProductResultPager{
-		client:    client,
+		pipeline:  client.p,
 		request:   req,
 		responder: client.getMultiplePagesFragmentWithGroupingNextLinkHandleResponse,
 		advancer: func(resp *OdataProductResultResponse) (*azcore.Request, error) {
@@ -339,7 +339,7 @@ func (client *pagingOperations) GetMultiplePagesRetryFirst() (ProductResultPager
 		return nil, err
 	}
 	return &productResultPager{
-		client:    client,
+		pipeline:  client.p,
 		request:   req,
 		responder: client.getMultiplePagesRetryFirstHandleResponse,
 		advancer: func(resp *ProductResultResponse) (*azcore.Request, error) {
@@ -387,7 +387,7 @@ func (client *pagingOperations) GetMultiplePagesRetrySecond() (ProductResultPage
 		return nil, err
 	}
 	return &productResultPager{
-		client:    client,
+		pipeline:  client.p,
 		request:   req,
 		responder: client.getMultiplePagesRetrySecondHandleResponse,
 		advancer: func(resp *ProductResultResponse) (*azcore.Request, error) {
@@ -435,7 +435,7 @@ func (client *pagingOperations) GetMultiplePagesWithOffset(pagingGetMultiplePage
 		return nil, err
 	}
 	return &productResultPager{
-		client:    client,
+		pipeline:  client.p,
 		request:   req,
 		responder: client.getMultiplePagesWithOffsetHandleResponse,
 		advancer: func(resp *ProductResultResponse) (*azcore.Request, error) {
@@ -493,7 +493,7 @@ func (client *pagingOperations) GetNoItemNamePages() (ProductResultValuePager, e
 		return nil, err
 	}
 	return &productResultValuePager{
-		client:    client,
+		pipeline:  client.p,
 		request:   req,
 		responder: client.getNoItemNamePagesHandleResponse,
 		advancer: func(resp *ProductResultValueResponse) (*azcore.Request, error) {
@@ -583,7 +583,7 @@ func (client *pagingOperations) GetOdataMultiplePages(pagingGetOdataMultiplePage
 		return nil, err
 	}
 	return &odataProductResultPager{
-		client:    client,
+		pipeline:  client.p,
 		request:   req,
 		responder: client.getOdataMultiplePagesHandleResponse,
 		advancer: func(resp *OdataProductResultResponse) (*azcore.Request, error) {
@@ -640,7 +640,7 @@ func (client *pagingOperations) GetSinglePages() (ProductResultPager, error) {
 		return nil, err
 	}
 	return &productResultPager{
-		client:    client,
+		pipeline:  client.p,
 		request:   req,
 		responder: client.getSinglePagesHandleResponse,
 		advancer: func(resp *ProductResultResponse) (*azcore.Request, error) {
@@ -688,7 +688,7 @@ func (client *pagingOperations) GetSinglePagesFailure() (ProductResultPager, err
 		return nil, err
 	}
 	return &productResultPager{
-		client:    client,
+		pipeline:  client.p,
 		request:   req,
 		responder: client.getSinglePagesFailureHandleResponse,
 		advancer: func(resp *ProductResultResponse) (*azcore.Request, error) {

--- a/test/storage/2019-07-07/azblob/container.go
+++ b/test/storage/2019-07-07/azblob/container.go
@@ -785,7 +785,7 @@ func (client *containerOperations) ListBlobFlatSegment(containerListBlobFlatSegm
 		return nil, err
 	}
 	return &listBlobsFlatSegmentResponsePager{
-		client:    client,
+		pipeline:  client.p,
 		request:   req,
 		responder: client.listBlobFlatSegmentHandleResponse,
 		advancer: func(resp *ListBlobsFlatSegmentResponseResponse) (*azcore.Request, error) {
@@ -875,7 +875,7 @@ func (client *containerOperations) ListBlobHierarchySegment(delimiter string, co
 		return nil, err
 	}
 	return &listBlobsHierarchySegmentResponsePager{
-		client:    client,
+		pipeline:  client.p,
 		request:   req,
 		responder: client.listBlobHierarchySegmentHandleResponse,
 		advancer: func(resp *ListBlobsHierarchySegmentResponseResponse) (*azcore.Request, error) {

--- a/test/storage/2019-07-07/azblob/pagers.go
+++ b/test/storage/2019-07-07/azblob/pagers.go
@@ -28,8 +28,8 @@ type listBlobsFlatSegmentResponseHandleResponse func(*azcore.Response) (*ListBlo
 type listBlobsFlatSegmentResponseAdvancePage func(*ListBlobsFlatSegmentResponseResponse) (*azcore.Request, error)
 
 type listBlobsFlatSegmentResponsePager struct {
-	// the client for making the request
-	client *containerOperations
+	// the pipeline for making the request
+	pipeline azcore.Pipeline
 	// contains the pending request
 	request *azcore.Request
 	// callback for handling the HTTP response
@@ -58,7 +58,7 @@ func (p *listBlobsFlatSegmentResponsePager) NextPage(ctx context.Context) bool {
 		}
 		p.request = req
 	}
-	resp, err := p.client.p.Do(ctx, p.request)
+	resp, err := p.pipeline.Do(ctx, p.request)
 	if err != nil {
 		p.err = err
 		return false
@@ -94,8 +94,8 @@ type listBlobsHierarchySegmentResponseHandleResponse func(*azcore.Response) (*Li
 type listBlobsHierarchySegmentResponseAdvancePage func(*ListBlobsHierarchySegmentResponseResponse) (*azcore.Request, error)
 
 type listBlobsHierarchySegmentResponsePager struct {
-	// the client for making the request
-	client *containerOperations
+	// the pipeline for making the request
+	pipeline azcore.Pipeline
 	// contains the pending request
 	request *azcore.Request
 	// callback for handling the HTTP response
@@ -124,7 +124,7 @@ func (p *listBlobsHierarchySegmentResponsePager) NextPage(ctx context.Context) b
 		}
 		p.request = req
 	}
-	resp, err := p.client.p.Do(ctx, p.request)
+	resp, err := p.pipeline.Do(ctx, p.request)
 	if err != nil {
 		p.err = err
 		return false
@@ -160,8 +160,8 @@ type listContainersSegmentResponseHandleResponse func(*azcore.Response) (*ListCo
 type listContainersSegmentResponseAdvancePage func(*ListContainersSegmentResponseResponse) (*azcore.Request, error)
 
 type listContainersSegmentResponsePager struct {
-	// the client for making the request
-	client *serviceOperations
+	// the pipeline for making the request
+	pipeline azcore.Pipeline
 	// contains the pending request
 	request *azcore.Request
 	// callback for handling the HTTP response
@@ -190,7 +190,7 @@ func (p *listContainersSegmentResponsePager) NextPage(ctx context.Context) bool 
 		}
 		p.request = req
 	}
-	resp, err := p.client.p.Do(ctx, p.request)
+	resp, err := p.pipeline.Do(ctx, p.request)
 	if err != nil {
 		p.err = err
 		return false

--- a/test/storage/2019-07-07/azblob/service.go
+++ b/test/storage/2019-07-07/azblob/service.go
@@ -314,7 +314,7 @@ func (client *serviceOperations) ListContainersSegment(serviceListContainersSegm
 		return nil, err
 	}
 	return &listContainersSegmentResponsePager{
-		client:    client,
+		pipeline:  client.p,
 		request:   req,
 		responder: client.listContainersSegmentHandleResponse,
 		advancer: func(resp *ListContainersSegmentResponseResponse) (*azcore.Request, error) {


### PR DESCRIPTION
Changed discriminator interface type name suffix to 'Classification'.
Use swagger-defined discriminator enum values if available.
Pager types don't need the client, just the client's pipeline.
Updated to latest M4.