### PR TITLE
Remove the `client.ByInspecting()` callback in responder

### DIFF
--- a/src/Model/MethodGo.cs
+++ b/src/Model/MethodGo.cs
@@ -475,7 +475,6 @@ namespace AutoRest.Go.Model
                 var decorators = new List<string>
                 {
                     "resp",
-                    "client.ByInspecting()",
                     string.Format("azure.WithErrorUnlessStatusCode({0})", string.Join(",", ResponseCodes.ToArray()))
                 };
 

--- a/test/src/tests/generated/additionalproperties/pets.go
+++ b/test/src/tests/generated/additionalproperties/pets.go
@@ -93,7 +93,6 @@ func (client PetsClient) CreateAPInPropertiesSender(req *http.Request) (*http.Re
 func (client PetsClient) CreateAPInPropertiesResponder(resp *http.Response) (result PetAPInProperties, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -164,7 +163,6 @@ func (client PetsClient) CreateAPInPropertiesWithAPStringSender(req *http.Reques
 func (client PetsClient) CreateAPInPropertiesWithAPStringResponder(resp *http.Response) (result PetAPInPropertiesWithAPString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -234,7 +232,6 @@ func (client PetsClient) CreateAPObjectSender(req *http.Request) (*http.Response
 func (client PetsClient) CreateAPObjectResponder(resp *http.Response) (result PetAPObject, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -304,7 +301,6 @@ func (client PetsClient) CreateAPStringSender(req *http.Request) (*http.Response
 func (client PetsClient) CreateAPStringResponder(resp *http.Response) (result PetAPString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -374,7 +370,6 @@ func (client PetsClient) CreateAPTrueSender(req *http.Request) (*http.Response, 
 func (client PetsClient) CreateAPTrueResponder(resp *http.Response) (result PetAPTrue, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -437,7 +432,6 @@ func (client PetsClient) CreateCatAPTrueSender(req *http.Request) (*http.Respons
 func (client PetsClient) CreateCatAPTrueResponder(resp *http.Response) (result CatAPTrue, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())

--- a/test/src/tests/generated/arraygroup/array.go
+++ b/test/src/tests/generated/arraygroup/array.go
@@ -86,7 +86,6 @@ func (client ArrayClient) GetArrayEmptySender(req *http.Request) (*http.Response
 func (client ArrayClient) GetArrayEmptyResponder(resp *http.Response) (result ListListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -147,7 +146,6 @@ func (client ArrayClient) GetArrayItemEmptySender(req *http.Request) (*http.Resp
 func (client ArrayClient) GetArrayItemEmptyResponder(resp *http.Response) (result ListListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -208,7 +206,6 @@ func (client ArrayClient) GetArrayItemNullSender(req *http.Request) (*http.Respo
 func (client ArrayClient) GetArrayItemNullResponder(resp *http.Response) (result ListListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -269,7 +266,6 @@ func (client ArrayClient) GetArrayNullSender(req *http.Request) (*http.Response,
 func (client ArrayClient) GetArrayNullResponder(resp *http.Response) (result ListListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -330,7 +326,6 @@ func (client ArrayClient) GetArrayValidSender(req *http.Request) (*http.Response
 func (client ArrayClient) GetArrayValidResponder(resp *http.Response) (result ListListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -392,7 +387,6 @@ func (client ArrayClient) GetBase64URLSender(req *http.Request) (*http.Response,
 func (client ArrayClient) GetBase64URLResponder(resp *http.Response) (result ListBase64URL, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -453,7 +447,6 @@ func (client ArrayClient) GetBooleanInvalidNullSender(req *http.Request) (*http.
 func (client ArrayClient) GetBooleanInvalidNullResponder(resp *http.Response) (result ListBool, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -514,7 +507,6 @@ func (client ArrayClient) GetBooleanInvalidStringSender(req *http.Request) (*htt
 func (client ArrayClient) GetBooleanInvalidStringResponder(resp *http.Response) (result ListBool, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -575,7 +567,6 @@ func (client ArrayClient) GetBooleanTfftSender(req *http.Request) (*http.Respons
 func (client ArrayClient) GetBooleanTfftResponder(resp *http.Response) (result ListBool, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -636,7 +627,6 @@ func (client ArrayClient) GetByteInvalidNullSender(req *http.Request) (*http.Res
 func (client ArrayClient) GetByteInvalidNullResponder(resp *http.Response) (result ListByteArray, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -698,7 +688,6 @@ func (client ArrayClient) GetByteValidSender(req *http.Request) (*http.Response,
 func (client ArrayClient) GetByteValidResponder(resp *http.Response) (result ListByteArray, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -759,7 +748,6 @@ func (client ArrayClient) GetComplexEmptySender(req *http.Request) (*http.Respon
 func (client ArrayClient) GetComplexEmptyResponder(resp *http.Response) (result ListProduct, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -821,7 +809,6 @@ func (client ArrayClient) GetComplexItemEmptySender(req *http.Request) (*http.Re
 func (client ArrayClient) GetComplexItemEmptyResponder(resp *http.Response) (result ListProduct, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -883,7 +870,6 @@ func (client ArrayClient) GetComplexItemNullSender(req *http.Request) (*http.Res
 func (client ArrayClient) GetComplexItemNullResponder(resp *http.Response) (result ListProduct, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -944,7 +930,6 @@ func (client ArrayClient) GetComplexNullSender(req *http.Request) (*http.Respons
 func (client ArrayClient) GetComplexNullResponder(resp *http.Response) (result ListProduct, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1006,7 +991,6 @@ func (client ArrayClient) GetComplexValidSender(req *http.Request) (*http.Respon
 func (client ArrayClient) GetComplexValidResponder(resp *http.Response) (result ListProduct, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1067,7 +1051,6 @@ func (client ArrayClient) GetDateInvalidCharsSender(req *http.Request) (*http.Re
 func (client ArrayClient) GetDateInvalidCharsResponder(resp *http.Response) (result ListDate, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1128,7 +1111,6 @@ func (client ArrayClient) GetDateInvalidNullSender(req *http.Request) (*http.Res
 func (client ArrayClient) GetDateInvalidNullResponder(resp *http.Response) (result ListDate, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1189,7 +1171,6 @@ func (client ArrayClient) GetDateTimeInvalidCharsSender(req *http.Request) (*htt
 func (client ArrayClient) GetDateTimeInvalidCharsResponder(resp *http.Response) (result ListDateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1250,7 +1231,6 @@ func (client ArrayClient) GetDateTimeInvalidNullSender(req *http.Request) (*http
 func (client ArrayClient) GetDateTimeInvalidNullResponder(resp *http.Response) (result ListDateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1312,7 +1292,6 @@ func (client ArrayClient) GetDateTimeRfc1123ValidSender(req *http.Request) (*htt
 func (client ArrayClient) GetDateTimeRfc1123ValidResponder(resp *http.Response) (result ListDateTimeRfc1123, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1374,7 +1353,6 @@ func (client ArrayClient) GetDateTimeValidSender(req *http.Request) (*http.Respo
 func (client ArrayClient) GetDateTimeValidResponder(resp *http.Response) (result ListDateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1435,7 +1413,6 @@ func (client ArrayClient) GetDateValidSender(req *http.Request) (*http.Response,
 func (client ArrayClient) GetDateValidResponder(resp *http.Response) (result ListDate, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1496,7 +1473,6 @@ func (client ArrayClient) GetDictionaryEmptySender(req *http.Request) (*http.Res
 func (client ArrayClient) GetDictionaryEmptyResponder(resp *http.Response) (result ListSetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1558,7 +1534,6 @@ func (client ArrayClient) GetDictionaryItemEmptySender(req *http.Request) (*http
 func (client ArrayClient) GetDictionaryItemEmptyResponder(resp *http.Response) (result ListSetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1620,7 +1595,6 @@ func (client ArrayClient) GetDictionaryItemNullSender(req *http.Request) (*http.
 func (client ArrayClient) GetDictionaryItemNullResponder(resp *http.Response) (result ListSetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1681,7 +1655,6 @@ func (client ArrayClient) GetDictionaryNullSender(req *http.Request) (*http.Resp
 func (client ArrayClient) GetDictionaryNullResponder(resp *http.Response) (result ListSetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1743,7 +1716,6 @@ func (client ArrayClient) GetDictionaryValidSender(req *http.Request) (*http.Res
 func (client ArrayClient) GetDictionaryValidResponder(resp *http.Response) (result ListSetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1804,7 +1776,6 @@ func (client ArrayClient) GetDoubleInvalidNullSender(req *http.Request) (*http.R
 func (client ArrayClient) GetDoubleInvalidNullResponder(resp *http.Response) (result ListFloat64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1865,7 +1836,6 @@ func (client ArrayClient) GetDoubleInvalidStringSender(req *http.Request) (*http
 func (client ArrayClient) GetDoubleInvalidStringResponder(resp *http.Response) (result ListFloat64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1926,7 +1896,6 @@ func (client ArrayClient) GetDoubleValidSender(req *http.Request) (*http.Respons
 func (client ArrayClient) GetDoubleValidResponder(resp *http.Response) (result ListFloat64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1987,7 +1956,6 @@ func (client ArrayClient) GetDurationValidSender(req *http.Request) (*http.Respo
 func (client ArrayClient) GetDurationValidResponder(resp *http.Response) (result ListTimeSpan, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2048,7 +2016,6 @@ func (client ArrayClient) GetEmptySender(req *http.Request) (*http.Response, err
 func (client ArrayClient) GetEmptyResponder(resp *http.Response) (result ListInt32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2109,7 +2076,6 @@ func (client ArrayClient) GetEnumValidSender(req *http.Request) (*http.Response,
 func (client ArrayClient) GetEnumValidResponder(resp *http.Response) (result ListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2170,7 +2136,6 @@ func (client ArrayClient) GetFloatInvalidNullSender(req *http.Request) (*http.Re
 func (client ArrayClient) GetFloatInvalidNullResponder(resp *http.Response) (result ListFloat64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2231,7 +2196,6 @@ func (client ArrayClient) GetFloatInvalidStringSender(req *http.Request) (*http.
 func (client ArrayClient) GetFloatInvalidStringResponder(resp *http.Response) (result ListFloat64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2292,7 +2256,6 @@ func (client ArrayClient) GetFloatValidSender(req *http.Request) (*http.Response
 func (client ArrayClient) GetFloatValidResponder(resp *http.Response) (result ListFloat64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2353,7 +2316,6 @@ func (client ArrayClient) GetIntegerValidSender(req *http.Request) (*http.Respon
 func (client ArrayClient) GetIntegerValidResponder(resp *http.Response) (result ListInt32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2414,7 +2376,6 @@ func (client ArrayClient) GetIntInvalidNullSender(req *http.Request) (*http.Resp
 func (client ArrayClient) GetIntInvalidNullResponder(resp *http.Response) (result ListInt32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2475,7 +2436,6 @@ func (client ArrayClient) GetIntInvalidStringSender(req *http.Request) (*http.Re
 func (client ArrayClient) GetIntInvalidStringResponder(resp *http.Response) (result ListInt32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2536,7 +2496,6 @@ func (client ArrayClient) GetInvalidSender(req *http.Request) (*http.Response, e
 func (client ArrayClient) GetInvalidResponder(resp *http.Response) (result ListInt32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2597,7 +2556,6 @@ func (client ArrayClient) GetLongInvalidNullSender(req *http.Request) (*http.Res
 func (client ArrayClient) GetLongInvalidNullResponder(resp *http.Response) (result ListInt64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2658,7 +2616,6 @@ func (client ArrayClient) GetLongInvalidStringSender(req *http.Request) (*http.R
 func (client ArrayClient) GetLongInvalidStringResponder(resp *http.Response) (result ListInt64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2719,7 +2676,6 @@ func (client ArrayClient) GetLongValidSender(req *http.Request) (*http.Response,
 func (client ArrayClient) GetLongValidResponder(resp *http.Response) (result ListInt64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2780,7 +2736,6 @@ func (client ArrayClient) GetNullSender(req *http.Request) (*http.Response, erro
 func (client ArrayClient) GetNullResponder(resp *http.Response) (result ListInt32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2841,7 +2796,6 @@ func (client ArrayClient) GetStringEnumValidSender(req *http.Request) (*http.Res
 func (client ArrayClient) GetStringEnumValidResponder(resp *http.Response) (result ListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2902,7 +2856,6 @@ func (client ArrayClient) GetStringValidSender(req *http.Request) (*http.Respons
 func (client ArrayClient) GetStringValidResponder(resp *http.Response) (result ListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2963,7 +2916,6 @@ func (client ArrayClient) GetStringWithInvalidSender(req *http.Request) (*http.R
 func (client ArrayClient) GetStringWithInvalidResponder(resp *http.Response) (result ListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -3024,7 +2976,6 @@ func (client ArrayClient) GetStringWithNullSender(req *http.Request) (*http.Resp
 func (client ArrayClient) GetStringWithNullResponder(resp *http.Response) (result ListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -3085,7 +3036,6 @@ func (client ArrayClient) GetUUIDInvalidCharsSender(req *http.Request) (*http.Re
 func (client ArrayClient) GetUUIDInvalidCharsResponder(resp *http.Response) (result ListUUID, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -3147,7 +3097,6 @@ func (client ArrayClient) GetUUIDValidSender(req *http.Request) (*http.Response,
 func (client ArrayClient) GetUUIDValidResponder(resp *http.Response) (result ListUUID, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -3216,7 +3165,6 @@ func (client ArrayClient) PutArrayValidSender(req *http.Request) (*http.Response
 func (client ArrayClient) PutArrayValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3284,7 +3232,6 @@ func (client ArrayClient) PutBooleanTfftSender(req *http.Request) (*http.Respons
 func (client ArrayClient) PutBooleanTfftResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3353,7 +3300,6 @@ func (client ArrayClient) PutByteValidSender(req *http.Request) (*http.Response,
 func (client ArrayClient) PutByteValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3422,7 +3368,6 @@ func (client ArrayClient) PutComplexValidSender(req *http.Request) (*http.Respon
 func (client ArrayClient) PutComplexValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3491,7 +3436,6 @@ func (client ArrayClient) PutDateTimeRfc1123ValidSender(req *http.Request) (*htt
 func (client ArrayClient) PutDateTimeRfc1123ValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3559,7 +3503,6 @@ func (client ArrayClient) PutDateTimeValidSender(req *http.Request) (*http.Respo
 func (client ArrayClient) PutDateTimeValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3627,7 +3570,6 @@ func (client ArrayClient) PutDateValidSender(req *http.Request) (*http.Response,
 func (client ArrayClient) PutDateValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3696,7 +3638,6 @@ func (client ArrayClient) PutDictionaryValidSender(req *http.Request) (*http.Res
 func (client ArrayClient) PutDictionaryValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3764,7 +3705,6 @@ func (client ArrayClient) PutDoubleValidSender(req *http.Request) (*http.Respons
 func (client ArrayClient) PutDoubleValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3832,7 +3772,6 @@ func (client ArrayClient) PutDurationValidSender(req *http.Request) (*http.Respo
 func (client ArrayClient) PutDurationValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3900,7 +3839,6 @@ func (client ArrayClient) PutEmptySender(req *http.Request) (*http.Response, err
 func (client ArrayClient) PutEmptyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3968,7 +3906,6 @@ func (client ArrayClient) PutEnumValidSender(req *http.Request) (*http.Response,
 func (client ArrayClient) PutEnumValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -4036,7 +3973,6 @@ func (client ArrayClient) PutFloatValidSender(req *http.Request) (*http.Response
 func (client ArrayClient) PutFloatValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -4104,7 +4040,6 @@ func (client ArrayClient) PutIntegerValidSender(req *http.Request) (*http.Respon
 func (client ArrayClient) PutIntegerValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -4172,7 +4107,6 @@ func (client ArrayClient) PutLongValidSender(req *http.Request) (*http.Response,
 func (client ArrayClient) PutLongValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -4240,7 +4174,6 @@ func (client ArrayClient) PutStringEnumValidSender(req *http.Request) (*http.Res
 func (client ArrayClient) PutStringEnumValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -4308,7 +4241,6 @@ func (client ArrayClient) PutStringValidSender(req *http.Request) (*http.Respons
 func (client ArrayClient) PutStringValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -4377,7 +4309,6 @@ func (client ArrayClient) PutUUIDValidSender(req *http.Request) (*http.Response,
 func (client ArrayClient) PutUUIDValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/azurereport/client.go
+++ b/test/src/tests/generated/azurereport/client.go
@@ -104,7 +104,6 @@ func (client BaseClient) GetReportSender(req *http.Request) (*http.Response, err
 func (client BaseClient) GetReportResponder(resp *http.Response) (result SetInt32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())

--- a/test/src/tests/generated/booleangroup/bool.go
+++ b/test/src/tests/generated/booleangroup/bool.go
@@ -83,7 +83,6 @@ func (client BoolClient) GetFalseSender(req *http.Request) (*http.Response, erro
 func (client BoolClient) GetFalseResponder(resp *http.Response) (result BoolModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -144,7 +143,6 @@ func (client BoolClient) GetInvalidSender(req *http.Request) (*http.Response, er
 func (client BoolClient) GetInvalidResponder(resp *http.Response) (result BoolModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -205,7 +203,6 @@ func (client BoolClient) GetNullSender(req *http.Request) (*http.Response, error
 func (client BoolClient) GetNullResponder(resp *http.Response) (result BoolModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -266,7 +263,6 @@ func (client BoolClient) GetTrueSender(req *http.Request) (*http.Response, error
 func (client BoolClient) GetTrueResponder(resp *http.Response) (result BoolModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -329,7 +325,6 @@ func (client BoolClient) PutFalseSender(req *http.Request) (*http.Response, erro
 func (client BoolClient) PutFalseResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -391,7 +386,6 @@ func (client BoolClient) PutTrueSender(req *http.Request) (*http.Response, error
 func (client BoolClient) PutTrueResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/bytegroup/byte.go
+++ b/test/src/tests/generated/bytegroup/byte.go
@@ -84,7 +84,6 @@ func (client ByteClient) GetEmptySender(req *http.Request) (*http.Response, erro
 func (client ByteClient) GetEmptyResponder(resp *http.Response) (result ByteArray, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -145,7 +144,6 @@ func (client ByteClient) GetInvalidSender(req *http.Request) (*http.Response, er
 func (client ByteClient) GetInvalidResponder(resp *http.Response) (result ByteArray, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -206,7 +204,6 @@ func (client ByteClient) GetNonASCIISender(req *http.Request) (*http.Response, e
 func (client ByteClient) GetNonASCIIResponder(resp *http.Response) (result ByteArray, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -267,7 +264,6 @@ func (client ByteClient) GetNullSender(req *http.Request) (*http.Response, error
 func (client ByteClient) GetNullResponder(resp *http.Response) (result ByteArray, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -338,7 +334,6 @@ func (client ByteClient) PutNonASCIISender(req *http.Request) (*http.Response, e
 func (client ByteClient) PutNonASCIIResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/complexgroup/array.go
+++ b/test/src/tests/generated/complexgroup/array.go
@@ -83,7 +83,6 @@ func (client ArrayClient) GetEmptySender(req *http.Request) (*http.Response, err
 func (client ArrayClient) GetEmptyResponder(resp *http.Response) (result ArrayWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -144,7 +143,6 @@ func (client ArrayClient) GetNotProvidedSender(req *http.Request) (*http.Respons
 func (client ArrayClient) GetNotProvidedResponder(resp *http.Response) (result ArrayWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -205,7 +203,6 @@ func (client ArrayClient) GetValidSender(req *http.Request) (*http.Response, err
 func (client ArrayClient) GetValidResponder(resp *http.Response) (result ArrayWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -270,7 +267,6 @@ func (client ArrayClient) PutEmptySender(req *http.Request) (*http.Response, err
 func (client ArrayClient) PutEmptyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -335,7 +331,6 @@ func (client ArrayClient) PutValidSender(req *http.Request) (*http.Response, err
 func (client ArrayClient) PutValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/complexgroup/basic.go
+++ b/test/src/tests/generated/complexgroup/basic.go
@@ -83,7 +83,6 @@ func (client BasicClient) GetEmptySender(req *http.Request) (*http.Response, err
 func (client BasicClient) GetEmptyResponder(resp *http.Response) (result Basic, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -144,7 +143,6 @@ func (client BasicClient) GetInvalidSender(req *http.Request) (*http.Response, e
 func (client BasicClient) GetInvalidResponder(resp *http.Response) (result Basic, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -205,7 +203,6 @@ func (client BasicClient) GetNotProvidedSender(req *http.Request) (*http.Respons
 func (client BasicClient) GetNotProvidedResponder(resp *http.Response) (result Basic, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -266,7 +263,6 @@ func (client BasicClient) GetNullSender(req *http.Request) (*http.Response, erro
 func (client BasicClient) GetNullResponder(resp *http.Response) (result Basic, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -327,7 +323,6 @@ func (client BasicClient) GetValidSender(req *http.Request) (*http.Response, err
 func (client BasicClient) GetValidResponder(resp *http.Response) (result Basic, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -398,7 +393,6 @@ func (client BasicClient) PutValidSender(req *http.Request) (*http.Response, err
 func (client BasicClient) PutValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/complexgroup/dictionary.go
+++ b/test/src/tests/generated/complexgroup/dictionary.go
@@ -83,7 +83,6 @@ func (client DictionaryClient) GetEmptySender(req *http.Request) (*http.Response
 func (client DictionaryClient) GetEmptyResponder(resp *http.Response) (result DictionaryWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -144,7 +143,6 @@ func (client DictionaryClient) GetNotProvidedSender(req *http.Request) (*http.Re
 func (client DictionaryClient) GetNotProvidedResponder(resp *http.Response) (result DictionaryWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -205,7 +203,6 @@ func (client DictionaryClient) GetNullSender(req *http.Request) (*http.Response,
 func (client DictionaryClient) GetNullResponder(resp *http.Response) (result DictionaryWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -266,7 +263,6 @@ func (client DictionaryClient) GetValidSender(req *http.Request) (*http.Response
 func (client DictionaryClient) GetValidResponder(resp *http.Response) (result DictionaryWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -331,7 +327,6 @@ func (client DictionaryClient) PutEmptySender(req *http.Request) (*http.Response
 func (client DictionaryClient) PutEmptyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -396,7 +391,6 @@ func (client DictionaryClient) PutValidSender(req *http.Request) (*http.Response
 func (client DictionaryClient) PutValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/complexgroup/flattencomplex.go
+++ b/test/src/tests/generated/complexgroup/flattencomplex.go
@@ -83,7 +83,6 @@ func (client FlattencomplexClient) GetValidSender(req *http.Request) (*http.Resp
 func (client FlattencomplexClient) GetValidResponder(resp *http.Response) (result MyBaseTypeModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())

--- a/test/src/tests/generated/complexgroup/inheritance.go
+++ b/test/src/tests/generated/complexgroup/inheritance.go
@@ -83,7 +83,6 @@ func (client InheritanceClient) GetValidSender(req *http.Request) (*http.Respons
 func (client InheritanceClient) GetValidResponder(resp *http.Response) (result Siamese, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -150,7 +149,6 @@ func (client InheritanceClient) PutValidSender(req *http.Request) (*http.Respons
 func (client InheritanceClient) PutValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/complexgroup/polymorphicrecursive.go
+++ b/test/src/tests/generated/complexgroup/polymorphicrecursive.go
@@ -85,7 +85,6 @@ func (client PolymorphicrecursiveClient) GetValidSender(req *http.Request) (*htt
 func (client PolymorphicrecursiveClient) GetValidResponder(resp *http.Response) (result FishModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -208,7 +207,6 @@ func (client PolymorphicrecursiveClient) PutValidSender(req *http.Request) (*htt
 func (client PolymorphicrecursiveClient) PutValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/complexgroup/polymorphism.go
+++ b/test/src/tests/generated/complexgroup/polymorphism.go
@@ -85,7 +85,6 @@ func (client PolymorphismClient) GetComplicatedSender(req *http.Request) (*http.
 func (client PolymorphismClient) GetComplicatedResponder(resp *http.Response) (result SalmonModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -148,7 +147,6 @@ func (client PolymorphismClient) GetComposedWithDiscriminatorSender(req *http.Re
 func (client PolymorphismClient) GetComposedWithDiscriminatorResponder(resp *http.Response) (result DotFishMarket, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -211,7 +209,6 @@ func (client PolymorphismClient) GetComposedWithoutDiscriminatorSender(req *http
 func (client PolymorphismClient) GetComposedWithoutDiscriminatorResponder(resp *http.Response) (result DotFishMarket, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -272,7 +269,6 @@ func (client PolymorphismClient) GetDotSyntaxSender(req *http.Request) (*http.Re
 func (client PolymorphismClient) GetDotSyntaxResponder(resp *http.Response) (result DotFishModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -333,7 +329,6 @@ func (client PolymorphismClient) GetValidSender(req *http.Request) (*http.Respon
 func (client PolymorphismClient) GetValidResponder(resp *http.Response) (result FishModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -397,7 +392,6 @@ func (client PolymorphismClient) PutComplicatedSender(req *http.Request) (*http.
 func (client PolymorphismClient) PutComplicatedResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -459,7 +453,6 @@ func (client PolymorphismClient) PutMissingDiscriminatorSender(req *http.Request
 func (client PolymorphismClient) PutMissingDiscriminatorResponder(resp *http.Response) (result SalmonModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -562,7 +555,6 @@ func (client PolymorphismClient) PutValidSender(req *http.Request) (*http.Respon
 func (client PolymorphismClient) PutValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -659,7 +651,6 @@ func (client PolymorphismClient) PutValidMissingRequiredSender(req *http.Request
 func (client PolymorphismClient) PutValidMissingRequiredResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/complexgroup/primitive.go
+++ b/test/src/tests/generated/complexgroup/primitive.go
@@ -83,7 +83,6 @@ func (client PrimitiveClient) GetBoolSender(req *http.Request) (*http.Response, 
 func (client PrimitiveClient) GetBoolResponder(resp *http.Response) (result BooleanWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -144,7 +143,6 @@ func (client PrimitiveClient) GetByteSender(req *http.Request) (*http.Response, 
 func (client PrimitiveClient) GetByteResponder(resp *http.Response) (result ByteWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -205,7 +203,6 @@ func (client PrimitiveClient) GetDateSender(req *http.Request) (*http.Response, 
 func (client PrimitiveClient) GetDateResponder(resp *http.Response) (result DateWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -266,7 +263,6 @@ func (client PrimitiveClient) GetDateTimeSender(req *http.Request) (*http.Respon
 func (client PrimitiveClient) GetDateTimeResponder(resp *http.Response) (result DatetimeWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -327,7 +323,6 @@ func (client PrimitiveClient) GetDateTimeRfc1123Sender(req *http.Request) (*http
 func (client PrimitiveClient) GetDateTimeRfc1123Responder(resp *http.Response) (result Datetimerfc1123Wrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -388,7 +383,6 @@ func (client PrimitiveClient) GetDoubleSender(req *http.Request) (*http.Response
 func (client PrimitiveClient) GetDoubleResponder(resp *http.Response) (result DoubleWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -449,7 +443,6 @@ func (client PrimitiveClient) GetDurationSender(req *http.Request) (*http.Respon
 func (client PrimitiveClient) GetDurationResponder(resp *http.Response) (result DurationWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -510,7 +503,6 @@ func (client PrimitiveClient) GetFloatSender(req *http.Request) (*http.Response,
 func (client PrimitiveClient) GetFloatResponder(resp *http.Response) (result FloatWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -571,7 +563,6 @@ func (client PrimitiveClient) GetIntSender(req *http.Request) (*http.Response, e
 func (client PrimitiveClient) GetIntResponder(resp *http.Response) (result IntWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -632,7 +623,6 @@ func (client PrimitiveClient) GetLongSender(req *http.Request) (*http.Response, 
 func (client PrimitiveClient) GetLongResponder(resp *http.Response) (result LongWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -693,7 +683,6 @@ func (client PrimitiveClient) GetStringSender(req *http.Request) (*http.Response
 func (client PrimitiveClient) GetStringResponder(resp *http.Response) (result StringWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -758,7 +747,6 @@ func (client PrimitiveClient) PutBoolSender(req *http.Request) (*http.Response, 
 func (client PrimitiveClient) PutBoolResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -822,7 +810,6 @@ func (client PrimitiveClient) PutByteSender(req *http.Request) (*http.Response, 
 func (client PrimitiveClient) PutByteResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -886,7 +873,6 @@ func (client PrimitiveClient) PutDateSender(req *http.Request) (*http.Response, 
 func (client PrimitiveClient) PutDateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -950,7 +936,6 @@ func (client PrimitiveClient) PutDateTimeSender(req *http.Request) (*http.Respon
 func (client PrimitiveClient) PutDateTimeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1014,7 +999,6 @@ func (client PrimitiveClient) PutDateTimeRfc1123Sender(req *http.Request) (*http
 func (client PrimitiveClient) PutDateTimeRfc1123Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1078,7 +1062,6 @@ func (client PrimitiveClient) PutDoubleSender(req *http.Request) (*http.Response
 func (client PrimitiveClient) PutDoubleResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1142,7 +1125,6 @@ func (client PrimitiveClient) PutDurationSender(req *http.Request) (*http.Respon
 func (client PrimitiveClient) PutDurationResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1206,7 +1188,6 @@ func (client PrimitiveClient) PutFloatSender(req *http.Request) (*http.Response,
 func (client PrimitiveClient) PutFloatResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1270,7 +1251,6 @@ func (client PrimitiveClient) PutIntSender(req *http.Request) (*http.Response, e
 func (client PrimitiveClient) PutIntResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1334,7 +1314,6 @@ func (client PrimitiveClient) PutLongSender(req *http.Request) (*http.Response, 
 func (client PrimitiveClient) PutLongResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1398,7 +1377,6 @@ func (client PrimitiveClient) PutStringSender(req *http.Request) (*http.Response
 func (client PrimitiveClient) PutStringResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/complexgroup/readonlyproperty.go
+++ b/test/src/tests/generated/complexgroup/readonlyproperty.go
@@ -84,7 +84,6 @@ func (client ReadonlypropertyClient) GetValidSender(req *http.Request) (*http.Re
 func (client ReadonlypropertyClient) GetValidResponder(resp *http.Response) (result ReadonlyObj, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -148,7 +147,6 @@ func (client ReadonlypropertyClient) PutValidSender(req *http.Request) (*http.Re
 func (client ReadonlypropertyClient) PutValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/custombaseurlgroup/paths.go
+++ b/test/src/tests/generated/custombaseurlgroup/paths.go
@@ -84,7 +84,6 @@ func (client PathsClient) GetEmptySender(req *http.Request) (*http.Response, err
 func (client PathsClient) GetEmptyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/dategroup/date.go
+++ b/test/src/tests/generated/dategroup/date.go
@@ -84,7 +84,6 @@ func (client DateClient) GetInvalidDateSender(req *http.Request) (*http.Response
 func (client DateClient) GetInvalidDateResponder(resp *http.Response) (result DateModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -145,7 +144,6 @@ func (client DateClient) GetMaxDateSender(req *http.Request) (*http.Response, er
 func (client DateClient) GetMaxDateResponder(resp *http.Response) (result DateModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -206,7 +204,6 @@ func (client DateClient) GetMinDateSender(req *http.Request) (*http.Response, er
 func (client DateClient) GetMinDateResponder(resp *http.Response) (result DateModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -267,7 +264,6 @@ func (client DateClient) GetNullSender(req *http.Request) (*http.Response, error
 func (client DateClient) GetNullResponder(resp *http.Response) (result DateModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -328,7 +324,6 @@ func (client DateClient) GetOverflowDateSender(req *http.Request) (*http.Respons
 func (client DateClient) GetOverflowDateResponder(resp *http.Response) (result DateModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -389,7 +384,6 @@ func (client DateClient) GetUnderflowDateSender(req *http.Request) (*http.Respon
 func (client DateClient) GetUnderflowDateResponder(resp *http.Response) (result DateModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -452,7 +446,6 @@ func (client DateClient) PutMaxDateSender(req *http.Request) (*http.Response, er
 func (client DateClient) PutMaxDateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -514,7 +507,6 @@ func (client DateClient) PutMinDateSender(req *http.Request) (*http.Response, er
 func (client DateClient) PutMinDateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/datetimegroup/datetime.go
+++ b/test/src/tests/generated/datetimegroup/datetime.go
@@ -84,7 +84,6 @@ func (client DatetimeClient) GetInvalidSender(req *http.Request) (*http.Response
 func (client DatetimeClient) GetInvalidResponder(resp *http.Response) (result DateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -146,7 +145,6 @@ func (client DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTimeSender(re
 func (client DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTimeResponder(resp *http.Response) (result DateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -207,7 +205,6 @@ func (client DatetimeClient) GetLocalNegativeOffsetMinDateTimeSender(req *http.R
 func (client DatetimeClient) GetLocalNegativeOffsetMinDateTimeResponder(resp *http.Response) (result DateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -269,7 +266,6 @@ func (client DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTimeSender(re
 func (client DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTimeResponder(resp *http.Response) (result DateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -331,7 +327,6 @@ func (client DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTimeSender(re
 func (client DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTimeResponder(resp *http.Response) (result DateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -392,7 +387,6 @@ func (client DatetimeClient) GetLocalPositiveOffsetMinDateTimeSender(req *http.R
 func (client DatetimeClient) GetLocalPositiveOffsetMinDateTimeResponder(resp *http.Response) (result DateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -454,7 +448,6 @@ func (client DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTimeSender(re
 func (client DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTimeResponder(resp *http.Response) (result DateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -515,7 +508,6 @@ func (client DatetimeClient) GetNullSender(req *http.Request) (*http.Response, e
 func (client DatetimeClient) GetNullResponder(resp *http.Response) (result DateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -576,7 +568,6 @@ func (client DatetimeClient) GetOverflowSender(req *http.Request) (*http.Respons
 func (client DatetimeClient) GetOverflowResponder(resp *http.Response) (result DateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -637,7 +628,6 @@ func (client DatetimeClient) GetUnderflowSender(req *http.Request) (*http.Respon
 func (client DatetimeClient) GetUnderflowResponder(resp *http.Response) (result DateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -698,7 +688,6 @@ func (client DatetimeClient) GetUtcLowercaseMaxDateTimeSender(req *http.Request)
 func (client DatetimeClient) GetUtcLowercaseMaxDateTimeResponder(resp *http.Response) (result DateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -759,7 +748,6 @@ func (client DatetimeClient) GetUtcMinDateTimeSender(req *http.Request) (*http.R
 func (client DatetimeClient) GetUtcMinDateTimeResponder(resp *http.Response) (result DateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -820,7 +808,6 @@ func (client DatetimeClient) GetUtcUppercaseMaxDateTimeSender(req *http.Request)
 func (client DatetimeClient) GetUtcUppercaseMaxDateTimeResponder(resp *http.Response) (result DateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -883,7 +870,6 @@ func (client DatetimeClient) PutLocalNegativeOffsetMaxDateTimeSender(req *http.R
 func (client DatetimeClient) PutLocalNegativeOffsetMaxDateTimeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -945,7 +931,6 @@ func (client DatetimeClient) PutLocalNegativeOffsetMinDateTimeSender(req *http.R
 func (client DatetimeClient) PutLocalNegativeOffsetMinDateTimeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1007,7 +992,6 @@ func (client DatetimeClient) PutLocalPositiveOffsetMaxDateTimeSender(req *http.R
 func (client DatetimeClient) PutLocalPositiveOffsetMaxDateTimeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1069,7 +1053,6 @@ func (client DatetimeClient) PutLocalPositiveOffsetMinDateTimeSender(req *http.R
 func (client DatetimeClient) PutLocalPositiveOffsetMinDateTimeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1131,7 +1114,6 @@ func (client DatetimeClient) PutUtcMaxDateTimeSender(req *http.Request) (*http.R
 func (client DatetimeClient) PutUtcMaxDateTimeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1193,7 +1175,6 @@ func (client DatetimeClient) PutUtcMinDateTimeSender(req *http.Request) (*http.R
 func (client DatetimeClient) PutUtcMinDateTimeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/datetimerfc1123group/datetimerfc1123.go
+++ b/test/src/tests/generated/datetimerfc1123group/datetimerfc1123.go
@@ -84,7 +84,6 @@ func (client Datetimerfc1123Client) GetInvalidSender(req *http.Request) (*http.R
 func (client Datetimerfc1123Client) GetInvalidResponder(resp *http.Response) (result DateTimeRfc1123, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -145,7 +144,6 @@ func (client Datetimerfc1123Client) GetNullSender(req *http.Request) (*http.Resp
 func (client Datetimerfc1123Client) GetNullResponder(resp *http.Response) (result DateTimeRfc1123, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -206,7 +204,6 @@ func (client Datetimerfc1123Client) GetOverflowSender(req *http.Request) (*http.
 func (client Datetimerfc1123Client) GetOverflowResponder(resp *http.Response) (result DateTimeRfc1123, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -267,7 +264,6 @@ func (client Datetimerfc1123Client) GetUnderflowSender(req *http.Request) (*http
 func (client Datetimerfc1123Client) GetUnderflowResponder(resp *http.Response) (result DateTimeRfc1123, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -328,7 +324,6 @@ func (client Datetimerfc1123Client) GetUtcLowercaseMaxDateTimeSender(req *http.R
 func (client Datetimerfc1123Client) GetUtcLowercaseMaxDateTimeResponder(resp *http.Response) (result DateTimeRfc1123, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -389,7 +384,6 @@ func (client Datetimerfc1123Client) GetUtcMinDateTimeSender(req *http.Request) (
 func (client Datetimerfc1123Client) GetUtcMinDateTimeResponder(resp *http.Response) (result DateTimeRfc1123, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -450,7 +444,6 @@ func (client Datetimerfc1123Client) GetUtcUppercaseMaxDateTimeSender(req *http.R
 func (client Datetimerfc1123Client) GetUtcUppercaseMaxDateTimeResponder(resp *http.Response) (result DateTimeRfc1123, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -513,7 +506,6 @@ func (client Datetimerfc1123Client) PutUtcMaxDateTimeSender(req *http.Request) (
 func (client Datetimerfc1123Client) PutUtcMaxDateTimeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -575,7 +567,6 @@ func (client Datetimerfc1123Client) PutUtcMinDateTimeSender(req *http.Request) (
 func (client Datetimerfc1123Client) PutUtcMinDateTimeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/dictionarygroup/dictionary.go
+++ b/test/src/tests/generated/dictionarygroup/dictionary.go
@@ -85,7 +85,6 @@ func (client DictionaryClient) GetArrayEmptySender(req *http.Request) (*http.Res
 func (client DictionaryClient) GetArrayEmptyResponder(resp *http.Response) (result SetListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -146,7 +145,6 @@ func (client DictionaryClient) GetArrayItemEmptySender(req *http.Request) (*http
 func (client DictionaryClient) GetArrayItemEmptyResponder(resp *http.Response) (result SetListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -207,7 +205,6 @@ func (client DictionaryClient) GetArrayItemNullSender(req *http.Request) (*http.
 func (client DictionaryClient) GetArrayItemNullResponder(resp *http.Response) (result SetListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -268,7 +265,6 @@ func (client DictionaryClient) GetArrayNullSender(req *http.Request) (*http.Resp
 func (client DictionaryClient) GetArrayNullResponder(resp *http.Response) (result SetListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -329,7 +325,6 @@ func (client DictionaryClient) GetArrayValidSender(req *http.Request) (*http.Res
 func (client DictionaryClient) GetArrayValidResponder(resp *http.Response) (result SetListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -391,7 +386,6 @@ func (client DictionaryClient) GetBase64URLSender(req *http.Request) (*http.Resp
 func (client DictionaryClient) GetBase64URLResponder(resp *http.Response) (result SetBase64URL, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -452,7 +446,6 @@ func (client DictionaryClient) GetBooleanInvalidNullSender(req *http.Request) (*
 func (client DictionaryClient) GetBooleanInvalidNullResponder(resp *http.Response) (result SetBool, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -513,7 +506,6 @@ func (client DictionaryClient) GetBooleanInvalidStringSender(req *http.Request) 
 func (client DictionaryClient) GetBooleanInvalidStringResponder(resp *http.Response) (result SetBool, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -574,7 +566,6 @@ func (client DictionaryClient) GetBooleanTfftSender(req *http.Request) (*http.Re
 func (client DictionaryClient) GetBooleanTfftResponder(resp *http.Response) (result SetBool, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -635,7 +626,6 @@ func (client DictionaryClient) GetByteInvalidNullSender(req *http.Request) (*htt
 func (client DictionaryClient) GetByteInvalidNullResponder(resp *http.Response) (result SetByteArray, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -697,7 +687,6 @@ func (client DictionaryClient) GetByteValidSender(req *http.Request) (*http.Resp
 func (client DictionaryClient) GetByteValidResponder(resp *http.Response) (result SetByteArray, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -758,7 +747,6 @@ func (client DictionaryClient) GetComplexEmptySender(req *http.Request) (*http.R
 func (client DictionaryClient) GetComplexEmptyResponder(resp *http.Response) (result SetWidget, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -820,7 +808,6 @@ func (client DictionaryClient) GetComplexItemEmptySender(req *http.Request) (*ht
 func (client DictionaryClient) GetComplexItemEmptyResponder(resp *http.Response) (result SetWidget, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -882,7 +869,6 @@ func (client DictionaryClient) GetComplexItemNullSender(req *http.Request) (*htt
 func (client DictionaryClient) GetComplexItemNullResponder(resp *http.Response) (result SetWidget, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -943,7 +929,6 @@ func (client DictionaryClient) GetComplexNullSender(req *http.Request) (*http.Re
 func (client DictionaryClient) GetComplexNullResponder(resp *http.Response) (result SetWidget, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1005,7 +990,6 @@ func (client DictionaryClient) GetComplexValidSender(req *http.Request) (*http.R
 func (client DictionaryClient) GetComplexValidResponder(resp *http.Response) (result SetWidget, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1066,7 +1050,6 @@ func (client DictionaryClient) GetDateInvalidCharsSender(req *http.Request) (*ht
 func (client DictionaryClient) GetDateInvalidCharsResponder(resp *http.Response) (result SetDate, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1127,7 +1110,6 @@ func (client DictionaryClient) GetDateInvalidNullSender(req *http.Request) (*htt
 func (client DictionaryClient) GetDateInvalidNullResponder(resp *http.Response) (result SetDate, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1188,7 +1170,6 @@ func (client DictionaryClient) GetDateTimeInvalidCharsSender(req *http.Request) 
 func (client DictionaryClient) GetDateTimeInvalidCharsResponder(resp *http.Response) (result SetDateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1249,7 +1230,6 @@ func (client DictionaryClient) GetDateTimeInvalidNullSender(req *http.Request) (
 func (client DictionaryClient) GetDateTimeInvalidNullResponder(resp *http.Response) (result SetDateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1311,7 +1291,6 @@ func (client DictionaryClient) GetDateTimeRfc1123ValidSender(req *http.Request) 
 func (client DictionaryClient) GetDateTimeRfc1123ValidResponder(resp *http.Response) (result SetDateTimeRfc1123, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1373,7 +1352,6 @@ func (client DictionaryClient) GetDateTimeValidSender(req *http.Request) (*http.
 func (client DictionaryClient) GetDateTimeValidResponder(resp *http.Response) (result SetDateTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1434,7 +1412,6 @@ func (client DictionaryClient) GetDateValidSender(req *http.Request) (*http.Resp
 func (client DictionaryClient) GetDateValidResponder(resp *http.Response) (result SetDate, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1495,7 +1472,6 @@ func (client DictionaryClient) GetDictionaryEmptySender(req *http.Request) (*htt
 func (client DictionaryClient) GetDictionaryEmptyResponder(resp *http.Response) (result SetSetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1557,7 +1533,6 @@ func (client DictionaryClient) GetDictionaryItemEmptySender(req *http.Request) (
 func (client DictionaryClient) GetDictionaryItemEmptyResponder(resp *http.Response) (result SetSetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1619,7 +1594,6 @@ func (client DictionaryClient) GetDictionaryItemNullSender(req *http.Request) (*
 func (client DictionaryClient) GetDictionaryItemNullResponder(resp *http.Response) (result SetSetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1680,7 +1654,6 @@ func (client DictionaryClient) GetDictionaryNullSender(req *http.Request) (*http
 func (client DictionaryClient) GetDictionaryNullResponder(resp *http.Response) (result SetSetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1742,7 +1715,6 @@ func (client DictionaryClient) GetDictionaryValidSender(req *http.Request) (*htt
 func (client DictionaryClient) GetDictionaryValidResponder(resp *http.Response) (result SetSetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1803,7 +1775,6 @@ func (client DictionaryClient) GetDoubleInvalidNullSender(req *http.Request) (*h
 func (client DictionaryClient) GetDoubleInvalidNullResponder(resp *http.Response) (result SetFloat64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1864,7 +1835,6 @@ func (client DictionaryClient) GetDoubleInvalidStringSender(req *http.Request) (
 func (client DictionaryClient) GetDoubleInvalidStringResponder(resp *http.Response) (result SetFloat64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1925,7 +1895,6 @@ func (client DictionaryClient) GetDoubleValidSender(req *http.Request) (*http.Re
 func (client DictionaryClient) GetDoubleValidResponder(resp *http.Response) (result SetFloat64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1986,7 +1955,6 @@ func (client DictionaryClient) GetDurationValidSender(req *http.Request) (*http.
 func (client DictionaryClient) GetDurationValidResponder(resp *http.Response) (result SetTimeSpan, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2047,7 +2015,6 @@ func (client DictionaryClient) GetEmptySender(req *http.Request) (*http.Response
 func (client DictionaryClient) GetEmptyResponder(resp *http.Response) (result SetInt32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2108,7 +2075,6 @@ func (client DictionaryClient) GetEmptyStringKeySender(req *http.Request) (*http
 func (client DictionaryClient) GetEmptyStringKeyResponder(resp *http.Response) (result SetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2169,7 +2135,6 @@ func (client DictionaryClient) GetFloatInvalidNullSender(req *http.Request) (*ht
 func (client DictionaryClient) GetFloatInvalidNullResponder(resp *http.Response) (result SetFloat64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2230,7 +2195,6 @@ func (client DictionaryClient) GetFloatInvalidStringSender(req *http.Request) (*
 func (client DictionaryClient) GetFloatInvalidStringResponder(resp *http.Response) (result SetFloat64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2291,7 +2255,6 @@ func (client DictionaryClient) GetFloatValidSender(req *http.Request) (*http.Res
 func (client DictionaryClient) GetFloatValidResponder(resp *http.Response) (result SetFloat64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2352,7 +2315,6 @@ func (client DictionaryClient) GetIntegerValidSender(req *http.Request) (*http.R
 func (client DictionaryClient) GetIntegerValidResponder(resp *http.Response) (result SetInt32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2413,7 +2375,6 @@ func (client DictionaryClient) GetIntInvalidNullSender(req *http.Request) (*http
 func (client DictionaryClient) GetIntInvalidNullResponder(resp *http.Response) (result SetInt32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2474,7 +2435,6 @@ func (client DictionaryClient) GetIntInvalidStringSender(req *http.Request) (*ht
 func (client DictionaryClient) GetIntInvalidStringResponder(resp *http.Response) (result SetInt32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2535,7 +2495,6 @@ func (client DictionaryClient) GetInvalidSender(req *http.Request) (*http.Respon
 func (client DictionaryClient) GetInvalidResponder(resp *http.Response) (result SetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2596,7 +2555,6 @@ func (client DictionaryClient) GetLongInvalidNullSender(req *http.Request) (*htt
 func (client DictionaryClient) GetLongInvalidNullResponder(resp *http.Response) (result SetInt64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2657,7 +2615,6 @@ func (client DictionaryClient) GetLongInvalidStringSender(req *http.Request) (*h
 func (client DictionaryClient) GetLongInvalidStringResponder(resp *http.Response) (result SetInt64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2718,7 +2675,6 @@ func (client DictionaryClient) GetLongValidSender(req *http.Request) (*http.Resp
 func (client DictionaryClient) GetLongValidResponder(resp *http.Response) (result SetInt64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2779,7 +2735,6 @@ func (client DictionaryClient) GetNullSender(req *http.Request) (*http.Response,
 func (client DictionaryClient) GetNullResponder(resp *http.Response) (result SetInt32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2840,7 +2795,6 @@ func (client DictionaryClient) GetNullKeySender(req *http.Request) (*http.Respon
 func (client DictionaryClient) GetNullKeyResponder(resp *http.Response) (result SetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2901,7 +2855,6 @@ func (client DictionaryClient) GetNullValueSender(req *http.Request) (*http.Resp
 func (client DictionaryClient) GetNullValueResponder(resp *http.Response) (result SetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -2962,7 +2915,6 @@ func (client DictionaryClient) GetStringValidSender(req *http.Request) (*http.Re
 func (client DictionaryClient) GetStringValidResponder(resp *http.Response) (result SetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -3023,7 +2975,6 @@ func (client DictionaryClient) GetStringWithInvalidSender(req *http.Request) (*h
 func (client DictionaryClient) GetStringWithInvalidResponder(resp *http.Response) (result SetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -3084,7 +3035,6 @@ func (client DictionaryClient) GetStringWithNullSender(req *http.Request) (*http
 func (client DictionaryClient) GetStringWithNullResponder(resp *http.Response) (result SetString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -3153,7 +3103,6 @@ func (client DictionaryClient) PutArrayValidSender(req *http.Request) (*http.Res
 func (client DictionaryClient) PutArrayValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3221,7 +3170,6 @@ func (client DictionaryClient) PutBooleanTfftSender(req *http.Request) (*http.Re
 func (client DictionaryClient) PutBooleanTfftResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3290,7 +3238,6 @@ func (client DictionaryClient) PutByteValidSender(req *http.Request) (*http.Resp
 func (client DictionaryClient) PutByteValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3359,7 +3306,6 @@ func (client DictionaryClient) PutComplexValidSender(req *http.Request) (*http.R
 func (client DictionaryClient) PutComplexValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3428,7 +3374,6 @@ func (client DictionaryClient) PutDateTimeRfc1123ValidSender(req *http.Request) 
 func (client DictionaryClient) PutDateTimeRfc1123ValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3497,7 +3442,6 @@ func (client DictionaryClient) PutDateTimeValidSender(req *http.Request) (*http.
 func (client DictionaryClient) PutDateTimeValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3565,7 +3509,6 @@ func (client DictionaryClient) PutDateValidSender(req *http.Request) (*http.Resp
 func (client DictionaryClient) PutDateValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3634,7 +3577,6 @@ func (client DictionaryClient) PutDictionaryValidSender(req *http.Request) (*htt
 func (client DictionaryClient) PutDictionaryValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3702,7 +3644,6 @@ func (client DictionaryClient) PutDoubleValidSender(req *http.Request) (*http.Re
 func (client DictionaryClient) PutDoubleValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3770,7 +3711,6 @@ func (client DictionaryClient) PutDurationValidSender(req *http.Request) (*http.
 func (client DictionaryClient) PutDurationValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3838,7 +3778,6 @@ func (client DictionaryClient) PutEmptySender(req *http.Request) (*http.Response
 func (client DictionaryClient) PutEmptyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3906,7 +3845,6 @@ func (client DictionaryClient) PutFloatValidSender(req *http.Request) (*http.Res
 func (client DictionaryClient) PutFloatValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -3974,7 +3912,6 @@ func (client DictionaryClient) PutIntegerValidSender(req *http.Request) (*http.R
 func (client DictionaryClient) PutIntegerValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -4042,7 +3979,6 @@ func (client DictionaryClient) PutLongValidSender(req *http.Request) (*http.Resp
 func (client DictionaryClient) PutLongValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -4110,7 +4046,6 @@ func (client DictionaryClient) PutStringValidSender(req *http.Request) (*http.Re
 func (client DictionaryClient) PutStringValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/durationgroup/duration.go
+++ b/test/src/tests/generated/durationgroup/duration.go
@@ -83,7 +83,6 @@ func (client DurationClient) GetInvalidSender(req *http.Request) (*http.Response
 func (client DurationClient) GetInvalidResponder(resp *http.Response) (result TimeSpan, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -144,7 +143,6 @@ func (client DurationClient) GetNullSender(req *http.Request) (*http.Response, e
 func (client DurationClient) GetNullResponder(resp *http.Response) (result TimeSpan, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -205,7 +203,6 @@ func (client DurationClient) GetPositiveDurationSender(req *http.Request) (*http
 func (client DurationClient) GetPositiveDurationResponder(resp *http.Response) (result TimeSpan, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -268,7 +265,6 @@ func (client DurationClient) PutPositiveDurationSender(req *http.Request) (*http
 func (client DurationClient) PutPositiveDurationResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/filegroup/files.go
+++ b/test/src/tests/generated/filegroup/files.go
@@ -84,7 +84,6 @@ func (client FilesClient) GetEmptyFileResponder(resp *http.Response) (result Rea
 	result.Value = &resp.Body
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK))
 	result.Response = autorest.Response{Response: resp}
 	return
@@ -144,7 +143,6 @@ func (client FilesClient) GetFileResponder(resp *http.Response) (result ReadClos
 	result.Value = &resp.Body
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK))
 	result.Response = autorest.Response{Response: resp}
 	return
@@ -204,7 +202,6 @@ func (client FilesClient) GetFileLargeResponder(resp *http.Response) (result Rea
 	result.Value = &resp.Body
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK))
 	result.Response = autorest.Response{Response: resp}
 	return

--- a/test/src/tests/generated/formdatagroup/formdata.go
+++ b/test/src/tests/generated/formdatagroup/formdata.go
@@ -94,7 +94,6 @@ func (client FormdataClient) UploadFileResponder(resp *http.Response) (result Re
 	result.Value = &resp.Body
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK))
 	result.Response = autorest.Response{Response: resp}
 	return
@@ -158,7 +157,6 @@ func (client FormdataClient) UploadFileViaBodyResponder(resp *http.Response) (re
 	result.Value = &resp.Body
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK))
 	result.Response = autorest.Response{Response: resp}
 	return

--- a/test/src/tests/generated/headergroup/header.go
+++ b/test/src/tests/generated/headergroup/header.go
@@ -85,7 +85,6 @@ func (client HeaderClient) CustomRequestIDSender(req *http.Request) (*http.Respo
 func (client HeaderClient) CustomRequestIDResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -151,7 +150,6 @@ func (client HeaderClient) ParamBoolSender(req *http.Request) (*http.Response, e
 func (client HeaderClient) ParamBoolResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -222,7 +220,6 @@ func (client HeaderClient) ParamByteSender(req *http.Request) (*http.Response, e
 func (client HeaderClient) ParamByteResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -288,7 +285,6 @@ func (client HeaderClient) ParamDateSender(req *http.Request) (*http.Response, e
 func (client HeaderClient) ParamDateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -354,7 +350,6 @@ func (client HeaderClient) ParamDatetimeSender(req *http.Request) (*http.Respons
 func (client HeaderClient) ParamDatetimeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -424,7 +419,6 @@ func (client HeaderClient) ParamDatetimeRfc1123Sender(req *http.Request) (*http.
 func (client HeaderClient) ParamDatetimeRfc1123Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -490,7 +484,6 @@ func (client HeaderClient) ParamDoubleSender(req *http.Request) (*http.Response,
 func (client HeaderClient) ParamDoubleResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -555,7 +548,6 @@ func (client HeaderClient) ParamDurationSender(req *http.Request) (*http.Respons
 func (client HeaderClient) ParamDurationResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -624,7 +616,6 @@ func (client HeaderClient) ParamEnumSender(req *http.Request) (*http.Response, e
 func (client HeaderClient) ParamEnumResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -687,7 +678,6 @@ func (client HeaderClient) ParamExistingKeySender(req *http.Request) (*http.Resp
 func (client HeaderClient) ParamExistingKeyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -753,7 +743,6 @@ func (client HeaderClient) ParamFloatSender(req *http.Request) (*http.Response, 
 func (client HeaderClient) ParamFloatResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -819,7 +808,6 @@ func (client HeaderClient) ParamIntegerSender(req *http.Request) (*http.Response
 func (client HeaderClient) ParamIntegerResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -885,7 +873,6 @@ func (client HeaderClient) ParamLongSender(req *http.Request) (*http.Response, e
 func (client HeaderClient) ParamLongResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -948,7 +935,6 @@ func (client HeaderClient) ParamProtectedKeySender(req *http.Request) (*http.Res
 func (client HeaderClient) ParamProtectedKeyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1017,7 +1003,6 @@ func (client HeaderClient) ParamStringSender(req *http.Request) (*http.Response,
 func (client HeaderClient) ParamStringResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1080,7 +1065,6 @@ func (client HeaderClient) ResponseBoolSender(req *http.Request) (*http.Response
 func (client HeaderClient) ResponseBoolResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1143,7 +1127,6 @@ func (client HeaderClient) ResponseByteSender(req *http.Request) (*http.Response
 func (client HeaderClient) ResponseByteResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1206,7 +1189,6 @@ func (client HeaderClient) ResponseDateSender(req *http.Request) (*http.Response
 func (client HeaderClient) ResponseDateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1269,7 +1251,6 @@ func (client HeaderClient) ResponseDatetimeSender(req *http.Request) (*http.Resp
 func (client HeaderClient) ResponseDatetimeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1333,7 +1314,6 @@ func (client HeaderClient) ResponseDatetimeRfc1123Sender(req *http.Request) (*ht
 func (client HeaderClient) ResponseDatetimeRfc1123Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1396,7 +1376,6 @@ func (client HeaderClient) ResponseDoubleSender(req *http.Request) (*http.Respon
 func (client HeaderClient) ResponseDoubleResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1459,7 +1438,6 @@ func (client HeaderClient) ResponseDurationSender(req *http.Request) (*http.Resp
 func (client HeaderClient) ResponseDurationResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1522,7 +1500,6 @@ func (client HeaderClient) ResponseEnumSender(req *http.Request) (*http.Response
 func (client HeaderClient) ResponseEnumResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1582,7 +1559,6 @@ func (client HeaderClient) ResponseExistingKeySender(req *http.Request) (*http.R
 func (client HeaderClient) ResponseExistingKeyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1645,7 +1621,6 @@ func (client HeaderClient) ResponseFloatSender(req *http.Request) (*http.Respons
 func (client HeaderClient) ResponseFloatResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1708,7 +1683,6 @@ func (client HeaderClient) ResponseIntegerSender(req *http.Request) (*http.Respo
 func (client HeaderClient) ResponseIntegerResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1771,7 +1745,6 @@ func (client HeaderClient) ResponseLongSender(req *http.Request) (*http.Response
 func (client HeaderClient) ResponseLongResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1831,7 +1804,6 @@ func (client HeaderClient) ResponseProtectedKeySender(req *http.Request) (*http.
 func (client HeaderClient) ResponseProtectedKeyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1894,7 +1866,6 @@ func (client HeaderClient) ResponseStringSender(req *http.Request) (*http.Respon
 func (client HeaderClient) ResponseStringResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/httpinfrastructuregroup/httpclientfailure.go
+++ b/test/src/tests/generated/httpinfrastructuregroup/httpclientfailure.go
@@ -91,7 +91,6 @@ func (client HTTPClientFailureClient) Delete400Sender(req *http.Request) (*http.
 func (client HTTPClientFailureClient) Delete400Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -159,7 +158,6 @@ func (client HTTPClientFailureClient) Delete407Sender(req *http.Request) (*http.
 func (client HTTPClientFailureClient) Delete407Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -227,7 +225,6 @@ func (client HTTPClientFailureClient) Delete417Sender(req *http.Request) (*http.
 func (client HTTPClientFailureClient) Delete417Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -288,7 +285,6 @@ func (client HTTPClientFailureClient) Get400Sender(req *http.Request) (*http.Res
 func (client HTTPClientFailureClient) Get400Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -349,7 +345,6 @@ func (client HTTPClientFailureClient) Get402Sender(req *http.Request) (*http.Res
 func (client HTTPClientFailureClient) Get402Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -410,7 +405,6 @@ func (client HTTPClientFailureClient) Get403Sender(req *http.Request) (*http.Res
 func (client HTTPClientFailureClient) Get403Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -471,7 +465,6 @@ func (client HTTPClientFailureClient) Get411Sender(req *http.Request) (*http.Res
 func (client HTTPClientFailureClient) Get411Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -532,7 +525,6 @@ func (client HTTPClientFailureClient) Get412Sender(req *http.Request) (*http.Res
 func (client HTTPClientFailureClient) Get412Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -593,7 +585,6 @@ func (client HTTPClientFailureClient) Get416Sender(req *http.Request) (*http.Res
 func (client HTTPClientFailureClient) Get416Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -654,7 +645,6 @@ func (client HTTPClientFailureClient) Head400Sender(req *http.Request) (*http.Re
 func (client HTTPClientFailureClient) Head400Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -715,7 +705,6 @@ func (client HTTPClientFailureClient) Head401Sender(req *http.Request) (*http.Re
 func (client HTTPClientFailureClient) Head401Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -776,7 +765,6 @@ func (client HTTPClientFailureClient) Head410Sender(req *http.Request) (*http.Re
 func (client HTTPClientFailureClient) Head410Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -837,7 +825,6 @@ func (client HTTPClientFailureClient) Head429Sender(req *http.Request) (*http.Re
 func (client HTTPClientFailureClient) Head429Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -905,7 +892,6 @@ func (client HTTPClientFailureClient) Patch400Sender(req *http.Request) (*http.R
 func (client HTTPClientFailureClient) Patch400Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -973,7 +959,6 @@ func (client HTTPClientFailureClient) Patch405Sender(req *http.Request) (*http.R
 func (client HTTPClientFailureClient) Patch405Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1041,7 +1026,6 @@ func (client HTTPClientFailureClient) Patch414Sender(req *http.Request) (*http.R
 func (client HTTPClientFailureClient) Patch414Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1109,7 +1093,6 @@ func (client HTTPClientFailureClient) Post400Sender(req *http.Request) (*http.Re
 func (client HTTPClientFailureClient) Post400Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1177,7 +1160,6 @@ func (client HTTPClientFailureClient) Post406Sender(req *http.Request) (*http.Re
 func (client HTTPClientFailureClient) Post406Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1245,7 +1227,6 @@ func (client HTTPClientFailureClient) Post415Sender(req *http.Request) (*http.Re
 func (client HTTPClientFailureClient) Post415Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1313,7 +1294,6 @@ func (client HTTPClientFailureClient) Put400Sender(req *http.Request) (*http.Res
 func (client HTTPClientFailureClient) Put400Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1381,7 +1361,6 @@ func (client HTTPClientFailureClient) Put404Sender(req *http.Request) (*http.Res
 func (client HTTPClientFailureClient) Put404Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1449,7 +1428,6 @@ func (client HTTPClientFailureClient) Put409Sender(req *http.Request) (*http.Res
 func (client HTTPClientFailureClient) Put409Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1517,7 +1495,6 @@ func (client HTTPClientFailureClient) Put413Sender(req *http.Request) (*http.Res
 func (client HTTPClientFailureClient) Put413Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())

--- a/test/src/tests/generated/httpinfrastructuregroup/httpfailure.go
+++ b/test/src/tests/generated/httpinfrastructuregroup/httpfailure.go
@@ -83,7 +83,6 @@ func (client HTTPFailureClient) GetEmptyErrorSender(req *http.Request) (*http.Re
 func (client HTTPFailureClient) GetEmptyErrorResponder(resp *http.Response) (result Bool, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -144,7 +143,6 @@ func (client HTTPFailureClient) GetNoModelEmptySender(req *http.Request) (*http.
 func (client HTTPFailureClient) GetNoModelEmptyResponder(resp *http.Response) (result Bool, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -205,7 +203,6 @@ func (client HTTPFailureClient) GetNoModelErrorSender(req *http.Request) (*http.
 func (client HTTPFailureClient) GetNoModelErrorResponder(resp *http.Response) (result Bool, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())

--- a/test/src/tests/generated/httpinfrastructuregroup/httpredirects.go
+++ b/test/src/tests/generated/httpinfrastructuregroup/httpredirects.go
@@ -90,7 +90,6 @@ func (client HTTPRedirectsClient) Delete307Sender(req *http.Request) (*http.Resp
 func (client HTTPRedirectsClient) Delete307Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusTemporaryRedirect),
 		autorest.ByClosing())
 	result.Response = resp
@@ -150,7 +149,6 @@ func (client HTTPRedirectsClient) Get300Sender(req *http.Request) (*http.Respons
 func (client HTTPRedirectsClient) Get300Responder(resp *http.Response) (result ListString, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusMultipleChoices),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -211,7 +209,6 @@ func (client HTTPRedirectsClient) Get301Sender(req *http.Request) (*http.Respons
 func (client HTTPRedirectsClient) Get301Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusMovedPermanently),
 		autorest.ByClosing())
 	result.Response = resp
@@ -271,7 +268,6 @@ func (client HTTPRedirectsClient) Get302Sender(req *http.Request) (*http.Respons
 func (client HTTPRedirectsClient) Get302Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusFound),
 		autorest.ByClosing())
 	result.Response = resp
@@ -331,7 +327,6 @@ func (client HTTPRedirectsClient) Get307Sender(req *http.Request) (*http.Respons
 func (client HTTPRedirectsClient) Get307Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusTemporaryRedirect),
 		autorest.ByClosing())
 	result.Response = resp
@@ -391,7 +386,6 @@ func (client HTTPRedirectsClient) Head300Sender(req *http.Request) (*http.Respon
 func (client HTTPRedirectsClient) Head300Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusMultipleChoices),
 		autorest.ByClosing())
 	result.Response = resp
@@ -451,7 +445,6 @@ func (client HTTPRedirectsClient) Head301Sender(req *http.Request) (*http.Respon
 func (client HTTPRedirectsClient) Head301Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusMovedPermanently),
 		autorest.ByClosing())
 	result.Response = resp
@@ -511,7 +504,6 @@ func (client HTTPRedirectsClient) Head302Sender(req *http.Request) (*http.Respon
 func (client HTTPRedirectsClient) Head302Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusFound),
 		autorest.ByClosing())
 	result.Response = resp
@@ -571,7 +563,6 @@ func (client HTTPRedirectsClient) Head307Sender(req *http.Request) (*http.Respon
 func (client HTTPRedirectsClient) Head307Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusTemporaryRedirect),
 		autorest.ByClosing())
 	result.Response = resp
@@ -639,7 +630,6 @@ func (client HTTPRedirectsClient) Patch302Sender(req *http.Request) (*http.Respo
 func (client HTTPRedirectsClient) Patch302Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusFound),
 		autorest.ByClosing())
 	result.Response = resp
@@ -706,7 +696,6 @@ func (client HTTPRedirectsClient) Patch307Sender(req *http.Request) (*http.Respo
 func (client HTTPRedirectsClient) Patch307Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusTemporaryRedirect),
 		autorest.ByClosing())
 	result.Response = resp
@@ -774,7 +763,6 @@ func (client HTTPRedirectsClient) Post303Sender(req *http.Request) (*http.Respon
 func (client HTTPRedirectsClient) Post303Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusSeeOther),
 		autorest.ByClosing())
 	result.Response = resp
@@ -841,7 +829,6 @@ func (client HTTPRedirectsClient) Post307Sender(req *http.Request) (*http.Respon
 func (client HTTPRedirectsClient) Post307Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusTemporaryRedirect),
 		autorest.ByClosing())
 	result.Response = resp
@@ -909,7 +896,6 @@ func (client HTTPRedirectsClient) Put301Sender(req *http.Request) (*http.Respons
 func (client HTTPRedirectsClient) Put301Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusMovedPermanently),
 		autorest.ByClosing())
 	result.Response = resp
@@ -976,7 +962,6 @@ func (client HTTPRedirectsClient) Put307Sender(req *http.Request) (*http.Respons
 func (client HTTPRedirectsClient) Put307Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusTemporaryRedirect),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/httpinfrastructuregroup/httpretry.go
+++ b/test/src/tests/generated/httpinfrastructuregroup/httpretry.go
@@ -90,7 +90,6 @@ func (client HTTPRetryClient) Delete503Sender(req *http.Request) (*http.Response
 func (client HTTPRetryClient) Delete503Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -150,7 +149,6 @@ func (client HTTPRetryClient) Get502Sender(req *http.Request) (*http.Response, e
 func (client HTTPRetryClient) Get502Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -210,7 +208,6 @@ func (client HTTPRetryClient) Head408Sender(req *http.Request) (*http.Response, 
 func (client HTTPRetryClient) Head408Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -277,7 +274,6 @@ func (client HTTPRetryClient) Patch500Sender(req *http.Request) (*http.Response,
 func (client HTTPRetryClient) Patch500Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -344,7 +340,6 @@ func (client HTTPRetryClient) Patch504Sender(req *http.Request) (*http.Response,
 func (client HTTPRetryClient) Patch504Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -411,7 +406,6 @@ func (client HTTPRetryClient) Post503Sender(req *http.Request) (*http.Response, 
 func (client HTTPRetryClient) Post503Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -478,7 +472,6 @@ func (client HTTPRetryClient) Put500Sender(req *http.Request) (*http.Response, e
 func (client HTTPRetryClient) Put500Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -545,7 +538,6 @@ func (client HTTPRetryClient) Put504Sender(req *http.Request) (*http.Response, e
 func (client HTTPRetryClient) Put504Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/httpinfrastructuregroup/httpserverfailure.go
+++ b/test/src/tests/generated/httpinfrastructuregroup/httpserverfailure.go
@@ -91,7 +91,6 @@ func (client HTTPServerFailureClient) Delete505Sender(req *http.Request) (*http.
 func (client HTTPServerFailureClient) Delete505Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -152,7 +151,6 @@ func (client HTTPServerFailureClient) Get501Sender(req *http.Request) (*http.Res
 func (client HTTPServerFailureClient) Get501Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -213,7 +211,6 @@ func (client HTTPServerFailureClient) Head501Sender(req *http.Request) (*http.Re
 func (client HTTPServerFailureClient) Head501Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -281,7 +278,6 @@ func (client HTTPServerFailureClient) Post505Sender(req *http.Request) (*http.Re
 func (client HTTPServerFailureClient) Post505Responder(resp *http.Response) (result Error, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())

--- a/test/src/tests/generated/httpinfrastructuregroup/httpsuccess.go
+++ b/test/src/tests/generated/httpinfrastructuregroup/httpsuccess.go
@@ -90,7 +90,6 @@ func (client HTTPSuccessClient) Delete200Sender(req *http.Request) (*http.Respon
 func (client HTTPSuccessClient) Delete200Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -157,7 +156,6 @@ func (client HTTPSuccessClient) Delete202Sender(req *http.Request) (*http.Respon
 func (client HTTPSuccessClient) Delete202Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -224,7 +222,6 @@ func (client HTTPSuccessClient) Delete204Sender(req *http.Request) (*http.Respon
 func (client HTTPSuccessClient) Delete204Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp
@@ -284,7 +281,6 @@ func (client HTTPSuccessClient) Get200Sender(req *http.Request) (*http.Response,
 func (client HTTPSuccessClient) Get200Responder(resp *http.Response) (result Bool, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -345,7 +341,6 @@ func (client HTTPSuccessClient) Head200Sender(req *http.Request) (*http.Response
 func (client HTTPSuccessClient) Head200Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -405,7 +400,6 @@ func (client HTTPSuccessClient) Head204Sender(req *http.Request) (*http.Response
 func (client HTTPSuccessClient) Head204Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp
@@ -465,7 +459,6 @@ func (client HTTPSuccessClient) Head404Sender(req *http.Request) (*http.Response
 func (client HTTPSuccessClient) Head404Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent, http.StatusNotFound),
 		autorest.ByClosing())
 	result.Response = resp
@@ -532,7 +525,6 @@ func (client HTTPSuccessClient) Patch200Sender(req *http.Request) (*http.Respons
 func (client HTTPSuccessClient) Patch200Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -599,7 +591,6 @@ func (client HTTPSuccessClient) Patch202Sender(req *http.Request) (*http.Respons
 func (client HTTPSuccessClient) Patch202Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -666,7 +657,6 @@ func (client HTTPSuccessClient) Patch204Sender(req *http.Request) (*http.Respons
 func (client HTTPSuccessClient) Patch204Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp
@@ -733,7 +723,6 @@ func (client HTTPSuccessClient) Post200Sender(req *http.Request) (*http.Response
 func (client HTTPSuccessClient) Post200Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -800,7 +789,6 @@ func (client HTTPSuccessClient) Post201Sender(req *http.Request) (*http.Response
 func (client HTTPSuccessClient) Post201Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
 		autorest.ByClosing())
 	result.Response = resp
@@ -867,7 +855,6 @@ func (client HTTPSuccessClient) Post202Sender(req *http.Request) (*http.Response
 func (client HTTPSuccessClient) Post202Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -934,7 +921,6 @@ func (client HTTPSuccessClient) Post204Sender(req *http.Request) (*http.Response
 func (client HTTPSuccessClient) Post204Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1001,7 +987,6 @@ func (client HTTPSuccessClient) Put200Sender(req *http.Request) (*http.Response,
 func (client HTTPSuccessClient) Put200Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1068,7 +1053,6 @@ func (client HTTPSuccessClient) Put201Sender(req *http.Request) (*http.Response,
 func (client HTTPSuccessClient) Put201Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1135,7 +1119,6 @@ func (client HTTPSuccessClient) Put202Sender(req *http.Request) (*http.Response,
 func (client HTTPSuccessClient) Put202Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1202,7 +1185,6 @@ func (client HTTPSuccessClient) Put204Sender(req *http.Request) (*http.Response,
 func (client HTTPSuccessClient) Put204Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/httpinfrastructuregroup/multipleresponses.go
+++ b/test/src/tests/generated/httpinfrastructuregroup/multipleresponses.go
@@ -84,7 +84,6 @@ func (client MultipleResponsesClient) Get200Model201ModelDefaultError200ValidSen
 func (client MultipleResponsesClient) Get200Model201ModelDefaultError200ValidResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -146,7 +145,6 @@ func (client MultipleResponsesClient) Get200Model201ModelDefaultError201ValidSen
 func (client MultipleResponsesClient) Get200Model201ModelDefaultError201ValidResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -208,7 +206,6 @@ func (client MultipleResponsesClient) Get200Model201ModelDefaultError400ValidSen
 func (client MultipleResponsesClient) Get200Model201ModelDefaultError400ValidResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -269,7 +266,6 @@ func (client MultipleResponsesClient) Get200Model204NoModelDefaultError200ValidS
 func (client MultipleResponsesClient) Get200Model204NoModelDefaultError200ValidResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -330,7 +326,6 @@ func (client MultipleResponsesClient) Get200Model204NoModelDefaultError201Invali
 func (client MultipleResponsesClient) Get200Model204NoModelDefaultError201InvalidResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -391,7 +386,6 @@ func (client MultipleResponsesClient) Get200Model204NoModelDefaultError202NoneSe
 func (client MultipleResponsesClient) Get200Model204NoModelDefaultError202NoneResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -452,7 +446,6 @@ func (client MultipleResponsesClient) Get200Model204NoModelDefaultError204ValidS
 func (client MultipleResponsesClient) Get200Model204NoModelDefaultError204ValidResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -514,7 +507,6 @@ func (client MultipleResponsesClient) Get200Model204NoModelDefaultError400ValidS
 func (client MultipleResponsesClient) Get200Model204NoModelDefaultError400ValidResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -575,7 +567,6 @@ func (client MultipleResponsesClient) Get200ModelA200InvalidSender(req *http.Req
 func (client MultipleResponsesClient) Get200ModelA200InvalidResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -637,7 +628,6 @@ func (client MultipleResponsesClient) Get200ModelA200NoneSender(req *http.Reques
 func (client MultipleResponsesClient) Get200ModelA200NoneResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -698,7 +688,6 @@ func (client MultipleResponsesClient) Get200ModelA200ValidSender(req *http.Reque
 func (client MultipleResponsesClient) Get200ModelA200ValidResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -759,7 +748,6 @@ func (client MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError
 func (client MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError200ValidResponder(resp *http.Response) (result SetObject, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -820,7 +808,6 @@ func (client MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError
 func (client MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError201ValidResponder(resp *http.Response) (result SetObject, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -882,7 +869,6 @@ func (client MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError
 func (client MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError400ValidResponder(resp *http.Response) (result SetObject, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -943,7 +929,6 @@ func (client MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError
 func (client MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError404ValidResponder(resp *http.Response) (result SetObject, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -1004,7 +989,6 @@ func (client MultipleResponsesClient) Get200ModelA202ValidSender(req *http.Reque
 func (client MultipleResponsesClient) Get200ModelA202ValidResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1065,7 +1049,6 @@ func (client MultipleResponsesClient) Get200ModelA400InvalidSender(req *http.Req
 func (client MultipleResponsesClient) Get200ModelA400InvalidResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1126,7 +1109,6 @@ func (client MultipleResponsesClient) Get200ModelA400NoneSender(req *http.Reques
 func (client MultipleResponsesClient) Get200ModelA400NoneResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1187,7 +1169,6 @@ func (client MultipleResponsesClient) Get200ModelA400ValidSender(req *http.Reque
 func (client MultipleResponsesClient) Get200ModelA400ValidResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1248,7 +1229,6 @@ func (client MultipleResponsesClient) Get202None204NoneDefaultError202NoneSender
 func (client MultipleResponsesClient) Get202None204NoneDefaultError202NoneResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1308,7 +1288,6 @@ func (client MultipleResponsesClient) Get202None204NoneDefaultError204NoneSender
 func (client MultipleResponsesClient) Get202None204NoneDefaultError204NoneResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1369,7 +1348,6 @@ func (client MultipleResponsesClient) Get202None204NoneDefaultError400ValidSende
 func (client MultipleResponsesClient) Get202None204NoneDefaultError400ValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1429,7 +1407,6 @@ func (client MultipleResponsesClient) Get202None204NoneDefaultNone202InvalidSend
 func (client MultipleResponsesClient) Get202None204NoneDefaultNone202InvalidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1489,7 +1466,6 @@ func (client MultipleResponsesClient) Get202None204NoneDefaultNone204NoneSender(
 func (client MultipleResponsesClient) Get202None204NoneDefaultNone204NoneResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1549,7 +1525,6 @@ func (client MultipleResponsesClient) Get202None204NoneDefaultNone400InvalidSend
 func (client MultipleResponsesClient) Get202None204NoneDefaultNone400InvalidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1609,7 +1584,6 @@ func (client MultipleResponsesClient) Get202None204NoneDefaultNone400NoneSender(
 func (client MultipleResponsesClient) Get202None204NoneDefaultNone400NoneResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1669,7 +1643,6 @@ func (client MultipleResponsesClient) GetDefaultModelA200NoneSender(req *http.Re
 func (client MultipleResponsesClient) GetDefaultModelA200NoneResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1730,7 +1703,6 @@ func (client MultipleResponsesClient) GetDefaultModelA200ValidSender(req *http.R
 func (client MultipleResponsesClient) GetDefaultModelA200ValidResponder(resp *http.Response) (result A, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1791,7 +1763,6 @@ func (client MultipleResponsesClient) GetDefaultModelA400NoneSender(req *http.Re
 func (client MultipleResponsesClient) GetDefaultModelA400NoneResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1851,7 +1822,6 @@ func (client MultipleResponsesClient) GetDefaultModelA400ValidSender(req *http.R
 func (client MultipleResponsesClient) GetDefaultModelA400ValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1911,7 +1881,6 @@ func (client MultipleResponsesClient) GetDefaultNone200InvalidSender(req *http.R
 func (client MultipleResponsesClient) GetDefaultNone200InvalidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1971,7 +1940,6 @@ func (client MultipleResponsesClient) GetDefaultNone200NoneSender(req *http.Requ
 func (client MultipleResponsesClient) GetDefaultNone200NoneResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -2031,7 +1999,6 @@ func (client MultipleResponsesClient) GetDefaultNone400InvalidSender(req *http.R
 func (client MultipleResponsesClient) GetDefaultNone400InvalidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -2091,7 +2058,6 @@ func (client MultipleResponsesClient) GetDefaultNone400NoneSender(req *http.Requ
 func (client MultipleResponsesClient) GetDefaultNone400NoneResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/integergroup/int.go
+++ b/test/src/tests/generated/integergroup/int.go
@@ -84,7 +84,6 @@ func (client IntClient) GetInvalidSender(req *http.Request) (*http.Response, err
 func (client IntClient) GetInvalidResponder(resp *http.Response) (result Int32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -145,7 +144,6 @@ func (client IntClient) GetInvalidUnixTimeSender(req *http.Request) (*http.Respo
 func (client IntClient) GetInvalidUnixTimeResponder(resp *http.Response) (result UnixTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -206,7 +204,6 @@ func (client IntClient) GetNullSender(req *http.Request) (*http.Response, error)
 func (client IntClient) GetNullResponder(resp *http.Response) (result Int32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -267,7 +264,6 @@ func (client IntClient) GetNullUnixTimeSender(req *http.Request) (*http.Response
 func (client IntClient) GetNullUnixTimeResponder(resp *http.Response) (result UnixTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -328,7 +324,6 @@ func (client IntClient) GetOverflowInt32Sender(req *http.Request) (*http.Respons
 func (client IntClient) GetOverflowInt32Responder(resp *http.Response) (result Int32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -389,7 +384,6 @@ func (client IntClient) GetOverflowInt64Sender(req *http.Request) (*http.Respons
 func (client IntClient) GetOverflowInt64Responder(resp *http.Response) (result Int64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -450,7 +444,6 @@ func (client IntClient) GetUnderflowInt32Sender(req *http.Request) (*http.Respon
 func (client IntClient) GetUnderflowInt32Responder(resp *http.Response) (result Int32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -511,7 +504,6 @@ func (client IntClient) GetUnderflowInt64Sender(req *http.Request) (*http.Respon
 func (client IntClient) GetUnderflowInt64Responder(resp *http.Response) (result Int64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -572,7 +564,6 @@ func (client IntClient) GetUnixTimeSender(req *http.Request) (*http.Response, er
 func (client IntClient) GetUnixTimeResponder(resp *http.Response) (result UnixTime, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -635,7 +626,6 @@ func (client IntClient) PutMax32Sender(req *http.Request) (*http.Response, error
 func (client IntClient) PutMax32Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -697,7 +687,6 @@ func (client IntClient) PutMax64Sender(req *http.Request) (*http.Response, error
 func (client IntClient) PutMax64Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -759,7 +748,6 @@ func (client IntClient) PutMin32Sender(req *http.Request) (*http.Response, error
 func (client IntClient) PutMin32Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -821,7 +809,6 @@ func (client IntClient) PutMin64Sender(req *http.Request) (*http.Response, error
 func (client IntClient) PutMin64Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -883,7 +870,6 @@ func (client IntClient) PutUnixTimeDateSender(req *http.Request) (*http.Response
 func (client IntClient) PutUnixTimeDateResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/lrogroup/lroretrys.go
+++ b/test/src/tests/generated/lrogroup/lroretrys.go
@@ -84,7 +84,6 @@ func (client LRORetrysClient) Delete202Retry200Sender(req *http.Request) (future
 func (client LRORetrysClient) Delete202Retry200Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -145,7 +144,6 @@ func (client LRORetrysClient) DeleteAsyncRelativeRetrySucceededSender(req *http.
 func (client LRORetrysClient) DeleteAsyncRelativeRetrySucceededResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -207,7 +205,6 @@ func (client LRORetrysClient) DeleteProvisioning202Accepted200SucceededSender(re
 func (client LRORetrysClient) DeleteProvisioning202Accepted200SucceededResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -276,7 +273,6 @@ func (client LRORetrysClient) Post202Retry200Sender(req *http.Request) (future L
 func (client LRORetrysClient) Post202Retry200Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -345,7 +341,6 @@ func (client LRORetrysClient) PostAsyncRelativeRetrySucceededSender(req *http.Re
 func (client LRORetrysClient) PostAsyncRelativeRetrySucceededResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -414,7 +409,6 @@ func (client LRORetrysClient) Put201CreatingSucceeded200Sender(req *http.Request
 func (client LRORetrysClient) Put201CreatingSucceeded200Responder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -484,7 +478,6 @@ func (client LRORetrysClient) PutAsyncRelativeRetrySucceededSender(req *http.Req
 func (client LRORetrysClient) PutAsyncRelativeRetrySucceededResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())

--- a/test/src/tests/generated/lrogroup/lros.go
+++ b/test/src/tests/generated/lrogroup/lros.go
@@ -84,7 +84,6 @@ func (client LROsClient) Delete202NoRetry204Sender(req *http.Request) (future LR
 func (client LROsClient) Delete202NoRetry204Responder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -146,7 +145,6 @@ func (client LROsClient) Delete202Retry200Sender(req *http.Request) (future LROs
 func (client LROsClient) Delete202Retry200Responder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -207,7 +205,6 @@ func (client LROsClient) Delete204SucceededSender(req *http.Request) (future LRO
 func (client LROsClient) Delete204SucceededResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp
@@ -268,7 +265,6 @@ func (client LROsClient) DeleteAsyncNoHeaderInRetrySender(req *http.Request) (fu
 func (client LROsClient) DeleteAsyncNoHeaderInRetryResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp
@@ -329,7 +325,6 @@ func (client LROsClient) DeleteAsyncNoRetrySucceededSender(req *http.Request) (f
 func (client LROsClient) DeleteAsyncNoRetrySucceededResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -390,7 +385,6 @@ func (client LROsClient) DeleteAsyncRetrycanceledSender(req *http.Request) (futu
 func (client LROsClient) DeleteAsyncRetrycanceledResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -451,7 +445,6 @@ func (client LROsClient) DeleteAsyncRetryFailedSender(req *http.Request) (future
 func (client LROsClient) DeleteAsyncRetryFailedResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -512,7 +505,6 @@ func (client LROsClient) DeleteAsyncRetrySucceededSender(req *http.Request) (fut
 func (client LROsClient) DeleteAsyncRetrySucceededResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -573,7 +565,6 @@ func (client LROsClient) DeleteNoHeaderInRetrySender(req *http.Request) (future 
 func (client LROsClient) DeleteNoHeaderInRetryResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp
@@ -635,7 +626,6 @@ func (client LROsClient) DeleteProvisioning202Accepted200SucceededSender(req *ht
 func (client LROsClient) DeleteProvisioning202Accepted200SucceededResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -698,7 +688,6 @@ func (client LROsClient) DeleteProvisioning202Deletingcanceled200Sender(req *htt
 func (client LROsClient) DeleteProvisioning202Deletingcanceled200Responder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -761,7 +750,6 @@ func (client LROsClient) DeleteProvisioning202DeletingFailed200Sender(req *http.
 func (client LROsClient) DeleteProvisioning202DeletingFailed200Responder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -823,7 +811,6 @@ func (client LROsClient) Post200WithPayloadSender(req *http.Request) (future LRO
 func (client LROsClient) Post200WithPayloadResponder(resp *http.Response) (result Sku, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -892,7 +879,6 @@ func (client LROsClient) Post202NoRetry204Sender(req *http.Request) (future LROs
 func (client LROsClient) Post202NoRetry204Responder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -961,7 +947,6 @@ func (client LROsClient) Post202Retry200Sender(req *http.Request) (future LROsPo
 func (client LROsClient) Post202Retry200Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1030,7 +1015,6 @@ func (client LROsClient) PostAsyncNoRetrySucceededSender(req *http.Request) (fut
 func (client LROsClient) PostAsyncNoRetrySucceededResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1100,7 +1084,6 @@ func (client LROsClient) PostAsyncRetrycanceledSender(req *http.Request) (future
 func (client LROsClient) PostAsyncRetrycanceledResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1169,7 +1152,6 @@ func (client LROsClient) PostAsyncRetryFailedSender(req *http.Request) (future L
 func (client LROsClient) PostAsyncRetryFailedResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1238,7 +1220,6 @@ func (client LROsClient) PostAsyncRetrySucceededSender(req *http.Request) (futur
 func (client LROsClient) PostAsyncRetrySucceededResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1301,7 +1282,6 @@ func (client LROsClient) PostDoubleHeadersFinalAzureHeaderGetSender(req *http.Re
 func (client LROsClient) PostDoubleHeadersFinalAzureHeaderGetResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1364,7 +1344,6 @@ func (client LROsClient) PostDoubleHeadersFinalAzureHeaderGetDefaultSender(req *
 func (client LROsClient) PostDoubleHeadersFinalAzureHeaderGetDefaultResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1426,7 +1405,6 @@ func (client LROsClient) PostDoubleHeadersFinalLocationGetSender(req *http.Reque
 func (client LROsClient) PostDoubleHeadersFinalLocationGetResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1496,7 +1474,6 @@ func (client LROsClient) Put200Acceptedcanceled200Sender(req *http.Request) (fut
 func (client LROsClient) Put200Acceptedcanceled200Responder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1565,7 +1542,6 @@ func (client LROsClient) Put200SucceededSender(req *http.Request) (future LROsPu
 func (client LROsClient) Put200SucceededResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1634,7 +1610,6 @@ func (client LROsClient) Put200SucceededNoStateSender(req *http.Request) (future
 func (client LROsClient) Put200SucceededNoStateResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1704,7 +1679,6 @@ func (client LROsClient) Put200UpdatingSucceeded204Sender(req *http.Request) (fu
 func (client LROsClient) Put200UpdatingSucceeded204Responder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1774,7 +1748,6 @@ func (client LROsClient) Put201CreatingFailed200Sender(req *http.Request) (futur
 func (client LROsClient) Put201CreatingFailed200Responder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1844,7 +1817,6 @@ func (client LROsClient) Put201CreatingSucceeded200Sender(req *http.Request) (fu
 func (client LROsClient) Put201CreatingSucceeded200Responder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1913,7 +1885,6 @@ func (client LROsClient) Put202Retry200Sender(req *http.Request) (future LROsPut
 func (client LROsClient) Put202Retry200Responder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1982,7 +1953,6 @@ func (client LROsClient) PutAsyncNoHeaderInRetrySender(req *http.Request) (futur
 func (client LROsClient) PutAsyncNoHeaderInRetryResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -2050,7 +2020,6 @@ func (client LROsClient) PutAsyncNonResourceSender(req *http.Request) (future LR
 func (client LROsClient) PutAsyncNonResourceResponder(resp *http.Response) (result Sku, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -2120,7 +2089,6 @@ func (client LROsClient) PutAsyncNoRetrycanceledSender(req *http.Request) (futur
 func (client LROsClient) PutAsyncNoRetrycanceledResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -2190,7 +2158,6 @@ func (client LROsClient) PutAsyncNoRetrySucceededSender(req *http.Request) (futu
 func (client LROsClient) PutAsyncNoRetrySucceededResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -2260,7 +2227,6 @@ func (client LROsClient) PutAsyncRetryFailedSender(req *http.Request) (future LR
 func (client LROsClient) PutAsyncRetryFailedResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -2330,7 +2296,6 @@ func (client LROsClient) PutAsyncRetrySucceededSender(req *http.Request) (future
 func (client LROsClient) PutAsyncRetrySucceededResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -2398,7 +2363,6 @@ func (client LROsClient) PutAsyncSubResourceSender(req *http.Request) (future LR
 func (client LROsClient) PutAsyncSubResourceResponder(resp *http.Response) (result SubProduct, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -2467,7 +2431,6 @@ func (client LROsClient) PutNoHeaderInRetrySender(req *http.Request) (future LRO
 func (client LROsClient) PutNoHeaderInRetryResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -2535,7 +2498,6 @@ func (client LROsClient) PutNonResourceSender(req *http.Request) (future LROsPut
 func (client LROsClient) PutNonResourceResponder(resp *http.Response) (result Sku, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -2603,7 +2565,6 @@ func (client LROsClient) PutSubResourceSender(req *http.Request) (future LROsPut
 func (client LROsClient) PutSubResourceResponder(resp *http.Response) (result SubProduct, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())

--- a/test/src/tests/generated/lrogroup/lrosads.go
+++ b/test/src/tests/generated/lrogroup/lrosads.go
@@ -83,7 +83,6 @@ func (client LROSADsClient) Delete202NonRetry400Sender(req *http.Request) (futur
 func (client LROSADsClient) Delete202NonRetry400Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -144,7 +143,6 @@ func (client LROSADsClient) Delete202RetryInvalidHeaderSender(req *http.Request)
 func (client LROSADsClient) Delete202RetryInvalidHeaderResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -204,7 +202,6 @@ func (client LROSADsClient) Delete204SucceededSender(req *http.Request) (future 
 func (client LROSADsClient) Delete204SucceededResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
 		autorest.ByClosing())
 	result.Response = resp
@@ -265,7 +262,6 @@ func (client LROSADsClient) DeleteAsyncRelativeRetry400Sender(req *http.Request)
 func (client LROSADsClient) DeleteAsyncRelativeRetry400Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -326,7 +322,6 @@ func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidHeaderSender(req *htt
 func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidHeaderResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -387,7 +382,6 @@ func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidJSONPollingSender(req
 func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidJSONPollingResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -448,7 +442,6 @@ func (client LROSADsClient) DeleteAsyncRelativeRetryNoStatusSender(req *http.Req
 func (client LROSADsClient) DeleteAsyncRelativeRetryNoStatusResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -508,7 +501,6 @@ func (client LROSADsClient) DeleteNonRetry400Sender(req *http.Request) (future L
 func (client LROSADsClient) DeleteNonRetry400Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -576,7 +568,6 @@ func (client LROSADsClient) Post202NoLocationSender(req *http.Request) (future L
 func (client LROSADsClient) Post202NoLocationResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -643,7 +634,6 @@ func (client LROSADsClient) Post202NonRetry400Sender(req *http.Request) (future 
 func (client LROSADsClient) Post202NonRetry400Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -711,7 +701,6 @@ func (client LROSADsClient) Post202RetryInvalidHeaderSender(req *http.Request) (
 func (client LROSADsClient) Post202RetryInvalidHeaderResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -779,7 +768,6 @@ func (client LROSADsClient) PostAsyncRelativeRetry400Sender(req *http.Request) (
 func (client LROSADsClient) PostAsyncRelativeRetry400Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -848,7 +836,6 @@ func (client LROSADsClient) PostAsyncRelativeRetryInvalidHeaderSender(req *http.
 func (client LROSADsClient) PostAsyncRelativeRetryInvalidHeaderResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -917,7 +904,6 @@ func (client LROSADsClient) PostAsyncRelativeRetryInvalidJSONPollingSender(req *
 func (client LROSADsClient) PostAsyncRelativeRetryInvalidJSONPollingResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -986,7 +972,6 @@ func (client LROSADsClient) PostAsyncRelativeRetryNoPayloadSender(req *http.Requ
 func (client LROSADsClient) PostAsyncRelativeRetryNoPayloadResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1053,7 +1038,6 @@ func (client LROSADsClient) PostNonRetry400Sender(req *http.Request) (future LRO
 func (client LROSADsClient) PostNonRetry400Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1121,7 +1105,6 @@ func (client LROSADsClient) Put200InvalidJSONSender(req *http.Request) (future L
 func (client LROSADsClient) Put200InvalidJSONResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1190,7 +1173,6 @@ func (client LROSADsClient) PutAsyncRelativeRetry400Sender(req *http.Request) (f
 func (client LROSADsClient) PutAsyncRelativeRetry400Responder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1260,7 +1242,6 @@ func (client LROSADsClient) PutAsyncRelativeRetryInvalidHeaderSender(req *http.R
 func (client LROSADsClient) PutAsyncRelativeRetryInvalidHeaderResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1330,7 +1311,6 @@ func (client LROSADsClient) PutAsyncRelativeRetryInvalidJSONPollingSender(req *h
 func (client LROSADsClient) PutAsyncRelativeRetryInvalidJSONPollingResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1400,7 +1380,6 @@ func (client LROSADsClient) PutAsyncRelativeRetryNoStatusSender(req *http.Reques
 func (client LROSADsClient) PutAsyncRelativeRetryNoStatusResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1470,7 +1449,6 @@ func (client LROSADsClient) PutAsyncRelativeRetryNoStatusPayloadSender(req *http
 func (client LROSADsClient) PutAsyncRelativeRetryNoStatusPayloadResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1539,7 +1517,6 @@ func (client LROSADsClient) PutError201NoProvisioningStatePayloadSender(req *htt
 func (client LROSADsClient) PutError201NoProvisioningStatePayloadResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1608,7 +1585,6 @@ func (client LROSADsClient) PutNonRetry201Creating400Sender(req *http.Request) (
 func (client LROSADsClient) PutNonRetry201Creating400Responder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1677,7 +1653,6 @@ func (client LROSADsClient) PutNonRetry201Creating400InvalidJSONSender(req *http
 func (client LROSADsClient) PutNonRetry201Creating400InvalidJSONResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1745,7 +1720,6 @@ func (client LROSADsClient) PutNonRetry400Sender(req *http.Request) (future LROS
 func (client LROSADsClient) PutNonRetry400Responder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())

--- a/test/src/tests/generated/lrogroup/lroscustomheader.go
+++ b/test/src/tests/generated/lrogroup/lroscustomheader.go
@@ -93,7 +93,6 @@ func (client LROsCustomHeaderClient) Post202Retry200Sender(req *http.Request) (f
 func (client LROsCustomHeaderClient) Post202Retry200Responder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -162,7 +161,6 @@ func (client LROsCustomHeaderClient) PostAsyncRetrySucceededSender(req *http.Req
 func (client LROsCustomHeaderClient) PostAsyncRetrySucceededResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByClosing())
 	result.Response = resp
@@ -232,7 +230,6 @@ func (client LROsCustomHeaderClient) Put201CreatingSucceeded200Sender(req *http.
 func (client LROsCustomHeaderClient) Put201CreatingSucceeded200Responder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -302,7 +299,6 @@ func (client LROsCustomHeaderClient) PutAsyncRetrySucceededSender(req *http.Requ
 func (client LROsCustomHeaderClient) PutAsyncRetrySucceededResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())

--- a/test/src/tests/generated/modelflatteninggroup/client.go
+++ b/test/src/tests/generated/modelflatteninggroup/client.go
@@ -96,7 +96,6 @@ func (client BaseClient) GetArraySender(req *http.Request) (*http.Response, erro
 func (client BaseClient) GetArrayResponder(resp *http.Response) (result ListFlattenedProduct, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -157,7 +156,6 @@ func (client BaseClient) GetDictionarySender(req *http.Request) (*http.Response,
 func (client BaseClient) GetDictionaryResponder(resp *http.Response) (result SetFlattenedProduct, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -218,7 +216,6 @@ func (client BaseClient) GetResourceCollectionSender(req *http.Request) (*http.R
 func (client BaseClient) GetResourceCollectionResponder(resp *http.Response) (result ResourceCollection, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -280,7 +277,6 @@ func (client BaseClient) GetWrappedArraySender(req *http.Request) (*http.Respons
 func (client BaseClient) GetWrappedArrayResponder(resp *http.Response) (result ListProductWrapper, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -359,7 +355,6 @@ func (client BaseClient) PostFlattenedSimpleProductSender(req *http.Request) (*h
 func (client BaseClient) PostFlattenedSimpleProductResponder(resp *http.Response) (result SimpleProduct, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -427,7 +422,6 @@ func (client BaseClient) PutArraySender(req *http.Request) (*http.Response, erro
 func (client BaseClient) PutArrayResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -494,7 +488,6 @@ func (client BaseClient) PutDictionarySender(req *http.Request) (*http.Response,
 func (client BaseClient) PutDictionaryResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -561,7 +554,6 @@ func (client BaseClient) PutResourceCollectionSender(req *http.Request) (*http.R
 func (client BaseClient) PutResourceCollectionResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -639,7 +631,6 @@ func (client BaseClient) PutSimpleProductSender(req *http.Request) (*http.Respon
 func (client BaseClient) PutSimpleProductResponder(resp *http.Response) (result SimpleProduct, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -723,7 +714,6 @@ func (client BaseClient) PutSimpleProductWithGroupingSender(req *http.Request) (
 func (client BaseClient) PutSimpleProductWithGroupingResponder(resp *http.Response) (result SimpleProduct, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -792,7 +782,6 @@ func (client BaseClient) PutWrappedArraySender(req *http.Request) (*http.Respons
 func (client BaseClient) PutWrappedArrayResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/morecustombaseurigroup/paths.go
+++ b/test/src/tests/generated/morecustombaseurigroup/paths.go
@@ -101,7 +101,6 @@ func (client PathsClient) GetEmptySender(req *http.Request) (*http.Response, err
 func (client PathsClient) GetEmptyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/numbergroup/number.go
+++ b/test/src/tests/generated/numbergroup/number.go
@@ -84,7 +84,6 @@ func (client NumberClient) GetBigDecimalSender(req *http.Request) (*http.Respons
 func (client NumberClient) GetBigDecimalResponder(resp *http.Response) (result Decimal, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -145,7 +144,6 @@ func (client NumberClient) GetBigDecimalNegativeDecimalSender(req *http.Request)
 func (client NumberClient) GetBigDecimalNegativeDecimalResponder(resp *http.Response) (result Decimal, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -206,7 +204,6 @@ func (client NumberClient) GetBigDecimalPositiveDecimalSender(req *http.Request)
 func (client NumberClient) GetBigDecimalPositiveDecimalResponder(resp *http.Response) (result Decimal, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -267,7 +264,6 @@ func (client NumberClient) GetBigDoubleSender(req *http.Request) (*http.Response
 func (client NumberClient) GetBigDoubleResponder(resp *http.Response) (result Float64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -328,7 +324,6 @@ func (client NumberClient) GetBigDoubleNegativeDecimalSender(req *http.Request) 
 func (client NumberClient) GetBigDoubleNegativeDecimalResponder(resp *http.Response) (result Float64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -389,7 +384,6 @@ func (client NumberClient) GetBigDoublePositiveDecimalSender(req *http.Request) 
 func (client NumberClient) GetBigDoublePositiveDecimalResponder(resp *http.Response) (result Float64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -450,7 +444,6 @@ func (client NumberClient) GetBigFloatSender(req *http.Request) (*http.Response,
 func (client NumberClient) GetBigFloatResponder(resp *http.Response) (result Float64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -511,7 +504,6 @@ func (client NumberClient) GetInvalidDecimalSender(req *http.Request) (*http.Res
 func (client NumberClient) GetInvalidDecimalResponder(resp *http.Response) (result Decimal, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -572,7 +564,6 @@ func (client NumberClient) GetInvalidDoubleSender(req *http.Request) (*http.Resp
 func (client NumberClient) GetInvalidDoubleResponder(resp *http.Response) (result Float64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -633,7 +624,6 @@ func (client NumberClient) GetInvalidFloatSender(req *http.Request) (*http.Respo
 func (client NumberClient) GetInvalidFloatResponder(resp *http.Response) (result Float64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -694,7 +684,6 @@ func (client NumberClient) GetNullSender(req *http.Request) (*http.Response, err
 func (client NumberClient) GetNullResponder(resp *http.Response) (result Float64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -755,7 +744,6 @@ func (client NumberClient) GetSmallDecimalSender(req *http.Request) (*http.Respo
 func (client NumberClient) GetSmallDecimalResponder(resp *http.Response) (result Decimal, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -816,7 +804,6 @@ func (client NumberClient) GetSmallDoubleSender(req *http.Request) (*http.Respon
 func (client NumberClient) GetSmallDoubleResponder(resp *http.Response) (result Float64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -877,7 +864,6 @@ func (client NumberClient) GetSmallFloatSender(req *http.Request) (*http.Respons
 func (client NumberClient) GetSmallFloatResponder(resp *http.Response) (result Float64, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -940,7 +926,6 @@ func (client NumberClient) PutBigDecimalSender(req *http.Request) (*http.Respons
 func (client NumberClient) PutBigDecimalResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1002,7 +987,6 @@ func (client NumberClient) PutBigDecimalNegativeDecimalSender(req *http.Request)
 func (client NumberClient) PutBigDecimalNegativeDecimalResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1064,7 +1048,6 @@ func (client NumberClient) PutBigDecimalPositiveDecimalSender(req *http.Request)
 func (client NumberClient) PutBigDecimalPositiveDecimalResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1126,7 +1109,6 @@ func (client NumberClient) PutBigDoubleSender(req *http.Request) (*http.Response
 func (client NumberClient) PutBigDoubleResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1188,7 +1170,6 @@ func (client NumberClient) PutBigDoubleNegativeDecimalSender(req *http.Request) 
 func (client NumberClient) PutBigDoubleNegativeDecimalResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1250,7 +1231,6 @@ func (client NumberClient) PutBigDoublePositiveDecimalSender(req *http.Request) 
 func (client NumberClient) PutBigDoublePositiveDecimalResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1312,7 +1292,6 @@ func (client NumberClient) PutBigFloatSender(req *http.Request) (*http.Response,
 func (client NumberClient) PutBigFloatResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1374,7 +1353,6 @@ func (client NumberClient) PutSmallDecimalSender(req *http.Request) (*http.Respo
 func (client NumberClient) PutSmallDecimalResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1436,7 +1414,6 @@ func (client NumberClient) PutSmallDoubleSender(req *http.Request) (*http.Respon
 func (client NumberClient) PutSmallDoubleResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1498,7 +1475,6 @@ func (client NumberClient) PutSmallFloatSender(req *http.Request) (*http.Respons
 func (client NumberClient) PutSmallFloatResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/optionalgroup/explicit.go
+++ b/test/src/tests/generated/optionalgroup/explicit.go
@@ -88,7 +88,6 @@ func (client ExplicitClient) PostOptionalArrayHeaderSender(req *http.Request) (*
 func (client ExplicitClient) PostOptionalArrayHeaderResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -153,7 +152,6 @@ func (client ExplicitClient) PostOptionalArrayParameterSender(req *http.Request)
 func (client ExplicitClient) PostOptionalArrayParameterResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -218,7 +216,6 @@ func (client ExplicitClient) PostOptionalArrayPropertySender(req *http.Request) 
 func (client ExplicitClient) PostOptionalArrayPropertyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -290,7 +287,6 @@ func (client ExplicitClient) PostOptionalClassParameterSender(req *http.Request)
 func (client ExplicitClient) PostOptionalClassParameterResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -365,7 +361,6 @@ func (client ExplicitClient) PostOptionalClassPropertySender(req *http.Request) 
 func (client ExplicitClient) PostOptionalClassPropertyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -429,7 +424,6 @@ func (client ExplicitClient) PostOptionalIntegerHeaderSender(req *http.Request) 
 func (client ExplicitClient) PostOptionalIntegerHeaderResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -494,7 +488,6 @@ func (client ExplicitClient) PostOptionalIntegerParameterSender(req *http.Reques
 func (client ExplicitClient) PostOptionalIntegerParameterResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -559,7 +552,6 @@ func (client ExplicitClient) PostOptionalIntegerPropertySender(req *http.Request
 func (client ExplicitClient) PostOptionalIntegerPropertyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -623,7 +615,6 @@ func (client ExplicitClient) PostOptionalStringHeaderSender(req *http.Request) (
 func (client ExplicitClient) PostOptionalStringHeaderResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -688,7 +679,6 @@ func (client ExplicitClient) PostOptionalStringParameterSender(req *http.Request
 func (client ExplicitClient) PostOptionalStringParameterResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -753,7 +743,6 @@ func (client ExplicitClient) PostOptionalStringPropertySender(req *http.Request)
 func (client ExplicitClient) PostOptionalStringPropertyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -821,7 +810,6 @@ func (client ExplicitClient) PostRequiredArrayHeaderSender(req *http.Request) (*
 func (client ExplicitClient) PostRequiredArrayHeaderResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -890,7 +878,6 @@ func (client ExplicitClient) PostRequiredArrayParameterSender(req *http.Request)
 func (client ExplicitClient) PostRequiredArrayParameterResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -959,7 +946,6 @@ func (client ExplicitClient) PostRequiredArrayPropertySender(req *http.Request) 
 func (client ExplicitClient) PostRequiredArrayPropertyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1028,7 +1014,6 @@ func (client ExplicitClient) PostRequiredClassParameterSender(req *http.Request)
 func (client ExplicitClient) PostRequiredClassParameterResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1098,7 +1083,6 @@ func (client ExplicitClient) PostRequiredClassPropertySender(req *http.Request) 
 func (client ExplicitClient) PostRequiredClassPropertyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1160,7 +1144,6 @@ func (client ExplicitClient) PostRequiredIntegerHeaderSender(req *http.Request) 
 func (client ExplicitClient) PostRequiredIntegerHeaderResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1223,7 +1206,6 @@ func (client ExplicitClient) PostRequiredIntegerParameterSender(req *http.Reques
 func (client ExplicitClient) PostRequiredIntegerParameterResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1292,7 +1274,6 @@ func (client ExplicitClient) PostRequiredIntegerPropertySender(req *http.Request
 func (client ExplicitClient) PostRequiredIntegerPropertyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1354,7 +1335,6 @@ func (client ExplicitClient) PostRequiredStringHeaderSender(req *http.Request) (
 func (client ExplicitClient) PostRequiredStringHeaderResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1417,7 +1397,6 @@ func (client ExplicitClient) PostRequiredStringParameterSender(req *http.Request
 func (client ExplicitClient) PostRequiredStringParameterResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1486,7 +1465,6 @@ func (client ExplicitClient) PostRequiredStringPropertySender(req *http.Request)
 func (client ExplicitClient) PostRequiredStringPropertyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/optionalgroup/implicit.go
+++ b/test/src/tests/generated/optionalgroup/implicit.go
@@ -89,7 +89,6 @@ func (client ImplicitClient) GetOptionalGlobalQuerySender(req *http.Request) (*h
 func (client ImplicitClient) GetOptionalGlobalQueryResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -153,7 +152,6 @@ func (client ImplicitClient) GetRequiredGlobalPathSender(req *http.Request) (*ht
 func (client ImplicitClient) GetRequiredGlobalPathResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -218,7 +216,6 @@ func (client ImplicitClient) GetRequiredGlobalQuerySender(req *http.Request) (*h
 func (client ImplicitClient) GetRequiredGlobalQueryResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -282,7 +279,6 @@ func (client ImplicitClient) GetRequiredPathSender(req *http.Request) (*http.Res
 func (client ImplicitClient) GetRequiredPathResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -347,7 +343,6 @@ func (client ImplicitClient) PutOptionalBodySender(req *http.Request) (*http.Res
 func (client ImplicitClient) PutOptionalBodyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -411,7 +406,6 @@ func (client ImplicitClient) PutOptionalHeaderSender(req *http.Request) (*http.R
 func (client ImplicitClient) PutOptionalHeaderResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -477,7 +471,6 @@ func (client ImplicitClient) PutOptionalQuerySender(req *http.Request) (*http.Re
 func (client ImplicitClient) PutOptionalQueryResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/paginggroup/paging.go
+++ b/test/src/tests/generated/paginggroup/paging.go
@@ -104,7 +104,6 @@ func (client PagingClient) GetMultiplePagesSender(req *http.Request) (*http.Resp
 func (client PagingClient) GetMultiplePagesResponder(resp *http.Response) (result ProductResult, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -203,7 +202,6 @@ func (client PagingClient) GetMultiplePagesFailureSender(req *http.Request) (*ht
 func (client PagingClient) GetMultiplePagesFailureResponder(resp *http.Response) (result ProductResult, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -302,7 +300,6 @@ func (client PagingClient) GetMultiplePagesFailureURISender(req *http.Request) (
 func (client PagingClient) GetMultiplePagesFailureURIResponder(resp *http.Response) (result ProductResult, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -418,7 +415,6 @@ func (client PagingClient) GetMultiplePagesFragmentNextLinkSender(req *http.Requ
 func (client PagingClient) GetMultiplePagesFragmentNextLinkResponder(resp *http.Response) (result OdataProductResult, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -514,7 +510,6 @@ func (client PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkSender(re
 func (client PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkResponder(resp *http.Response) (result OdataProductResult, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -616,7 +611,6 @@ func (client PagingClient) GetMultiplePagesLROResponder(resp *http.Response) (re
 func (client PagingClient) getMultiplePagesLROResponder(resp *http.Response) (result ProductResult, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -714,7 +708,6 @@ func (client PagingClient) GetMultiplePagesRetryFirstSender(req *http.Request) (
 func (client PagingClient) GetMultiplePagesRetryFirstResponder(resp *http.Response) (result ProductResult, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -814,7 +807,6 @@ func (client PagingClient) GetMultiplePagesRetrySecondSender(req *http.Request) 
 func (client PagingClient) GetMultiplePagesRetrySecondResponder(resp *http.Response) (result ProductResult, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -937,7 +929,6 @@ func (client PagingClient) GetMultiplePagesWithOffsetSender(req *http.Request) (
 func (client PagingClient) GetMultiplePagesWithOffsetResponder(resp *http.Response) (result ProductResult, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1036,7 +1027,6 @@ func (client PagingClient) GetNoItemNamePagesSender(req *http.Request) (*http.Re
 func (client PagingClient) GetNoItemNamePagesResponder(resp *http.Response) (result ProductResultValue, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1134,7 +1124,6 @@ func (client PagingClient) GetNullNextLinkNamePagesSender(req *http.Request) (*h
 func (client PagingClient) GetNullNextLinkNamePagesResponder(resp *http.Response) (result ProductResult, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1215,7 +1204,6 @@ func (client PagingClient) GetOdataMultiplePagesSender(req *http.Request) (*http
 func (client PagingClient) GetOdataMultiplePagesResponder(resp *http.Response) (result OdataProductResult, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1314,7 +1302,6 @@ func (client PagingClient) GetSinglePagesSender(req *http.Request) (*http.Respon
 func (client PagingClient) GetSinglePagesResponder(resp *http.Response) (result ProductResult, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1413,7 +1400,6 @@ func (client PagingClient) GetSinglePagesFailureSender(req *http.Request) (*http
 func (client PagingClient) GetSinglePagesFailureResponder(resp *http.Response) (result ProductResult, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1525,7 +1511,6 @@ func (client PagingClient) NextFragmentSender(req *http.Request) (*http.Response
 func (client PagingClient) NextFragmentResponder(resp *http.Response) (result OdataProductResult, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -1600,7 +1585,6 @@ func (client PagingClient) NextFragmentWithGroupingSender(req *http.Request) (*h
 func (client PagingClient) NextFragmentWithGroupingResponder(resp *http.Response) (result OdataProductResult, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())

--- a/test/src/tests/generated/report/client.go
+++ b/test/src/tests/generated/report/client.go
@@ -104,7 +104,6 @@ func (client BaseClient) GetReportSender(req *http.Request) (*http.Response, err
 func (client BaseClient) GetReportResponder(resp *http.Response) (result SetInt32, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())

--- a/test/src/tests/generated/stringgroup/enum.go
+++ b/test/src/tests/generated/stringgroup/enum.go
@@ -84,7 +84,6 @@ func (client EnumClient) GetNotExpandableSender(req *http.Request) (*http.Respon
 func (client EnumClient) GetNotExpandableResponder(resp *http.Response) (result StringModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -145,7 +144,6 @@ func (client EnumClient) GetReferencedSender(req *http.Request) (*http.Response,
 func (client EnumClient) GetReferencedResponder(resp *http.Response) (result StringModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -206,7 +204,6 @@ func (client EnumClient) GetReferencedConstantSender(req *http.Request) (*http.R
 func (client EnumClient) GetReferencedConstantResponder(resp *http.Response) (result RefColorConstant, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -269,7 +266,6 @@ func (client EnumClient) PutNotExpandableSender(req *http.Request) (*http.Respon
 func (client EnumClient) PutNotExpandableResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -331,7 +327,6 @@ func (client EnumClient) PutReferencedSender(req *http.Request) (*http.Response,
 func (client EnumClient) PutReferencedResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -399,7 +394,6 @@ func (client EnumClient) PutReferencedConstantSender(req *http.Request) (*http.R
 func (client EnumClient) PutReferencedConstantResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/stringgroup/string.go
+++ b/test/src/tests/generated/stringgroup/string.go
@@ -83,7 +83,6 @@ func (client StringClient) GetBase64EncodedSender(req *http.Request) (*http.Resp
 func (client StringClient) GetBase64EncodedResponder(resp *http.Response) (result Base64URL, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -144,7 +143,6 @@ func (client StringClient) GetBase64URLEncodedSender(req *http.Request) (*http.R
 func (client StringClient) GetBase64URLEncodedResponder(resp *http.Response) (result Base64URL, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -205,7 +203,6 @@ func (client StringClient) GetEmptySender(req *http.Request) (*http.Response, er
 func (client StringClient) GetEmptyResponder(resp *http.Response) (result StringModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -266,7 +263,6 @@ func (client StringClient) GetMbcsSender(req *http.Request) (*http.Response, err
 func (client StringClient) GetMbcsResponder(resp *http.Response) (result StringModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -327,7 +323,6 @@ func (client StringClient) GetNotProvidedSender(req *http.Request) (*http.Respon
 func (client StringClient) GetNotProvidedResponder(resp *http.Response) (result StringModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -388,7 +383,6 @@ func (client StringClient) GetNullSender(req *http.Request) (*http.Response, err
 func (client StringClient) GetNullResponder(resp *http.Response) (result StringModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -449,7 +443,6 @@ func (client StringClient) GetNullBase64URLEncodedSender(req *http.Request) (*ht
 func (client StringClient) GetNullBase64URLEncodedResponder(resp *http.Response) (result Base64URL, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -511,7 +504,6 @@ func (client StringClient) GetWhitespaceSender(req *http.Request) (*http.Respons
 func (client StringClient) GetWhitespaceResponder(resp *http.Response) (result StringModel, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Value),
 		autorest.ByClosing())
@@ -574,7 +566,6 @@ func (client StringClient) PutBase64URLEncodedSender(req *http.Request) (*http.R
 func (client StringClient) PutBase64URLEncodedResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -636,7 +627,6 @@ func (client StringClient) PutEmptySender(req *http.Request) (*http.Response, er
 func (client StringClient) PutEmptyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -698,7 +688,6 @@ func (client StringClient) PutMbcsSender(req *http.Request) (*http.Response, err
 func (client StringClient) PutMbcsResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -763,7 +752,6 @@ func (client StringClient) PutNullSender(req *http.Request) (*http.Response, err
 func (client StringClient) PutNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -826,7 +814,6 @@ func (client StringClient) PutWhitespaceSender(req *http.Request) (*http.Respons
 func (client StringClient) PutWhitespaceResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/urlgroup/pathitems.go
+++ b/test/src/tests/generated/urlgroup/pathitems.go
@@ -108,7 +108,6 @@ func (client PathItemsClient) GetAllWithValuesSender(req *http.Request) (*http.R
 func (client PathItemsClient) GetAllWithValuesResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -193,7 +192,6 @@ func (client PathItemsClient) GetGlobalAndLocalQueryNullSender(req *http.Request
 func (client PathItemsClient) GetGlobalAndLocalQueryNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -278,7 +276,6 @@ func (client PathItemsClient) GetGlobalQueryNullSender(req *http.Request) (*http
 func (client PathItemsClient) GetGlobalQueryNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -363,7 +360,6 @@ func (client PathItemsClient) GetLocalPathItemQueryNullSender(req *http.Request)
 func (client PathItemsClient) GetLocalPathItemQueryNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/urlgroup/paths.go
+++ b/test/src/tests/generated/urlgroup/paths.go
@@ -923,7 +923,7 @@ func (client PathsClient) FloatScientificNegative(ctx context.Context) (result a
 // FloatScientificNegativePreparer prepares the FloatScientificNegative request.
 func (client PathsClient) FloatScientificNegativePreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"floatPath": autorest.Encode("path", -1.034e-20),
+		"floatPath": autorest.Encode("path", -1.034E-20),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -986,7 +986,7 @@ func (client PathsClient) FloatScientificPositive(ctx context.Context) (result a
 // FloatScientificPositivePreparer prepares the FloatScientificPositive request.
 func (client PathsClient) FloatScientificPositivePreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"floatPath": autorest.Encode("path", 1.034e+20),
+		"floatPath": autorest.Encode("path", 1.034E+20),
 	}
 
 	preparer := autorest.CreatePreparer(

--- a/test/src/tests/generated/urlgroup/paths.go
+++ b/test/src/tests/generated/urlgroup/paths.go
@@ -99,7 +99,6 @@ func (client PathsClient) ArrayCsvInPathSender(req *http.Request) (*http.Respons
 func (client PathsClient) ArrayCsvInPathResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -165,7 +164,6 @@ func (client PathsClient) Base64URLSender(req *http.Request) (*http.Response, er
 func (client PathsClient) Base64URLResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -229,7 +227,6 @@ func (client PathsClient) ByteEmptySender(req *http.Request) (*http.Response, er
 func (client PathsClient) ByteEmptyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -301,7 +298,6 @@ func (client PathsClient) ByteMultiByteSender(req *http.Request) (*http.Response
 func (client PathsClient) ByteMultiByteResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -373,7 +369,6 @@ func (client PathsClient) ByteNullSender(req *http.Request) (*http.Response, err
 func (client PathsClient) ByteNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusBadRequest),
 		autorest.ByClosing())
 	result.Response = resp
@@ -439,7 +434,6 @@ func (client PathsClient) DateNullSender(req *http.Request) (*http.Response, err
 func (client PathsClient) DateNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusBadRequest),
 		autorest.ByClosing())
 	result.Response = resp
@@ -505,7 +499,6 @@ func (client PathsClient) DateTimeNullSender(req *http.Request) (*http.Response,
 func (client PathsClient) DateTimeNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusBadRequest),
 		autorest.ByClosing())
 	result.Response = resp
@@ -569,7 +562,6 @@ func (client PathsClient) DateTimeValidSender(req *http.Request) (*http.Response
 func (client PathsClient) DateTimeValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -633,7 +625,6 @@ func (client PathsClient) DateValidSender(req *http.Request) (*http.Response, er
 func (client PathsClient) DateValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -697,7 +688,6 @@ func (client PathsClient) DoubleDecimalNegativeSender(req *http.Request) (*http.
 func (client PathsClient) DoubleDecimalNegativeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -761,7 +751,6 @@ func (client PathsClient) DoubleDecimalPositiveSender(req *http.Request) (*http.
 func (client PathsClient) DoubleDecimalPositiveResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -827,7 +816,6 @@ func (client PathsClient) EnumNullSender(req *http.Request) (*http.Response, err
 func (client PathsClient) EnumNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusBadRequest),
 		autorest.ByClosing())
 	result.Response = resp
@@ -893,7 +881,6 @@ func (client PathsClient) EnumValidSender(req *http.Request) (*http.Response, er
 func (client PathsClient) EnumValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -936,7 +923,7 @@ func (client PathsClient) FloatScientificNegative(ctx context.Context) (result a
 // FloatScientificNegativePreparer prepares the FloatScientificNegative request.
 func (client PathsClient) FloatScientificNegativePreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"floatPath": autorest.Encode("path", -1.034E-20),
+		"floatPath": autorest.Encode("path", -1.034e-20),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -957,7 +944,6 @@ func (client PathsClient) FloatScientificNegativeSender(req *http.Request) (*htt
 func (client PathsClient) FloatScientificNegativeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1000,7 +986,7 @@ func (client PathsClient) FloatScientificPositive(ctx context.Context) (result a
 // FloatScientificPositivePreparer prepares the FloatScientificPositive request.
 func (client PathsClient) FloatScientificPositivePreparer(ctx context.Context) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"floatPath": autorest.Encode("path", 1.034E+20),
+		"floatPath": autorest.Encode("path", 1.034e+20),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1021,7 +1007,6 @@ func (client PathsClient) FloatScientificPositiveSender(req *http.Request) (*htt
 func (client PathsClient) FloatScientificPositiveResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1085,7 +1070,6 @@ func (client PathsClient) GetBooleanFalseSender(req *http.Request) (*http.Respon
 func (client PathsClient) GetBooleanFalseResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1149,7 +1133,6 @@ func (client PathsClient) GetBooleanTrueSender(req *http.Request) (*http.Respons
 func (client PathsClient) GetBooleanTrueResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1213,7 +1196,6 @@ func (client PathsClient) GetIntNegativeOneMillionSender(req *http.Request) (*ht
 func (client PathsClient) GetIntNegativeOneMillionResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1277,7 +1259,6 @@ func (client PathsClient) GetIntOneMillionSender(req *http.Request) (*http.Respo
 func (client PathsClient) GetIntOneMillionResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1341,7 +1322,6 @@ func (client PathsClient) GetNegativeTenBillionSender(req *http.Request) (*http.
 func (client PathsClient) GetNegativeTenBillionResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1405,7 +1385,6 @@ func (client PathsClient) GetTenBillionSender(req *http.Request) (*http.Response
 func (client PathsClient) GetTenBillionResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1469,7 +1448,6 @@ func (client PathsClient) StringEmptySender(req *http.Request) (*http.Response, 
 func (client PathsClient) StringEmptyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1535,7 +1513,6 @@ func (client PathsClient) StringNullSender(req *http.Request) (*http.Response, e
 func (client PathsClient) StringNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusBadRequest),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1599,7 +1576,6 @@ func (client PathsClient) StringUnicodeSender(req *http.Request) (*http.Response
 func (client PathsClient) StringUnicodeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1663,7 +1639,6 @@ func (client PathsClient) StringURLEncodedSender(req *http.Request) (*http.Respo
 func (client PathsClient) StringURLEncodedResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1729,7 +1704,6 @@ func (client PathsClient) UnixTimeURLSender(req *http.Request) (*http.Response, 
 func (client PathsClient) UnixTimeURLResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/urlgroup/queries.go
+++ b/test/src/tests/generated/urlgroup/queries.go
@@ -1333,7 +1333,7 @@ func (client QueriesClient) FloatScientificNegative(ctx context.Context) (result
 // FloatScientificNegativePreparer prepares the FloatScientificNegative request.
 func (client QueriesClient) FloatScientificNegativePreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"floatQuery": autorest.Encode("query", -1.034e-20),
+		"floatQuery": autorest.Encode("query", -1.034E-20),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1397,7 +1397,7 @@ func (client QueriesClient) FloatScientificPositive(ctx context.Context) (result
 // FloatScientificPositivePreparer prepares the FloatScientificPositive request.
 func (client QueriesClient) FloatScientificPositivePreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"floatQuery": autorest.Encode("query", 1.034e+20),
+		"floatQuery": autorest.Encode("query", 1.034E+20),
 	}
 
 	preparer := autorest.CreatePreparer(

--- a/test/src/tests/generated/urlgroup/queries.go
+++ b/test/src/tests/generated/urlgroup/queries.go
@@ -92,7 +92,6 @@ func (client QueriesClient) ArrayStringCsvEmptySender(req *http.Request) (*http.
 func (client QueriesClient) ArrayStringCsvEmptyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -160,7 +159,6 @@ func (client QueriesClient) ArrayStringCsvNullSender(req *http.Request) (*http.R
 func (client QueriesClient) ArrayStringCsvNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -230,7 +228,6 @@ func (client QueriesClient) ArrayStringCsvValidSender(req *http.Request) (*http.
 func (client QueriesClient) ArrayStringCsvValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -300,7 +297,6 @@ func (client QueriesClient) ArrayStringPipesValidSender(req *http.Request) (*htt
 func (client QueriesClient) ArrayStringPipesValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -370,7 +366,6 @@ func (client QueriesClient) ArrayStringSsvValidSender(req *http.Request) (*http.
 func (client QueriesClient) ArrayStringSsvValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -440,7 +435,6 @@ func (client QueriesClient) ArrayStringTsvValidSender(req *http.Request) (*http.
 func (client QueriesClient) ArrayStringTsvValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -505,7 +499,6 @@ func (client QueriesClient) ByteEmptySender(req *http.Request) (*http.Response, 
 func (client QueriesClient) ByteEmptyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -573,7 +566,6 @@ func (client QueriesClient) ByteMultiByteSender(req *http.Request) (*http.Respon
 func (client QueriesClient) ByteMultiByteResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -641,7 +633,6 @@ func (client QueriesClient) ByteNullSender(req *http.Request) (*http.Response, e
 func (client QueriesClient) ByteNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -709,7 +700,6 @@ func (client QueriesClient) DateNullSender(req *http.Request) (*http.Response, e
 func (client QueriesClient) DateNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -777,7 +767,6 @@ func (client QueriesClient) DateTimeNullSender(req *http.Request) (*http.Respons
 func (client QueriesClient) DateTimeNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -842,7 +831,6 @@ func (client QueriesClient) DateTimeValidSender(req *http.Request) (*http.Respon
 func (client QueriesClient) DateTimeValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -907,7 +895,6 @@ func (client QueriesClient) DateValidSender(req *http.Request) (*http.Response, 
 func (client QueriesClient) DateValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -972,7 +959,6 @@ func (client QueriesClient) DoubleDecimalNegativeSender(req *http.Request) (*htt
 func (client QueriesClient) DoubleDecimalNegativeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1037,7 +1023,6 @@ func (client QueriesClient) DoubleDecimalPositiveSender(req *http.Request) (*htt
 func (client QueriesClient) DoubleDecimalPositiveResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1105,7 +1090,6 @@ func (client QueriesClient) DoubleNullSender(req *http.Request) (*http.Response,
 func (client QueriesClient) DoubleNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1173,7 +1157,6 @@ func (client QueriesClient) EnumNullSender(req *http.Request) (*http.Response, e
 func (client QueriesClient) EnumNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1241,7 +1224,6 @@ func (client QueriesClient) EnumValidSender(req *http.Request) (*http.Response, 
 func (client QueriesClient) EnumValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1309,7 +1291,6 @@ func (client QueriesClient) FloatNullSender(req *http.Request) (*http.Response, 
 func (client QueriesClient) FloatNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1352,7 +1333,7 @@ func (client QueriesClient) FloatScientificNegative(ctx context.Context) (result
 // FloatScientificNegativePreparer prepares the FloatScientificNegative request.
 func (client QueriesClient) FloatScientificNegativePreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"floatQuery": autorest.Encode("query", -1.034E-20),
+		"floatQuery": autorest.Encode("query", -1.034e-20),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1374,7 +1355,6 @@ func (client QueriesClient) FloatScientificNegativeSender(req *http.Request) (*h
 func (client QueriesClient) FloatScientificNegativeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1417,7 +1397,7 @@ func (client QueriesClient) FloatScientificPositive(ctx context.Context) (result
 // FloatScientificPositivePreparer prepares the FloatScientificPositive request.
 func (client QueriesClient) FloatScientificPositivePreparer(ctx context.Context) (*http.Request, error) {
 	queryParameters := map[string]interface{}{
-		"floatQuery": autorest.Encode("query", 1.034E+20),
+		"floatQuery": autorest.Encode("query", 1.034e+20),
 	}
 
 	preparer := autorest.CreatePreparer(
@@ -1439,7 +1419,6 @@ func (client QueriesClient) FloatScientificPositiveSender(req *http.Request) (*h
 func (client QueriesClient) FloatScientificPositiveResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1504,7 +1483,6 @@ func (client QueriesClient) GetBooleanFalseSender(req *http.Request) (*http.Resp
 func (client QueriesClient) GetBooleanFalseResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1572,7 +1550,6 @@ func (client QueriesClient) GetBooleanNullSender(req *http.Request) (*http.Respo
 func (client QueriesClient) GetBooleanNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1637,7 +1614,6 @@ func (client QueriesClient) GetBooleanTrueSender(req *http.Request) (*http.Respo
 func (client QueriesClient) GetBooleanTrueResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1702,7 +1678,6 @@ func (client QueriesClient) GetIntNegativeOneMillionSender(req *http.Request) (*
 func (client QueriesClient) GetIntNegativeOneMillionResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1770,7 +1745,6 @@ func (client QueriesClient) GetIntNullSender(req *http.Request) (*http.Response,
 func (client QueriesClient) GetIntNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1835,7 +1809,6 @@ func (client QueriesClient) GetIntOneMillionSender(req *http.Request) (*http.Res
 func (client QueriesClient) GetIntOneMillionResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1903,7 +1876,6 @@ func (client QueriesClient) GetLongNullSender(req *http.Request) (*http.Response
 func (client QueriesClient) GetLongNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -1968,7 +1940,6 @@ func (client QueriesClient) GetNegativeTenBillionSender(req *http.Request) (*htt
 func (client QueriesClient) GetNegativeTenBillionResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -2033,7 +2004,6 @@ func (client QueriesClient) GetTenBillionSender(req *http.Request) (*http.Respon
 func (client QueriesClient) GetTenBillionResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -2098,7 +2068,6 @@ func (client QueriesClient) StringEmptySender(req *http.Request) (*http.Response
 func (client QueriesClient) StringEmptyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -2166,7 +2135,6 @@ func (client QueriesClient) StringNullSender(req *http.Request) (*http.Response,
 func (client QueriesClient) StringNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -2231,7 +2199,6 @@ func (client QueriesClient) StringUnicodeSender(req *http.Request) (*http.Respon
 func (client QueriesClient) StringUnicodeResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -2296,7 +2263,6 @@ func (client QueriesClient) StringURLEncodedSender(req *http.Request) (*http.Res
 func (client QueriesClient) StringURLEncodedResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/urlmultigroup/queries.go
+++ b/test/src/tests/generated/urlmultigroup/queries.go
@@ -91,7 +91,6 @@ func (client QueriesClient) ArrayStringMultiEmptySender(req *http.Request) (*htt
 func (client QueriesClient) ArrayStringMultiEmptyResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -159,7 +158,6 @@ func (client QueriesClient) ArrayStringMultiNullSender(req *http.Request) (*http
 func (client QueriesClient) ArrayStringMultiNullResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -229,7 +227,6 @@ func (client QueriesClient) ArrayStringMultiValidSender(req *http.Request) (*htt
 func (client QueriesClient) ArrayStringMultiValidResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp

--- a/test/src/tests/generated/validationgroup/client.go
+++ b/test/src/tests/generated/validationgroup/client.go
@@ -102,7 +102,6 @@ func (client BaseClient) GetWithConstantInPathSender(req *http.Request) (*http.R
 func (client BaseClient) GetWithConstantInPathResponder(resp *http.Response) (result autorest.Response, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result.Response = resp
@@ -197,7 +196,6 @@ func (client BaseClient) PostWithConstantInBodySender(req *http.Request) (*http.
 func (client BaseClient) PostWithConstantInBodyResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -312,7 +310,6 @@ func (client BaseClient) ValidationOfBodySender(req *http.Request) (*http.Respon
 func (client BaseClient) ValidationOfBodyResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
@@ -400,7 +397,6 @@ func (client BaseClient) ValidationOfMethodParametersSender(req *http.Request) (
 func (client BaseClient) ValidationOfMethodParametersResponder(resp *http.Response) (result Product, err error) {
 	err = autorest.Respond(
 		resp,
-		client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-go/issues/9221