### PR TITLE
Fix for walking discriminator parents

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -812,6 +812,9 @@ function formatStatusCodes(statusCodes: Array<string>): string {
       case '404':
         asHTTPStatus.push('http.StatusNotFound');
         break;
+      case '409':
+        asHTTPStatus.push('http.StatusConflict');
+        break;
       default:
         throw console.error(`unhandled status code ${rawCode}`);
     }


### PR DESCRIPTION
Only walk parents that are themselves discriminators, and when no more
are left exit the loop.
Add 409 http.StatusConflict to list of formatted status codes.