### PR TITLE
Adding x-ms-long-running-operations-options compatibility

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -295,7 +295,13 @@ function generateOperation(clientName: string, op: Operation, imports: ImportMan
       text += `\t\treturn nil, err\n`;
       text += `\t}\n`;
     }
-    text += `\tpt, err := createPollingTracker("${clientName}.${op.language.go!.name}", resp, client.${info.protocolNaming.errorMethod})\n`;
+    // LRO operation might have a special configuration set in x-ms-long-running-operation-options
+    // which indicates a specific url to perform the final Get operation on
+    let finalState = '';
+    if (op.extensions?.['x-ms-long-running-operation-options']?.['final-state-via']) {
+      finalState = op.extensions?.['x-ms-long-running-operation-options']?.['final-state-via'];
+    }
+    text += `\tpt, err := createPollingTracker("${clientName}.${op.language.go!.name}", "${finalState}", resp, client.${info.protocolNaming.errorMethod})\n`;
     text += `\tif err != nil {\n`;
     text += `\t\treturn nil, err\n`;
     text += `\t}\n`;

--- a/src/generator/pollers.ts
+++ b/src/generator/pollers.ts
@@ -306,7 +306,7 @@ type pollingTrackerBase struct {
     FinalStateVia string \`json:"finalStateVia"\`
 
 	  // the original request URL of the initial request for the polling operation
-	  OriginalURI string \`json: "originalURI"\`
+	  OriginalURI string \`json:"originalURI"\`
 
 		// used to hold an error object returned from the service
 		Err error \`json:"error,omitempty"\`

--- a/src/generator/pollers.ts
+++ b/src/generator/pollers.ts
@@ -56,7 +56,6 @@ export async function generatePollers(session: Session<CodeModel>): Promise<stri
       finalResponse = `FinalResponse(ctx context.Context) (*${responseType}, error) {
         // checking if there was a FinalStateVia configuration to re-route the final GET
         // request to the value specified in the FinalStateVia property on the poller
-        // this will override what is in the FinalGetURI
         err := p.pt.setFinalState()
         if err != nil {
           return nil, err

--- a/src/generator/pollers.ts
+++ b/src/generator/pollers.ts
@@ -264,9 +264,6 @@ type pollingTracker interface {
   // converts an *azcore.Response to an error
   handleError(resp *azcore.Response) error
 
-  // returns the desired configuration for the final GET URI that overrides the value set in the finalGetURL
-	finalStateVia() string
-
   // sets the FinalGetURI to the value pointed to in FinalStateVia
 	setFinalState() error
 }
@@ -302,7 +299,7 @@ type pollingTrackerBase struct {
 		FinalGetURI string \`json:"resultURI"\`
 
     // stores the name of the header that the final get should be performed on, 
-    //can be empty which will go to default behavior
+    // can be empty which will go to default behavior
     FinalStateVia string \`json:"finalStateVia"\`
 
 	  // the original request URL of the initial request for the polling operation
@@ -536,10 +533,6 @@ type pollingTrackerBase struct {
   
   func (pt *pollingTrackerBase) handleError(resp *azcore.Response) error {
     return pt.errorHandler(resp)
-  }
-
-  func (pt *pollingTrackerBase) finalStateVia() string {
-    return pt.FinalStateVia
   }
 
 func (pt *pollingTrackerBase) setFinalState() error {

--- a/src/generator/pollers.ts
+++ b/src/generator/pollers.ts
@@ -56,6 +56,7 @@ export async function generatePollers(session: Session<CodeModel>): Promise<stri
       finalResponse = `FinalResponse(ctx context.Context) (*${responseType}, error) {
         // checking if there was a FinalStateVia configuration to re-route the final GET
         // request to the value specified in the FinalStateVia property on the poller
+        // this will override what is in the FinalGetURI
         err := p.pt.setFinalState()
         if err != nil {
           return nil, err

--- a/test/autorest/generated/lrogroup/lroretrys.go
+++ b/test/autorest/generated/lrogroup/lroretrys.go
@@ -64,7 +64,7 @@ func (client *lroRetrysOperations) BeginDelete202Retry200(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lroRetrysOperations.Delete202Retry200", resp, client.delete202Retry200HandleError)
+	pt, err := createPollingTracker("lroRetrysOperations.Delete202Retry200", "", resp, client.delete202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (client *lroRetrysOperations) BeginDeleteAsyncRelativeRetrySucceeded(ctx co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lroRetrysOperations.DeleteAsyncRelativeRetrySucceeded", resp, client.deleteAsyncRelativeRetrySucceededHandleError)
+	pt, err := createPollingTracker("lroRetrysOperations.DeleteAsyncRelativeRetrySucceeded", "", resp, client.deleteAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (client *lroRetrysOperations) BeginDeleteProvisioning202Accepted200Succeede
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lroRetrysOperations.DeleteProvisioning202Accepted200Succeeded", resp, client.deleteProvisioning202Accepted200SucceededHandleError)
+	pt, err := createPollingTracker("lroRetrysOperations.DeleteProvisioning202Accepted200Succeeded", "", resp, client.deleteProvisioning202Accepted200SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +272,7 @@ func (client *lroRetrysOperations) BeginPost202Retry200(ctx context.Context, lro
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lroRetrysOperations.Post202Retry200", resp, client.post202Retry200HandleError)
+	pt, err := createPollingTracker("lroRetrysOperations.Post202Retry200", "", resp, client.post202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +344,7 @@ func (client *lroRetrysOperations) BeginPostAsyncRelativeRetrySucceeded(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lroRetrysOperations.PostAsyncRelativeRetrySucceeded", resp, client.postAsyncRelativeRetrySucceededHandleError)
+	pt, err := createPollingTracker("lroRetrysOperations.PostAsyncRelativeRetrySucceeded", "", resp, client.postAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +416,7 @@ func (client *lroRetrysOperations) BeginPut201CreatingSucceeded200(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lroRetrysOperations.Put201CreatingSucceeded200", resp, client.put201CreatingSucceeded200HandleError)
+	pt, err := createPollingTracker("lroRetrysOperations.Put201CreatingSucceeded200", "", resp, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -489,7 +489,7 @@ func (client *lroRetrysOperations) BeginPutAsyncRelativeRetrySucceeded(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lroRetrysOperations.PutAsyncRelativeRetrySucceeded", resp, client.putAsyncRelativeRetrySucceededHandleError)
+	pt, err := createPollingTracker("lroRetrysOperations.PutAsyncRelativeRetrySucceeded", "", resp, client.putAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lros.go
+++ b/test/autorest/generated/lrogroup/lros.go
@@ -7,10 +7,9 @@ package lrogroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"time"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
 // LrOSOperations contains the methods for the LrOS group.

--- a/test/autorest/generated/lrogroup/lros.go
+++ b/test/autorest/generated/lrogroup/lros.go
@@ -7,9 +7,10 @@ package lrogroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
 // LrOSOperations contains the methods for the LrOS group.
@@ -192,7 +193,7 @@ func (client *lrOSOperations) BeginDelete202NoRetry204(ctx context.Context) (*Pr
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.Delete202NoRetry204", resp, client.delete202NoRetry204HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Delete202NoRetry204", "", resp, client.delete202NoRetry204HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +263,7 @@ func (client *lrOSOperations) BeginDelete202Retry200(ctx context.Context) (*Prod
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.Delete202Retry200", resp, client.delete202Retry200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Delete202Retry200", "", resp, client.delete202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +333,7 @@ func (client *lrOSOperations) BeginDelete204Succeeded(ctx context.Context) (*HTT
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.Delete204Succeeded", resp, client.delete204SucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.Delete204Succeeded", "", resp, client.delete204SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +403,7 @@ func (client *lrOSOperations) BeginDeleteAsyncNoHeaderInRetry(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.DeleteAsyncNoHeaderInRetry", resp, client.deleteAsyncNoHeaderInRetryHandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteAsyncNoHeaderInRetry", "", resp, client.deleteAsyncNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +472,7 @@ func (client *lrOSOperations) BeginDeleteAsyncNoRetrySucceeded(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.DeleteAsyncNoRetrySucceeded", resp, client.deleteAsyncNoRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteAsyncNoRetrySucceeded", "", resp, client.deleteAsyncNoRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -540,7 +541,7 @@ func (client *lrOSOperations) BeginDeleteAsyncRetryFailed(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.DeleteAsyncRetryFailed", resp, client.deleteAsyncRetryFailedHandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteAsyncRetryFailed", "", resp, client.deleteAsyncRetryFailedHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -609,7 +610,7 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrySucceeded(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.DeleteAsyncRetrySucceeded", resp, client.deleteAsyncRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteAsyncRetrySucceeded", "", resp, client.deleteAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -678,7 +679,7 @@ func (client *lrOSOperations) BeginDeleteAsyncRetrycanceled(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.DeleteAsyncRetrycanceled", resp, client.deleteAsyncRetrycanceledHandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteAsyncRetrycanceled", "", resp, client.deleteAsyncRetrycanceledHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -747,7 +748,7 @@ func (client *lrOSOperations) BeginDeleteNoHeaderInRetry(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.DeleteNoHeaderInRetry", resp, client.deleteNoHeaderInRetryHandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteNoHeaderInRetry", "", resp, client.deleteNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -816,7 +817,7 @@ func (client *lrOSOperations) BeginDeleteProvisioning202Accepted200Succeeded(ctx
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.DeleteProvisioning202Accepted200Succeeded", resp, client.deleteProvisioning202Accepted200SucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteProvisioning202Accepted200Succeeded", "", resp, client.deleteProvisioning202Accepted200SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -886,7 +887,7 @@ func (client *lrOSOperations) BeginDeleteProvisioning202DeletingFailed200(ctx co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.DeleteProvisioning202DeletingFailed200", resp, client.deleteProvisioning202DeletingFailed200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteProvisioning202DeletingFailed200", "", resp, client.deleteProvisioning202DeletingFailed200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -956,7 +957,7 @@ func (client *lrOSOperations) BeginDeleteProvisioning202Deletingcanceled200(ctx 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.DeleteProvisioning202Deletingcanceled200", resp, client.deleteProvisioning202Deletingcanceled200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.DeleteProvisioning202Deletingcanceled200", "", resp, client.deleteProvisioning202Deletingcanceled200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1026,7 +1027,7 @@ func (client *lrOSOperations) BeginPost200WithPayload(ctx context.Context) (*Sku
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.Post200WithPayload", resp, client.post200WithPayloadHandleError)
+	pt, err := createPollingTracker("lrOSOperations.Post200WithPayload", "", resp, client.post200WithPayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1096,7 +1097,7 @@ func (client *lrOSOperations) BeginPost202NoRetry204(ctx context.Context, lrOSPo
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.Post202NoRetry204", resp, client.post202NoRetry204HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Post202NoRetry204", "", resp, client.post202NoRetry204HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1169,7 +1170,7 @@ func (client *lrOSOperations) BeginPost202Retry200(ctx context.Context, lrOSPost
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.Post202Retry200", resp, client.post202Retry200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Post202Retry200", "", resp, client.post202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1241,7 +1242,7 @@ func (client *lrOSOperations) BeginPostAsyncNoRetrySucceeded(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PostAsyncNoRetrySucceeded", resp, client.postAsyncNoRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PostAsyncNoRetrySucceeded", "", resp, client.postAsyncNoRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1314,7 +1315,7 @@ func (client *lrOSOperations) BeginPostAsyncRetryFailed(ctx context.Context, lrO
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PostAsyncRetryFailed", resp, client.postAsyncRetryFailedHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PostAsyncRetryFailed", "", resp, client.postAsyncRetryFailedHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1386,7 +1387,7 @@ func (client *lrOSOperations) BeginPostAsyncRetrySucceeded(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PostAsyncRetrySucceeded", resp, client.postAsyncRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PostAsyncRetrySucceeded", "", resp, client.postAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1459,7 +1460,7 @@ func (client *lrOSOperations) BeginPostAsyncRetrycanceled(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PostAsyncRetrycanceled", resp, client.postAsyncRetrycanceledHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PostAsyncRetrycanceled", "", resp, client.postAsyncRetrycanceledHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1531,7 +1532,7 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PostDoubleHeadersFinalAzureHeaderGet", resp, client.postDoubleHeadersFinalAzureHeaderGetHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PostDoubleHeadersFinalAzureHeaderGet", "azure-async-operation", resp, client.postDoubleHeadersFinalAzureHeaderGetHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1601,7 +1602,7 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(c
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PostDoubleHeadersFinalAzureHeaderGetDefault", resp, client.postDoubleHeadersFinalAzureHeaderGetDefaultHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PostDoubleHeadersFinalAzureHeaderGetDefault", "", resp, client.postDoubleHeadersFinalAzureHeaderGetDefaultHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1671,7 +1672,7 @@ func (client *lrOSOperations) BeginPostDoubleHeadersFinalLocationGet(ctx context
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PostDoubleHeadersFinalLocationGet", resp, client.postDoubleHeadersFinalLocationGetHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PostDoubleHeadersFinalLocationGet", "location", resp, client.postDoubleHeadersFinalLocationGetHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1741,7 +1742,7 @@ func (client *lrOSOperations) BeginPut200Acceptedcanceled200(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.Put200Acceptedcanceled200", resp, client.put200Acceptedcanceled200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Put200Acceptedcanceled200", "", resp, client.put200Acceptedcanceled200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1814,7 +1815,7 @@ func (client *lrOSOperations) BeginPut200Succeeded(ctx context.Context, lrOSPut2
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.Put200Succeeded", resp, client.put200SucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.Put200Succeeded", "", resp, client.put200SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1887,7 +1888,7 @@ func (client *lrOSOperations) BeginPut200SucceededNoState(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.Put200SucceededNoState", resp, client.put200SucceededNoStateHandleError)
+	pt, err := createPollingTracker("lrOSOperations.Put200SucceededNoState", "", resp, client.put200SucceededNoStateHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1960,7 +1961,7 @@ func (client *lrOSOperations) BeginPut200UpdatingSucceeded204(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.Put200UpdatingSucceeded204", resp, client.put200UpdatingSucceeded204HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Put200UpdatingSucceeded204", "", resp, client.put200UpdatingSucceeded204HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2033,7 +2034,7 @@ func (client *lrOSOperations) BeginPut201CreatingFailed200(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.Put201CreatingFailed200", resp, client.put201CreatingFailed200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Put201CreatingFailed200", "", resp, client.put201CreatingFailed200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2106,7 +2107,7 @@ func (client *lrOSOperations) BeginPut201CreatingSucceeded200(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.Put201CreatingSucceeded200", resp, client.put201CreatingSucceeded200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Put201CreatingSucceeded200", "", resp, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2179,7 +2180,7 @@ func (client *lrOSOperations) BeginPut202Retry200(ctx context.Context, lrOSPut20
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.Put202Retry200", resp, client.put202Retry200HandleError)
+	pt, err := createPollingTracker("lrOSOperations.Put202Retry200", "", resp, client.put202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2252,7 +2253,7 @@ func (client *lrOSOperations) BeginPutAsyncNoHeaderInRetry(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PutAsyncNoHeaderInRetry", resp, client.putAsyncNoHeaderInRetryHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutAsyncNoHeaderInRetry", "", resp, client.putAsyncNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2325,7 +2326,7 @@ func (client *lrOSOperations) BeginPutAsyncNoRetrySucceeded(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PutAsyncNoRetrySucceeded", resp, client.putAsyncNoRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutAsyncNoRetrySucceeded", "", resp, client.putAsyncNoRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2398,7 +2399,7 @@ func (client *lrOSOperations) BeginPutAsyncNoRetrycanceled(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PutAsyncNoRetrycanceled", resp, client.putAsyncNoRetrycanceledHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutAsyncNoRetrycanceled", "", resp, client.putAsyncNoRetrycanceledHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2471,7 +2472,7 @@ func (client *lrOSOperations) BeginPutAsyncNonResource(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PutAsyncNonResource", resp, client.putAsyncNonResourceHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutAsyncNonResource", "", resp, client.putAsyncNonResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2544,7 +2545,7 @@ func (client *lrOSOperations) BeginPutAsyncRetryFailed(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PutAsyncRetryFailed", resp, client.putAsyncRetryFailedHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutAsyncRetryFailed", "", resp, client.putAsyncRetryFailedHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2617,7 +2618,7 @@ func (client *lrOSOperations) BeginPutAsyncRetrySucceeded(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PutAsyncRetrySucceeded", resp, client.putAsyncRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutAsyncRetrySucceeded", "", resp, client.putAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2690,7 +2691,7 @@ func (client *lrOSOperations) BeginPutAsyncSubResource(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PutAsyncSubResource", resp, client.putAsyncSubResourceHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutAsyncSubResource", "", resp, client.putAsyncSubResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2763,7 +2764,7 @@ func (client *lrOSOperations) BeginPutNoHeaderInRetry(ctx context.Context, lrOSP
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PutNoHeaderInRetry", resp, client.putNoHeaderInRetryHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutNoHeaderInRetry", "", resp, client.putNoHeaderInRetryHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2836,7 +2837,7 @@ func (client *lrOSOperations) BeginPutNonResource(ctx context.Context, lrOSPutNo
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PutNonResource", resp, client.putNonResourceHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutNonResource", "", resp, client.putNonResourceHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -2909,7 +2910,7 @@ func (client *lrOSOperations) BeginPutSubResource(ctx context.Context, lrOSPutSu
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSOperations.PutSubResource", resp, client.putSubResourceHandleError)
+	pt, err := createPollingTracker("lrOSOperations.PutSubResource", "", resp, client.putSubResourceHandleError)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lrosads.go
+++ b/test/autorest/generated/lrogroup/lrosads.go
@@ -140,7 +140,7 @@ func (client *lrosaDsOperations) BeginDelete202NonRetry400(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.Delete202NonRetry400", resp, client.delete202NonRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.Delete202NonRetry400", "", resp, client.delete202NonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func (client *lrosaDsOperations) BeginDelete202RetryInvalidHeader(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.Delete202RetryInvalidHeader", resp, client.delete202RetryInvalidHeaderHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.Delete202RetryInvalidHeader", "", resp, client.delete202RetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +278,7 @@ func (client *lrosaDsOperations) BeginDelete204Succeeded(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.Delete204Succeeded", resp, client.delete204SucceededHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.Delete204Succeeded", "", resp, client.delete204SucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -347,7 +347,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetry400(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetry400", resp, client.deleteAsyncRelativeRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetry400", "", resp, client.deleteAsyncRelativeRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +416,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetryInvalidHeader", resp, client.deleteAsyncRelativeRetryInvalidHeaderHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetryInvalidHeader", "", resp, client.deleteAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -485,7 +485,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryInvalidJSONPolling
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetryInvalidJSONPolling", resp, client.deleteAsyncRelativeRetryInvalidJsonPollingHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetryInvalidJSONPolling", "", resp, client.deleteAsyncRelativeRetryInvalidJsonPollingHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -554,7 +554,7 @@ func (client *lrosaDsOperations) BeginDeleteAsyncRelativeRetryNoStatus(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetryNoStatus", resp, client.deleteAsyncRelativeRetryNoStatusHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.DeleteAsyncRelativeRetryNoStatus", "", resp, client.deleteAsyncRelativeRetryNoStatusHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -623,7 +623,7 @@ func (client *lrosaDsOperations) BeginDeleteNonRetry400(ctx context.Context) (*H
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.DeleteNonRetry400", resp, client.deleteNonRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.DeleteNonRetry400", "", resp, client.deleteNonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -692,7 +692,7 @@ func (client *lrosaDsOperations) BeginPost202NoLocation(ctx context.Context, lro
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.Post202NoLocation", resp, client.post202NoLocationHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.Post202NoLocation", "", resp, client.post202NoLocationHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -764,7 +764,7 @@ func (client *lrosaDsOperations) BeginPost202NonRetry400(ctx context.Context, lr
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.Post202NonRetry400", resp, client.post202NonRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.Post202NonRetry400", "", resp, client.post202NonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -836,7 +836,7 @@ func (client *lrosaDsOperations) BeginPost202RetryInvalidHeader(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.Post202RetryInvalidHeader", resp, client.post202RetryInvalidHeaderHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.Post202RetryInvalidHeader", "", resp, client.post202RetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -908,7 +908,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetry400(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.PostAsyncRelativeRetry400", resp, client.postAsyncRelativeRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PostAsyncRelativeRetry400", "", resp, client.postAsyncRelativeRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -980,7 +980,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidHeader(ctx co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.PostAsyncRelativeRetryInvalidHeader", resp, client.postAsyncRelativeRetryInvalidHeaderHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PostAsyncRelativeRetryInvalidHeader", "", resp, client.postAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1052,7 +1052,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryInvalidJSONPolling(c
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.PostAsyncRelativeRetryInvalidJSONPolling", resp, client.postAsyncRelativeRetryInvalidJsonPollingHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PostAsyncRelativeRetryInvalidJSONPolling", "", resp, client.postAsyncRelativeRetryInvalidJsonPollingHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1124,7 +1124,7 @@ func (client *lrosaDsOperations) BeginPostAsyncRelativeRetryNoPayload(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.PostAsyncRelativeRetryNoPayload", resp, client.postAsyncRelativeRetryNoPayloadHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PostAsyncRelativeRetryNoPayload", "", resp, client.postAsyncRelativeRetryNoPayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1196,7 +1196,7 @@ func (client *lrosaDsOperations) BeginPostNonRetry400(ctx context.Context, lrosa
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.PostNonRetry400", resp, client.postNonRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PostNonRetry400", "", resp, client.postNonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1268,7 +1268,7 @@ func (client *lrosaDsOperations) BeginPut200InvalidJSON(ctx context.Context, lro
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.Put200InvalidJSON", resp, client.put200InvalidJsonHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.Put200InvalidJSON", "", resp, client.put200InvalidJsonHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1341,7 +1341,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetry400(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.PutAsyncRelativeRetry400", resp, client.putAsyncRelativeRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutAsyncRelativeRetry400", "", resp, client.putAsyncRelativeRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1414,7 +1414,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidHeader(ctx con
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.PutAsyncRelativeRetryInvalidHeader", resp, client.putAsyncRelativeRetryInvalidHeaderHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutAsyncRelativeRetryInvalidHeader", "", resp, client.putAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1487,7 +1487,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryInvalidJSONPolling(ct
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.PutAsyncRelativeRetryInvalidJSONPolling", resp, client.putAsyncRelativeRetryInvalidJsonPollingHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutAsyncRelativeRetryInvalidJSONPolling", "", resp, client.putAsyncRelativeRetryInvalidJsonPollingHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1560,7 +1560,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatus(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.PutAsyncRelativeRetryNoStatus", resp, client.putAsyncRelativeRetryNoStatusHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutAsyncRelativeRetryNoStatus", "", resp, client.putAsyncRelativeRetryNoStatusHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1633,7 +1633,7 @@ func (client *lrosaDsOperations) BeginPutAsyncRelativeRetryNoStatusPayload(ctx c
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.PutAsyncRelativeRetryNoStatusPayload", resp, client.putAsyncRelativeRetryNoStatusPayloadHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutAsyncRelativeRetryNoStatusPayload", "", resp, client.putAsyncRelativeRetryNoStatusPayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1706,7 +1706,7 @@ func (client *lrosaDsOperations) BeginPutError201NoProvisioningStatePayload(ctx 
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.PutError201NoProvisioningStatePayload", resp, client.putError201NoProvisioningStatePayloadHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutError201NoProvisioningStatePayload", "", resp, client.putError201NoProvisioningStatePayloadHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1779,7 +1779,7 @@ func (client *lrosaDsOperations) BeginPutNonRetry201Creating400(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.PutNonRetry201Creating400", resp, client.putNonRetry201Creating400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutNonRetry201Creating400", "", resp, client.putNonRetry201Creating400HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1852,7 +1852,7 @@ func (client *lrosaDsOperations) BeginPutNonRetry201Creating400InvalidJSON(ctx c
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.PutNonRetry201Creating400InvalidJSON", resp, client.putNonRetry201Creating400InvalidJsonHandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutNonRetry201Creating400InvalidJSON", "", resp, client.putNonRetry201Creating400InvalidJsonHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -1925,7 +1925,7 @@ func (client *lrosaDsOperations) BeginPutNonRetry400(ctx context.Context, lrosaD
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrosaDsOperations.PutNonRetry400", resp, client.putNonRetry400HandleError)
+	pt, err := createPollingTracker("lrosaDsOperations.PutNonRetry400", "", resp, client.putNonRetry400HandleError)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lroscustomheader.go
+++ b/test/autorest/generated/lrogroup/lroscustomheader.go
@@ -52,7 +52,7 @@ func (client *lrOSCustomHeaderOperations) BeginPost202Retry200(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSCustomHeaderOperations.Post202Retry200", resp, client.post202Retry200HandleError)
+	pt, err := createPollingTracker("lrOSCustomHeaderOperations.Post202Retry200", "", resp, client.post202Retry200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (client *lrOSCustomHeaderOperations) BeginPostAsyncRetrySucceeded(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSCustomHeaderOperations.PostAsyncRetrySucceeded", resp, client.postAsyncRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSCustomHeaderOperations.PostAsyncRetrySucceeded", "", resp, client.postAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (client *lrOSCustomHeaderOperations) BeginPut201CreatingSucceeded200(ctx co
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSCustomHeaderOperations.Put201CreatingSucceeded200", resp, client.put201CreatingSucceeded200HandleError)
+	pt, err := createPollingTracker("lrOSCustomHeaderOperations.Put201CreatingSucceeded200", "", resp, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +269,7 @@ func (client *lrOSCustomHeaderOperations) BeginPutAsyncRetrySucceeded(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	pt, err := createPollingTracker("lrOSCustomHeaderOperations.PutAsyncRetrySucceeded", resp, client.putAsyncRetrySucceededHandleError)
+	pt, err := createPollingTracker("lrOSCustomHeaderOperations.PutAsyncRetrySucceeded", "", resp, client.putAsyncRetrySucceededHandleError)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/pollers.go
+++ b/test/autorest/generated/lrogroup/pollers.go
@@ -107,6 +107,12 @@ func (p *productPoller) Poll(ctx context.Context) (*http.Response, error) {
 }
 
 func (p *productPoller) FinalResponse(ctx context.Context) (*ProductResponse, error) {
+	// checking if there was a FinalStateVia configuration to re-route the final GET
+	// request to the value specified in the FinalStateVia property on the poller
+	err := p.pt.setFinalState()
+	if err != nil {
+		return nil, err
+	}
 	if p.pt.finalGetURL() == "" {
 		// we can end up in this situation if the async operation returns a 200
 		// with no polling URLs.  in that case return the response which should
@@ -206,6 +212,12 @@ func (p *skuPoller) Poll(ctx context.Context) (*http.Response, error) {
 }
 
 func (p *skuPoller) FinalResponse(ctx context.Context) (*SkuResponse, error) {
+	// checking if there was a FinalStateVia configuration to re-route the final GET
+	// request to the value specified in the FinalStateVia property on the poller
+	err := p.pt.setFinalState()
+	if err != nil {
+		return nil, err
+	}
 	if p.pt.finalGetURL() == "" {
 		// we can end up in this situation if the async operation returns a 200
 		// with no polling URLs.  in that case return the response which should
@@ -305,6 +317,12 @@ func (p *subProductPoller) Poll(ctx context.Context) (*http.Response, error) {
 }
 
 func (p *subProductPoller) FinalResponse(ctx context.Context) (*SubProductResponse, error) {
+	// checking if there was a FinalStateVia configuration to re-route the final GET
+	// request to the value specified in the FinalStateVia property on the poller
+	err := p.pt.setFinalState()
+	if err != nil {
+		return nil, err
+	}
 	if p.pt.finalGetURL() == "" {
 		// we can end up in this situation if the async operation returns a 200
 		// with no polling URLs.  in that case return the response which should

--- a/test/autorest/generated/lrogroup/pollers.go
+++ b/test/autorest/generated/lrogroup/pollers.go
@@ -109,6 +109,7 @@ func (p *productPoller) Poll(ctx context.Context) (*http.Response, error) {
 func (p *productPoller) FinalResponse(ctx context.Context) (*ProductResponse, error) {
 	// checking if there was a FinalStateVia configuration to re-route the final GET
 	// request to the value specified in the FinalStateVia property on the poller
+	// this will override what is in the FinalGetURI
 	err := p.pt.setFinalState()
 	if err != nil {
 		return nil, err
@@ -214,6 +215,7 @@ func (p *skuPoller) Poll(ctx context.Context) (*http.Response, error) {
 func (p *skuPoller) FinalResponse(ctx context.Context) (*SkuResponse, error) {
 	// checking if there was a FinalStateVia configuration to re-route the final GET
 	// request to the value specified in the FinalStateVia property on the poller
+	// this will override what is in the FinalGetURI
 	err := p.pt.setFinalState()
 	if err != nil {
 		return nil, err
@@ -319,6 +321,7 @@ func (p *subProductPoller) Poll(ctx context.Context) (*http.Response, error) {
 func (p *subProductPoller) FinalResponse(ctx context.Context) (*SubProductResponse, error) {
 	// checking if there was a FinalStateVia configuration to re-route the final GET
 	// request to the value specified in the FinalStateVia property on the poller
+	// this will override what is in the FinalGetURI
 	err := p.pt.setFinalState()
 	if err != nil {
 		return nil, err

--- a/test/autorest/generated/lrogroup/pollers.go
+++ b/test/autorest/generated/lrogroup/pollers.go
@@ -109,7 +109,6 @@ func (p *productPoller) Poll(ctx context.Context) (*http.Response, error) {
 func (p *productPoller) FinalResponse(ctx context.Context) (*ProductResponse, error) {
 	// checking if there was a FinalStateVia configuration to re-route the final GET
 	// request to the value specified in the FinalStateVia property on the poller
-	// this will override what is in the FinalGetURI
 	err := p.pt.setFinalState()
 	if err != nil {
 		return nil, err
@@ -215,7 +214,6 @@ func (p *skuPoller) Poll(ctx context.Context) (*http.Response, error) {
 func (p *skuPoller) FinalResponse(ctx context.Context) (*SkuResponse, error) {
 	// checking if there was a FinalStateVia configuration to re-route the final GET
 	// request to the value specified in the FinalStateVia property on the poller
-	// this will override what is in the FinalGetURI
 	err := p.pt.setFinalState()
 	if err != nil {
 		return nil, err
@@ -321,7 +319,6 @@ func (p *subProductPoller) Poll(ctx context.Context) (*http.Response, error) {
 func (p *subProductPoller) FinalResponse(ctx context.Context) (*SubProductResponse, error) {
 	// checking if there was a FinalStateVia configuration to re-route the final GET
 	// request to the value specified in the FinalStateVia property on the poller
-	// this will override what is in the FinalGetURI
 	err := p.pt.setFinalState()
 	if err != nil {
 		return nil, err

--- a/test/autorest/generated/lrogroup/pollers_helper.go
+++ b/test/autorest/generated/lrogroup/pollers_helper.go
@@ -88,9 +88,6 @@ type pollingTracker interface {
 	// converts an *azcore.Response to an error
 	handleError(resp *azcore.Response) error
 
-	// returns the desired configuration for the final GET URI that overrides the value set in the finalGetURL
-	finalStateVia() string
-
 	// sets the FinalGetURI to the value pointed to in FinalStateVia
 	setFinalState() error
 }
@@ -126,7 +123,7 @@ type pollingTrackerBase struct {
 	FinalGetURI string `json:"resultURI"`
 
 	// stores the name of the header that the final get should be performed on,
-	//can be empty which will go to default behavior
+	// can be empty which will go to default behavior
 	FinalStateVia string `json:"finalStateVia"`
 
 	// the original request URL of the initial request for the polling operation
@@ -360,10 +357,6 @@ func (pt *pollingTrackerBase) initPollingMethod() error {
 
 func (pt *pollingTrackerBase) handleError(resp *azcore.Response) error {
 	return pt.errorHandler(resp)
-}
-
-func (pt *pollingTrackerBase) finalStateVia() string {
-	return pt.FinalStateVia
 }
 
 func (pt *pollingTrackerBase) setFinalState() error {

--- a/test/autorest/generated/lrogroup/pollers_helper.go
+++ b/test/autorest/generated/lrogroup/pollers_helper.go
@@ -130,7 +130,7 @@ type pollingTrackerBase struct {
 	FinalStateVia string `json:"finalStateVia"`
 
 	// the original request URL of the initial request for the polling operation
-	OriginalURI string `json: "originalURI"`
+	OriginalURI string `json:"originalURI"`
 
 	// used to hold an error object returned from the service
 	Err error `json:"error,omitempty"`

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -491,7 +491,6 @@ func TestLROBeginPostAsyncRetrycanceled(t *testing.T) {
 }
 
 func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
-	t.Skip("need to fix poller implementation, must not do a final get on location in this case")
 	op := getLROSOperations(t)
 	resp, err := op.BeginPostDoubleHeadersFinalAzureHeaderGet(context.Background())
 	if err != nil {
@@ -513,8 +512,7 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
 	helpers.VerifyStatusCode(t, res.RawResponse, 200)
 	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
 		Resource: lrogroup.Resource{
-			ID:   to.StringPtr("100"),
-			Name: to.StringPtr("foo"),
+			ID: to.StringPtr("100"),
 		},
 	})
 }
@@ -567,12 +565,7 @@ func TestLROBeginPostDoubleHeadersFinalLocationGet(t *testing.T) {
 		t.Fatal(err)
 	}
 	helpers.VerifyStatusCode(t, res.RawResponse, 200)
-	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{
-		Resource: lrogroup.Resource{
-			ID:   to.StringPtr("100"),
-			Name: to.StringPtr("foo"),
-		},
-	})
+	helpers.DeepEqualOrFatal(t, res.Product, &lrogroup.Product{})
 }
 
 func TestLROBeginPut200Acceptedcanceled200(t *testing.T) {


### PR DESCRIPTION
This PR adds functionality for x-ms-long-running-operations-options that allows setting the final get URL for LRO operation to those specified in the final-state-via field. 