### PR TITLE
Final response handler for Pollers and updating tests

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -303,7 +303,12 @@ function generateOperation(clientName: string, op: Operation, imports: ImportMan
     text += `\t\t\tpt: pt,\n`;
     text += `\t\t\tpipeline: client.p,\n`;
     text += `\t}\n`;
-    text += `\tresult.PollUntilDone = func(ctx context.Context, frequency time.Duration)(*${op.language.go!.pollerType.responseType}Response, error) {\n`;
+    // http pollers will simply return an *http.Response
+    if (op.language.go!.pollerType.name === 'HTTPPoller') {
+      text += `\tresult.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {\n`;
+    } else {
+      text += `\tresult.PollUntilDone = func(ctx context.Context, frequency time.Duration)(*${op.language.go!.pollerType.responseType}Response, error) {\n`;
+    }
     text += `\t\treturn ${camelCase(op.language.go!.pollerType.name)}PollUntilDone(ctx, result.Poller, frequency)\n`;
     text += `\t}\n`;
     text += `\treturn result, nil\n`;

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -299,17 +299,18 @@ function generateOperation(clientName: string, op: Operation, imports: ImportMan
     text += `\tif err != nil {\n`;
     text += `\t\treturn nil, err\n`;
     text += `\t}\n`;
-    text += `\tresult.Poller = &${camelCase(op.language.go!.pollerType.name)}{\n`;
+    text += `\tpoller := &${camelCase(op.language.go!.pollerType.name)}{\n`;
     text += `\t\t\tpt: pt,\n`;
     text += `\t\t\tpipeline: client.p,\n`;
     text += `\t}\n`;
+    text += '\tresult.Poller = poller\n';
     // http pollers will simply return an *http.Response
     if (op.language.go!.pollerType.name === 'HTTPPoller') {
       text += `\tresult.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {\n`;
     } else {
       text += `\tresult.PollUntilDone = func(ctx context.Context, frequency time.Duration)(*${op.language.go!.pollerType.responseType}Response, error) {\n`;
     }
-    text += `\t\treturn ${camelCase(op.language.go!.pollerType.name)}PollUntilDone(ctx, result.Poller, frequency)\n`;
+    text += `\t\treturn poller.pollUntilDone(ctx, frequency)\n`;
     text += `\t}\n`;
     text += `\treturn result, nil\n`;
     // closing braces

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -302,7 +302,6 @@ function generateOperation(clientName: string, op: Operation, imports: ImportMan
     text += `\tresult.Poller = &${camelCase(op.language.go!.pollerType.name)}{\n`;
     text += `\t\t\tpt: pt,\n`;
     text += `\t\t\tpipeline: client.p,\n`;
-    text += `\t\t\tresponse: client.${info.protocolNaming.responseMethod},\n`;
     text += `\t}\n`;
     text += `\tresult.PollUntilDone = func(ctx context.Context, frequency time.Duration)(*${op.language.go!.pollerType.responseType}Response, error) {\n`;
     text += `\t\treturn ${camelCase(op.language.go!.pollerType.name)}PollUntilDone(ctx, result.Poller, frequency)\n`;
@@ -954,7 +953,6 @@ function addResumePollerMethod(op: Operation, clientName: string): string {
   text += `\treturn &${camelCase(op.language.go!.pollerType.name)}{\n`;
   text += '\t\tpipeline: client.p,\n';
   text += '\t\tpt: pt,\n';
-  text += `\t\tresponse: client.${info.protocolNaming.responseMethod},\n`;
   text += '\t}, nil\n';
   text += '}\n';
   return text;

--- a/src/generator/pollers.ts
+++ b/src/generator/pollers.ts
@@ -137,7 +137,7 @@ func (p *${pollerName}) ResumeToken() (string, error) {
   return string(js), nil
 }
 
-func ${pollerName}PollUntilDone(ctx context.Context, p ${pollerInterface}, frequency time.Duration) ${pollUntilDoneResponse} {
+func (p *${pollerName}) pollUntilDone(ctx context.Context, frequency time.Duration) ${pollUntilDoneResponse} {
     for {
         resp, err := p.Poll(ctx)
         if err != nil {

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -410,7 +410,7 @@ function createResponseType(codeModel: CodeModel, group: OperationGroup, op: Ope
       const description = `${name} contains the HTTP response from the call to the service endpoint`;
       const object = new ObjectSchema(name, description);
       object.language.go = object.language.default;
-      const pollUntilDone = newProperty('PollUntilDone', 'PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received', newObject('func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error)', 'TODO'));
+      const pollUntilDone = newProperty('PollUntilDone', 'PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received', newObject('func(ctx context.Context, frequency time.Duration) (*http.Response, error)', 'TODO'));
       const getPoller = newProperty('Poller', 'Poller contains an initialized poller', newObject('HTTPPoller', 'TODO'));
       pollUntilDone.schema.language.go!.lroPointerException = true;
       getPoller.schema.language.go!.lroPointerException = true;

--- a/test/autorest/generated/lrogroup/lroretrys.go
+++ b/test/autorest/generated/lrogroup/lroretrys.go
@@ -71,7 +71,6 @@ func (client *lroRetrysOperations) BeginDelete202Retry200(ctx context.Context) (
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.delete202Retry200HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -87,7 +86,6 @@ func (client *lroRetrysOperations) ResumeDelete202Retry200(token string) (HTTPPo
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.delete202Retry200HandleResponse,
 	}, nil
 }
 
@@ -141,7 +139,6 @@ func (client *lroRetrysOperations) BeginDeleteAsyncRelativeRetrySucceeded(ctx co
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteAsyncRelativeRetrySucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -157,7 +154,6 @@ func (client *lroRetrysOperations) ResumeDeleteAsyncRelativeRetrySucceeded(token
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteAsyncRelativeRetrySucceededHandleResponse,
 	}, nil
 }
 
@@ -211,7 +207,6 @@ func (client *lroRetrysOperations) BeginDeleteProvisioning202Accepted200Succeede
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteProvisioning202Accepted200SucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -227,7 +222,6 @@ func (client *lroRetrysOperations) ResumeDeleteProvisioning202Accepted200Succeed
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteProvisioning202Accepted200SucceededHandleResponse,
 	}, nil
 }
 
@@ -282,7 +276,6 @@ func (client *lroRetrysOperations) BeginPost202Retry200(ctx context.Context, lro
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.post202Retry200HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -298,7 +291,6 @@ func (client *lroRetrysOperations) ResumePost202Retry200(token string) (HTTPPoll
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.post202Retry200HandleResponse,
 	}, nil
 }
 
@@ -355,7 +347,6 @@ func (client *lroRetrysOperations) BeginPostAsyncRelativeRetrySucceeded(ctx cont
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.postAsyncRelativeRetrySucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -371,7 +362,6 @@ func (client *lroRetrysOperations) ResumePostAsyncRelativeRetrySucceeded(token s
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.postAsyncRelativeRetrySucceededHandleResponse,
 	}, nil
 }
 
@@ -428,7 +418,6 @@ func (client *lroRetrysOperations) BeginPut201CreatingSucceeded200(ctx context.C
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.put201CreatingSucceeded200HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -444,7 +433,6 @@ func (client *lroRetrysOperations) ResumePut201CreatingSucceeded200(token string
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.put201CreatingSucceeded200HandleResponse,
 	}, nil
 }
 
@@ -502,7 +490,6 @@ func (client *lroRetrysOperations) BeginPutAsyncRelativeRetrySucceeded(ctx conte
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putAsyncRelativeRetrySucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -518,7 +505,6 @@ func (client *lroRetrysOperations) ResumePutAsyncRelativeRetrySucceeded(token st
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putAsyncRelativeRetrySucceededHandleResponse,
 	}, nil
 }
 

--- a/test/autorest/generated/lrogroup/lroretrys.go
+++ b/test/autorest/generated/lrogroup/lroretrys.go
@@ -68,12 +68,13 @@ func (client *lroRetrysOperations) BeginDelete202Retry200(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -136,12 +137,13 @@ func (client *lroRetrysOperations) BeginDeleteAsyncRelativeRetrySucceeded(ctx co
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -204,12 +206,13 @@ func (client *lroRetrysOperations) BeginDeleteProvisioning202Accepted200Succeede
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -273,12 +276,13 @@ func (client *lroRetrysOperations) BeginPost202Retry200(ctx context.Context, lro
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -344,12 +348,13 @@ func (client *lroRetrysOperations) BeginPostAsyncRelativeRetrySucceeded(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -415,12 +420,13 @@ func (client *lroRetrysOperations) BeginPut201CreatingSucceeded200(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -487,12 +493,13 @@ func (client *lroRetrysOperations) BeginPutAsyncRelativeRetrySucceeded(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }

--- a/test/autorest/generated/lrogroup/lroretrys.go
+++ b/test/autorest/generated/lrogroup/lroretrys.go
@@ -72,7 +72,7 @@ func (client *lroRetrysOperations) BeginDelete202Retry200(ctx context.Context) (
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -140,7 +140,7 @@ func (client *lroRetrysOperations) BeginDeleteAsyncRelativeRetrySucceeded(ctx co
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -277,7 +277,7 @@ func (client *lroRetrysOperations) BeginPost202Retry200(ctx context.Context, lro
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -348,7 +348,7 @@ func (client *lroRetrysOperations) BeginPostAsyncRelativeRetrySucceeded(ctx cont
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil

--- a/test/autorest/generated/lrogroup/lros.go
+++ b/test/autorest/generated/lrogroup/lros.go
@@ -199,7 +199,6 @@ func (client *lrOSOperations) BeginDelete202NoRetry204(ctx context.Context) (*Pr
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.delete202NoRetry204HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -215,7 +214,6 @@ func (client *lrOSOperations) ResumeDelete202NoRetry204(token string) (ProductPo
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.delete202NoRetry204HandleResponse,
 	}, nil
 }
 
@@ -270,7 +268,6 @@ func (client *lrOSOperations) BeginDelete202Retry200(ctx context.Context) (*Prod
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.delete202Retry200HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -286,7 +283,6 @@ func (client *lrOSOperations) ResumeDelete202Retry200(token string) (ProductPoll
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.delete202Retry200HandleResponse,
 	}, nil
 }
 
@@ -341,7 +337,6 @@ func (client *lrOSOperations) BeginDelete204Succeeded(ctx context.Context) (*HTT
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.delete204SucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -357,7 +352,6 @@ func (client *lrOSOperations) ResumeDelete204Succeeded(token string) (HTTPPoller
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.delete204SucceededHandleResponse,
 	}, nil
 }
 
@@ -412,7 +406,6 @@ func (client *lrOSOperations) BeginDeleteAsyncNoHeaderInRetry(ctx context.Contex
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteAsyncNoHeaderInRetryHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -428,7 +421,6 @@ func (client *lrOSOperations) ResumeDeleteAsyncNoHeaderInRetry(token string) (HT
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteAsyncNoHeaderInRetryHandleResponse,
 	}, nil
 }
 
@@ -482,7 +474,6 @@ func (client *lrOSOperations) BeginDeleteAsyncNoRetrySucceeded(ctx context.Conte
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteAsyncNoRetrySucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -498,7 +489,6 @@ func (client *lrOSOperations) ResumeDeleteAsyncNoRetrySucceeded(token string) (H
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteAsyncNoRetrySucceededHandleResponse,
 	}, nil
 }
 
@@ -552,7 +542,6 @@ func (client *lrOSOperations) BeginDeleteAsyncRetryFailed(ctx context.Context) (
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteAsyncRetryFailedHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -568,7 +557,6 @@ func (client *lrOSOperations) ResumeDeleteAsyncRetryFailed(token string) (HTTPPo
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteAsyncRetryFailedHandleResponse,
 	}, nil
 }
 
@@ -622,7 +610,6 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrySucceeded(ctx context.Context
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteAsyncRetrySucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -638,7 +625,6 @@ func (client *lrOSOperations) ResumeDeleteAsyncRetrySucceeded(token string) (HTT
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteAsyncRetrySucceededHandleResponse,
 	}, nil
 }
 
@@ -692,7 +678,6 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrycanceled(ctx context.Context)
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteAsyncRetrycanceledHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -708,7 +693,6 @@ func (client *lrOSOperations) ResumeDeleteAsyncRetrycanceled(token string) (HTTP
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteAsyncRetrycanceledHandleResponse,
 	}, nil
 }
 
@@ -762,7 +746,6 @@ func (client *lrOSOperations) BeginDeleteNoHeaderInRetry(ctx context.Context) (*
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteNoHeaderInRetryHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -778,7 +761,6 @@ func (client *lrOSOperations) ResumeDeleteNoHeaderInRetry(token string) (HTTPPol
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteNoHeaderInRetryHandleResponse,
 	}, nil
 }
 
@@ -832,7 +814,6 @@ func (client *lrOSOperations) BeginDeleteProvisioning202Accepted200Succeeded(ctx
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteProvisioning202Accepted200SucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -848,7 +829,6 @@ func (client *lrOSOperations) ResumeDeleteProvisioning202Accepted200Succeeded(to
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteProvisioning202Accepted200SucceededHandleResponse,
 	}, nil
 }
 
@@ -903,7 +883,6 @@ func (client *lrOSOperations) BeginDeleteProvisioning202DeletingFailed200(ctx co
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteProvisioning202DeletingFailed200HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -919,7 +898,6 @@ func (client *lrOSOperations) ResumeDeleteProvisioning202DeletingFailed200(token
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteProvisioning202DeletingFailed200HandleResponse,
 	}, nil
 }
 
@@ -974,7 +952,6 @@ func (client *lrOSOperations) BeginDeleteProvisioning202Deletingcanceled200(ctx 
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteProvisioning202Deletingcanceled200HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -990,7 +967,6 @@ func (client *lrOSOperations) ResumeDeleteProvisioning202Deletingcanceled200(tok
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteProvisioning202Deletingcanceled200HandleResponse,
 	}, nil
 }
 
@@ -1045,7 +1021,6 @@ func (client *lrOSOperations) BeginPost200WithPayload(ctx context.Context) (*Sku
 	result.Poller = &skuPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.post200WithPayloadHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*SkuResponse, error) {
 		return skuPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1061,7 +1036,6 @@ func (client *lrOSOperations) ResumePost200WithPayload(token string) (SkuPoller,
 	return &skuPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.post200WithPayloadHandleResponse,
 	}, nil
 }
 
@@ -1116,7 +1090,6 @@ func (client *lrOSOperations) BeginPost202NoRetry204(ctx context.Context, lrOSPo
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.post202NoRetry204HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1132,7 +1105,6 @@ func (client *lrOSOperations) ResumePost202NoRetry204(token string) (ProductPoll
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.post202NoRetry204HandleResponse,
 	}, nil
 }
 
@@ -1190,7 +1162,6 @@ func (client *lrOSOperations) BeginPost202Retry200(ctx context.Context, lrOSPost
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.post202Retry200HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1206,7 +1177,6 @@ func (client *lrOSOperations) ResumePost202Retry200(token string) (HTTPPoller, e
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.post202Retry200HandleResponse,
 	}, nil
 }
 
@@ -1263,7 +1233,6 @@ func (client *lrOSOperations) BeginPostAsyncNoRetrySucceeded(ctx context.Context
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.postAsyncNoRetrySucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1279,7 +1248,6 @@ func (client *lrOSOperations) ResumePostAsyncNoRetrySucceeded(token string) (Pro
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.postAsyncNoRetrySucceededHandleResponse,
 	}, nil
 }
 
@@ -1337,7 +1305,6 @@ func (client *lrOSOperations) BeginPostAsyncRetryFailed(ctx context.Context, lrO
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.postAsyncRetryFailedHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1353,7 +1320,6 @@ func (client *lrOSOperations) ResumePostAsyncRetryFailed(token string) (HTTPPoll
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.postAsyncRetryFailedHandleResponse,
 	}, nil
 }
 
@@ -1410,7 +1376,6 @@ func (client *lrOSOperations) BeginPostAsyncRetrySucceeded(ctx context.Context, 
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.postAsyncRetrySucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1426,7 +1391,6 @@ func (client *lrOSOperations) ResumePostAsyncRetrySucceeded(token string) (Produ
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.postAsyncRetrySucceededHandleResponse,
 	}, nil
 }
 
@@ -1484,7 +1448,6 @@ func (client *lrOSOperations) BeginPostAsyncRetrycanceled(ctx context.Context, l
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.postAsyncRetrycanceledHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1500,7 +1463,6 @@ func (client *lrOSOperations) ResumePostAsyncRetrycanceled(token string) (HTTPPo
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.postAsyncRetrycanceledHandleResponse,
 	}, nil
 }
 
@@ -1557,7 +1519,6 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx cont
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.postDoubleHeadersFinalAzureHeaderGetHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1573,7 +1534,6 @@ func (client *lrOSOperations) ResumePostDoubleHeadersFinalAzureHeaderGet(token s
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.postDoubleHeadersFinalAzureHeaderGetHandleResponse,
 	}, nil
 }
 
@@ -1628,7 +1588,6 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(c
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.postDoubleHeadersFinalAzureHeaderGetDefaultHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1644,7 +1603,6 @@ func (client *lrOSOperations) ResumePostDoubleHeadersFinalAzureHeaderGetDefault(
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.postDoubleHeadersFinalAzureHeaderGetDefaultHandleResponse,
 	}, nil
 }
 
@@ -1699,7 +1657,6 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalLocationGet(ctx context
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.postDoubleHeadersFinalLocationGetHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1715,7 +1672,6 @@ func (client *lrOSOperations) ResumePostDoubleHeadersFinalLocationGet(token stri
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.postDoubleHeadersFinalLocationGetHandleResponse,
 	}, nil
 }
 
@@ -1770,7 +1726,6 @@ func (client *lrOSOperations) BeginPut200Acceptedcanceled200(ctx context.Context
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.put200Acceptedcanceled200HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1786,7 +1741,6 @@ func (client *lrOSOperations) ResumePut200Acceptedcanceled200(token string) (Pro
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.put200Acceptedcanceled200HandleResponse,
 	}, nil
 }
 
@@ -1844,7 +1798,6 @@ func (client *lrOSOperations) BeginPut200Succeeded(ctx context.Context, lrOSPut2
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.put200SucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1860,7 +1813,6 @@ func (client *lrOSOperations) ResumePut200Succeeded(token string) (ProductPoller
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.put200SucceededHandleResponse,
 	}, nil
 }
 
@@ -1918,7 +1870,6 @@ func (client *lrOSOperations) BeginPut200SucceededNoState(ctx context.Context, l
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.put200SucceededNoStateHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1934,7 +1885,6 @@ func (client *lrOSOperations) ResumePut200SucceededNoState(token string) (Produc
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.put200SucceededNoStateHandleResponse,
 	}, nil
 }
 
@@ -1992,7 +1942,6 @@ func (client *lrOSOperations) BeginPut200UpdatingSucceeded204(ctx context.Contex
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.put200UpdatingSucceeded204HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -2008,7 +1957,6 @@ func (client *lrOSOperations) ResumePut200UpdatingSucceeded204(token string) (Pr
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.put200UpdatingSucceeded204HandleResponse,
 	}, nil
 }
 
@@ -2066,7 +2014,6 @@ func (client *lrOSOperations) BeginPut201CreatingFailed200(ctx context.Context, 
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.put201CreatingFailed200HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -2082,7 +2029,6 @@ func (client *lrOSOperations) ResumePut201CreatingFailed200(token string) (Produ
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.put201CreatingFailed200HandleResponse,
 	}, nil
 }
 
@@ -2140,7 +2086,6 @@ func (client *lrOSOperations) BeginPut201CreatingSucceeded200(ctx context.Contex
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.put201CreatingSucceeded200HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -2156,7 +2101,6 @@ func (client *lrOSOperations) ResumePut201CreatingSucceeded200(token string) (Pr
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.put201CreatingSucceeded200HandleResponse,
 	}, nil
 }
 
@@ -2214,7 +2158,6 @@ func (client *lrOSOperations) BeginPut202Retry200(ctx context.Context, lrOSPut20
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.put202Retry200HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -2230,7 +2173,6 @@ func (client *lrOSOperations) ResumePut202Retry200(token string) (ProductPoller,
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.put202Retry200HandleResponse,
 	}, nil
 }
 
@@ -2288,7 +2230,6 @@ func (client *lrOSOperations) BeginPutAsyncNoHeaderInRetry(ctx context.Context, 
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putAsyncNoHeaderInRetryHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -2304,7 +2245,6 @@ func (client *lrOSOperations) ResumePutAsyncNoHeaderInRetry(token string) (Produ
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putAsyncNoHeaderInRetryHandleResponse,
 	}, nil
 }
 
@@ -2362,7 +2302,6 @@ func (client *lrOSOperations) BeginPutAsyncNoRetrySucceeded(ctx context.Context,
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putAsyncNoRetrySucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -2378,7 +2317,6 @@ func (client *lrOSOperations) ResumePutAsyncNoRetrySucceeded(token string) (Prod
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putAsyncNoRetrySucceededHandleResponse,
 	}, nil
 }
 
@@ -2436,7 +2374,6 @@ func (client *lrOSOperations) BeginPutAsyncNoRetrycanceled(ctx context.Context, 
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putAsyncNoRetrycanceledHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -2452,7 +2389,6 @@ func (client *lrOSOperations) ResumePutAsyncNoRetrycanceled(token string) (Produ
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putAsyncNoRetrycanceledHandleResponse,
 	}, nil
 }
 
@@ -2510,7 +2446,6 @@ func (client *lrOSOperations) BeginPutAsyncNonResource(ctx context.Context, lrOS
 	result.Poller = &skuPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putAsyncNonResourceHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*SkuResponse, error) {
 		return skuPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -2526,7 +2461,6 @@ func (client *lrOSOperations) ResumePutAsyncNonResource(token string) (SkuPoller
 	return &skuPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putAsyncNonResourceHandleResponse,
 	}, nil
 }
 
@@ -2584,7 +2518,6 @@ func (client *lrOSOperations) BeginPutAsyncRetryFailed(ctx context.Context, lrOS
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putAsyncRetryFailedHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -2600,7 +2533,6 @@ func (client *lrOSOperations) ResumePutAsyncRetryFailed(token string) (ProductPo
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putAsyncRetryFailedHandleResponse,
 	}, nil
 }
 
@@ -2658,7 +2590,6 @@ func (client *lrOSOperations) BeginPutAsyncRetrySucceeded(ctx context.Context, l
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putAsyncRetrySucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -2674,7 +2605,6 @@ func (client *lrOSOperations) ResumePutAsyncRetrySucceeded(token string) (Produc
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putAsyncRetrySucceededHandleResponse,
 	}, nil
 }
 
@@ -2732,7 +2662,6 @@ func (client *lrOSOperations) BeginPutAsyncSubResource(ctx context.Context, lrOS
 	result.Poller = &subProductPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putAsyncSubResourceHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*SubProductResponse, error) {
 		return subProductPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -2748,7 +2677,6 @@ func (client *lrOSOperations) ResumePutAsyncSubResource(token string) (SubProduc
 	return &subProductPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putAsyncSubResourceHandleResponse,
 	}, nil
 }
 
@@ -2806,7 +2734,6 @@ func (client *lrOSOperations) BeginPutNoHeaderInRetry(ctx context.Context, lrOSP
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putNoHeaderInRetryHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -2822,7 +2749,6 @@ func (client *lrOSOperations) ResumePutNoHeaderInRetry(token string) (ProductPol
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putNoHeaderInRetryHandleResponse,
 	}, nil
 }
 
@@ -2880,7 +2806,6 @@ func (client *lrOSOperations) BeginPutNonResource(ctx context.Context, lrOSPutNo
 	result.Poller = &skuPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putNonResourceHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*SkuResponse, error) {
 		return skuPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -2896,7 +2821,6 @@ func (client *lrOSOperations) ResumePutNonResource(token string) (SkuPoller, err
 	return &skuPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putNonResourceHandleResponse,
 	}, nil
 }
 
@@ -2954,7 +2878,6 @@ func (client *lrOSOperations) BeginPutSubResource(ctx context.Context, lrOSPutSu
 	result.Poller = &subProductPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putSubResourceHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*SubProductResponse, error) {
 		return subProductPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -2970,7 +2893,6 @@ func (client *lrOSOperations) ResumePutSubResource(token string) (SubProductPoll
 	return &subProductPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putSubResourceHandleResponse,
 	}, nil
 }
 

--- a/test/autorest/generated/lrogroup/lros.go
+++ b/test/autorest/generated/lrogroup/lros.go
@@ -338,7 +338,7 @@ func (client *lrOSOperations) BeginDelete204Succeeded(ctx context.Context) (*HTT
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -407,7 +407,7 @@ func (client *lrOSOperations) BeginDeleteAsyncNoHeaderInRetry(ctx context.Contex
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -475,7 +475,7 @@ func (client *lrOSOperations) BeginDeleteAsyncNoRetrySucceeded(ctx context.Conte
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -543,7 +543,7 @@ func (client *lrOSOperations) BeginDeleteAsyncRetryFailed(ctx context.Context) (
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -611,7 +611,7 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrySucceeded(ctx context.Context
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -679,7 +679,7 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrycanceled(ctx context.Context)
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -747,7 +747,7 @@ func (client *lrOSOperations) BeginDeleteNoHeaderInRetry(ctx context.Context) (*
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -1163,7 +1163,7 @@ func (client *lrOSOperations) BeginPost202Retry200(ctx context.Context, lrOSPost
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -1306,7 +1306,7 @@ func (client *lrOSOperations) BeginPostAsyncRetryFailed(ctx context.Context, lrO
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -1449,7 +1449,7 @@ func (client *lrOSOperations) BeginPostAsyncRetrycanceled(ctx context.Context, l
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil

--- a/test/autorest/generated/lrogroup/lros.go
+++ b/test/autorest/generated/lrogroup/lros.go
@@ -196,12 +196,13 @@ func (client *lrOSOperations) BeginDelete202NoRetry204(ctx context.Context) (*Pr
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -265,12 +266,13 @@ func (client *lrOSOperations) BeginDelete202Retry200(ctx context.Context) (*Prod
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -334,12 +336,13 @@ func (client *lrOSOperations) BeginDelete204Succeeded(ctx context.Context) (*HTT
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -403,12 +406,13 @@ func (client *lrOSOperations) BeginDeleteAsyncNoHeaderInRetry(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -471,12 +475,13 @@ func (client *lrOSOperations) BeginDeleteAsyncNoRetrySucceeded(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -539,12 +544,13 @@ func (client *lrOSOperations) BeginDeleteAsyncRetryFailed(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -607,12 +613,13 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrySucceeded(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -675,12 +682,13 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrycanceled(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -743,12 +751,13 @@ func (client *lrOSOperations) BeginDeleteNoHeaderInRetry(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -811,12 +820,13 @@ func (client *lrOSOperations) BeginDeleteProvisioning202Accepted200Succeeded(ctx
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -880,12 +890,13 @@ func (client *lrOSOperations) BeginDeleteProvisioning202DeletingFailed200(ctx co
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -949,12 +960,13 @@ func (client *lrOSOperations) BeginDeleteProvisioning202Deletingcanceled200(ctx 
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1018,12 +1030,13 @@ func (client *lrOSOperations) BeginPost200WithPayload(ctx context.Context) (*Sku
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &skuPoller{
+	poller := &skuPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*SkuResponse, error) {
-		return skuPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1087,12 +1100,13 @@ func (client *lrOSOperations) BeginPost202NoRetry204(ctx context.Context, lrOSPo
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1159,12 +1173,13 @@ func (client *lrOSOperations) BeginPost202Retry200(ctx context.Context, lrOSPost
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1230,12 +1245,13 @@ func (client *lrOSOperations) BeginPostAsyncNoRetrySucceeded(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1302,12 +1318,13 @@ func (client *lrOSOperations) BeginPostAsyncRetryFailed(ctx context.Context, lrO
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1373,12 +1390,13 @@ func (client *lrOSOperations) BeginPostAsyncRetrySucceeded(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1445,12 +1463,13 @@ func (client *lrOSOperations) BeginPostAsyncRetrycanceled(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1516,12 +1535,13 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1585,12 +1605,13 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(c
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1654,12 +1675,13 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalLocationGet(ctx context
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1723,12 +1745,13 @@ func (client *lrOSOperations) BeginPut200Acceptedcanceled200(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1795,12 +1818,13 @@ func (client *lrOSOperations) BeginPut200Succeeded(ctx context.Context, lrOSPut2
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1867,12 +1891,13 @@ func (client *lrOSOperations) BeginPut200SucceededNoState(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1939,12 +1964,13 @@ func (client *lrOSOperations) BeginPut200UpdatingSucceeded204(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -2011,12 +2037,13 @@ func (client *lrOSOperations) BeginPut201CreatingFailed200(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -2083,12 +2110,13 @@ func (client *lrOSOperations) BeginPut201CreatingSucceeded200(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -2155,12 +2183,13 @@ func (client *lrOSOperations) BeginPut202Retry200(ctx context.Context, lrOSPut20
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -2227,12 +2256,13 @@ func (client *lrOSOperations) BeginPutAsyncNoHeaderInRetry(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -2299,12 +2329,13 @@ func (client *lrOSOperations) BeginPutAsyncNoRetrySucceeded(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -2371,12 +2402,13 @@ func (client *lrOSOperations) BeginPutAsyncNoRetrycanceled(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -2443,12 +2475,13 @@ func (client *lrOSOperations) BeginPutAsyncNonResource(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &skuPoller{
+	poller := &skuPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*SkuResponse, error) {
-		return skuPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -2515,12 +2548,13 @@ func (client *lrOSOperations) BeginPutAsyncRetryFailed(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -2587,12 +2621,13 @@ func (client *lrOSOperations) BeginPutAsyncRetrySucceeded(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -2659,12 +2694,13 @@ func (client *lrOSOperations) BeginPutAsyncSubResource(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &subProductPoller{
+	poller := &subProductPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*SubProductResponse, error) {
-		return subProductPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -2731,12 +2767,13 @@ func (client *lrOSOperations) BeginPutNoHeaderInRetry(ctx context.Context, lrOSP
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -2803,12 +2840,13 @@ func (client *lrOSOperations) BeginPutNonResource(ctx context.Context, lrOSPutNo
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &skuPoller{
+	poller := &skuPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*SkuResponse, error) {
-		return skuPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -2875,12 +2913,13 @@ func (client *lrOSOperations) BeginPutSubResource(ctx context.Context, lrOSPutSu
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &subProductPoller{
+	poller := &subProductPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*SubProductResponse, error) {
-		return subProductPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }

--- a/test/autorest/generated/lrogroup/lrosads.go
+++ b/test/autorest/generated/lrogroup/lrosads.go
@@ -147,7 +147,6 @@ func (client *lrosaDsOperations) BeginDelete202NonRetry400(ctx context.Context) 
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.delete202NonRetry400HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -163,7 +162,6 @@ func (client *lrosaDsOperations) ResumeDelete202NonRetry400(token string) (HTTPP
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.delete202NonRetry400HandleResponse,
 	}, nil
 }
 
@@ -217,7 +215,6 @@ func (client *lrosaDsOperations) BeginDelete202RetryInvalidHeader(ctx context.Co
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.delete202RetryInvalidHeaderHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -233,7 +230,6 @@ func (client *lrosaDsOperations) ResumeDelete202RetryInvalidHeader(token string)
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.delete202RetryInvalidHeaderHandleResponse,
 	}, nil
 }
 
@@ -287,7 +283,6 @@ func (client *lrosaDsOperations) BeginDelete204Succeeded(ctx context.Context) (*
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.delete204SucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -303,7 +298,6 @@ func (client *lrosaDsOperations) ResumeDelete204Succeeded(token string) (HTTPPol
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.delete204SucceededHandleResponse,
 	}, nil
 }
 
@@ -357,7 +351,6 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetry400(ctx context.Co
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteAsyncRelativeRetry400HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -373,7 +366,6 @@ func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetry400(token string)
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteAsyncRelativeRetry400HandleResponse,
 	}, nil
 }
 
@@ -427,7 +419,6 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx 
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteAsyncRelativeRetryInvalidHeaderHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -443,7 +434,6 @@ func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetryInvalidHeader(tok
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteAsyncRelativeRetryInvalidHeaderHandleResponse,
 	}, nil
 }
 
@@ -497,7 +487,6 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidJSONPolling
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteAsyncRelativeRetryInvalidJsonPollingHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -513,7 +502,6 @@ func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetryInvalidJSONPollin
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteAsyncRelativeRetryInvalidJsonPollingHandleResponse,
 	}, nil
 }
 
@@ -567,7 +555,6 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryNoStatus(ctx conte
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteAsyncRelativeRetryNoStatusHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -583,7 +570,6 @@ func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetryNoStatus(token st
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteAsyncRelativeRetryNoStatusHandleResponse,
 	}, nil
 }
 
@@ -637,7 +623,6 @@ func (client *lrosaDsOperations) BeginDeleteNonRetry400(ctx context.Context) (*H
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.deleteNonRetry400HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -653,7 +638,6 @@ func (client *lrosaDsOperations) ResumeDeleteNonRetry400(token string) (HTTPPoll
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.deleteNonRetry400HandleResponse,
 	}, nil
 }
 
@@ -707,7 +691,6 @@ func (client *lrosaDsOperations) BeginPost202NoLocation(ctx context.Context, lro
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.post202NoLocationHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -723,7 +706,6 @@ func (client *lrosaDsOperations) ResumePost202NoLocation(token string) (HTTPPoll
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.post202NoLocationHandleResponse,
 	}, nil
 }
 
@@ -780,7 +762,6 @@ func (client *lrosaDsOperations) BeginPost202NonRetry400(ctx context.Context, lr
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.post202NonRetry400HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -796,7 +777,6 @@ func (client *lrosaDsOperations) ResumePost202NonRetry400(token string) (HTTPPol
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.post202NonRetry400HandleResponse,
 	}, nil
 }
 
@@ -853,7 +833,6 @@ func (client *lrosaDsOperations) BeginPost202RetryInvalidHeader(ctx context.Cont
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.post202RetryInvalidHeaderHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -869,7 +848,6 @@ func (client *lrosaDsOperations) ResumePost202RetryInvalidHeader(token string) (
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.post202RetryInvalidHeaderHandleResponse,
 	}, nil
 }
 
@@ -926,7 +904,6 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetry400(ctx context.Cont
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.postAsyncRelativeRetry400HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -942,7 +919,6 @@ func (client *lrosaDsOperations) ResumePostAsyncRelativeRetry400(token string) (
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.postAsyncRelativeRetry400HandleResponse,
 	}, nil
 }
 
@@ -999,7 +975,6 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidHeader(ctx co
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.postAsyncRelativeRetryInvalidHeaderHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1015,7 +990,6 @@ func (client *lrosaDsOperations) ResumePostAsyncRelativeRetryInvalidHeader(token
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.postAsyncRelativeRetryInvalidHeaderHandleResponse,
 	}, nil
 }
 
@@ -1072,7 +1046,6 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidJSONPolling(c
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.postAsyncRelativeRetryInvalidJsonPollingHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1088,7 +1061,6 @@ func (client *lrosaDsOperations) ResumePostAsyncRelativeRetryInvalidJSONPolling(
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.postAsyncRelativeRetryInvalidJsonPollingHandleResponse,
 	}, nil
 }
 
@@ -1145,7 +1117,6 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryNoPayload(ctx contex
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.postAsyncRelativeRetryNoPayloadHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1161,7 +1132,6 @@ func (client *lrosaDsOperations) ResumePostAsyncRelativeRetryNoPayload(token str
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.postAsyncRelativeRetryNoPayloadHandleResponse,
 	}, nil
 }
 
@@ -1218,7 +1188,6 @@ func (client *lrosaDsOperations) BeginPostNonRetry400(ctx context.Context, lrosa
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.postNonRetry400HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1234,7 +1203,6 @@ func (client *lrosaDsOperations) ResumePostNonRetry400(token string) (HTTPPoller
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.postNonRetry400HandleResponse,
 	}, nil
 }
 
@@ -1291,7 +1259,6 @@ func (client *lrosaDsOperations) BeginPut200InvalidJSON(ctx context.Context, lro
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.put200InvalidJsonHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1307,7 +1274,6 @@ func (client *lrosaDsOperations) ResumePut200InvalidJSON(token string) (ProductP
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.put200InvalidJsonHandleResponse,
 	}, nil
 }
 
@@ -1365,7 +1331,6 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetry400(ctx context.Conte
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putAsyncRelativeRetry400HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1381,7 +1346,6 @@ func (client *lrosaDsOperations) ResumePutAsyncRelativeRetry400(token string) (P
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putAsyncRelativeRetry400HandleResponse,
 	}, nil
 }
 
@@ -1439,7 +1403,6 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidHeader(ctx con
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putAsyncRelativeRetryInvalidHeaderHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1455,7 +1418,6 @@ func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryInvalidHeader(token 
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putAsyncRelativeRetryInvalidHeaderHandleResponse,
 	}, nil
 }
 
@@ -1513,7 +1475,6 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidJSONPolling(ct
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putAsyncRelativeRetryInvalidJsonPollingHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1529,7 +1490,6 @@ func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryInvalidJSONPolling(t
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putAsyncRelativeRetryInvalidJsonPollingHandleResponse,
 	}, nil
 }
 
@@ -1587,7 +1547,6 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatus(ctx context.
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putAsyncRelativeRetryNoStatusHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1603,7 +1562,6 @@ func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryNoStatus(token strin
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putAsyncRelativeRetryNoStatusHandleResponse,
 	}, nil
 }
 
@@ -1661,7 +1619,6 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatusPayload(ctx c
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putAsyncRelativeRetryNoStatusPayloadHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1677,7 +1634,6 @@ func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryNoStatusPayload(toke
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putAsyncRelativeRetryNoStatusPayloadHandleResponse,
 	}, nil
 }
 
@@ -1735,7 +1691,6 @@ func (client *lrosaDsOperations) BeginPutError201NoProvisioningStatePayload(ctx 
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putError201NoProvisioningStatePayloadHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1751,7 +1706,6 @@ func (client *lrosaDsOperations) ResumePutError201NoProvisioningStatePayload(tok
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putError201NoProvisioningStatePayloadHandleResponse,
 	}, nil
 }
 
@@ -1809,7 +1763,6 @@ func (client *lrosaDsOperations) BeginPutNonRetry201Creating400(ctx context.Cont
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putNonRetry201Creating400HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1825,7 +1778,6 @@ func (client *lrosaDsOperations) ResumePutNonRetry201Creating400(token string) (
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putNonRetry201Creating400HandleResponse,
 	}, nil
 }
 
@@ -1883,7 +1835,6 @@ func (client *lrosaDsOperations) BeginPutNonRetry201Creating400InvalidJSON(ctx c
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putNonRetry201Creating400InvalidJsonHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1899,7 +1850,6 @@ func (client *lrosaDsOperations) ResumePutNonRetry201Creating400InvalidJSON(toke
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putNonRetry201Creating400InvalidJsonHandleResponse,
 	}, nil
 }
 
@@ -1957,7 +1907,6 @@ func (client *lrosaDsOperations) BeginPutNonRetry400(ctx context.Context, lrosaD
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putNonRetry400HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -1973,7 +1922,6 @@ func (client *lrosaDsOperations) ResumePutNonRetry400(token string) (ProductPoll
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putNonRetry400HandleResponse,
 	}, nil
 }
 

--- a/test/autorest/generated/lrogroup/lrosads.go
+++ b/test/autorest/generated/lrogroup/lrosads.go
@@ -144,12 +144,13 @@ func (client *lrosaDsOperations) BeginDelete202NonRetry400(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -212,12 +213,13 @@ func (client *lrosaDsOperations) BeginDelete202RetryInvalidHeader(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -280,12 +282,13 @@ func (client *lrosaDsOperations) BeginDelete204Succeeded(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -348,12 +351,13 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetry400(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -416,12 +420,13 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx 
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -484,12 +489,13 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidJSONPolling
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -552,12 +558,13 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryNoStatus(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -620,12 +627,13 @@ func (client *lrosaDsOperations) BeginDeleteNonRetry400(ctx context.Context) (*H
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -688,12 +696,13 @@ func (client *lrosaDsOperations) BeginPost202NoLocation(ctx context.Context, lro
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -759,12 +768,13 @@ func (client *lrosaDsOperations) BeginPost202NonRetry400(ctx context.Context, lr
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -830,12 +840,13 @@ func (client *lrosaDsOperations) BeginPost202RetryInvalidHeader(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -901,12 +912,13 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetry400(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -972,12 +984,13 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidHeader(ctx co
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1043,12 +1056,13 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidJSONPolling(c
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1114,12 +1128,13 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryNoPayload(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1185,12 +1200,13 @@ func (client *lrosaDsOperations) BeginPostNonRetry400(ctx context.Context, lrosa
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1256,12 +1272,13 @@ func (client *lrosaDsOperations) BeginPut200InvalidJSON(ctx context.Context, lro
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1328,12 +1345,13 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetry400(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1400,12 +1418,13 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidHeader(ctx con
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1472,12 +1491,13 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidJSONPolling(ct
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1544,12 +1564,13 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatus(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1616,12 +1637,13 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatusPayload(ctx c
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1688,12 +1710,13 @@ func (client *lrosaDsOperations) BeginPutError201NoProvisioningStatePayload(ctx 
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1760,12 +1783,13 @@ func (client *lrosaDsOperations) BeginPutNonRetry201Creating400(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1832,12 +1856,13 @@ func (client *lrosaDsOperations) BeginPutNonRetry201Creating400InvalidJSON(ctx c
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -1904,12 +1929,13 @@ func (client *lrosaDsOperations) BeginPutNonRetry400(ctx context.Context, lrosaD
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }

--- a/test/autorest/generated/lrogroup/lrosads.go
+++ b/test/autorest/generated/lrogroup/lrosads.go
@@ -148,7 +148,7 @@ func (client *lrosaDsOperations) BeginDelete202NonRetry400(ctx context.Context) 
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -216,7 +216,7 @@ func (client *lrosaDsOperations) BeginDelete202RetryInvalidHeader(ctx context.Co
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -284,7 +284,7 @@ func (client *lrosaDsOperations) BeginDelete204Succeeded(ctx context.Context) (*
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -352,7 +352,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetry400(ctx context.Co
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -420,7 +420,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx 
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -488,7 +488,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidJSONPolling
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -556,7 +556,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryNoStatus(ctx conte
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -624,7 +624,7 @@ func (client *lrosaDsOperations) BeginDeleteNonRetry400(ctx context.Context) (*H
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -692,7 +692,7 @@ func (client *lrosaDsOperations) BeginPost202NoLocation(ctx context.Context, lro
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -763,7 +763,7 @@ func (client *lrosaDsOperations) BeginPost202NonRetry400(ctx context.Context, lr
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -834,7 +834,7 @@ func (client *lrosaDsOperations) BeginPost202RetryInvalidHeader(ctx context.Cont
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -905,7 +905,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetry400(ctx context.Cont
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -976,7 +976,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidHeader(ctx co
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -1047,7 +1047,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidJSONPolling(c
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -1118,7 +1118,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryNoPayload(ctx contex
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -1189,7 +1189,7 @@ func (client *lrosaDsOperations) BeginPostNonRetry400(ctx context.Context, lrosa
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil

--- a/test/autorest/generated/lrogroup/lroscustomheader.go
+++ b/test/autorest/generated/lrogroup/lroscustomheader.go
@@ -59,7 +59,6 @@ func (client *lrOSCustomHeaderOperations) BeginPost202Retry200(ctx context.Conte
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.post202Retry200HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -75,7 +74,6 @@ func (client *lrOSCustomHeaderOperations) ResumePost202Retry200(token string) (H
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.post202Retry200HandleResponse,
 	}, nil
 }
 
@@ -132,7 +130,6 @@ func (client *lrOSCustomHeaderOperations) BeginPostAsyncRetrySucceeded(ctx conte
 	result.Poller = &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.postAsyncRetrySucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -148,7 +145,6 @@ func (client *lrOSCustomHeaderOperations) ResumePostAsyncRetrySucceeded(token st
 	return &httpPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.postAsyncRetrySucceededHandleResponse,
 	}, nil
 }
 
@@ -205,7 +201,6 @@ func (client *lrOSCustomHeaderOperations) BeginPut201CreatingSucceeded200(ctx co
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.put201CreatingSucceeded200HandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -221,7 +216,6 @@ func (client *lrOSCustomHeaderOperations) ResumePut201CreatingSucceeded200(token
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.put201CreatingSucceeded200HandleResponse,
 	}, nil
 }
 
@@ -279,7 +273,6 @@ func (client *lrOSCustomHeaderOperations) BeginPutAsyncRetrySucceeded(ctx contex
 	result.Poller = &productPoller{
 		pt:       pt,
 		pipeline: client.p,
-		response: client.putAsyncRetrySucceededHandleResponse,
 	}
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 		return productPollerPollUntilDone(ctx, result.Poller, frequency)
@@ -295,7 +288,6 @@ func (client *lrOSCustomHeaderOperations) ResumePutAsyncRetrySucceeded(token str
 	return &productPoller{
 		pipeline: client.p,
 		pt:       pt,
-		response: client.putAsyncRetrySucceededHandleResponse,
 	}, nil
 }
 

--- a/test/autorest/generated/lrogroup/lroscustomheader.go
+++ b/test/autorest/generated/lrogroup/lroscustomheader.go
@@ -60,7 +60,7 @@ func (client *lrOSCustomHeaderOperations) BeginPost202Retry200(ctx context.Conte
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil
@@ -131,7 +131,7 @@ func (client *lrOSCustomHeaderOperations) BeginPostAsyncRetrySucceeded(ctx conte
 		pt:       pt,
 		pipeline: client.p,
 	}
-	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error) {
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
 	}
 	return result, nil

--- a/test/autorest/generated/lrogroup/lroscustomheader.go
+++ b/test/autorest/generated/lrogroup/lroscustomheader.go
@@ -56,12 +56,13 @@ func (client *lrOSCustomHeaderOperations) BeginPost202Retry200(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -127,12 +128,13 @@ func (client *lrOSCustomHeaderOperations) BeginPostAsyncRetrySucceeded(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &httpPoller{
+	poller := &httpPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-		return httpPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -198,12 +200,13 @@ func (client *lrOSCustomHeaderOperations) BeginPut201CreatingSucceeded200(ctx co
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }
@@ -270,12 +273,13 @@ func (client *lrOSCustomHeaderOperations) BeginPutAsyncRetrySucceeded(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	result.Poller = &productPoller{
+	poller := &productPoller{
 		pt:       pt,
 		pipeline: client.p,
 	}
+	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
-		return productPollerPollUntilDone(ctx, result.Poller, frequency)
+		return poller.pollUntilDone(ctx, frequency)
 	}
 	return result, nil
 }

--- a/test/autorest/generated/lrogroup/models.go
+++ b/test/autorest/generated/lrogroup/models.go
@@ -34,7 +34,7 @@ func (e CloudError) Error() string {
 // HTTPResponse contains the HTTP response from the call to the service endpoint
 type HTTPResponse struct {
 	// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received
-	PollUntilDone func(ctx context.Context, frequency time.Duration) (*HTTPResponse, error)
+	PollUntilDone func(ctx context.Context, frequency time.Duration) (*http.Response, error)
 
 	// Poller contains an initialized poller
 	Poller HTTPPoller

--- a/test/autorest/generated/lrogroup/pollers.go
+++ b/test/autorest/generated/lrogroup/pollers.go
@@ -61,10 +61,13 @@ func (p *httpPoller) ResumeToken() (string, error) {
 }
 
 func httpPollerPollUntilDone(ctx context.Context, p HTTPPoller, frequency time.Duration) (*http.Response, error) {
-	for !p.Done() {
+	for {
 		resp, err := p.Poll(ctx)
 		if err != nil {
 			return nil, err
+		}
+		if p.Done() {
+			break
 		}
 		if delay := azcore.RetryAfter(resp); delay > 0 {
 			time.Sleep(delay)
@@ -73,14 +76,6 @@ func httpPollerPollUntilDone(ctx context.Context, p HTTPPoller, frequency time.D
 		}
 	}
 	return p.FinalResponse(), nil
-}
-
-func (p *httpPoller) handleResponse(resp *azcore.Response) (*HTTPResponse, error) {
-	result := HTTPResponse{RawResponse: resp.Response}
-	if !resp.HasStatusCode(pollingCodes[:]...) {
-		return nil, p.pt.handleError(resp)
-	}
-	return &result, nil
 }
 
 // ProductPoller provides polling facilities until the operation completes
@@ -154,10 +149,13 @@ func (p *productPoller) ResumeToken() (string, error) {
 }
 
 func productPollerPollUntilDone(ctx context.Context, p ProductPoller, frequency time.Duration) (*ProductResponse, error) {
-	for !p.Done() {
+	for {
 		resp, err := p.Poll(ctx)
 		if err != nil {
 			return nil, err
+		}
+		if p.Done() {
+			break
 		}
 		if delay := azcore.RetryAfter(resp); delay > 0 {
 			time.Sleep(delay)
@@ -250,10 +248,13 @@ func (p *skuPoller) ResumeToken() (string, error) {
 }
 
 func skuPollerPollUntilDone(ctx context.Context, p SkuPoller, frequency time.Duration) (*SkuResponse, error) {
-	for !p.Done() {
+	for {
 		resp, err := p.Poll(ctx)
 		if err != nil {
 			return nil, err
+		}
+		if p.Done() {
+			break
 		}
 		if delay := azcore.RetryAfter(resp); delay > 0 {
 			time.Sleep(delay)
@@ -346,10 +347,13 @@ func (p *subProductPoller) ResumeToken() (string, error) {
 }
 
 func subProductPollerPollUntilDone(ctx context.Context, p SubProductPoller, frequency time.Duration) (*SubProductResponse, error) {
-	for !p.Done() {
+	for {
 		resp, err := p.Poll(ctx)
 		if err != nil {
 			return nil, err
+		}
+		if p.Done() {
+			break
 		}
 		if delay := azcore.RetryAfter(resp); delay > 0 {
 			time.Sleep(delay)

--- a/test/autorest/generated/lrogroup/pollers.go
+++ b/test/autorest/generated/lrogroup/pollers.go
@@ -60,7 +60,7 @@ func (p *httpPoller) ResumeToken() (string, error) {
 	return string(js), nil
 }
 
-func httpPollerPollUntilDone(ctx context.Context, p HTTPPoller, frequency time.Duration) (*HTTPResponse, error) {
+func httpPollerPollUntilDone(ctx context.Context, p HTTPPoller, frequency time.Duration) (*http.Response, error) {
 	for !p.Done() {
 		resp, err := p.Poll(ctx)
 		if err != nil {
@@ -72,7 +72,7 @@ func httpPollerPollUntilDone(ctx context.Context, p HTTPPoller, frequency time.D
 			time.Sleep(frequency)
 		}
 	}
-	return p.FinalResponse(ctx)
+	return p.FinalResponse(), nil
 }
 
 func (p *httpPoller) handleResponse(resp *azcore.Response) (*HTTPResponse, error) {

--- a/test/autorest/generated/lrogroup/pollers.go
+++ b/test/autorest/generated/lrogroup/pollers.go
@@ -60,7 +60,7 @@ func (p *httpPoller) ResumeToken() (string, error) {
 	return string(js), nil
 }
 
-func httpPollerPollUntilDone(ctx context.Context, p HTTPPoller, frequency time.Duration) (*http.Response, error) {
+func (p *httpPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 	for {
 		resp, err := p.Poll(ctx)
 		if err != nil {
@@ -148,7 +148,7 @@ func (p *productPoller) ResumeToken() (string, error) {
 	return string(js), nil
 }
 
-func productPollerPollUntilDone(ctx context.Context, p ProductPoller, frequency time.Duration) (*ProductResponse, error) {
+func (p *productPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 	for {
 		resp, err := p.Poll(ctx)
 		if err != nil {
@@ -247,7 +247,7 @@ func (p *skuPoller) ResumeToken() (string, error) {
 	return string(js), nil
 }
 
-func skuPollerPollUntilDone(ctx context.Context, p SkuPoller, frequency time.Duration) (*SkuResponse, error) {
+func (p *skuPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*SkuResponse, error) {
 	for {
 		resp, err := p.Poll(ctx)
 		if err != nil {
@@ -346,7 +346,7 @@ func (p *subProductPoller) ResumeToken() (string, error) {
 	return string(js), nil
 }
 
-func subProductPollerPollUntilDone(ctx context.Context, p SubProductPoller, frequency time.Duration) (*SubProductResponse, error) {
+func (p *subProductPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*SubProductResponse, error) {
 	for {
 		resp, err := p.Poll(ctx)
 		if err != nil {

--- a/test/autorest/generated/lrogroup/pollers_helper.go
+++ b/test/autorest/generated/lrogroup/pollers_helper.go
@@ -84,6 +84,9 @@ type pollingTracker interface {
 
 	// returns the cached HTTP response after a call to pollForStatus(), can be nil
 	latestResponse() *azcore.Response
+
+	// converts an *azcore.Response to an error
+	handleError(resp *azcore.Response) error
 }
 
 type methodErrorHandler func(resp *azcore.Response) error
@@ -340,6 +343,10 @@ func (pt *pollingTrackerBase) initPollingMethod() error {
 	}
 	// it's ok if we didn't find a polling header, this will be handled elsewhere
 	return nil
+}
+
+func (pt *pollingTrackerBase) handleError(resp *azcore.Response) error {
+	return pt.errorHandler(resp)
 }
 
 // DELETE

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -75,7 +75,7 @@ func TestLROBeginDelete202NoRetry204(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	resp, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestLROBeginDelete202Retry200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	resp, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +115,7 @@ func TestLROBeginDelete204Succeeded(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +183,7 @@ func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,7 +205,7 @@ func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -228,7 +228,7 @@ func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,7 +250,7 @@ func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -272,7 +272,7 @@ func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	resp, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +294,7 @@ func TestLROBeginDeleteProvisioning202DeletingFailed200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	resp, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -315,7 +315,7 @@ func TestLROBeginDeleteProvisioning202Deletingcanceled200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	resp, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -336,7 +336,7 @@ func TestLROBeginPost200WithPayload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	resp, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -362,7 +362,7 @@ func TestLROBeginPost202NoRetry204(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	resp, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -384,7 +384,7 @@ func TestLROBeginPost202Retry200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -406,7 +406,7 @@ func TestLROBeginPostAsyncNoRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -435,7 +435,7 @@ func TestLROBeginPostAsyncRetryFailed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	_, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -456,7 +456,7 @@ func TestLROBeginPostAsyncRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -485,7 +485,7 @@ func TestLROBeginPostAsyncRetrycanceled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	_, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -507,7 +507,7 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -535,7 +535,7 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGetDefault(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -563,7 +563,7 @@ func TestLROBeginPostDoubleHeadersFinalLocationGet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -592,7 +592,7 @@ func TestLROBeginPut200Acceptedcanceled200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	_, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err == nil {
 		t.Fatal("Expected an error but did not receive one")
 	}
@@ -610,7 +610,7 @@ func TestLROBeginPut200Succeeded(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected an error but did not receive one")
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -635,7 +635,7 @@ func TestLROBeginPut200SucceededNoState(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected an error but did not receive one")
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -664,7 +664,7 @@ func TestLROBeginPut200UpdatingSucceeded204(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -696,7 +696,7 @@ func TestLROBeginPut201CreatingFailed200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	_, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -717,7 +717,7 @@ func TestLROBeginPut201CreatingSucceeded200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -749,7 +749,7 @@ func TestLROBeginPut202Retry200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -780,7 +780,7 @@ func TestLROBeginPutAsyncNoHeaderInRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -811,7 +811,7 @@ func TestLROBeginPutAsyncNoRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -843,7 +843,7 @@ func TestLROBeginPutAsyncNoRetrycanceled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	_, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -864,7 +864,7 @@ func TestLROBeginPutAsyncNonResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -891,7 +891,7 @@ func TestLROBeginPutAsyncRetryFailed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	_, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -912,7 +912,7 @@ func TestLROBeginPutAsyncRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -943,7 +943,7 @@ func TestLROBeginPutAsyncSubResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -974,7 +974,7 @@ func TestLROBeginPutNoHeaderInRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1005,7 +1005,7 @@ func TestLROBeginPutNonResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1032,7 +1032,7 @@ func TestLROBeginPutSubResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -69,31 +69,11 @@ func TestLROBeginDelete202NoRetry204(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for !poller.Done() {
-		_, err := poller.Poll(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	resp, err = poller.FinalResponse(context.Background())
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
 	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
-	resp1, err := op.BeginDelete202NoRetry204(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
-	_, err = poller.ResumeToken()
-	if err == nil {
-		t.Fatal("did not receive an error but was expecting one")
-	}
 }
 
 func TestLROBeginDelete202Retry200(t *testing.T) {
@@ -111,23 +91,7 @@ func TestLROBeginDelete202Retry200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for !poller.Done() {
-		_, err := poller.Poll(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	resp, err = poller.FinalResponse(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-	resp1, err := op.BeginDelete202Retry200(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,23 +109,7 @@ func TestLROBeginDelete204Succeeded(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
-	for !poller.Done() {
-		_, err := poller.Poll(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	resp, err = poller.FinalResponse(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
-	resp1, err := op.BeginDelete204Succeeded(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,23 +132,7 @@ func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for !poller.Done() {
-		_, err := poller.Poll(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	resp, err = poller.FinalResponse(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
-	resp1, err := op.BeginDeleteAsyncNoHeaderInRetry(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,23 +154,7 @@ func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for !poller.Done() {
-		_, err := poller.Poll(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	resp, err = poller.FinalResponse(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
-	resp1, err := op.BeginDeleteAsyncNoRetrySucceeded(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,23 +177,7 @@ func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for !poller.Done() {
-		_, err := poller.Poll(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	resp, err = poller.FinalResponse(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
-	resp1, err := op.BeginDeleteAsyncRetryFailed(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,23 +199,7 @@ func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for !poller.Done() {
-		_, err := poller.Poll(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	resp, err = poller.FinalResponse(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
-	resp1, err := op.BeginDeleteAsyncRetrySucceeded(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -338,23 +222,7 @@ func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for !poller.Done() {
-		_, err := poller.Poll(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	resp, err = poller.FinalResponse(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-	resp1, err := op.BeginDeleteAsyncRetrycanceled(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -376,23 +244,7 @@ func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for !poller.Done() {
-		_, err := poller.Poll(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	resp, err = poller.FinalResponse(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
-	resp1, err := op.BeginDeleteNoHeaderInRetry(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -414,23 +266,7 @@ func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for !poller.Done() {
-		_, err := poller.Poll(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	resp, err = poller.FinalResponse(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-	resp1, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -452,22 +288,7 @@ func TestLROBeginDeleteProvisioning202DeletingFailed200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for !poller.Done() {
-		_, err := poller.Poll(context.Background())
-		if err == nil {
-			t.Fatal("expected an error but did not receive one")
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	resp, err = poller.FinalResponse(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp1, err := op.BeginDeleteProvisioning202DeletingFailed200(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -488,22 +309,7 @@ func TestLROBeginDeleteProvisioning202Deletingcanceled200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for !poller.Done() {
-		_, err := poller.Poll(context.Background())
-		if err == nil {
-			t.Fatal("expected an error but did not receive one")
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	resp, err = poller.FinalResponse(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp1, err := op.BeginDeleteProvisioning202Deletingcanceled200(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -524,23 +330,7 @@ func TestLROBeginPost200WithPayload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for !poller.Done() {
-		_, err := poller.Poll(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	resp, err = poller.FinalResponse(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-	resp1, err := op.BeginPost200WithPayload(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -562,23 +352,7 @@ func TestLROBeginPost202NoRetry204(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for !poller.Done() {
-		_, err := poller.Poll(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	resp, err = poller.FinalResponse(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
-	resp1, err := op.BeginPost202NoRetry204(context.Background(), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -600,23 +374,7 @@ func TestLROBeginPost202Retry200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for !poller.Done() {
-		_, err := poller.Poll(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	resp, err = poller.FinalResponse(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-	resp1, err := op.BeginPost202Retry200(context.Background(), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -704,7 +704,7 @@ func TestLROBeginPut201CreatingFailed200(t *testing.T) {
 
 func TestLROBeginPut201CreatingSucceeded200(t *testing.T) {
 	op := getLROSOperations(t)
-	resp, err := op.BeginPut201CreatingSucceeded200(context.Background(), nil)
+	resp, err := op.BeginPut201CreatingSucceeded200(context.Background(), &lrogroup.LrOSPut201CreatingSucceeded200Options{Product: &lrogroup.Product{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -736,7 +736,7 @@ func TestLROBeginPut201CreatingSucceeded200(t *testing.T) {
 func TestLROBeginPut202Retry200(t *testing.T) {
 	t.Skip("problem with the poller")
 	op := getLROSOperations(t)
-	resp, err := op.BeginPut202Retry200(context.Background(), nil)
+	resp, err := op.BeginPut202Retry200(context.Background(), &lrogroup.LrOSPut202Retry200Options{Product: &lrogroup.Product{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -767,7 +767,7 @@ func TestLROBeginPut202Retry200(t *testing.T) {
 
 func TestLROBeginPutAsyncNoHeaderInRetry(t *testing.T) {
 	op := getLROSOperations(t)
-	resp, err := op.BeginPutAsyncNoHeaderInRetry(context.Background(), nil)
+	resp, err := op.BeginPutAsyncNoHeaderInRetry(context.Background(), &lrogroup.LrOSPutAsyncNoHeaderInRetryOptions{Product: &lrogroup.Product{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -798,7 +798,7 @@ func TestLROBeginPutAsyncNoHeaderInRetry(t *testing.T) {
 
 func TestLROBeginPutAsyncNoRetrySucceeded(t *testing.T) {
 	op := getLROSOperations(t)
-	resp, err := op.BeginPutAsyncNoRetrySucceeded(context.Background(), nil)
+	resp, err := op.BeginPutAsyncNoRetrySucceeded(context.Background(), &lrogroup.LrOSPutAsyncNoRetrySucceededOptions{Product: &lrogroup.Product{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -843,10 +843,19 @@ func TestLROBeginPutAsyncNoRetrycanceled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
+	if res != nil {
+		t.Fatal("expected a nil response with the error")
+	}
+	// var cloudErr lrogroup.CloudError
+	// if !errors.As(err, &cloudErr) {
+	// 	t.Fatal("expected a CloudError but did not receive one")
+	// } else {
+	// 	helpers.DeepEqualOrFatal(t, cloudErr, lrogroup.CloudError{})
+	// }
 }
 
 func TestLROBeginPutAsyncNonResource(t *testing.T) {

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -39,22 +39,23 @@ func httpClientWithCookieJar() azcore.Transport {
 	})
 }
 
-// func TestLROResumeWrongPoller(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	resp, err := op.Delete202NoRetry204(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller := resp.GetPoller()
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	_, err = op.ResumeProductPoller(rt)
-// 	if err == nil {
-// 		t.Fatal("expected an error but did not find receive one")
-// 	}
-// }
+func TestLROResumeWrongPoller(t *testing.T) {
+	// TODO discuss what sort of check we want with the new design to avoid resuming from the wrong poller type
+	op := getLROSOperations(t)
+	resp, err := op.BeginDelete202NoRetry204(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = op.ResumePost200WithPayload(rt)
+	if err == nil {
+		t.Fatal("expected an error but did not find receive one")
+	}
+}
 
 func TestLROBeginDelete202NoRetry204(t *testing.T) {
 	op := getLROSOperations(t)
@@ -71,7 +72,7 @@ func TestLROBeginDelete202NoRetry204(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +94,7 @@ func TestLROBeginDelete202Retry200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +112,7 @@ func TestLROBeginDelete204Succeeded(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +135,7 @@ func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +157,7 @@ func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +180,7 @@ func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +202,7 @@ func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +225,7 @@ func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,7 +247,7 @@ func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +269,7 @@ func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -290,7 +291,7 @@ func TestLROBeginDeleteProvisioning202DeletingFailed200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -311,7 +312,7 @@ func TestLROBeginDeleteProvisioning202Deletingcanceled200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -332,7 +333,7 @@ func TestLROBeginPost200WithPayload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -358,7 +359,7 @@ func TestLROBeginPost202NoRetry204(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -380,706 +381,665 @@ func TestLROBeginPost202Retry200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
 	helpers.VerifyStatusCode(t, res, 200)
 }
 
-// func TestLROBeginPostAsyncNoRetrySucceeded(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPostAsyncNoRetrySucceeded(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPostAsyncNoRetrySucceededPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPostAsyncNoRetrySucceeded(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginPostAsyncNoRetrySucceeded(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePostAsyncNoRetrySucceeded(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+	})
+}
 
-// func TestLROBeginPostAsyncRetryFailed(t *testing.T) {
-// 	t.Skip("CloudError unmarshalling fails")
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPostAsyncRetryFailed(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPostAsyncRetryFailedPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPostAsyncRetryFailed(t *testing.T) {
+	t.Skip("CloudError unmarshalling fails")
+	op := getLROSOperations(t)
+	resp, err := op.BeginPostAsyncRetryFailed(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePostAsyncRetryFailed(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error but did not receive one")
+	}
+}
 
-// func TestLROBeginPostAsyncRetrySucceeded(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPostAsyncRetrySucceeded(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPostAsyncRetrySucceededPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPostAsyncRetrySucceeded(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginPostAsyncRetrySucceeded(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePostAsyncRetrySucceeded(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+	})
+}
 
-// func TestLROBeginPostAsyncRetrycanceled(t *testing.T) {
-// 	t.Skip("CloudError unmarshalling failed")
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPostAsyncRetrycanceled(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPostAsyncRetrycanceledPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPostAsyncRetrycanceled(t *testing.T) {
+	t.Skip("CloudError unmarshalling failed")
+	op := getLROSOperations(t)
+	resp, err := op.BeginPostAsyncRetrycanceled(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePostAsyncRetrycanceled(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error but did not receive one")
+	}
+}
 
-// func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPostDoubleHeadersFinalAzureHeaderGet(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPostDoubleHeadersFinalAzureHeaderGetPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
+	t.Skip("need to fix poller implementation, must not do a final get on location in this case")
+	op := getLROSOperations(t)
+	resp, err := op.BeginPostDoubleHeadersFinalAzureHeaderGet(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePostDoubleHeadersFinalAzureHeaderGet(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+	})
+}
 
-// func TestLROBeginPostDoubleHeadersFinalAzureHeaderGetDefault(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPostDoubleHeadersFinalAzureHeaderGetDefault(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPostDoubleHeadersFinalAzureHeaderGetDefaultPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPostDoubleHeadersFinalAzureHeaderGetDefault(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginPostDoubleHeadersFinalAzureHeaderGetDefault(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePostDoubleHeadersFinalAzureHeaderGetDefault(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+	})
+}
 
-// func TestLROBeginPostDoubleHeadersFinalLocationGet(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPostDoubleHeadersFinalLocationGet(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPostDoubleHeadersFinalLocationGetPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPostDoubleHeadersFinalLocationGet(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginPostDoubleHeadersFinalLocationGet(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePostDoubleHeadersFinalLocationGet(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+	})
+}
 
-// func TestLROBeginPut200Acceptedcanceled200(t *testing.T) {
-// 	t.Skip("missing error info returned for error")
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPut200Acceptedcanceled200(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPut200Acceptedcanceled200Poller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPut200Acceptedcanceled200(t *testing.T) {
+	t.Skip("missing error info returned for error")
+	op := getLROSOperations(t)
+	resp, err := op.BeginPut200Acceptedcanceled200(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePut200Acceptedcanceled200(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err == nil {
+		t.Fatal("Expected an error but did not receive one")
+	}
+}
 
-// func TestLROBeginPut200Succeeded(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPut200Succeeded(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	_, err = poller.ResumeToken()
-// 	if err == nil {
-// 		t.Fatal("expected an error but did not receive one")
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPut200Succeeded(t *testing.T) {
+	t.Skip("problem with poller code")
+	op := getLROSOperations(t)
+	resp, err := op.BeginPut200Succeeded(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	_, err = poller.ResumeToken()
+	if err == nil {
+		t.Fatal("Expected an error but did not receive one")
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+	})
+}
 
-// func TestLROBeginPut200SucceededNoState(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPut200SucceededNoState(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	_, err = poller.ResumeToken()
-// 	if err == nil {
-// 		t.Fatal("expected an error but did not receive one")
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPut200SucceededNoState(t *testing.T) {
+	t.Skip("problem with the poller")
+	op := getLROSOperations(t)
+	resp, err := op.BeginPut200SucceededNoState(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	_, err = poller.ResumeToken()
+	if err == nil {
+		t.Fatal("Expected an error but did not receive one")
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+	})
+}
 
-// func TestLROBeginPut200UpdatingSucceeded204(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPut200UpdatingSucceeded204(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPut200UpdatingSucceeded204Poller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+// TODO check if this test should actually be returning a 200 or a 204
+func TestLROBeginPut200UpdatingSucceeded204(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginPut200UpdatingSucceeded204(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePut200UpdatingSucceeded204(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+		Properties: &lrogroup.ProductProperties{
+			ProvisioningState: to.StringPtr("Succeeded"),
+		},
+	})
+}
 
-// func TestLROBeginPut201CreatingFailed200(t *testing.T) {
-// 	t.Skip("missing error info message returned for error")
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPut201CreatingFailed200(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPut201CreatingFailed200Poller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPut201CreatingFailed200(t *testing.T) {
+	t.Skip("missing error info message returned for error")
+	op := getLROSOperations(t)
+	resp, err := op.BeginPut201CreatingFailed200(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePut201CreatingFailed200(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error but did not receive one")
+	}
+}
 
-// func TestLROBeginPut201CreatingSucceeded200(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPut201CreatingSucceeded200(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPut201CreatingSucceeded200Poller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPut201CreatingSucceeded200(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginPut201CreatingSucceeded200(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePut201CreatingSucceeded200(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+		Properties: &lrogroup.ProductProperties{
+			ProvisioningState: to.StringPtr("Succeeded"),
+		},
+	})
+}
 
-// func TestLROBeginPut202Retry200(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPut202Retry200(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPut202Retry200Poller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPut202Retry200(t *testing.T) {
+	t.Skip("problem with the poller")
+	op := getLROSOperations(t)
+	resp, err := op.BeginPut202Retry200(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePut202Retry200(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+		Properties: &lrogroup.ProductProperties{
+			ProvisioningState: to.StringPtr("Succeeded"),
+		},
+	})
+}
 
-// func TestLROBeginPutAsyncNoHeaderInRetry(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPutAsyncNoHeaderInRetry(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPutAsyncNoHeaderInRetryPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPutAsyncNoHeaderInRetry(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginPutAsyncNoHeaderInRetry(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePutAsyncNoHeaderInRetry(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+		Properties: &lrogroup.ProductProperties{
+			ProvisioningState: to.StringPtr("Succeeded"),
+		},
+	})
+}
 
-// func TestLROBeginPutAsyncNoRetrySucceeded(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPutAsyncNoRetrySucceeded(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPutAsyncNoRetrySucceededPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPutAsyncNoRetrySucceeded(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginPutAsyncNoRetrySucceeded(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePutAsyncNoRetrySucceeded(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+		Properties: &lrogroup.ProductProperties{
+			ProvisioningState: to.StringPtr("Succeeded"),
+		},
+	})
+}
 
-// func TestLROBeginPutAsyncNoRetrycanceled(t *testing.T) {
-// 	t.Skip("CloudError unmarshalling failed")
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPutAsyncNoRetrycanceled(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPutAsyncNoRetrycanceledPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPutAsyncNoRetrycanceled(t *testing.T) {
+	t.Skip("CloudError unmarshalling failed")
+	op := getLROSOperations(t)
+	resp, err := op.BeginPutAsyncNoRetrycanceled(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePutAsyncNoRetrycanceled(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error but did not receive one")
+	}
+}
 
-// func TestLROBeginPutAsyncNonResource(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPutAsyncNonResource(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPutAsyncNonResourcePoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPutAsyncNonResource(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginPutAsyncNonResource(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePutAsyncNonResource(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Sku, &lrogroup.Sku{
+		ID:   to.StringPtr("100"),
+		Name: to.StringPtr("sku"),
+	})
+}
 
-// func TestLROBeginPutAsyncRetryFailed(t *testing.T) {
-// 	t.Skip("CloudError unmarshalling failed")
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPutAsyncRetryFailed(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPutAsyncRetryFailedPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPutAsyncRetryFailed(t *testing.T) {
+	t.Skip("CloudError unmarshalling failed")
+	op := getLROSOperations(t)
+	resp, err := op.BeginPutAsyncRetryFailed(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePutAsyncRetryFailed(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error but did not receive one")
+	}
+}
 
-// func TestLROBeginPutAsyncRetrySucceeded(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPutAsyncRetrySucceeded(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPutAsyncRetrySucceededPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPutAsyncRetrySucceeded(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginPutAsyncRetrySucceeded(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePutAsyncRetrySucceeded(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+		Properties: &lrogroup.ProductProperties{
+			ProvisioningState: to.StringPtr("Succeeded"),
+		},
+	})
+}
 
-// func TestLROBeginPutAsyncSubResource(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPutAsyncSubResource(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPutAsyncSubResourcePoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPutAsyncSubResource(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginPutAsyncSubResource(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePutAsyncSubResource(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.SubProduct, &lrogroup.SubProduct{
+		SubResource: lrogroup.SubResource{
+			ID: to.StringPtr("100"),
+		},
+		Properties: &lrogroup.SubProductProperties{
+			ProvisioningState: to.StringPtr("Succeeded"),
+		},
+	})
+}
 
-// func TestLROBeginPutNoHeaderInRetry(t *testing.T) {
-// 	t.Skip("The test needs to fix some underlying problems with the poller returning an error")
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPutNoHeaderInRetry(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPutNoHeaderInRetryPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPutNoHeaderInRetry(t *testing.T) {
+	t.Skip("problem with the poller")
+	op := getLROSOperations(t)
+	resp, err := op.BeginPutNoHeaderInRetry(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePutNoHeaderInRetry(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID: to.StringPtr("100"),
+		},
+		Properties: &lrogroup.ProductProperties{
+			ProvisioningState: to.StringPtr("Succeeded"),
+		},
+	})
+}
 
-// func TestLROBeginPutNonResource(t *testing.T) {
-// 	t.Skip("The test needs to fix some underlying problems with the poller returning an error")
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPutNonResource(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPutNonResourcePoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPutNonResource(t *testing.T) {
+	t.Skip("The test needs to fix some underlying problems with the poller returning an error")
+	op := getLROSOperations(t)
+	resp, err := op.BeginPutNonResource(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePutNonResource(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Sku, &lrogroup.Sku{
+		ID:   to.StringPtr("100"),
+		Name: to.StringPtr("sku"),
+	})
+}
 
-// func TestLROBeginPutSubResource(t *testing.T) {
-// 	t.Skip("The test needs to fix some underlying problems with the poller returning an error")
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPutSubResource(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPutSubResourcePoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPutSubResource(t *testing.T) {
+	t.Skip("The test needs to fix some underlying problems with the poller returning an error")
+	op := getLROSOperations(t)
+	resp, err := op.BeginPutSubResource(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePutSubResource(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.SubProduct, &lrogroup.SubProduct{
+		SubResource: lrogroup.SubResource{
+			ID: to.StringPtr("100"),
+		},
+		Properties: &lrogroup.SubProductProperties{
+			ProvisioningState: to.StringPtr("Succeeded"),
+		},
+	})
+}

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -96,421 +96,532 @@ func TestLROBeginDelete202NoRetry204(t *testing.T) {
 	}
 }
 
-// func TestLROBeginDelete202Retry200(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginDelete202Retry200(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSDelete202Retry200Poller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	_, err = poller.ResumeToken()
-// 	if err == nil {
-// 		t.Fatal("did not receive an error but was expecting one")
-// 	}
-// }
+func TestLROBeginDelete202Retry200(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginDelete202Retry200(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumeDelete202Retry200(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for !poller.Done() {
+		_, err := poller.Poll(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	resp, err = poller.FinalResponse(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
+	resp1, err := op.BeginDelete202Retry200(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
+}
 
-// func TestLROBeginDelete204Succeeded(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginDelete204Succeeded(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	_, err = poller.ResumeToken()
-// 	if err == nil {
-// 		t.Fatal("expected an error but did not receive one")
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp, 204)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp, 204)
-// 	_, err = poller.ResumeToken()
-// 	if err == nil {
-// 		t.Fatal("did not receive an error but was expecting one")
-// 	}
-// }
+func TestLROBeginDelete204Succeeded(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginDelete204Succeeded(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	_, err = poller.ResumeToken()
+	if err == nil {
+		t.Fatal("expected an error but did not receive one")
+	}
+	for !poller.Done() {
+		_, err := poller.Poll(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	resp, err = poller.FinalResponse(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
+	resp1, err := op.BeginDelete204Succeeded(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
+}
 
-// func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginDeleteAsyncNoHeaderInRetry(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSDeleteAsyncNoHeaderInRetryPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	_, err = poller.ResumeToken()
-// 	if err == nil {
-// 		t.Fatal("did not receive an error but was expecting one")
-// 	}
-// }
+func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
+	t.Skip("pending on CloudError field fix")
+	op := getLROSOperations(t)
+	resp, err := op.BeginDeleteAsyncNoHeaderInRetry(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumeDeleteAsyncNoHeaderInRetry(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for !poller.Done() {
+		_, err := poller.Poll(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	resp, err = poller.FinalResponse(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
+	resp1, err := op.BeginDeleteAsyncNoHeaderInRetry(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
+}
 
-// func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginDeleteAsyncNoRetrySucceeded(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSDeleteAsyncNoRetrySucceededPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	_, err = poller.ResumeToken()
-// 	if err == nil {
-// 		t.Fatal("did not receive an error but was expecting one")
-// 	}
-// }
+func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginDeleteAsyncNoRetrySucceeded(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumeDeleteAsyncNoRetrySucceeded(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for !poller.Done() {
+		_, err := poller.Poll(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	resp, err = poller.FinalResponse(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
+	resp1, err := op.BeginDeleteAsyncNoRetrySucceeded(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
+}
 
-// func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
-// 	t.Skip("CloudError unmarshalling is failing")
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginDeleteAsyncRetryFailed(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSDeleteAsyncRetryFailedPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
+	t.Skip("CloudError unmarshalling is failing")
+	op := getLROSOperations(t)
+	resp, err := op.BeginDeleteAsyncRetryFailed(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumeDeleteAsyncRetryFailed(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for !poller.Done() {
+		_, err := poller.Poll(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	resp, err = poller.FinalResponse(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
+	resp1, err := op.BeginDeleteAsyncRetryFailed(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
+}
 
-// func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginDeleteAsyncRetrySucceeded(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSDeleteAsyncRetrySucceededPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginDeleteAsyncRetrySucceeded(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumeDeleteAsyncRetrySucceeded(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for !poller.Done() {
+		_, err := poller.Poll(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	resp, err = poller.FinalResponse(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
+	resp1, err := op.BeginDeleteAsyncRetrySucceeded(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
+}
 
-// func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
-// 	t.Skip("CloudError unmarshalling is failing")
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginDeleteAsyncRetrycanceled(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSDeleteAsyncRetrycanceledPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
+	t.Skip("CloudError unmarshalling is failing")
+	op := getLROSOperations(t)
+	resp, err := op.BeginDeleteAsyncRetrycanceled(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumeDeleteAsyncRetrycanceled(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for !poller.Done() {
+		_, err := poller.Poll(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	resp, err = poller.FinalResponse(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
+	resp1, err := op.BeginDeleteAsyncRetrycanceled(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
+}
 
-// func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginDeleteNoHeaderInRetry(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSDeleteNoHeaderInRetryPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
-// }
+func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginDeleteNoHeaderInRetry(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumeDeleteNoHeaderInRetry(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for !poller.Done() {
+		_, err := poller.Poll(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	resp, err = poller.FinalResponse(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
+	resp1, err := op.BeginDeleteNoHeaderInRetry(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
+}
 
-// func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSDeleteProvisioning202Accepted200SucceededPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumeDeleteProvisioning202Accepted200Succeeded(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for !poller.Done() {
+		_, err := poller.Poll(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	resp, err = poller.FinalResponse(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
+	resp1, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
+}
 
-// func TestLROBeginDeleteProvisioning202DeletingFailed200(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginDeleteProvisioning202DeletingFailed200(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSDeleteProvisioning202DeletingFailed200Poller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	_, err = poller.Response()
-// 	if err == nil {
-// 		t.Fatal("expected an error but did not receive one")
-// 	}
-// 	_, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err == nil {
-// 		t.Fatal("expected an error but did not receive one")
-// 	}
-// }
+func TestLROBeginDeleteProvisioning202DeletingFailed200(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginDeleteProvisioning202DeletingFailed200(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumeDeleteProvisioning202DeletingFailed200(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for !poller.Done() {
+		_, err := poller.Poll(context.Background())
+		if err == nil {
+			t.Fatal("expected an error but did not receive one")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	resp, err = poller.FinalResponse(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp1, err := op.BeginDeleteProvisioning202DeletingFailed200(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	if err == nil {
+		t.Fatal("expected an error but did not receive one")
+	}
+}
 
-// func TestLROBeginDeleteProvisioning202Deletingcanceled200(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginDeleteProvisioning202Deletingcanceled200(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSDeleteProvisioning202Deletingcanceled200Poller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	_, err = poller.Response()
-// 	if err == nil {
-// 		t.Fatal("expected an error but did not receive one")
-// 	}
-// 	_, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err == nil {
-// 		t.Fatal("expected an error but did not receive one")
-// 	}
-// }
+func TestLROBeginDeleteProvisioning202Deletingcanceled200(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginDeleteProvisioning202Deletingcanceled200(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumeDeleteProvisioning202Deletingcanceled200(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for !poller.Done() {
+		_, err := poller.Poll(context.Background())
+		if err == nil {
+			t.Fatal("expected an error but did not receive one")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	resp, err = poller.FinalResponse(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp1, err := op.BeginDeleteProvisioning202Deletingcanceled200(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	if err == nil {
+		t.Fatal("expected an error but did not receive one")
+	}
+}
 
-// func TestLROBeginPost200WithPayload(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPost200WithPayload(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPost200WithPayloadPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPost200WithPayload(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginPost200WithPayload(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePost200WithPayload(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for !poller.Done() {
+		_, err := poller.Poll(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	resp, err = poller.FinalResponse(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
+	resp1, err := op.BeginPost200WithPayload(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
+}
 
-// func TestLROBeginPost202NoRetry204(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPost202NoRetry204(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPost202NoRetry204Poller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
-// }
+func TestLROBeginPost202NoRetry204(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginPost202NoRetry204(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePost202NoRetry204(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for !poller.Done() {
+		_, err := poller.Poll(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	resp, err = poller.FinalResponse(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
+	resp1, err := op.BeginPost202NoRetry204(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
+}
 
-// func TestLROBeginPost202Retry200(t *testing.T) {
-// 	op := getLROSOperations(t)
-// 	poller, err := op.BeginPost202Retry200(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLrOSPost202Retry200Poller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLROBeginPost202Retry200(t *testing.T) {
+	op := getLROSOperations(t)
+	resp, err := op.BeginPost202Retry200(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePost202Retry200(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for !poller.Done() {
+		_, err := poller.Poll(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	resp, err = poller.FinalResponse(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
+	resp1, err := op.BeginPost202Retry200(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = resp1.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
+}
 
 // func TestLROBeginPostAsyncNoRetrySucceeded(t *testing.T) {
 // 	op := getLROSOperations(t)

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/to"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
@@ -335,6 +337,10 @@ func TestLROBeginPost200WithPayload(t *testing.T) {
 		t.Fatal(err)
 	}
 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, resp.Sku, &lrogroup.Sku{
+		ID:   to.StringPtr("1"),
+		Name: to.StringPtr("product"),
+	})
 }
 
 func TestLROBeginPost202NoRetry204(t *testing.T) {

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -51,9 +51,12 @@ func TestLROResumeWrongPoller(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = op.ResumePost200WithPayload(rt)
+	diffPoller, err := op.ResumePost200WithPayload(rt)
 	if err == nil {
 		t.Fatal("expected an error but did not find receive one")
+	}
+	if diffPoller != nil {
+		t.Fatal("expected a nil poller from the resume operation")
 	}
 }
 

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -111,11 +111,11 @@ func TestLROBeginDelete204Succeeded(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
+	helpers.VerifyStatusCode(t, res, 204)
 }
 
 func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
@@ -134,11 +134,11 @@ func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 204)
+	helpers.VerifyStatusCode(t, res, 204)
 }
 
 func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
@@ -156,11 +156,11 @@ func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
+	helpers.VerifyStatusCode(t, res, 200)
 }
 
 func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
@@ -179,11 +179,11 @@ func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
+	helpers.VerifyStatusCode(t, res, 200)
 }
 
 func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
@@ -201,11 +201,11 @@ func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
+	helpers.VerifyStatusCode(t, res, 200)
 }
 
 func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
@@ -224,11 +224,11 @@ func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
+	helpers.VerifyStatusCode(t, res, 200)
 }
 
 func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
@@ -246,11 +246,11 @@ func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 202)
+	helpers.VerifyStatusCode(t, res, 204)
 }
 
 func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
@@ -380,11 +380,11 @@ func TestLROBeginPost202Retry200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err = resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
+	res, err := resp.PollUntilDone(context.Background(), time.Duration(1)*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
+	helpers.VerifyStatusCode(t, res, 200)
 }
 
 // func TestLROBeginPostAsyncNoRetrySucceeded(t *testing.T) {


### PR DESCRIPTION
This PR removes the operation specific response handler for handling final responses on pollers and adds some updated lro tests based on the new behavior. 