### PR TITLE
Workaround for undefined tags

### DIFF
--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -66,6 +66,13 @@ async function process(session: Session<CodeModel>) {
         obj.language.go!.needsDateTimeMarshalling = true;
       }
     }
+    if (!obj.language.go!.marshallingFormat) {
+      // TODO: workaround due to https://github.com/Azure/autorest.go/issues/412
+      // this type isn't used as a parameter/return value so it has no marshalling format.
+      // AutoRest doesn't make the global configuration available at present so hard-code
+      // the format to JSON as the vast majority of specs use JSON.
+      obj.language.go!.marshallingFormat = 'json';
+    }
   }
   // fix up enum types
   for (const choice of values(session.model.schemas.choices)) {
@@ -481,9 +488,6 @@ function createResponseType(codeModel: CodeModel, group: OperationGroup, op: Ope
     }
   } else if (!responseTypeCreated(codeModel, firstResp.schema) || isLROOperation(op)) {
     firstResp.schema.language.go!.responseType = generateResponseTypeName(firstResp.schema);
-    if (isLROOperation(op)) {
-      firstResp.schema.language.go!.responseType.name = `${firstResp.schema.language.go!.responseType.name}`;
-    }
     firstResp.schema.language.go!.properties = [
       newProperty('RawResponse', 'RawResponse contains the underlying HTTP response.', newObject('http.Response', 'TODO'))
     ];

--- a/test/autorest/generated/azurespecialsgroup/models.go
+++ b/test/autorest/generated/azurespecialsgroup/models.go
@@ -74,8 +74,8 @@ type HeaderCustomNamedRequestIDResponse struct {
 }
 
 type OdataFilter struct {
-	ID   *int32  `undefined:"id"`
-	Name *string `undefined:"name"`
+	ID   *int32  `json:"id,omitempty"`
+	Name *string `json:"name,omitempty"`
 }
 
 // OdataGetWithFilterOptions contains the optional parameters for the Odata.GetWithFilter method.

--- a/test/autorest/generated/lrogroup/models.go
+++ b/test/autorest/generated/lrogroup/models.go
@@ -359,18 +359,18 @@ type LrosaDsPutNonRetry400Options struct {
 }
 
 type OperationResult struct {
-	Error *OperationResultError `undefined:"error"`
+	Error *OperationResultError `json:"error,omitempty"`
 
 	// The status of the request
-	Status *OperationResultStatus `undefined:"status"`
+	Status *OperationResultStatus `json:"status,omitempty"`
 }
 
 type OperationResultError struct {
 	// The error code for an operation failure
-	Code *int32 `undefined:"code"`
+	Code *int32 `json:"code,omitempty"`
 
 	// The detailed arror message
-	Message *string `undefined:"message"`
+	Message *string `json:"message,omitempty"`
 }
 
 type Product struct {

--- a/test/autorest/generated/paginggroup/models.go
+++ b/test/autorest/generated/paginggroup/models.go
@@ -34,7 +34,7 @@ type OdataProductResultResponse struct {
 
 type OperationResult struct {
 	// The status of the request
-	Status *OperationResultStatus `undefined:"status"`
+	Status *OperationResultStatus `json:"status,omitempty"`
 }
 
 // PagingGetMultiplePagesLroOptions contains the optional parameters for the Paging.GetMultiplePagesLro method.


### PR DESCRIPTION
Set the marshalling format to JSON if it's missing; this is to work
around a bug in AutoRest.
Removed some redundant code.