### PR TITLE
Update Resume method and LRO retry tests

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -295,7 +295,7 @@ function generateOperation(clientName: string, op: Operation, imports: ImportMan
       text += `\t\treturn nil, err\n`;
       text += `\t}\n`;
     }
-    text += `\tpt, err := createPollingTracker("${op.language.go!.pollerType.name}", resp, client.${info.protocolNaming.errorMethod})\n`;
+    text += `\tpt, err := createPollingTracker("${clientName}.${op.language.go!.name}", resp, client.${info.protocolNaming.errorMethod})\n`;
     text += `\tif err != nil {\n`;
     text += `\t\treturn nil, err\n`;
     text += `\t}\n`;
@@ -952,7 +952,7 @@ function generateReturnsInfo(op: Operation, forHandler: boolean): string[] {
 function addResumePollerMethod(op: Operation, clientName: string): string {
   const info = <OperationNaming>op.language.go!;
   let text = `func (client *${clientName}) Resume${op.language.go!.name}(token string) (${op.language.go!.pollerType.name}, error) {\n`;
-  text += `\tpt, err := resumePollingTracker("${op.language.go!.pollerType.name}", token, client.${info.protocolNaming.errorMethod})\n`;
+  text += `\tpt, err := resumePollingTracker("${clientName}.${op.language.go!.name}", token, client.${info.protocolNaming.errorMethod})\n`;
   text += '\tif err != nil {\n';
   text += '\t\treturn nil, err\n';
   text += '\t}\n';

--- a/test/autorest/generated/lrogroup/lroretrys.go
+++ b/test/autorest/generated/lrogroup/lroretrys.go
@@ -64,7 +64,7 @@ func (client *lroRetrysOperations) BeginDelete202Retry200(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.delete202Retry200HandleError)
+	pt, err := createPollingTracker("lroRetrysOperations.Delete202Retry200", resp, client.delete202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (client *lroRetrysOperations) BeginDelete202Retry200(ctx context.Context) (
 }
 
 func (client *lroRetrysOperations) ResumeDelete202Retry200(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.delete202Retry200HandleError)
+	pt, err := resumePollingTracker("lroRetrysOperations.Delete202Retry200", token, client.delete202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (client *lroRetrysOperations) BeginDeleteAsyncRelativeRetrySucceeded(ctx co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.deleteAsyncRelativeRetrySucceededHandleError)
+	pt, err := createPollingTracker("lroRetrysOperations.DeleteAsyncRelativeRetrySucceeded", resp, client.deleteAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func (client *lroRetrysOperations) BeginDeleteAsyncRelativeRetrySucceeded(ctx co
 }
 
 func (client *lroRetrysOperations) ResumeDeleteAsyncRelativeRetrySucceeded(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.deleteAsyncRelativeRetrySucceededHandleError)
+	pt, err := resumePollingTracker("lroRetrysOperations.DeleteAsyncRelativeRetrySucceeded", token, client.deleteAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (client *lroRetrysOperations) BeginDeleteProvisioning202Accepted200Succeede
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.deleteProvisioning202Accepted200SucceededHandleError)
+	pt, err := createPollingTracker("lroRetrysOperations.DeleteProvisioning202Accepted200Succeeded", resp, client.deleteProvisioning202Accepted200SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func (client *lroRetrysOperations) BeginDeleteProvisioning202Accepted200Succeede
 }
 
 func (client *lroRetrysOperations) ResumeDeleteProvisioning202Accepted200Succeeded(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.deleteProvisioning202Accepted200SucceededHandleError)
+	pt, err := resumePollingTracker("lroRetrysOperations.DeleteProvisioning202Accepted200Succeeded", token, client.deleteProvisioning202Accepted200SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +272,7 @@ func (client *lroRetrysOperations) BeginPost202Retry200(ctx context.Context, lro
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.post202Retry200HandleError)
+	pt, err := createPollingTracker("lroRetrysOperations.Post202Retry200", resp, client.post202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +288,7 @@ func (client *lroRetrysOperations) BeginPost202Retry200(ctx context.Context, lro
 }
 
 func (client *lroRetrysOperations) ResumePost202Retry200(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.post202Retry200HandleError)
+	pt, err := resumePollingTracker("lroRetrysOperations.Post202Retry200", token, client.post202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +344,7 @@ func (client *lroRetrysOperations) BeginPostAsyncRelativeRetrySucceeded(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.postAsyncRelativeRetrySucceededHandleError)
+	pt, err := createPollingTracker("lroRetrysOperations.PostAsyncRelativeRetrySucceeded", resp, client.postAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +360,7 @@ func (client *lroRetrysOperations) BeginPostAsyncRelativeRetrySucceeded(ctx cont
 }
 
 func (client *lroRetrysOperations) ResumePostAsyncRelativeRetrySucceeded(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.postAsyncRelativeRetrySucceededHandleError)
+	pt, err := resumePollingTracker("lroRetrysOperations.PostAsyncRelativeRetrySucceeded", token, client.postAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +416,7 @@ func (client *lroRetrysOperations) BeginPut201CreatingSucceeded200(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.put201CreatingSucceeded200HandleError)
+	pt, err := createPollingTracker("lroRetrysOperations.Put201CreatingSucceeded200", resp, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -432,7 +432,7 @@ func (client *lroRetrysOperations) BeginPut201CreatingSucceeded200(ctx context.C
 }
 
 func (client *lroRetrysOperations) ResumePut201CreatingSucceeded200(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.put201CreatingSucceeded200HandleError)
+	pt, err := resumePollingTracker("lroRetrysOperations.Put201CreatingSucceeded200", token, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -489,7 +489,7 @@ func (client *lroRetrysOperations) BeginPutAsyncRelativeRetrySucceeded(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putAsyncRelativeRetrySucceededHandleError)
+	pt, err := createPollingTracker("lroRetrysOperations.PutAsyncRelativeRetrySucceeded", resp, client.putAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -505,7 +505,7 @@ func (client *lroRetrysOperations) BeginPutAsyncRelativeRetrySucceeded(ctx conte
 }
 
 func (client *lroRetrysOperations) ResumePutAsyncRelativeRetrySucceeded(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putAsyncRelativeRetrySucceededHandleError)
+	pt, err := resumePollingTracker("lroRetrysOperations.PutAsyncRelativeRetrySucceeded", token, client.putAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lros.go
+++ b/test/autorest/generated/lrogroup/lros.go
@@ -192,7 +192,7 @@ func (client *lrOSOperations) BeginDelete202NoRetry204(ctx context.Context) (*Pr
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.delete202NoRetry204HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Delete202NoRetry204", resp, client.delete202NoRetry204HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,7 @@ func (client *lrOSOperations) BeginDelete202NoRetry204(ctx context.Context) (*Pr
 }
 
 func (client *lrOSOperations) ResumeDelete202NoRetry204(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.delete202NoRetry204HandleError)
+	pt, err := resumePollingTracker("lrOSOperations.Delete202NoRetry204", token, client.delete202NoRetry204HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +262,7 @@ func (client *lrOSOperations) BeginDelete202Retry200(ctx context.Context) (*Prod
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.delete202Retry200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Delete202Retry200", resp, client.delete202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +278,7 @@ func (client *lrOSOperations) BeginDelete202Retry200(ctx context.Context) (*Prod
 }
 
 func (client *lrOSOperations) ResumeDelete202Retry200(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.delete202Retry200HandleError)
+	pt, err := resumePollingTracker("lrOSOperations.Delete202Retry200", token, client.delete202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +332,7 @@ func (client *lrOSOperations) BeginDelete204Succeeded(ctx context.Context) (*HTT
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.delete204SucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.Delete204Succeeded", resp, client.delete204SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +348,7 @@ func (client *lrOSOperations) BeginDelete204Succeeded(ctx context.Context) (*HTT
 }
 
 func (client *lrOSOperations) ResumeDelete204Succeeded(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.delete204SucceededHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.Delete204Succeeded", token, client.delete204SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +402,7 @@ func (client *lrOSOperations) BeginDeleteAsyncNoHeaderInRetry(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.deleteAsyncNoHeaderInRetryHandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteAsyncNoHeaderInRetry", resp, client.deleteAsyncNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -418,7 +418,7 @@ func (client *lrOSOperations) BeginDeleteAsyncNoHeaderInRetry(ctx context.Contex
 }
 
 func (client *lrOSOperations) ResumeDeleteAsyncNoHeaderInRetry(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.deleteAsyncNoHeaderInRetryHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.DeleteAsyncNoHeaderInRetry", token, client.deleteAsyncNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +471,7 @@ func (client *lrOSOperations) BeginDeleteAsyncNoRetrySucceeded(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.deleteAsyncNoRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteAsyncNoRetrySucceeded", resp, client.deleteAsyncNoRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -487,7 +487,7 @@ func (client *lrOSOperations) BeginDeleteAsyncNoRetrySucceeded(ctx context.Conte
 }
 
 func (client *lrOSOperations) ResumeDeleteAsyncNoRetrySucceeded(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.deleteAsyncNoRetrySucceededHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.DeleteAsyncNoRetrySucceeded", token, client.deleteAsyncNoRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -540,7 +540,7 @@ func (client *lrOSOperations) BeginDeleteAsyncRetryFailed(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.deleteAsyncRetryFailedHandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteAsyncRetryFailed", resp, client.deleteAsyncRetryFailedHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -556,7 +556,7 @@ func (client *lrOSOperations) BeginDeleteAsyncRetryFailed(ctx context.Context) (
 }
 
 func (client *lrOSOperations) ResumeDeleteAsyncRetryFailed(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.deleteAsyncRetryFailedHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.DeleteAsyncRetryFailed", token, client.deleteAsyncRetryFailedHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -609,7 +609,7 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrySucceeded(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.deleteAsyncRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteAsyncRetrySucceeded", resp, client.deleteAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -625,7 +625,7 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrySucceeded(ctx context.Context
 }
 
 func (client *lrOSOperations) ResumeDeleteAsyncRetrySucceeded(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.deleteAsyncRetrySucceededHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.DeleteAsyncRetrySucceeded", token, client.deleteAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -678,7 +678,7 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrycanceled(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.deleteAsyncRetrycanceledHandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteAsyncRetrycanceled", resp, client.deleteAsyncRetrycanceledHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -694,7 +694,7 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrycanceled(ctx context.Context)
 }
 
 func (client *lrOSOperations) ResumeDeleteAsyncRetrycanceled(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.deleteAsyncRetrycanceledHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.DeleteAsyncRetrycanceled", token, client.deleteAsyncRetrycanceledHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -747,7 +747,7 @@ func (client *lrOSOperations) BeginDeleteNoHeaderInRetry(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.deleteNoHeaderInRetryHandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteNoHeaderInRetry", resp, client.deleteNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -763,7 +763,7 @@ func (client *lrOSOperations) BeginDeleteNoHeaderInRetry(ctx context.Context) (*
 }
 
 func (client *lrOSOperations) ResumeDeleteNoHeaderInRetry(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.deleteNoHeaderInRetryHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.DeleteNoHeaderInRetry", token, client.deleteNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -816,7 +816,7 @@ func (client *lrOSOperations) BeginDeleteProvisioning202Accepted200Succeeded(ctx
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.deleteProvisioning202Accepted200SucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteProvisioning202Accepted200Succeeded", resp, client.deleteProvisioning202Accepted200SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -832,7 +832,7 @@ func (client *lrOSOperations) BeginDeleteProvisioning202Accepted200Succeeded(ctx
 }
 
 func (client *lrOSOperations) ResumeDeleteProvisioning202Accepted200Succeeded(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.deleteProvisioning202Accepted200SucceededHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.DeleteProvisioning202Accepted200Succeeded", token, client.deleteProvisioning202Accepted200SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -886,7 +886,7 @@ func (client *lrOSOperations) BeginDeleteProvisioning202DeletingFailed200(ctx co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.deleteProvisioning202DeletingFailed200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteProvisioning202DeletingFailed200", resp, client.deleteProvisioning202DeletingFailed200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -902,7 +902,7 @@ func (client *lrOSOperations) BeginDeleteProvisioning202DeletingFailed200(ctx co
 }
 
 func (client *lrOSOperations) ResumeDeleteProvisioning202DeletingFailed200(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.deleteProvisioning202DeletingFailed200HandleError)
+	pt, err := resumePollingTracker("lrOSOperations.DeleteProvisioning202DeletingFailed200", token, client.deleteProvisioning202DeletingFailed200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -956,7 +956,7 @@ func (client *lrOSOperations) BeginDeleteProvisioning202Deletingcanceled200(ctx 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.deleteProvisioning202Deletingcanceled200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteProvisioning202Deletingcanceled200", resp, client.deleteProvisioning202Deletingcanceled200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -972,7 +972,7 @@ func (client *lrOSOperations) BeginDeleteProvisioning202Deletingcanceled200(ctx 
 }
 
 func (client *lrOSOperations) ResumeDeleteProvisioning202Deletingcanceled200(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.deleteProvisioning202Deletingcanceled200HandleError)
+	pt, err := resumePollingTracker("lrOSOperations.DeleteProvisioning202Deletingcanceled200", token, client.deleteProvisioning202Deletingcanceled200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1026,7 +1026,7 @@ func (client *lrOSOperations) BeginPost200WithPayload(ctx context.Context) (*Sku
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("SkuPoller", resp, client.post200WithPayloadHandleError)
+	pt, err := createPollingTracker("lrOSOperations.Post200WithPayload", resp, client.post200WithPayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1042,7 +1042,7 @@ func (client *lrOSOperations) BeginPost200WithPayload(ctx context.Context) (*Sku
 }
 
 func (client *lrOSOperations) ResumePost200WithPayload(token string) (SkuPoller, error) {
-	pt, err := resumePollingTracker("SkuPoller", token, client.post200WithPayloadHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.Post200WithPayload", token, client.post200WithPayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1096,7 +1096,7 @@ func (client *lrOSOperations) BeginPost202NoRetry204(ctx context.Context, lrOSPo
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.post202NoRetry204HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Post202NoRetry204", resp, client.post202NoRetry204HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1112,7 +1112,7 @@ func (client *lrOSOperations) BeginPost202NoRetry204(ctx context.Context, lrOSPo
 }
 
 func (client *lrOSOperations) ResumePost202NoRetry204(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.post202NoRetry204HandleError)
+	pt, err := resumePollingTracker("lrOSOperations.Post202NoRetry204", token, client.post202NoRetry204HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1169,7 +1169,7 @@ func (client *lrOSOperations) BeginPost202Retry200(ctx context.Context, lrOSPost
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.post202Retry200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Post202Retry200", resp, client.post202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1185,7 +1185,7 @@ func (client *lrOSOperations) BeginPost202Retry200(ctx context.Context, lrOSPost
 }
 
 func (client *lrOSOperations) ResumePost202Retry200(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.post202Retry200HandleError)
+	pt, err := resumePollingTracker("lrOSOperations.Post202Retry200", token, client.post202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1241,7 +1241,7 @@ func (client *lrOSOperations) BeginPostAsyncNoRetrySucceeded(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.postAsyncNoRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PostAsyncNoRetrySucceeded", resp, client.postAsyncNoRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1257,7 +1257,7 @@ func (client *lrOSOperations) BeginPostAsyncNoRetrySucceeded(ctx context.Context
 }
 
 func (client *lrOSOperations) ResumePostAsyncNoRetrySucceeded(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.postAsyncNoRetrySucceededHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PostAsyncNoRetrySucceeded", token, client.postAsyncNoRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1314,7 +1314,7 @@ func (client *lrOSOperations) BeginPostAsyncRetryFailed(ctx context.Context, lrO
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.postAsyncRetryFailedHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PostAsyncRetryFailed", resp, client.postAsyncRetryFailedHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1330,7 +1330,7 @@ func (client *lrOSOperations) BeginPostAsyncRetryFailed(ctx context.Context, lrO
 }
 
 func (client *lrOSOperations) ResumePostAsyncRetryFailed(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.postAsyncRetryFailedHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PostAsyncRetryFailed", token, client.postAsyncRetryFailedHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1386,7 +1386,7 @@ func (client *lrOSOperations) BeginPostAsyncRetrySucceeded(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.postAsyncRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PostAsyncRetrySucceeded", resp, client.postAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1402,7 +1402,7 @@ func (client *lrOSOperations) BeginPostAsyncRetrySucceeded(ctx context.Context, 
 }
 
 func (client *lrOSOperations) ResumePostAsyncRetrySucceeded(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.postAsyncRetrySucceededHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PostAsyncRetrySucceeded", token, client.postAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1459,7 +1459,7 @@ func (client *lrOSOperations) BeginPostAsyncRetrycanceled(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.postAsyncRetrycanceledHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PostAsyncRetrycanceled", resp, client.postAsyncRetrycanceledHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1475,7 +1475,7 @@ func (client *lrOSOperations) BeginPostAsyncRetrycanceled(ctx context.Context, l
 }
 
 func (client *lrOSOperations) ResumePostAsyncRetrycanceled(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.postAsyncRetrycanceledHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PostAsyncRetrycanceled", token, client.postAsyncRetrycanceledHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1531,7 +1531,7 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.postDoubleHeadersFinalAzureHeaderGetHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PostDoubleHeadersFinalAzureHeaderGet", resp, client.postDoubleHeadersFinalAzureHeaderGetHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1547,7 +1547,7 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx cont
 }
 
 func (client *lrOSOperations) ResumePostDoubleHeadersFinalAzureHeaderGet(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.postDoubleHeadersFinalAzureHeaderGetHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PostDoubleHeadersFinalAzureHeaderGet", token, client.postDoubleHeadersFinalAzureHeaderGetHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1601,7 +1601,7 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(c
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.postDoubleHeadersFinalAzureHeaderGetDefaultHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PostDoubleHeadersFinalAzureHeaderGetDefault", resp, client.postDoubleHeadersFinalAzureHeaderGetDefaultHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1617,7 +1617,7 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(c
 }
 
 func (client *lrOSOperations) ResumePostDoubleHeadersFinalAzureHeaderGetDefault(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.postDoubleHeadersFinalAzureHeaderGetDefaultHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PostDoubleHeadersFinalAzureHeaderGetDefault", token, client.postDoubleHeadersFinalAzureHeaderGetDefaultHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1671,7 +1671,7 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalLocationGet(ctx context
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.postDoubleHeadersFinalLocationGetHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PostDoubleHeadersFinalLocationGet", resp, client.postDoubleHeadersFinalLocationGetHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1687,7 +1687,7 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalLocationGet(ctx context
 }
 
 func (client *lrOSOperations) ResumePostDoubleHeadersFinalLocationGet(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.postDoubleHeadersFinalLocationGetHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PostDoubleHeadersFinalLocationGet", token, client.postDoubleHeadersFinalLocationGetHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1741,7 +1741,7 @@ func (client *lrOSOperations) BeginPut200Acceptedcanceled200(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.put200Acceptedcanceled200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Put200Acceptedcanceled200", resp, client.put200Acceptedcanceled200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1757,7 +1757,7 @@ func (client *lrOSOperations) BeginPut200Acceptedcanceled200(ctx context.Context
 }
 
 func (client *lrOSOperations) ResumePut200Acceptedcanceled200(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.put200Acceptedcanceled200HandleError)
+	pt, err := resumePollingTracker("lrOSOperations.Put200Acceptedcanceled200", token, client.put200Acceptedcanceled200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1814,7 +1814,7 @@ func (client *lrOSOperations) BeginPut200Succeeded(ctx context.Context, lrOSPut2
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.put200SucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.Put200Succeeded", resp, client.put200SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1830,7 +1830,7 @@ func (client *lrOSOperations) BeginPut200Succeeded(ctx context.Context, lrOSPut2
 }
 
 func (client *lrOSOperations) ResumePut200Succeeded(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.put200SucceededHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.Put200Succeeded", token, client.put200SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1887,7 +1887,7 @@ func (client *lrOSOperations) BeginPut200SucceededNoState(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.put200SucceededNoStateHandleError)
+	pt, err := createPollingTracker("lrOSOperations.Put200SucceededNoState", resp, client.put200SucceededNoStateHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1903,7 +1903,7 @@ func (client *lrOSOperations) BeginPut200SucceededNoState(ctx context.Context, l
 }
 
 func (client *lrOSOperations) ResumePut200SucceededNoState(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.put200SucceededNoStateHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.Put200SucceededNoState", token, client.put200SucceededNoStateHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1960,7 +1960,7 @@ func (client *lrOSOperations) BeginPut200UpdatingSucceeded204(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.put200UpdatingSucceeded204HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Put200UpdatingSucceeded204", resp, client.put200UpdatingSucceeded204HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1976,7 +1976,7 @@ func (client *lrOSOperations) BeginPut200UpdatingSucceeded204(ctx context.Contex
 }
 
 func (client *lrOSOperations) ResumePut200UpdatingSucceeded204(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.put200UpdatingSucceeded204HandleError)
+	pt, err := resumePollingTracker("lrOSOperations.Put200UpdatingSucceeded204", token, client.put200UpdatingSucceeded204HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2033,7 +2033,7 @@ func (client *lrOSOperations) BeginPut201CreatingFailed200(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.put201CreatingFailed200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Put201CreatingFailed200", resp, client.put201CreatingFailed200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2049,7 +2049,7 @@ func (client *lrOSOperations) BeginPut201CreatingFailed200(ctx context.Context, 
 }
 
 func (client *lrOSOperations) ResumePut201CreatingFailed200(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.put201CreatingFailed200HandleError)
+	pt, err := resumePollingTracker("lrOSOperations.Put201CreatingFailed200", token, client.put201CreatingFailed200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2106,7 +2106,7 @@ func (client *lrOSOperations) BeginPut201CreatingSucceeded200(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.put201CreatingSucceeded200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Put201CreatingSucceeded200", resp, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2122,7 +2122,7 @@ func (client *lrOSOperations) BeginPut201CreatingSucceeded200(ctx context.Contex
 }
 
 func (client *lrOSOperations) ResumePut201CreatingSucceeded200(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.put201CreatingSucceeded200HandleError)
+	pt, err := resumePollingTracker("lrOSOperations.Put201CreatingSucceeded200", token, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2179,7 +2179,7 @@ func (client *lrOSOperations) BeginPut202Retry200(ctx context.Context, lrOSPut20
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.put202Retry200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Put202Retry200", resp, client.put202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2195,7 +2195,7 @@ func (client *lrOSOperations) BeginPut202Retry200(ctx context.Context, lrOSPut20
 }
 
 func (client *lrOSOperations) ResumePut202Retry200(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.put202Retry200HandleError)
+	pt, err := resumePollingTracker("lrOSOperations.Put202Retry200", token, client.put202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2252,7 +2252,7 @@ func (client *lrOSOperations) BeginPutAsyncNoHeaderInRetry(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putAsyncNoHeaderInRetryHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutAsyncNoHeaderInRetry", resp, client.putAsyncNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2268,7 +2268,7 @@ func (client *lrOSOperations) BeginPutAsyncNoHeaderInRetry(ctx context.Context, 
 }
 
 func (client *lrOSOperations) ResumePutAsyncNoHeaderInRetry(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putAsyncNoHeaderInRetryHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PutAsyncNoHeaderInRetry", token, client.putAsyncNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2325,7 +2325,7 @@ func (client *lrOSOperations) BeginPutAsyncNoRetrySucceeded(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putAsyncNoRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutAsyncNoRetrySucceeded", resp, client.putAsyncNoRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2341,7 +2341,7 @@ func (client *lrOSOperations) BeginPutAsyncNoRetrySucceeded(ctx context.Context,
 }
 
 func (client *lrOSOperations) ResumePutAsyncNoRetrySucceeded(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putAsyncNoRetrySucceededHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PutAsyncNoRetrySucceeded", token, client.putAsyncNoRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2398,7 +2398,7 @@ func (client *lrOSOperations) BeginPutAsyncNoRetrycanceled(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putAsyncNoRetrycanceledHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutAsyncNoRetrycanceled", resp, client.putAsyncNoRetrycanceledHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2414,7 +2414,7 @@ func (client *lrOSOperations) BeginPutAsyncNoRetrycanceled(ctx context.Context, 
 }
 
 func (client *lrOSOperations) ResumePutAsyncNoRetrycanceled(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putAsyncNoRetrycanceledHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PutAsyncNoRetrycanceled", token, client.putAsyncNoRetrycanceledHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2471,7 +2471,7 @@ func (client *lrOSOperations) BeginPutAsyncNonResource(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("SkuPoller", resp, client.putAsyncNonResourceHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutAsyncNonResource", resp, client.putAsyncNonResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2487,7 +2487,7 @@ func (client *lrOSOperations) BeginPutAsyncNonResource(ctx context.Context, lrOS
 }
 
 func (client *lrOSOperations) ResumePutAsyncNonResource(token string) (SkuPoller, error) {
-	pt, err := resumePollingTracker("SkuPoller", token, client.putAsyncNonResourceHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PutAsyncNonResource", token, client.putAsyncNonResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2544,7 +2544,7 @@ func (client *lrOSOperations) BeginPutAsyncRetryFailed(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putAsyncRetryFailedHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutAsyncRetryFailed", resp, client.putAsyncRetryFailedHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2560,7 +2560,7 @@ func (client *lrOSOperations) BeginPutAsyncRetryFailed(ctx context.Context, lrOS
 }
 
 func (client *lrOSOperations) ResumePutAsyncRetryFailed(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putAsyncRetryFailedHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PutAsyncRetryFailed", token, client.putAsyncRetryFailedHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2617,7 +2617,7 @@ func (client *lrOSOperations) BeginPutAsyncRetrySucceeded(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putAsyncRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutAsyncRetrySucceeded", resp, client.putAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2633,7 +2633,7 @@ func (client *lrOSOperations) BeginPutAsyncRetrySucceeded(ctx context.Context, l
 }
 
 func (client *lrOSOperations) ResumePutAsyncRetrySucceeded(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putAsyncRetrySucceededHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PutAsyncRetrySucceeded", token, client.putAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2690,7 +2690,7 @@ func (client *lrOSOperations) BeginPutAsyncSubResource(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("SubProductPoller", resp, client.putAsyncSubResourceHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutAsyncSubResource", resp, client.putAsyncSubResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2706,7 +2706,7 @@ func (client *lrOSOperations) BeginPutAsyncSubResource(ctx context.Context, lrOS
 }
 
 func (client *lrOSOperations) ResumePutAsyncSubResource(token string) (SubProductPoller, error) {
-	pt, err := resumePollingTracker("SubProductPoller", token, client.putAsyncSubResourceHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PutAsyncSubResource", token, client.putAsyncSubResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2763,7 +2763,7 @@ func (client *lrOSOperations) BeginPutNoHeaderInRetry(ctx context.Context, lrOSP
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putNoHeaderInRetryHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutNoHeaderInRetry", resp, client.putNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2779,7 +2779,7 @@ func (client *lrOSOperations) BeginPutNoHeaderInRetry(ctx context.Context, lrOSP
 }
 
 func (client *lrOSOperations) ResumePutNoHeaderInRetry(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putNoHeaderInRetryHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PutNoHeaderInRetry", token, client.putNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2836,7 +2836,7 @@ func (client *lrOSOperations) BeginPutNonResource(ctx context.Context, lrOSPutNo
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("SkuPoller", resp, client.putNonResourceHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutNonResource", resp, client.putNonResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2852,7 +2852,7 @@ func (client *lrOSOperations) BeginPutNonResource(ctx context.Context, lrOSPutNo
 }
 
 func (client *lrOSOperations) ResumePutNonResource(token string) (SkuPoller, error) {
-	pt, err := resumePollingTracker("SkuPoller", token, client.putNonResourceHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PutNonResource", token, client.putNonResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2909,7 +2909,7 @@ func (client *lrOSOperations) BeginPutSubResource(ctx context.Context, lrOSPutSu
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("SubProductPoller", resp, client.putSubResourceHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutSubResource", resp, client.putSubResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2925,7 +2925,7 @@ func (client *lrOSOperations) BeginPutSubResource(ctx context.Context, lrOSPutSu
 }
 
 func (client *lrOSOperations) ResumePutSubResource(token string) (SubProductPoller, error) {
-	pt, err := resumePollingTracker("SubProductPoller", token, client.putSubResourceHandleError)
+	pt, err := resumePollingTracker("lrOSOperations.PutSubResource", token, client.putSubResourceHandleError)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lrosads.go
+++ b/test/autorest/generated/lrogroup/lrosads.go
@@ -140,7 +140,7 @@ func (client *lrosaDsOperations) BeginDelete202NonRetry400(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.delete202NonRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.Delete202NonRetry400", resp, client.delete202NonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (client *lrosaDsOperations) BeginDelete202NonRetry400(ctx context.Context) 
 }
 
 func (client *lrosaDsOperations) ResumeDelete202NonRetry400(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.delete202NonRetry400HandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.Delete202NonRetry400", token, client.delete202NonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func (client *lrosaDsOperations) BeginDelete202RetryInvalidHeader(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.delete202RetryInvalidHeaderHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.Delete202RetryInvalidHeader", resp, client.delete202RetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func (client *lrosaDsOperations) BeginDelete202RetryInvalidHeader(ctx context.Co
 }
 
 func (client *lrosaDsOperations) ResumeDelete202RetryInvalidHeader(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.delete202RetryInvalidHeaderHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.Delete202RetryInvalidHeader", token, client.delete202RetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +278,7 @@ func (client *lrosaDsOperations) BeginDelete204Succeeded(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.delete204SucceededHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.Delete204Succeeded", resp, client.delete204SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +294,7 @@ func (client *lrosaDsOperations) BeginDelete204Succeeded(ctx context.Context) (*
 }
 
 func (client *lrosaDsOperations) ResumeDelete204Succeeded(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.delete204SucceededHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.Delete204Succeeded", token, client.delete204SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -347,7 +347,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetry400(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.deleteAsyncRelativeRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetry400", resp, client.deleteAsyncRelativeRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +363,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetry400(ctx context.Co
 }
 
 func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetry400(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.deleteAsyncRelativeRetry400HandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetry400", token, client.deleteAsyncRelativeRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +416,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.deleteAsyncRelativeRetryInvalidHeaderHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetryInvalidHeader", resp, client.deleteAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -432,7 +432,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx 
 }
 
 func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetryInvalidHeader(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.deleteAsyncRelativeRetryInvalidHeaderHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetryInvalidHeader", token, client.deleteAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -485,7 +485,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidJSONPolling
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.deleteAsyncRelativeRetryInvalidJsonPollingHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetryInvalidJSONPolling", resp, client.deleteAsyncRelativeRetryInvalidJsonPollingHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -501,7 +501,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidJSONPolling
 }
 
 func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetryInvalidJSONPolling(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.deleteAsyncRelativeRetryInvalidJsonPollingHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetryInvalidJSONPolling", token, client.deleteAsyncRelativeRetryInvalidJsonPollingHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -554,7 +554,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryNoStatus(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.deleteAsyncRelativeRetryNoStatusHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetryNoStatus", resp, client.deleteAsyncRelativeRetryNoStatusHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -570,7 +570,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryNoStatus(ctx conte
 }
 
 func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetryNoStatus(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.deleteAsyncRelativeRetryNoStatusHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetryNoStatus", token, client.deleteAsyncRelativeRetryNoStatusHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -623,7 +623,7 @@ func (client *lrosaDsOperations) BeginDeleteNonRetry400(ctx context.Context) (*H
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.deleteNonRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.DeleteNonRetry400", resp, client.deleteNonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -639,7 +639,7 @@ func (client *lrosaDsOperations) BeginDeleteNonRetry400(ctx context.Context) (*H
 }
 
 func (client *lrosaDsOperations) ResumeDeleteNonRetry400(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.deleteNonRetry400HandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.DeleteNonRetry400", token, client.deleteNonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -692,7 +692,7 @@ func (client *lrosaDsOperations) BeginPost202NoLocation(ctx context.Context, lro
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.post202NoLocationHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.Post202NoLocation", resp, client.post202NoLocationHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -708,7 +708,7 @@ func (client *lrosaDsOperations) BeginPost202NoLocation(ctx context.Context, lro
 }
 
 func (client *lrosaDsOperations) ResumePost202NoLocation(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.post202NoLocationHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.Post202NoLocation", token, client.post202NoLocationHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -764,7 +764,7 @@ func (client *lrosaDsOperations) BeginPost202NonRetry400(ctx context.Context, lr
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.post202NonRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.Post202NonRetry400", resp, client.post202NonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -780,7 +780,7 @@ func (client *lrosaDsOperations) BeginPost202NonRetry400(ctx context.Context, lr
 }
 
 func (client *lrosaDsOperations) ResumePost202NonRetry400(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.post202NonRetry400HandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.Post202NonRetry400", token, client.post202NonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -836,7 +836,7 @@ func (client *lrosaDsOperations) BeginPost202RetryInvalidHeader(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.post202RetryInvalidHeaderHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.Post202RetryInvalidHeader", resp, client.post202RetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -852,7 +852,7 @@ func (client *lrosaDsOperations) BeginPost202RetryInvalidHeader(ctx context.Cont
 }
 
 func (client *lrosaDsOperations) ResumePost202RetryInvalidHeader(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.post202RetryInvalidHeaderHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.Post202RetryInvalidHeader", token, client.post202RetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -908,7 +908,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetry400(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.postAsyncRelativeRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PostAsyncRelativeRetry400", resp, client.postAsyncRelativeRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -924,7 +924,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetry400(ctx context.Cont
 }
 
 func (client *lrosaDsOperations) ResumePostAsyncRelativeRetry400(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.postAsyncRelativeRetry400HandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.PostAsyncRelativeRetry400", token, client.postAsyncRelativeRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -980,7 +980,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidHeader(ctx co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.postAsyncRelativeRetryInvalidHeaderHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PostAsyncRelativeRetryInvalidHeader", resp, client.postAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -996,7 +996,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidHeader(ctx co
 }
 
 func (client *lrosaDsOperations) ResumePostAsyncRelativeRetryInvalidHeader(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.postAsyncRelativeRetryInvalidHeaderHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.PostAsyncRelativeRetryInvalidHeader", token, client.postAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1052,7 +1052,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidJSONPolling(c
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.postAsyncRelativeRetryInvalidJsonPollingHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PostAsyncRelativeRetryInvalidJSONPolling", resp, client.postAsyncRelativeRetryInvalidJsonPollingHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1068,7 +1068,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidJSONPolling(c
 }
 
 func (client *lrosaDsOperations) ResumePostAsyncRelativeRetryInvalidJSONPolling(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.postAsyncRelativeRetryInvalidJsonPollingHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.PostAsyncRelativeRetryInvalidJSONPolling", token, client.postAsyncRelativeRetryInvalidJsonPollingHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1124,7 +1124,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryNoPayload(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.postAsyncRelativeRetryNoPayloadHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PostAsyncRelativeRetryNoPayload", resp, client.postAsyncRelativeRetryNoPayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1140,7 +1140,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryNoPayload(ctx contex
 }
 
 func (client *lrosaDsOperations) ResumePostAsyncRelativeRetryNoPayload(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.postAsyncRelativeRetryNoPayloadHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.PostAsyncRelativeRetryNoPayload", token, client.postAsyncRelativeRetryNoPayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1196,7 +1196,7 @@ func (client *lrosaDsOperations) BeginPostNonRetry400(ctx context.Context, lrosa
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.postNonRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PostNonRetry400", resp, client.postNonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1212,7 +1212,7 @@ func (client *lrosaDsOperations) BeginPostNonRetry400(ctx context.Context, lrosa
 }
 
 func (client *lrosaDsOperations) ResumePostNonRetry400(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.postNonRetry400HandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.PostNonRetry400", token, client.postNonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1268,7 +1268,7 @@ func (client *lrosaDsOperations) BeginPut200InvalidJSON(ctx context.Context, lro
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.put200InvalidJsonHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.Put200InvalidJSON", resp, client.put200InvalidJsonHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1284,7 +1284,7 @@ func (client *lrosaDsOperations) BeginPut200InvalidJSON(ctx context.Context, lro
 }
 
 func (client *lrosaDsOperations) ResumePut200InvalidJSON(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.put200InvalidJsonHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.Put200InvalidJSON", token, client.put200InvalidJsonHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1341,7 +1341,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetry400(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putAsyncRelativeRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutAsyncRelativeRetry400", resp, client.putAsyncRelativeRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1357,7 +1357,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetry400(ctx context.Conte
 }
 
 func (client *lrosaDsOperations) ResumePutAsyncRelativeRetry400(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putAsyncRelativeRetry400HandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.PutAsyncRelativeRetry400", token, client.putAsyncRelativeRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1414,7 +1414,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidHeader(ctx con
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putAsyncRelativeRetryInvalidHeaderHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutAsyncRelativeRetryInvalidHeader", resp, client.putAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1430,7 +1430,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidHeader(ctx con
 }
 
 func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryInvalidHeader(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putAsyncRelativeRetryInvalidHeaderHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.PutAsyncRelativeRetryInvalidHeader", token, client.putAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1487,7 +1487,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidJSONPolling(ct
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putAsyncRelativeRetryInvalidJsonPollingHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutAsyncRelativeRetryInvalidJSONPolling", resp, client.putAsyncRelativeRetryInvalidJsonPollingHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1503,7 +1503,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidJSONPolling(ct
 }
 
 func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryInvalidJSONPolling(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putAsyncRelativeRetryInvalidJsonPollingHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.PutAsyncRelativeRetryInvalidJSONPolling", token, client.putAsyncRelativeRetryInvalidJsonPollingHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1560,7 +1560,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatus(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putAsyncRelativeRetryNoStatusHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutAsyncRelativeRetryNoStatus", resp, client.putAsyncRelativeRetryNoStatusHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1576,7 +1576,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatus(ctx context.
 }
 
 func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryNoStatus(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putAsyncRelativeRetryNoStatusHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.PutAsyncRelativeRetryNoStatus", token, client.putAsyncRelativeRetryNoStatusHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1633,7 +1633,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatusPayload(ctx c
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putAsyncRelativeRetryNoStatusPayloadHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutAsyncRelativeRetryNoStatusPayload", resp, client.putAsyncRelativeRetryNoStatusPayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1649,7 +1649,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatusPayload(ctx c
 }
 
 func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryNoStatusPayload(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putAsyncRelativeRetryNoStatusPayloadHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.PutAsyncRelativeRetryNoStatusPayload", token, client.putAsyncRelativeRetryNoStatusPayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1706,7 +1706,7 @@ func (client *lrosaDsOperations) BeginPutError201NoProvisioningStatePayload(ctx 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putError201NoProvisioningStatePayloadHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutError201NoProvisioningStatePayload", resp, client.putError201NoProvisioningStatePayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1722,7 +1722,7 @@ func (client *lrosaDsOperations) BeginPutError201NoProvisioningStatePayload(ctx 
 }
 
 func (client *lrosaDsOperations) ResumePutError201NoProvisioningStatePayload(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putError201NoProvisioningStatePayloadHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.PutError201NoProvisioningStatePayload", token, client.putError201NoProvisioningStatePayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1779,7 +1779,7 @@ func (client *lrosaDsOperations) BeginPutNonRetry201Creating400(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putNonRetry201Creating400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutNonRetry201Creating400", resp, client.putNonRetry201Creating400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1795,7 +1795,7 @@ func (client *lrosaDsOperations) BeginPutNonRetry201Creating400(ctx context.Cont
 }
 
 func (client *lrosaDsOperations) ResumePutNonRetry201Creating400(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putNonRetry201Creating400HandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.PutNonRetry201Creating400", token, client.putNonRetry201Creating400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1852,7 +1852,7 @@ func (client *lrosaDsOperations) BeginPutNonRetry201Creating400InvalidJSON(ctx c
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putNonRetry201Creating400InvalidJsonHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutNonRetry201Creating400InvalidJSON", resp, client.putNonRetry201Creating400InvalidJsonHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1868,7 +1868,7 @@ func (client *lrosaDsOperations) BeginPutNonRetry201Creating400InvalidJSON(ctx c
 }
 
 func (client *lrosaDsOperations) ResumePutNonRetry201Creating400InvalidJSON(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putNonRetry201Creating400InvalidJsonHandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.PutNonRetry201Creating400InvalidJSON", token, client.putNonRetry201Creating400InvalidJsonHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1925,7 +1925,7 @@ func (client *lrosaDsOperations) BeginPutNonRetry400(ctx context.Context, lrosaD
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putNonRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutNonRetry400", resp, client.putNonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1941,7 +1941,7 @@ func (client *lrosaDsOperations) BeginPutNonRetry400(ctx context.Context, lrosaD
 }
 
 func (client *lrosaDsOperations) ResumePutNonRetry400(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putNonRetry400HandleError)
+	pt, err := resumePollingTracker("lrosaDsOperations.PutNonRetry400", token, client.putNonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lroscustomheader.go
+++ b/test/autorest/generated/lrogroup/lroscustomheader.go
@@ -52,7 +52,7 @@ func (client *lrOSCustomHeaderOperations) BeginPost202Retry200(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.post202Retry200HandleError)
+	pt, err := createPollingTracker("lrOSCustomHeaderOperations.Post202Retry200", resp, client.post202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (client *lrOSCustomHeaderOperations) BeginPost202Retry200(ctx context.Conte
 }
 
 func (client *lrOSCustomHeaderOperations) ResumePost202Retry200(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.post202Retry200HandleError)
+	pt, err := resumePollingTracker("lrOSCustomHeaderOperations.Post202Retry200", token, client.post202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (client *lrOSCustomHeaderOperations) BeginPostAsyncRetrySucceeded(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("HTTPPoller", resp, client.postAsyncRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSCustomHeaderOperations.PostAsyncRetrySucceeded", resp, client.postAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (client *lrOSCustomHeaderOperations) BeginPostAsyncRetrySucceeded(ctx conte
 }
 
 func (client *lrOSCustomHeaderOperations) ResumePostAsyncRetrySucceeded(token string) (HTTPPoller, error) {
-	pt, err := resumePollingTracker("HTTPPoller", token, client.postAsyncRetrySucceededHandleError)
+	pt, err := resumePollingTracker("lrOSCustomHeaderOperations.PostAsyncRetrySucceeded", token, client.postAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (client *lrOSCustomHeaderOperations) BeginPut201CreatingSucceeded200(ctx co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.put201CreatingSucceeded200HandleError)
+	pt, err := createPollingTracker("lrOSCustomHeaderOperations.Put201CreatingSucceeded200", resp, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func (client *lrOSCustomHeaderOperations) BeginPut201CreatingSucceeded200(ctx co
 }
 
 func (client *lrOSCustomHeaderOperations) ResumePut201CreatingSucceeded200(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.put201CreatingSucceeded200HandleError)
+	pt, err := resumePollingTracker("lrOSCustomHeaderOperations.Put201CreatingSucceeded200", token, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +269,7 @@ func (client *lrOSCustomHeaderOperations) BeginPutAsyncRetrySucceeded(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("ProductPoller", resp, client.putAsyncRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSCustomHeaderOperations.PutAsyncRetrySucceeded", resp, client.putAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func (client *lrOSCustomHeaderOperations) BeginPutAsyncRetrySucceeded(ctx contex
 }
 
 func (client *lrOSCustomHeaderOperations) ResumePutAsyncRetrySucceeded(token string) (ProductPoller, error) {
-	pt, err := resumePollingTracker("ProductPoller", token, client.putAsyncRetrySucceededHandleError)
+	pt, err := resumePollingTracker("lrOSCustomHeaderOperations.PutAsyncRetrySucceeded", token, client.putAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/lrogroup/lroretrys_test.go
+++ b/test/autorest/lrogroup/lroretrys_test.go
@@ -4,9 +4,13 @@
 package lrogrouptest
 
 import (
+	"context"
 	"generatortests/autorest/generated/lrogroup"
+	"generatortests/helpers"
 	"testing"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
 func getLRORetrysOperations(t *testing.T) lrogroup.LroRetrysOperations {
@@ -20,205 +24,183 @@ func getLRORetrysOperations(t *testing.T) lrogroup.LroRetrysOperations {
 	return client.LroRetrysOperations()
 }
 
-// func TestLRORetrysBeginDelete202Retry200(t *testing.T) {
-// 	op := getLRORetrysOperations(t)
-// 	poller, err := op.BeginDelete202Retry200(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLroRetrysDelete202Retry200Poller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLRORetrysBeginDelete202Retry200(t *testing.T) {
+	op := getLRORetrysOperations(t)
+	resp, err := op.BeginDelete202Retry200(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumeDelete202Retry200(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res, 200)
+}
 
-// func TestLRORetrysBeginDeleteAsyncRelativeRetrySucceeded(t *testing.T) {
-// 	op := getLRORetrysOperations(t)
-// 	poller, err := op.BeginDeleteAsyncRelativeRetrySucceeded(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLroRetrysDeleteAsyncRelativeRetrySucceededPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLRORetrysBeginDeleteAsyncRelativeRetrySucceeded(t *testing.T) {
+	op := getLRORetrysOperations(t)
+	resp, err := op.BeginDeleteAsyncRelativeRetrySucceeded(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumeDeleteAsyncRelativeRetrySucceeded(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res, 200)
+}
 
-// func TestLRORetrysBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
-// 	op := getLRORetrysOperations(t)
-// 	poller, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background())
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLroRetrysDeleteProvisioning202Accepted200SucceededPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLRORetrysBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
+	op := getLRORetrysOperations(t)
+	resp, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumeDeleteProvisioning202Accepted200Succeeded(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+		Properties: &lrogroup.ProductProperties{
+			ProvisioningState: to.StringPtr("Succeeded"),
+		},
+	})
+}
 
-// func TestLRORetrysBeginPost202Retry200(t *testing.T) {
-// 	op := getLRORetrysOperations(t)
-// 	poller, err := op.BeginPost202Retry200(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLroRetrysPost202Retry200Poller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLRORetrysBeginPost202Retry200(t *testing.T) {
+	op := getLRORetrysOperations(t)
+	resp, err := op.BeginPost202Retry200(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePost202Retry200(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res, 200)
+}
 
-// func TestLRORetrysBeginPostAsyncRelativeRetrySucceeded(t *testing.T) {
-// 	op := getLRORetrysOperations(t)
-// 	poller, err := op.BeginPostAsyncRelativeRetrySucceeded(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLroRetrysPostAsyncRelativeRetrySucceededPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLRORetrysBeginPostAsyncRelativeRetrySucceeded(t *testing.T) {
+	op := getLRORetrysOperations(t)
+	resp, err := op.BeginPostAsyncRelativeRetrySucceeded(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePostAsyncRelativeRetrySucceeded(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res, 200)
+}
 
-// func TestLRORetrysBeginPut201CreatingSucceeded200(t *testing.T) {
-// 	op := getLRORetrysOperations(t)
-// 	poller, err := op.BeginPut201CreatingSucceeded200(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLroRetrysPut201CreatingSucceeded200Poller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLRORetrysBeginPut201CreatingSucceeded200(t *testing.T) {
+	op := getLRORetrysOperations(t)
+	resp, err := op.BeginPut201CreatingSucceeded200(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePut201CreatingSucceeded200(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+		Properties: &lrogroup.ProductProperties{
+			ProvisioningState: to.StringPtr("Succeeded"),
+		},
+	})
+}
 
-// func TestLRORetrysBeginPutAsyncRelativeRetrySucceeded(t *testing.T) {
-// 	op := getLRORetrysOperations(t)
-// 	poller, err := op.BeginPutAsyncRelativeRetrySucceeded(context.Background(), nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	rt, err := poller.ResumeToken()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	poller, err = op.ResumeLroRetrysPutAsyncRelativeRetrySucceededPoller(rt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	for poller.Poll(context.Background()) {
-// 		time.Sleep(200 * time.Millisecond)
-// 	}
-// 	resp, err := poller.Response()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// 	resp, err = poller.Wait(context.Background(), time.Duration(1)*time.Second)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	helpers.VerifyStatusCode(t, resp.RawResponse, 200)
-// }
+func TestLRORetrysBeginPutAsyncRelativeRetrySucceeded(t *testing.T) {
+	op := getLRORetrysOperations(t)
+	resp, err := op.BeginPutAsyncRelativeRetrySucceeded(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller := resp.Poller
+	rt, err := poller.ResumeToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	poller, err = op.ResumePutAsyncRelativeRetrySucceeded(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, res.RawResponse, 200)
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
+		Resource: lrogroup.Resource{
+			ID:   to.StringPtr("100"),
+			Name: to.StringPtr("foo"),
+		},
+		Properties: &lrogroup.ProductProperties{
+			ProvisioningState: to.StringPtr("Succeeded"),
+		},
+	})
+}

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -40,7 +40,6 @@ func httpClientWithCookieJar() azcore.Transport {
 }
 
 func TestLROResumeWrongPoller(t *testing.T) {
-	// TODO discuss what sort of check we want with the new design to avoid resuming from the wrong poller type
 	op := getLROSOperations(t)
 	resp, err := op.BeginDelete202NoRetry204(context.Background())
 	if err != nil {


### PR DESCRIPTION
This PR updates the resume method to make sure pollers can only be resumed from tokens of pollers for the same operation on the same client. Also updating LRO retry tests to use the new design. 