### PR TITLE
Refactor discriminated type generation

### DIFF
--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -7,7 +7,6 @@ import { Session } from '@azure-tools/autorest-extension-base';
 import { comment } from '@azure-tools/codegen';
 import { ArraySchema, CodeModel, DictionarySchema, Language, Parameter, Schema, SchemaType } from '@azure-tools/codemodel';
 
-
 // returns the common source-file preamble (license comment, package name etc)
 export async function contentPreamble(session: Session<CodeModel>): Promise<string> {
   const headerText = comment(await session.getValue('header-text', 'MISSING LICENSE HEADER'), '// ');
@@ -70,8 +69,8 @@ export function substituteDiscriminator(schema: Schema): string {
       const dictElem = <Schema>dictSchema.elementType;
       return `map[string]${substituteDiscriminator(dictElem)}`;
     case SchemaType.Object:
-      if (schema.language.go!.discriminator) {
-        return schema.language.go!.discriminator;
+      if (schema.language.go!.discriminatorInterface) {
+        return schema.language.go!.discriminatorInterface;
       }
       return schema.language.go!.name;
     default:

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -304,14 +304,17 @@ function generateUnmarshallerForResponseEnvelope(structDef: StructDef) {
   let unmarshaller = `func (${receiver} *${structDef.Language.name}) UnmarshalJSON(data []byte) error {\n`;
   // add a custom unmarshaller to the response envelope
   // find the discriminated type field
-  let field = 'FIND';
-  let type = 'FIND';
+  let field = '';
+  let type = '';
   for (const prop of values(structDef.Properties)) {
     if (prop.isDiscriminator) {
       field = prop.language.go!.name;
       type = prop.schema.language.go!.discriminatorInterface;
       break;
     }
+  }
+  if (field === '' || type === '') {
+    throw console.error(`failed to the discriminated type field for response envelope ${structDef.Language.name}`);
   }
   unmarshaller += `\tt, err := unmarshal${type}(data)\n`;
   unmarshaller += '\tif err != nil {\n';

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -382,6 +382,11 @@ function generateDiscriminatedTypeMarshaller(obj: ObjectSchema, structDef: Struc
 }
 
 function generateDiscriminatedTypeUnmarshaller(obj: ObjectSchema, structDef: StructDef, parentType?: ObjectSchema) {
+  // there's a corner-case where a derived type might not add any new fields (Cookiecuttershark).
+  // in this case skip adding the unmarshaller as it's not necessary and doesn't compile.
+  if (!structDef.Properties || structDef.Properties.length === 0) {
+    return;
+  }
   const typeName = structDef.Language.name;
   const receiver = typeName[0].toLowerCase();
   let unmarshaller = `func (${receiver} *${typeName}) UnmarshalJSON(data []byte) error {\n`;
@@ -421,11 +426,7 @@ function generateDiscriminatedTypeUnmarshaller(obj: ObjectSchema, structDef: Str
     unmarshaller += '\treturn nil\n';
   }
   unmarshaller += '}\n\n';
-  // there's a corner-case where a derived type might not add any new fields (Cookiecuttershark).
-  // in this case skip adding the unmarshaller as it's not necessary and doesn't compile.
-  if (structDef.Properties && structDef.Properties.length > 0) {
-    structDef.Methods.push({ name: 'UnmarshalJSON', text: unmarshaller });
-  }
+  structDef.Methods.push({ name: 'UnmarshalJSON', text: unmarshaller });
 }
 
 function generateMarshaller(structDef: StructDef) {

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -345,8 +345,11 @@ function generateDiscriminatorMethods(obj: ObjectSchema, structDef: StructDef, p
       marshalInteral += `\tobjectMap["${prop.serializedName}"] = ${receiver}.${prop.language.go!.name}\n`;
     } else {
       marshalInteral += `\tif ${receiver}.${prop.language.go!.name} != nil {\n`;
-      // TODO: custom time marshalling
-      marshalInteral += `\t\tobjectMap["${prop.serializedName}"] = ${receiver}.${prop.language.go!.name}\n`;
+      if (prop.schema.language.go!.internalTimeType) {
+        marshalInteral += `\t\tobjectMap["${prop.serializedName}"] = (*${prop.schema.language.go!.internalTimeType})(${receiver}.${prop.language.go!.name})\n`;
+      } else {
+        marshalInteral += `\t\tobjectMap["${prop.serializedName}"] = ${receiver}.${prop.language.go!.name}\n`;
+      }
       marshalInteral += `\t}\n`;
     }
   }
@@ -363,7 +366,11 @@ function generateDiscriminatedTypeMarshaller(obj: ObjectSchema, structDef: Struc
   marshaller += `\tobjectMap := ${receiver}.${parentType!.language.go!.name}.marshalInternal(${obj.discriminatorValue})\n`;
   for (const prop of values(structDef.Properties)) {
     marshaller += `\tif ${receiver}.${prop.language.go!.name} != nil {\n`;
-    marshaller += `\t\tobjectMap["${prop.serializedName}"] = ${receiver}.${prop.language.go!.name}\n`;
+    if (prop.schema.language.go!.internalTimeType) {
+      marshaller += `\t\tobjectMap["${prop.serializedName}"] = (*${prop.schema.language.go!.internalTimeType})(${receiver}.${prop.language.go!.name})\n`;
+    } else {
+      marshaller += `\t\tobjectMap["${prop.serializedName}"] = ${receiver}.${prop.language.go!.name}\n`;
+    }
     marshaller += `\t}\n`;
   }
   marshaller += '\treturn json.Marshal(objectMap)\n';

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -673,7 +673,7 @@ function createProtocolResponse(client: string, op: Operation, imports: ImportMa
   }
   let target = `result.${schemaResponse.schema.language.go!.responseType.value}`;
   // when unmarshalling a wrapped XML array or discriminated type, unmarshal into the response type, not the field
-  if ((mediaType === 'XML' && schemaResponse.schema.type === SchemaType.Array) || schemaResponse.schema.language.go!.discriminator) {
+  if ((mediaType === 'XML' && schemaResponse.schema.type === SchemaType.Array) || schemaResponse.schema.language.go!.discriminatorInterface) {
     target = 'result';
   }
   text += `\treturn &result, resp.UnmarshalAs${mediaType}(&${target})\n`;

--- a/src/transform/namer.ts
+++ b/src/transform/namer.ts
@@ -57,7 +57,7 @@ export async function namer(session: Session<CodeModel>) {
     details.name = getEscapedReservedName(capitalizeAcronyms(pascalCase(details.name)), 'Model');
     if (obj.discriminator) {
       // if this is a discriminator add the interface name
-      details.discriminator = createPolymorphicInterfaceName(details.name);
+      details.discriminatorInterface = createPolymorphicInterfaceName(details.name);
     }
     for (const prop of values(obj.properties)) {
       const details = <Language>prop.language.go;

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -5,10 +5,10 @@
 
 import { camelCase, KnownMediaType, pascalCase, serialize } from '@azure-tools/codegen';
 import { Host, startSession, Session } from '@azure-tools/autorest-extension-base';
-import { ObjectSchema, ArraySchema, codeModelSchema, ChoiceValue, CodeModel, DateTimeSchema, GroupProperty, HttpHeader, HttpResponse, ImplementationLocation, Language, OperationGroup, SchemaType, NumberSchema, Operation, SchemaResponse, Parameter, Property, Protocols, Schema, DictionarySchema, Protocol, ChoiceSchema, SealedChoiceSchema, ConstantSchema } from '@azure-tools/codemodel';
+import { ObjectSchema, ArraySchema, ChoiceValue, codeModelSchema, CodeModel, DateTimeSchema, GroupProperty, HttpHeader, HttpResponse, ImplementationLocation, Language, OperationGroup, SchemaType, NumberSchema, Operation, SchemaResponse, Parameter, Property, Protocols, Schema, DictionarySchema, Protocol, ChoiceSchema, SealedChoiceSchema, ConstantSchema } from '@azure-tools/codemodel';
 import { items, values } from '@azure-tools/linq';
 import { aggregateParameters, isPageableOperation, isObjectSchema, isSchemaResponse, PagerInfo, isLROOperation, PollerInfo } from '../common/helpers';
-import { createPolymorphicInterfaceName, namer, removePrefix } from './namer';
+import { namer, removePrefix } from './namer';
 
 // The transformer adds Go-specific information to the code model.
 export async function transform(host: Host) {
@@ -38,14 +38,21 @@ async function process(session: Session<CodeModel>) {
   // fix up struct field types
   for (const obj of values(session.model.schemas.objects)) {
     if (obj.discriminator) {
-      const discriminator = annotateDiscriminatedTypes(obj);
-      if (discriminator) {
-        // discriminators will contain the root type of each discriminated type hierarchy
-        if (!session.model.language.go!.discriminators) {
-          session.model.language.go!.discriminators = new Array<ObjectSchema>();
+      // discriminators will contain the root type of each discriminated type hierarchy
+      if (!session.model.language.go!.discriminators) {
+        session.model.language.go!.discriminators = new Array<ObjectSchema>();
+      }
+      const defs = <Array<ObjectSchema>>session.model.language.go!.discriminators;
+      const rootDiscriminator = getRootDiscriminator(obj);
+      if (defs.indexOf(rootDiscriminator) < 0) {
+        rootDiscriminator.language.go!.rootDiscriminator = true;
+        defs.push(rootDiscriminator);
+        // fix up discriminator value to use the enum type if available
+        const discriminatorEnums = getDiscriminatorEnums(rootDiscriminator);
+        // for each child type in the hierarchy, fix up the discriminator value
+        for (const child of values(rootDiscriminator.children?.all)) {
+          (<ObjectSchema>child).discriminatorValue = getEnumForDiscriminatorValue((<ObjectSchema>child).discriminatorValue!, discriminatorEnums);
         }
-        const defs = <Array<ObjectSchema>>session.model.language.go!.discriminators;
-        defs.push(discriminator);
       }
     }
     for (const prop of values(obj.properties)) {
@@ -600,26 +607,14 @@ function generateResponseTypeName(schema: Schema): Language {
   }
 }
 
-function annotateDiscriminatedTypes(obj: ObjectSchema): ObjectSchema | undefined {
-  if (obj.language.go!.polymorphicInterfaces !== undefined) {
-    // this hierarchy of discriminated types has already been processed
-    return;
-  }
-  // we have a type in the hierarchy of polymorphic types, it can be one of three things
-  // 1. root - no parent types, only child types
-  // 2. intermediate root - has a parent and also has children (salmon in the test server)
-  // 3. child - has parent and no children
-  //
-  // for cases #1 and #2 we need to generate an interface type, and for
-  // case #2 the generated interface must also contain the parent interface
-  // for case #3 all that's required is to generate the marker method on
-  // the child type(s) for the applicable interface.
+function getRootDiscriminator(obj: ObjectSchema): ObjectSchema {
+  // discriminators can be a root or an "intermediate" root (Salmon in the test server)
 
   // walk to the root
   let root = obj;
   while (true) {
     if (!root.parents) {
-      // simple case, no parent types
+      // simple case, already at the root
       break;
     }
     for (const parent of values(root.parents?.immediate)) {
@@ -627,6 +622,7 @@ function annotateDiscriminatedTypes(obj: ObjectSchema): ObjectSchema | undefined
       // e.g. if type Foo is in a DictionaryOfFoo, then one of
       // Foo's parents will be DictionaryOfFoo which we ignore.
       if (isObjectSchema(parent) && parent.discriminator) {
+        root.language.go!.discriminatorParent = parent.language.go!.discriminatorInterface;
         root = parent;
       }
     }
@@ -638,62 +634,29 @@ function annotateDiscriminatedTypes(obj: ObjectSchema): ObjectSchema | undefined
       break;
     }
   }
-  // create the interface type name based on the current root
-  const rootType = root.language.go!.discriminator;
-  // use pre-defined enum values if available
-  const choices = getChoices(root);
-  if (!choices) {
-    // mark that we need to generate our own enum type
-    root.language.go!.discriminatorEnumNeeded = true;
-  }
-  recursiveAnnotateDiscriminatedTypes(root, rootType, rootType, choices);
   return root;
 }
 
-function recursiveAnnotateDiscriminatedTypes(obj: ObjectSchema, rootInterface: string, currentInterface: string, choices: Array<ChoiceValue> | undefined) {
-  if (!obj.language.go!.polymorphicInterfaces) {
-    obj.language.go!.polymorphicInterfaces = new Array<string>();
-  }
-  const interfaces = <Array<string>>obj.language.go!.polymorphicInterfaces;
-  interfaces.push(currentInterface);
-  // now walk all the children, annotating them with the interface
-  for (const child of values(obj.discriminator?.immediate)) {
-    const childSchema = <ObjectSchema>child;
-    if (!childSchema.language.go!.polymorphicInterfaces) {
-      // copy parent's interfaces
-      childSchema.language.go!.polymorphicInterfaces = [...<Array<string>>obj.language.go!.polymorphicInterfaces];
-    }
-    if (childSchema.discriminator && childSchema.discriminator.all) {
-      // case #2 - intermediate root
-      childSchema.language.go!.discriminatorParent = currentInterface;
-      recursiveAnnotateDiscriminatedTypes(childSchema, rootInterface, createPolymorphicInterfaceName(childSchema.language.go!.name), choices);
-    }
-    if (choices) {
-      // find the choice value that matches the current type's discriminator
-      let found = false;
-      for (const choice of values(choices)) {
-        if (choice.value === childSchema.discriminatorValue) {
-          childSchema.language.go!.discriminatorEnum = choice.language.go!.name;
-          childSchema.language.go!.discriminatorRealEnum = true;
-          found = true;
-          break;
-        }
-      }
-      if (!found) {
-        throw console.error(`failed to find discriminator choice value for type ${childSchema.language.go!.name}`);
-      }
-    } else {
-      // add the internal enum name for this sub-type
-      childSchema.language.go!.discriminatorEnum = `${camelCase(rootInterface)}${pascalCase(childSchema.discriminatorValue!)}`;
-    }
-  }
-}
-
-function getChoices(obj: ObjectSchema): Array<ChoiceValue> | undefined {
+// returns the set of enum values used for discriminators
+function getDiscriminatorEnums(obj: ObjectSchema): Array<ChoiceValue> | undefined {
   if (obj.discriminator?.property.schema.type === SchemaType.Choice) {
     return (<ChoiceSchema>obj.discriminator!.property.schema).choices;
   } else if (obj.discriminator?.property.schema.type === SchemaType.SealedChoice) {
     return (<SealedChoiceSchema>obj.discriminator!.property.schema).choices;
   }
   return undefined;
+}
+
+// returns the enum name for the specified discriminator value
+function getEnumForDiscriminatorValue(discValue: string, enums: Array<ChoiceValue> | undefined): string {
+  if (!enums) {
+    return `"${discValue}"`;
+  }
+  // find the choice value that matches the current type's discriminator
+  for (const enm of values(enums)) {
+    if (enm.value === discValue) {
+      return enm.language.go!.name;
+    }
+  }
+  throw console.error(`failed to find discriminator enum value for ${discValue}`);
 }

--- a/test/autorest/complexgroup/inheritance_test.go
+++ b/test/autorest/complexgroup/inheritance_test.go
@@ -28,44 +28,60 @@ func TestInheritanceGetValid(t *testing.T) {
 		t.Fatalf("GetValid: %v", err)
 	}
 	helpers.DeepEqualOrFatal(t, result.Siamese, &complexgroup.Siamese{
-		Breed: to.StringPtr("persian"),
-		Color: to.StringPtr("green"),
-		Hates: &[]complexgroup.Dog{
-			{
-				Food: to.StringPtr("tomato"),
-				ID:   to.Int32Ptr(1),
-				Name: to.StringPtr("Potato"),
+		Cat: complexgroup.Cat{
+			Pet: complexgroup.Pet{
+				ID:   to.Int32Ptr(2),
+				Name: to.StringPtr("Siameeee"),
 			},
-			{
-				Food: to.StringPtr("french fries"),
-				ID:   to.Int32Ptr(-1),
-				Name: to.StringPtr("Tomato"),
+			Color: to.StringPtr("green"),
+			Hates: &[]complexgroup.Dog{
+				{
+					Pet: complexgroup.Pet{
+						ID:   to.Int32Ptr(1),
+						Name: to.StringPtr("Potato"),
+					},
+					Food: to.StringPtr("tomato"),
+				},
+				{
+					Pet: complexgroup.Pet{
+						ID:   to.Int32Ptr(-1),
+						Name: to.StringPtr("Tomato"),
+					},
+					Food: to.StringPtr("french fries"),
+				},
 			},
 		},
-		ID:   to.Int32Ptr(2),
-		Name: to.StringPtr("Siameeee"),
+		Breed: to.StringPtr("persian"),
 	})
 }
 
 func TestInheritancePutValid(t *testing.T) {
 	client := getInheritanceOperations(t)
 	result, err := client.PutValid(context.Background(), complexgroup.Siamese{
-		Breed: to.StringPtr("persian"),
-		Color: to.StringPtr("green"),
-		Hates: &[]complexgroup.Dog{
-			{
-				Food: to.StringPtr("tomato"),
-				ID:   to.Int32Ptr(1),
-				Name: to.StringPtr("Potato"),
+		Cat: complexgroup.Cat{
+			Pet: complexgroup.Pet{
+				ID:   to.Int32Ptr(2),
+				Name: to.StringPtr("Siameeee"),
 			},
-			{
-				Food: to.StringPtr("french fries"),
-				ID:   to.Int32Ptr(-1),
-				Name: to.StringPtr("Tomato"),
+			Color: to.StringPtr("green"),
+			Hates: &[]complexgroup.Dog{
+				{
+					Pet: complexgroup.Pet{
+						ID:   to.Int32Ptr(1),
+						Name: to.StringPtr("Potato"),
+					},
+					Food: to.StringPtr("tomato"),
+				},
+				{
+					Pet: complexgroup.Pet{
+						ID:   to.Int32Ptr(-1),
+						Name: to.StringPtr("Tomato"),
+					},
+					Food: to.StringPtr("french fries"),
+				},
 			},
 		},
-		ID:   to.Int32Ptr(2),
-		Name: to.StringPtr("Siameeee"),
+		Breed: to.StringPtr("persian"),
 	})
 	if err != nil {
 		t.Fatalf("PutValid: %v", err)

--- a/test/autorest/complexgroup/polymorphicrecursive_test.go
+++ b/test/autorest/complexgroup/polymorphicrecursive_test.go
@@ -32,64 +32,84 @@ func TestGetValid(t *testing.T) {
 	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
 	sharkBday := time.Date(2012, time.January, 5, 1, 0, 0, 0, time.UTC)
 	helpers.DeepEqualOrFatal(t, result.Fish, &complexgroup.Salmon{
-		Fishtype: to.StringPtr("salmon"),
-		Iswild:   to.BoolPtr(true),
-		Length:   to.Float32Ptr(1),
-		Location: to.StringPtr("alaska"),
-		Siblings: &[]complexgroup.FishClassification{
-			&complexgroup.Shark{
-				Age:      to.Int32Ptr(6),
-				Birthday: &sharkBday,
-				Fishtype: to.StringPtr("shark"),
-				Length:   to.Float32Ptr(20),
-				Siblings: &[]complexgroup.FishClassification{
-					&complexgroup.Salmon{
-						Fishtype: to.StringPtr("salmon"),
-						Iswild:   to.BoolPtr(true),
-						Length:   to.Float32Ptr(2),
-						Location: to.StringPtr("atlantic"),
+		Fish: complexgroup.Fish{
+			Fishtype: to.StringPtr("salmon"),
+			Length:   to.Float32Ptr(1),
+			Siblings: &[]complexgroup.FishClassification{
+				&complexgroup.Shark{
+					Fish: complexgroup.Fish{
+						Fishtype: to.StringPtr("shark"),
+						Length:   to.Float32Ptr(20),
 						Siblings: &[]complexgroup.FishClassification{
-							&complexgroup.Shark{
-								Age:      to.Int32Ptr(6),
-								Birthday: &sharkBday,
-								Fishtype: to.StringPtr("shark"),
-								Length:   to.Float32Ptr(20),
-								Species:  to.StringPtr("predator"),
+							&complexgroup.Salmon{
+								Fish: complexgroup.Fish{
+									Fishtype: to.StringPtr("salmon"),
+									Length:   to.Float32Ptr(2),
+									Siblings: &[]complexgroup.FishClassification{
+										&complexgroup.Shark{
+											Fish: complexgroup.Fish{
+												Fishtype: to.StringPtr("shark"),
+												Length:   to.Float32Ptr(20),
+												Species:  to.StringPtr("predator"),
+											},
+											Age:      to.Int32Ptr(6),
+											Birthday: &sharkBday,
+										},
+										&complexgroup.Sawshark{
+											Shark: complexgroup.Shark{
+												Fish: complexgroup.Fish{
+													Fishtype: to.StringPtr("sawshark"),
+													Length:   to.Float32Ptr(10),
+													Species:  to.StringPtr("dangerous"),
+												},
+												Age:      to.Int32Ptr(105),
+												Birthday: &sawBday,
+											},
+											Picture: &[]byte{255, 255, 255, 255, 254},
+										},
+									},
+									Species: to.StringPtr("coho"),
+								},
+								Iswild:   to.BoolPtr(true),
+								Location: to.StringPtr("atlantic"),
 							},
 							&complexgroup.Sawshark{
-								Age:      to.Int32Ptr(105),
-								Birthday: &sawBday,
-								Fishtype: to.StringPtr("sawshark"),
-								Length:   to.Float32Ptr(10),
-								Picture:  &[]byte{255, 255, 255, 255, 254},
-								Species:  to.StringPtr("dangerous"),
+								Shark: complexgroup.Shark{
+									Fish: complexgroup.Fish{
+										Fishtype: to.StringPtr("sawshark"),
+										Length:   to.Float32Ptr(10),
+										Siblings: &[]complexgroup.FishClassification{},
+										Species:  to.StringPtr("dangerous"),
+									},
+									Age:      to.Int32Ptr(105),
+									Birthday: &sawBday,
+								},
+								Picture: &[]byte{255, 255, 255, 255, 254},
 							},
 						},
-						Species: to.StringPtr("coho"),
+						Species: to.StringPtr("predator"),
 					},
-					&complexgroup.Sawshark{
+					Age:      to.Int32Ptr(6),
+					Birthday: &sharkBday,
+				},
+				&complexgroup.Sawshark{
+					Shark: complexgroup.Shark{
+						Fish: complexgroup.Fish{
+							Fishtype: to.StringPtr("sawshark"),
+							Length:   to.Float32Ptr(10),
+							Siblings: &[]complexgroup.FishClassification{},
+							Species:  to.StringPtr("dangerous"),
+						},
 						Age:      to.Int32Ptr(105),
 						Birthday: &sawBday,
-						Fishtype: to.StringPtr("sawshark"),
-						Length:   to.Float32Ptr(10),
-						Picture:  &[]byte{255, 255, 255, 255, 254},
-						Siblings: &[]complexgroup.FishClassification{},
-						Species:  to.StringPtr("dangerous"),
 					},
+					Picture: &[]byte{255, 255, 255, 255, 254},
 				},
-				Species: to.StringPtr("predator"),
 			},
-			&complexgroup.Sawshark{
-				Age:      to.Int32Ptr(105),
-				Birthday: &sawBday,
-				Fishtype: to.StringPtr("sawshark"),
-				Length:   to.Float32Ptr(10),
-				Picture:  &[]byte{255, 255, 255, 255, 254},
-				Siblings: &[]complexgroup.FishClassification{},
-				Species:  to.StringPtr("dangerous"),
-			},
+			Species: to.StringPtr("king"),
 		},
-		Species: to.StringPtr("king"),
+		Iswild:   to.BoolPtr(true),
+		Location: to.StringPtr("alaska"),
 	})
 }
 
@@ -99,64 +119,84 @@ func TestPutValid(t *testing.T) {
 	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
 	sharkBday := time.Date(2012, time.January, 5, 1, 0, 0, 0, time.UTC)
 	result, err := client.PutValid(context.Background(), &complexgroup.Salmon{
-		Fishtype: to.StringPtr("salmon"),
-		Iswild:   to.BoolPtr(true),
-		Length:   to.Float32Ptr(1),
-		Location: to.StringPtr("alaska"),
-		Siblings: &[]complexgroup.FishClassification{
-			&complexgroup.Shark{
-				Age:      to.Int32Ptr(6),
-				Birthday: &sharkBday,
-				Fishtype: to.StringPtr("shark"),
-				Length:   to.Float32Ptr(20),
-				Siblings: &[]complexgroup.FishClassification{
-					&complexgroup.Salmon{
-						Fishtype: to.StringPtr("salmon"),
-						Iswild:   to.BoolPtr(true),
-						Length:   to.Float32Ptr(2),
-						Location: to.StringPtr("atlantic"),
+		Fish: complexgroup.Fish{
+			Fishtype: to.StringPtr("salmon"),
+			Length:   to.Float32Ptr(1),
+			Siblings: &[]complexgroup.FishClassification{
+				&complexgroup.Shark{
+					Fish: complexgroup.Fish{
+						Fishtype: to.StringPtr("shark"),
+						Length:   to.Float32Ptr(20),
 						Siblings: &[]complexgroup.FishClassification{
-							&complexgroup.Shark{
-								Age:      to.Int32Ptr(6),
-								Birthday: &sharkBday,
-								Fishtype: to.StringPtr("shark"),
-								Length:   to.Float32Ptr(20),
-								Species:  to.StringPtr("predator"),
+							&complexgroup.Salmon{
+								Fish: complexgroup.Fish{
+									Fishtype: to.StringPtr("salmon"),
+									Length:   to.Float32Ptr(2),
+									Siblings: &[]complexgroup.FishClassification{
+										&complexgroup.Shark{
+											Fish: complexgroup.Fish{
+												Fishtype: to.StringPtr("shark"),
+												Length:   to.Float32Ptr(20),
+												Species:  to.StringPtr("predator"),
+											},
+											Age:      to.Int32Ptr(6),
+											Birthday: &sharkBday,
+										},
+										&complexgroup.Sawshark{
+											Shark: complexgroup.Shark{
+												Fish: complexgroup.Fish{
+													Fishtype: to.StringPtr("sawshark"),
+													Length:   to.Float32Ptr(10),
+													Species:  to.StringPtr("dangerous"),
+												},
+												Age:      to.Int32Ptr(105),
+												Birthday: &sawBday,
+											},
+											Picture: &[]byte{255, 255, 255, 255, 254},
+										},
+									},
+									Species: to.StringPtr("coho"),
+								},
+								Iswild:   to.BoolPtr(true),
+								Location: to.StringPtr("atlantic"),
 							},
 							&complexgroup.Sawshark{
-								Age:      to.Int32Ptr(105),
-								Birthday: &sawBday,
-								Fishtype: to.StringPtr("sawshark"),
-								Length:   to.Float32Ptr(10),
-								Picture:  &[]byte{255, 255, 255, 255, 254},
-								Species:  to.StringPtr("dangerous"),
+								Shark: complexgroup.Shark{
+									Fish: complexgroup.Fish{
+										Fishtype: to.StringPtr("sawshark"),
+										Length:   to.Float32Ptr(10),
+										Siblings: &[]complexgroup.FishClassification{},
+										Species:  to.StringPtr("dangerous"),
+									},
+									Age:      to.Int32Ptr(105),
+									Birthday: &sawBday,
+								},
+								Picture: &[]byte{255, 255, 255, 255, 254},
 							},
 						},
-						Species: to.StringPtr("coho"),
+						Species: to.StringPtr("predator"),
 					},
-					&complexgroup.Sawshark{
+					Age:      to.Int32Ptr(6),
+					Birthday: &sharkBday,
+				},
+				&complexgroup.Sawshark{
+					Shark: complexgroup.Shark{
+						Fish: complexgroup.Fish{
+							Fishtype: to.StringPtr("sawshark"),
+							Length:   to.Float32Ptr(10),
+							Siblings: &[]complexgroup.FishClassification{},
+							Species:  to.StringPtr("dangerous"),
+						},
 						Age:      to.Int32Ptr(105),
 						Birthday: &sawBday,
-						Fishtype: to.StringPtr("sawshark"),
-						Length:   to.Float32Ptr(10),
-						Picture:  &[]byte{255, 255, 255, 255, 254},
-						Siblings: &[]complexgroup.FishClassification{},
-						Species:  to.StringPtr("dangerous"),
 					},
+					Picture: &[]byte{255, 255, 255, 255, 254},
 				},
-				Species: to.StringPtr("predator"),
 			},
-			&complexgroup.Sawshark{
-				Age:      to.Int32Ptr(105),
-				Birthday: &sawBday,
-				Fishtype: to.StringPtr("sawshark"),
-				Length:   to.Float32Ptr(10),
-				Picture:  &[]byte{255, 255, 255, 255, 254},
-				Siblings: &[]complexgroup.FishClassification{},
-				Species:  to.StringPtr("dangerous"),
-			},
+			Species: to.StringPtr("king"),
 		},
-		Species: to.StringPtr("king"),
+		Iswild:   to.BoolPtr(true),
+		Location: to.StringPtr("alaska"),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/complexgroup/polymorphism_test.go
+++ b/test/autorest/complexgroup/polymorphism_test.go
@@ -36,39 +36,56 @@ func TestPolymorphismGetComplicated(t *testing.T) {
 	goblinBday := time.Date(2015, time.August, 8, 0, 0, 0, 0, time.UTC)
 	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
 	sharkBday := time.Date(2012, time.January, 5, 1, 0, 0, 0, time.UTC)
-	helpers.DeepEqualOrFatal(t, salmon, &complexgroup.SmartSalmon{
+	expectedFish := complexgroup.Fish{
 		Fishtype: to.StringPtr("smart_salmon"),
-		Iswild:   to.BoolPtr(true),
 		Length:   to.Float32Ptr(1),
-		Location: to.StringPtr("alaska"),
 		Siblings: &[]complexgroup.FishClassification{
 			&complexgroup.Shark{
+				Fish: complexgroup.Fish{
+					Fishtype: to.StringPtr("shark"),
+					Length:   to.Float32Ptr(20),
+					Species:  to.StringPtr("predator")},
 				Age:      to.Int32Ptr(6),
 				Birthday: &sharkBday,
-				Fishtype: to.StringPtr("shark"),
-				Length:   to.Float32Ptr(20),
-				Species:  to.StringPtr("predator"),
 			},
 			&complexgroup.Sawshark{
-				Age:      to.Int32Ptr(105),
-				Birthday: &sawBday,
-				Fishtype: to.StringPtr("sawshark"),
-				Length:   to.Float32Ptr(10),
-				Picture:  &[]byte{255, 255, 255, 255, 254},
-				Species:  to.StringPtr("dangerous"),
+				Shark: complexgroup.Shark{
+					Fish: complexgroup.Fish{
+						Fishtype: to.StringPtr("sawshark"),
+						Length:   to.Float32Ptr(10),
+						Species:  to.StringPtr("dangerous"),
+					},
+					Age:      to.Int32Ptr(105),
+					Birthday: &sawBday,
+				},
+				Picture: &[]byte{255, 255, 255, 255, 254},
 			},
 			&complexgroup.Goblinshark{
-				Age:      to.Int32Ptr(1),
-				Birthday: &goblinBday,
-				Color:    complexgroup.GoblinSharkColor("pinkish-gray").ToPtr(),
-				Fishtype: to.StringPtr("goblin"),
-				Jawsize:  to.Int32Ptr(5),
-				Length:   to.Float32Ptr(30),
-				Species:  to.StringPtr("scary"),
+				Shark: complexgroup.Shark{
+					Fish: complexgroup.Fish{
+						Fishtype: to.StringPtr("goblin"),
+						Length:   to.Float32Ptr(30),
+						Species:  to.StringPtr("scary"),
+					},
+					Age:      to.Int32Ptr(1),
+					Birthday: &goblinBday,
+				},
+				Color:   complexgroup.GoblinSharkColor("pinkish-gray").ToPtr(),
+				Jawsize: to.Int32Ptr(5),
 			},
 		},
 		Species: to.StringPtr("king"),
+	}
+	expectedSalmon := complexgroup.Salmon{
+		Fish:     expectedFish,
+		Iswild:   to.BoolPtr(true),
+		Location: to.StringPtr("alaska"),
+	}
+	helpers.DeepEqualOrFatal(t, salmon, &complexgroup.SmartSalmon{
+		Salmon: expectedSalmon,
 	})
+	helpers.DeepEqualOrFatal(t, result.Salmon.GetSalmon(), &expectedSalmon)
+	helpers.DeepEqualOrFatal(t, result.Salmon.GetFish(), &expectedFish)
 }
 
 // GetComposedWithDiscriminator - Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
@@ -81,43 +98,55 @@ func TestPolymorphismGetComposedWithDiscriminator(t *testing.T) {
 	helpers.DeepEqualOrFatal(t, result.DotFishMarket, &complexgroup.DotFishMarket{
 		Fishes: &[]complexgroup.DotFishClassification{
 			&complexgroup.DotSalmon{
-				FishType: to.StringPtr("DotSalmon"),
+				DotFish: complexgroup.DotFish{
+					FishType: to.StringPtr("DotSalmon"),
+					Species:  to.StringPtr("king"),
+				},
 				Location: to.StringPtr("australia"),
 				Iswild:   to.BoolPtr(false),
-				Species:  to.StringPtr("king"),
 			},
 			&complexgroup.DotSalmon{
-				FishType: to.StringPtr("DotSalmon"),
+				DotFish: complexgroup.DotFish{
+					FishType: to.StringPtr("DotSalmon"),
+					Species:  to.StringPtr("king"),
+				},
 				Location: to.StringPtr("canada"),
 				Iswild:   to.BoolPtr(true),
-				Species:  to.StringPtr("king"),
 			},
 		},
 		Salmons: &[]complexgroup.DotSalmon{
 			{
-				FishType: to.StringPtr("DotSalmon"),
+				DotFish: complexgroup.DotFish{
+					FishType: to.StringPtr("DotSalmon"),
+					Species:  to.StringPtr("king"),
+				},
 				Location: to.StringPtr("sweden"),
 				Iswild:   to.BoolPtr(false),
-				Species:  to.StringPtr("king"),
 			},
 			{
-				FishType: to.StringPtr("DotSalmon"),
+				DotFish: complexgroup.DotFish{
+					FishType: to.StringPtr("DotSalmon"),
+					Species:  to.StringPtr("king"),
+				},
 				Location: to.StringPtr("atlantic"),
 				Iswild:   to.BoolPtr(true),
-				Species:  to.StringPtr("king"),
 			},
 		},
 		SampleFish: &complexgroup.DotSalmon{
-			FishType: to.StringPtr("DotSalmon"),
+			DotFish: complexgroup.DotFish{
+				FishType: to.StringPtr("DotSalmon"),
+				Species:  to.StringPtr("king"),
+			},
 			Location: to.StringPtr("australia"),
 			Iswild:   to.BoolPtr(false),
-			Species:  to.StringPtr("king"),
 		},
 		SampleSalmon: &complexgroup.DotSalmon{
-			FishType: to.StringPtr("DotSalmon"),
+			DotFish: complexgroup.DotFish{
+				FishType: to.StringPtr("DotSalmon"),
+				Species:  to.StringPtr("king"),
+			},
 			Location: to.StringPtr("sweden"),
 			Iswild:   to.BoolPtr(false),
-			Species:  to.StringPtr("king"),
 		},
 	})
 }
@@ -140,23 +169,29 @@ func TestPolymorphismGetComposedWithoutDiscriminator(t *testing.T) {
 		},
 		Salmons: &[]complexgroup.DotSalmon{
 			{
+				DotFish: complexgroup.DotFish{
+					Species: to.StringPtr("king"),
+				},
 				Location: to.StringPtr("sweden"),
 				Iswild:   to.BoolPtr(false),
-				Species:  to.StringPtr("king"),
 			},
 			{
+				DotFish: complexgroup.DotFish{
+					Species: to.StringPtr("king"),
+				},
 				Location: to.StringPtr("atlantic"),
 				Iswild:   to.BoolPtr(true),
-				Species:  to.StringPtr("king"),
 			},
 		},
 		SampleFish: &complexgroup.DotFish{
 			Species: to.StringPtr("king"),
 		},
 		SampleSalmon: &complexgroup.DotSalmon{
+			DotFish: complexgroup.DotFish{
+				Species: to.StringPtr("king"),
+			},
 			Location: to.StringPtr("sweden"),
 			Iswild:   to.BoolPtr(false),
-			Species:  to.StringPtr("king"),
 		},
 	})
 }
@@ -169,10 +204,12 @@ func TestPolymorphismGetDotSyntax(t *testing.T) {
 		t.Fatal(err)
 	}
 	helpers.DeepEqualOrFatal(t, result.DotFish, &complexgroup.DotSalmon{
-		FishType: to.StringPtr("DotSalmon"),
+		DotFish: complexgroup.DotFish{
+			FishType: to.StringPtr("DotSalmon"),
+			Species:  to.StringPtr("king"),
+		},
 		Location: to.StringPtr("sweden"),
 		Iswild:   to.BoolPtr(true),
-		Species:  to.StringPtr("king"),
 	})
 }
 
@@ -191,37 +228,49 @@ func TestPolymorphismGetValid(t *testing.T) {
 	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
 	sharkBday := time.Date(2012, time.January, 5, 1, 0, 0, 0, time.UTC)
 	helpers.DeepEqualOrFatal(t, salmon, &complexgroup.Salmon{
-		Fishtype: to.StringPtr("salmon"),
-		Iswild:   to.BoolPtr(true),
-		Length:   to.Float32Ptr(1),
-		Location: to.StringPtr("alaska"),
-		Siblings: &[]complexgroup.FishClassification{
-			&complexgroup.Shark{
-				Age:      to.Int32Ptr(6),
-				Birthday: &sharkBday,
-				Fishtype: to.StringPtr("shark"),
-				Length:   to.Float32Ptr(20),
-				Species:  to.StringPtr("predator"),
+		Fish: complexgroup.Fish{
+			Fishtype: to.StringPtr("salmon"),
+			Length:   to.Float32Ptr(1),
+			Siblings: &[]complexgroup.FishClassification{
+				&complexgroup.Shark{
+					Fish: complexgroup.Fish{
+						Fishtype: to.StringPtr("shark"),
+						Length:   to.Float32Ptr(20),
+						Species:  to.StringPtr("predator"),
+					},
+					Age:      to.Int32Ptr(6),
+					Birthday: &sharkBday,
+				},
+				&complexgroup.Sawshark{
+					Shark: complexgroup.Shark{
+						Fish: complexgroup.Fish{
+							Fishtype: to.StringPtr("sawshark"),
+							Length:   to.Float32Ptr(10),
+							Species:  to.StringPtr("dangerous"),
+						},
+						Age:      to.Int32Ptr(105),
+						Birthday: &sawBday,
+					},
+					Picture: &[]byte{255, 255, 255, 255, 254},
+				},
+				&complexgroup.Goblinshark{
+					Shark: complexgroup.Shark{
+						Fish: complexgroup.Fish{
+							Fishtype: to.StringPtr("goblin"),
+							Length:   to.Float32Ptr(30),
+							Species:  to.StringPtr("scary"),
+						},
+						Age:      to.Int32Ptr(1),
+						Birthday: &goblinBday,
+					},
+					Color:   complexgroup.GoblinSharkColor("pinkish-gray").ToPtr(),
+					Jawsize: to.Int32Ptr(5),
+				},
 			},
-			&complexgroup.Sawshark{
-				Age:      to.Int32Ptr(105),
-				Birthday: &sawBday,
-				Fishtype: to.StringPtr("sawshark"),
-				Length:   to.Float32Ptr(10),
-				Picture:  &[]byte{255, 255, 255, 255, 254},
-				Species:  to.StringPtr("dangerous"),
-			},
-			&complexgroup.Goblinshark{
-				Age:      to.Int32Ptr(1),
-				Birthday: &goblinBday,
-				Color:    complexgroup.GoblinSharkColor("pinkish-gray").ToPtr(),
-				Fishtype: to.StringPtr("goblin"),
-				Jawsize:  to.Int32Ptr(5),
-				Length:   to.Float32Ptr(30),
-				Species:  to.StringPtr("scary"),
-			},
+			Species: to.StringPtr("king"),
 		},
-		Species: to.StringPtr("king"),
+		Iswild:   to.BoolPtr(true),
+		Location: to.StringPtr("alaska"),
 	})
 }
 
@@ -237,33 +286,45 @@ func TestPolymorphismPutMissingDiscriminator(t *testing.T) {
 	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
 	sharkBday := time.Date(2012, time.January, 5, 1, 0, 0, 0, time.UTC)
 	result, err := client.PutMissingDiscriminator(context.Background(), &complexgroup.Salmon{
-		Iswild:   to.BoolPtr(true),
-		Length:   to.Float32Ptr(1),
-		Location: to.StringPtr("alaska"),
-		Siblings: &[]complexgroup.FishClassification{
-			&complexgroup.Shark{
-				Age:      to.Int32Ptr(6),
-				Birthday: &sharkBday,
-				Length:   to.Float32Ptr(20),
-				Species:  to.StringPtr("predator"),
+		Fish: complexgroup.Fish{
+			Length: to.Float32Ptr(1),
+			Siblings: &[]complexgroup.FishClassification{
+				&complexgroup.Shark{
+					Fish: complexgroup.Fish{
+						Length:  to.Float32Ptr(20),
+						Species: to.StringPtr("predator"),
+					},
+					Age:      to.Int32Ptr(6),
+					Birthday: &sharkBday,
+				},
+				&complexgroup.Sawshark{
+					Shark: complexgroup.Shark{
+						Fish: complexgroup.Fish{
+							Length:  to.Float32Ptr(10),
+							Species: to.StringPtr("dangerous"),
+						},
+						Age:      to.Int32Ptr(105),
+						Birthday: &sawBday,
+					},
+					Picture: &[]byte{255, 255, 255, 255, 254},
+				},
+				&complexgroup.Goblinshark{
+					Shark: complexgroup.Shark{
+						Fish: complexgroup.Fish{
+							Length:  to.Float32Ptr(30),
+							Species: to.StringPtr("scary"),
+						},
+						Age:      to.Int32Ptr(1),
+						Birthday: &goblinBday,
+					},
+					Color:   complexgroup.GoblinSharkColor("pinkish-gray").ToPtr(),
+					Jawsize: to.Int32Ptr(5),
+				},
 			},
-			&complexgroup.Sawshark{
-				Age:      to.Int32Ptr(105),
-				Birthday: &sawBday,
-				Length:   to.Float32Ptr(10),
-				Picture:  &[]byte{255, 255, 255, 255, 254},
-				Species:  to.StringPtr("dangerous"),
-			},
-			&complexgroup.Goblinshark{
-				Age:      to.Int32Ptr(1),
-				Birthday: &goblinBday,
-				Color:    complexgroup.GoblinSharkColor("pinkish-gray").ToPtr(),
-				Jawsize:  to.Int32Ptr(5),
-				Length:   to.Float32Ptr(30),
-				Species:  to.StringPtr("scary"),
-			},
+			Species: to.StringPtr("king"),
 		},
-		Species: to.StringPtr("king"),
+		Iswild:   to.BoolPtr(true),
+		Location: to.StringPtr("alaska"),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -278,33 +339,45 @@ func TestPolymorphismPutValid(t *testing.T) {
 	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
 	sharkBday := time.Date(2012, time.January, 5, 1, 0, 0, 0, time.UTC)
 	resp, err := client.PutValid(context.Background(), &complexgroup.Salmon{
-		Iswild:   to.BoolPtr(true),
-		Length:   to.Float32Ptr(1),
-		Location: to.StringPtr("alaska"),
-		Siblings: &[]complexgroup.FishClassification{
-			&complexgroup.Shark{
-				Age:      to.Int32Ptr(6),
-				Birthday: &sharkBday,
-				Length:   to.Float32Ptr(20),
-				Species:  to.StringPtr("predator"),
+		Fish: complexgroup.Fish{
+			Length: to.Float32Ptr(1),
+			Siblings: &[]complexgroup.FishClassification{
+				&complexgroup.Shark{
+					Fish: complexgroup.Fish{
+						Length:  to.Float32Ptr(20),
+						Species: to.StringPtr("predator"),
+					},
+					Age:      to.Int32Ptr(6),
+					Birthday: &sharkBday,
+				},
+				&complexgroup.Sawshark{
+					Shark: complexgroup.Shark{
+						Fish: complexgroup.Fish{
+							Length:  to.Float32Ptr(10),
+							Species: to.StringPtr("dangerous"),
+						},
+						Age:      to.Int32Ptr(105),
+						Birthday: &sawBday,
+					},
+					Picture: &[]byte{255, 255, 255, 255, 254},
+				},
+				&complexgroup.Goblinshark{
+					Shark: complexgroup.Shark{
+						Fish: complexgroup.Fish{
+							Length:  to.Float32Ptr(30),
+							Species: to.StringPtr("scary"),
+						},
+						Age:      to.Int32Ptr(1),
+						Birthday: &goblinBday,
+					},
+					Color:   complexgroup.GoblinSharkColor("pinkish-gray").ToPtr(),
+					Jawsize: to.Int32Ptr(5),
+				},
 			},
-			&complexgroup.Sawshark{
-				Age:      to.Int32Ptr(105),
-				Birthday: &sawBday,
-				Length:   to.Float32Ptr(10),
-				Picture:  &[]byte{255, 255, 255, 255, 254},
-				Species:  to.StringPtr("dangerous"),
-			},
-			&complexgroup.Goblinshark{
-				Age:      to.Int32Ptr(1),
-				Birthday: &goblinBday,
-				Color:    complexgroup.GoblinSharkColor("pinkish-gray").ToPtr(),
-				Jawsize:  to.Int32Ptr(5),
-				Length:   to.Float32Ptr(30),
-				Species:  to.StringPtr("scary"),
-			},
+			Species: to.StringPtr("king"),
 		},
-		Species: to.StringPtr("king"),
+		Iswild:   to.BoolPtr(true),
+		Location: to.StringPtr("alaska"),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/generated/complexgroup/models.go
+++ b/test/autorest/generated/complexgroup/models.go
@@ -810,7 +810,7 @@ func (s Shark) MarshalJSON() ([]byte, error) {
 		objectMap["age"] = s.Age
 	}
 	if s.Birthday != nil {
-		objectMap["birthday"] = s.Birthday
+		objectMap["birthday"] = (*timeRFC3339)(s.Birthday)
 	}
 	return json.Marshal(objectMap)
 }
@@ -847,7 +847,7 @@ func (s Shark) marshalInternal(discValue string) map[string]interface{} {
 		objectMap["age"] = s.Age
 	}
 	if s.Birthday != nil {
-		objectMap["birthday"] = s.Birthday
+		objectMap["birthday"] = (*timeRFC3339)(s.Birthday)
 	}
 	return objectMap
 }

--- a/test/autorest/generated/complexgroup/polymorphic_helpers.go
+++ b/test/autorest/generated/complexgroup/polymorphic_helpers.go
@@ -7,10 +7,6 @@ package complexgroup
 
 import "encoding/json"
 
-const (
-	dotFishClassificationDotSalmon = "DotSalmon"
-)
-
 func unmarshalDotFishClassification(body []byte) (DotFishClassification, error) {
 	var m map[string]interface{}
 	if err := json.Unmarshal(body, &m); err != nil {
@@ -18,7 +14,7 @@ func unmarshalDotFishClassification(body []byte) (DotFishClassification, error) 
 	}
 	var b DotFishClassification
 	switch m["fish.type"] {
-	case dotFishClassificationDotSalmon:
+	case "DotSalmon":
 		b = &DotSalmon{}
 	default:
 		b = &DotFish{}
@@ -42,15 +38,6 @@ func unmarshalDotFishClassificationArray(body []byte) (*[]DotFishClassification,
 	return &fArray, nil
 }
 
-const (
-	fishClassificationCookiecuttershark = "cookiecuttershark"
-	fishClassificationGoblin            = "goblin"
-	fishClassificationSalmon            = "salmon"
-	fishClassificationSawshark          = "sawshark"
-	fishClassificationShark             = "shark"
-	fishClassificationSmartSalmon       = "smart_salmon"
-)
-
 func unmarshalFishClassification(body []byte) (FishClassification, error) {
 	var m map[string]interface{}
 	if err := json.Unmarshal(body, &m); err != nil {
@@ -58,17 +45,17 @@ func unmarshalFishClassification(body []byte) (FishClassification, error) {
 	}
 	var b FishClassification
 	switch m["fishtype"] {
-	case fishClassificationCookiecuttershark:
+	case "cookiecuttershark":
 		b = &Cookiecuttershark{}
-	case fishClassificationGoblin:
+	case "goblin":
 		b = &Goblinshark{}
-	case fishClassificationSalmon:
+	case "salmon":
 		b = &Salmon{}
-	case fishClassificationSawshark:
+	case "sawshark":
 		b = &Sawshark{}
-	case fishClassificationShark:
+	case "shark":
 		b = &Shark{}
-	case fishClassificationSmartSalmon:
+	case "smart_salmon":
 		b = &SmartSalmon{}
 	default:
 		b = &Fish{}
@@ -99,7 +86,7 @@ func unmarshalSalmonClassification(body []byte) (SalmonClassification, error) {
 	}
 	var b SalmonClassification
 	switch m["fishtype"] {
-	case fishClassificationSmartSalmon:
+	case "smart_salmon":
 		b = &SmartSalmon{}
 	default:
 		b = &Salmon{}
@@ -130,11 +117,11 @@ func unmarshalSharkClassification(body []byte) (SharkClassification, error) {
 	}
 	var b SharkClassification
 	switch m["fishtype"] {
-	case fishClassificationCookiecuttershark:
+	case "cookiecuttershark":
 		b = &Cookiecuttershark{}
-	case fishClassificationGoblin:
+	case "goblin":
 		b = &Goblinshark{}
-	case fishClassificationSawshark:
+	case "sawshark":
 		b = &Sawshark{}
 	default:
 		b = &Shark{}
@@ -158,10 +145,6 @@ func unmarshalSharkClassificationArray(body []byte) (*[]SharkClassification, err
 	return &fArray, nil
 }
 
-const (
-	myBaseTypeClassificationKind1 = "Kind1"
-)
-
 func unmarshalMyBaseTypeClassification(body []byte) (MyBaseTypeClassification, error) {
 	var m map[string]interface{}
 	if err := json.Unmarshal(body, &m); err != nil {
@@ -169,7 +152,7 @@ func unmarshalMyBaseTypeClassification(body []byte) (MyBaseTypeClassification, e
 	}
 	var b MyBaseTypeClassification
 	switch m["kind"] {
-	case myBaseTypeClassificationKind1:
+	case "Kind1":
 		b = &MyDerivedType{}
 	default:
 		b = &MyBaseType{}

--- a/test/autorest/generated/httpinfrastructuregroup/models.go
+++ b/test/autorest/generated/httpinfrastructuregroup/models.go
@@ -11,7 +11,7 @@ import (
 )
 
 type B struct {
-	StatusCode     *string `json:"statusCode,omitempty"`
+	MyException
 	TextStatusCode *string `json:"textStatusCode,omitempty"`
 }
 

--- a/test/autorest/generated/lrogroup/models.go
+++ b/test/autorest/generated/lrogroup/models.go
@@ -759,21 +759,8 @@ type OperationResultError struct {
 }
 
 type Product struct {
-	// Resource Id
-	ID *string `json:"id,omitempty"`
-
-	// Resource Location
-	Location *string `json:"location,omitempty"`
-
-	// Resource Name
-	Name       *string            `json:"name,omitempty"`
+	Resource
 	Properties *ProductProperties `json:"properties,omitempty"`
-
-	// Dictionary of <string>
-	Tags *map[string]string `json:"tags,omitempty"`
-
-	// Resource Type
-	Type *string `json:"type,omitempty"`
 }
 
 type ProductProperties struct {
@@ -819,8 +806,7 @@ type SkuResponse struct {
 }
 
 type SubProduct struct {
-	// Sub Resource Id
-	ID         *string               `json:"id,omitempty"`
+	SubResource
 	Properties *SubProductProperties `json:"properties,omitempty"`
 }
 


### PR DESCRIPTION
Use composition for discriminated types hierarchy.
Change marker method to an exported GetType method used to retrieve the
base-type content.
Removed internal enums for discriminator values.
Split marshallers and unmarshallers for discriminated types separate
from counterparts for time and XML wrappers.