### PR TITLE
Add switch to disable exporting of client types

### DIFF
--- a/rushScripts/regeneration.js
+++ b/rushScripts/regeneration.js
@@ -48,7 +48,7 @@ for (namespace in goMappings) {
 } 
 
 const blobStorage = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/storage-dataplane-preview/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-07-07/blob.json';
-generate(blobStorage, 'test/storage/2019-07-07/azblob', '--credential-scope="https://storage.azure.com/.default" --module="azstorage"');
+generate(blobStorage, 'test/storage/2019-07-07/azblob', '--credential-scope="https://storage.azure.com/.default" --module="azstorage" --export-client="false"');
 
 // helper to log the package being generated before invocation
 function generate(inputFile, outputDir, additionalArgs) {

--- a/src/generator/gomod.ts
+++ b/src/generator/gomod.ts
@@ -16,6 +16,6 @@ export async function generateGoModFile(session: Session<CodeModel>): Promise<st
   text += 'go 1.13\n\n';
   // here we specify the minimum version of azcore as required by the code generator
   // TODO: come up with a way to get the latest minor/patch version.
-  text += 'require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.7.0\n';
+  text += 'require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.8.0\n';
   return text;
 }

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -52,11 +52,16 @@ export async function generateOperations(session: Session<CodeModel>): Promise<O
     const interfaceText = createInterfaceDefinition(group, imports);
     // stitch it all together
     let text = await contentPreamble(session);
+    const exportClient = await session.getValue('export-client', true);
+    let client = 'Client';
+    if (!exportClient) {
+      client = 'client';
+    }
     text += imports.text();
     text += interfaceText;
     text += `// ${clientName} implements the ${group.language.go!.clientName} interface.\n`;
     text += `type ${clientName} struct {\n`;
-    text += '\t*Client\n';
+    text += `\t*${client}\n`;
     if (group.language.go!.clientParams) {
       const clientParams = <Array<Parameter>>group.language.go!.clientParams;
       for (const clientParam of values(clientParams)) {

--- a/test/storage/2019-07-07/azblob/appendblob.go
+++ b/test/storage/2019-07-07/azblob/appendblob.go
@@ -27,7 +27,7 @@ type AppendBlobOperations interface {
 
 // appendBlobOperations implements the AppendBlobOperations interface.
 type appendBlobOperations struct {
-	*Client
+	*client
 }
 
 // AppendBlock - The Append Block operation commits a new block of data to the end of an existing append blob. The Append Block operation is permitted only if the blob was created with x-ms-blob-type set to AppendBlob. Append Block is supported only on version 2015-02-21 version or later.

--- a/test/storage/2019-07-07/azblob/blob.go
+++ b/test/storage/2019-07-07/azblob/blob.go
@@ -61,7 +61,7 @@ type BlobOperations interface {
 
 // blobOperations implements the BlobOperations interface.
 type blobOperations struct {
-	*Client
+	*client
 	pathRenameMode *PathRenameMode
 }
 

--- a/test/storage/2019-07-07/azblob/blockblob.go
+++ b/test/storage/2019-07-07/azblob/blockblob.go
@@ -31,7 +31,7 @@ type BlockBlobOperations interface {
 
 // blockBlobOperations implements the BlockBlobOperations interface.
 type blockBlobOperations struct {
-	*Client
+	*client
 }
 
 // CommitBlockList - The Commit Block List operation writes a blob by specifying the list of block IDs that make up the blob. In order to be written as part of a blob, a block must have been successfully written to the server in a prior Put Block operation. You can call Put Block List to update a blob by uploading only those blocks that have changed, then committing the new and existing blocks together. You can do this by specifying whether to commit a block from the committed block list or from the uncommitted block list, or to commit the most recently uploaded version of the block, whichever list it may belong to.

--- a/test/storage/2019-07-07/azblob/client.go
+++ b/test/storage/2019-07-07/azblob/client.go
@@ -14,7 +14,7 @@ import (
 const scope = "https://storage.azure.com/.default"
 
 // ClientOptions contains configuration settings for the default client's pipeline.
-type ClientOptions struct {
+type clientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
 	// LogOptions configures the built-in request logging policy behavior.
@@ -25,23 +25,23 @@ type ClientOptions struct {
 	Telemetry azcore.TelemetryOptions
 }
 
-// DefaultClientOptions creates a ClientOptions type initialized with default values.
-func DefaultClientOptions() ClientOptions {
-	return ClientOptions{
+// defaultClientOptions creates a clientOptions type initialized with default values.
+func defaultClientOptions() clientOptions {
+	return clientOptions{
 		HTTPClient: azcore.DefaultHTTPClientTransport(),
 		Retry:      azcore.DefaultRetryOptions(),
 	}
 }
 
-type Client struct {
+type client struct {
 	u *url.URL
 	p azcore.Pipeline
 }
 
-// NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, cred azcore.Credential, options *ClientOptions) (*Client, error) {
+// newClient creates an instance of the client type with the specified endpoint.
+func newClient(endpoint string, cred azcore.Credential, options *clientOptions) (*client, error) {
 	if options == nil {
-		o := DefaultClientOptions()
+		o := defaultClientOptions()
 		options = &o
 	}
 	p := azcore.NewPipeline(options.HTTPClient,
@@ -50,11 +50,11 @@ func NewClient(endpoint string, cred azcore.Credential, options *ClientOptions) 
 		azcore.NewRetryPolicy(&options.Retry),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
 		azcore.NewRequestLogPolicy(options.LogOptions))
-	return NewClientWithPipeline(endpoint, p)
+	return newClientWithPipeline(endpoint, p)
 }
 
-// NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
+// newClientWithPipeline creates an instance of the client type with the specified endpoint and pipeline.
+func newClientWithPipeline(endpoint string, p azcore.Pipeline) (*client, error) {
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
@@ -62,40 +62,40 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: u, p: p}, nil
+	return &client{u: u, p: p}, nil
 }
 
 // ServiceOperations returns the ServiceOperations associated with this client.
-func (client *Client) ServiceOperations() ServiceOperations {
-	return &serviceOperations{Client: client}
+func (client *client) ServiceOperations() ServiceOperations {
+	return &serviceOperations{client: client}
 }
 
 // ContainerOperations returns the ContainerOperations associated with this client.
-func (client *Client) ContainerOperations() ContainerOperations {
-	return &containerOperations{Client: client}
+func (client *client) ContainerOperations() ContainerOperations {
+	return &containerOperations{client: client}
 }
 
 // DirectoryOperations returns the DirectoryOperations associated with this client.
-func (client *Client) DirectoryOperations(pathRenameMode *PathRenameMode) DirectoryOperations {
-	return &directoryOperations{Client: client, pathRenameMode: pathRenameMode}
+func (client *client) DirectoryOperations(pathRenameMode *PathRenameMode) DirectoryOperations {
+	return &directoryOperations{client: client, pathRenameMode: pathRenameMode}
 }
 
 // BlobOperations returns the BlobOperations associated with this client.
-func (client *Client) BlobOperations(pathRenameMode *PathRenameMode) BlobOperations {
-	return &blobOperations{Client: client, pathRenameMode: pathRenameMode}
+func (client *client) BlobOperations(pathRenameMode *PathRenameMode) BlobOperations {
+	return &blobOperations{client: client, pathRenameMode: pathRenameMode}
 }
 
 // PageBlobOperations returns the PageBlobOperations associated with this client.
-func (client *Client) PageBlobOperations() PageBlobOperations {
-	return &pageBlobOperations{Client: client}
+func (client *client) PageBlobOperations() PageBlobOperations {
+	return &pageBlobOperations{client: client}
 }
 
 // AppendBlobOperations returns the AppendBlobOperations associated with this client.
-func (client *Client) AppendBlobOperations() AppendBlobOperations {
-	return &appendBlobOperations{Client: client}
+func (client *client) AppendBlobOperations() AppendBlobOperations {
+	return &appendBlobOperations{client: client}
 }
 
 // BlockBlobOperations returns the BlockBlobOperations associated with this client.
-func (client *Client) BlockBlobOperations() BlockBlobOperations {
-	return &blockBlobOperations{Client: client}
+func (client *client) BlockBlobOperations() BlockBlobOperations {
+	return &blockBlobOperations{client: client}
 }

--- a/test/storage/2019-07-07/azblob/container.go
+++ b/test/storage/2019-07-07/azblob/container.go
@@ -51,7 +51,7 @@ type ContainerOperations interface {
 
 // containerOperations implements the ContainerOperations interface.
 type containerOperations struct {
-	*Client
+	*client
 }
 
 // AcquireLease - [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite

--- a/test/storage/2019-07-07/azblob/directory.go
+++ b/test/storage/2019-07-07/azblob/directory.go
@@ -29,7 +29,7 @@ type DirectoryOperations interface {
 
 // directoryOperations implements the DirectoryOperations interface.
 type directoryOperations struct {
-	*Client
+	*client
 	pathRenameMode *PathRenameMode
 }
 

--- a/test/storage/2019-07-07/azblob/go.mod
+++ b/test/storage/2019-07-07/azblob/go.mod
@@ -2,4 +2,4 @@ module azstorage
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.7.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.8.0

--- a/test/storage/2019-07-07/azblob/pageblob.go
+++ b/test/storage/2019-07-07/azblob/pageblob.go
@@ -39,7 +39,7 @@ type PageBlobOperations interface {
 
 // pageBlobOperations implements the PageBlobOperations interface.
 type pageBlobOperations struct {
-	*Client
+	*client
 }
 
 // ClearPages - The Clear Pages operation clears a set of pages from a page blob

--- a/test/storage/2019-07-07/azblob/service.go
+++ b/test/storage/2019-07-07/azblob/service.go
@@ -35,7 +35,7 @@ type ServiceOperations interface {
 
 // serviceOperations implements the ServiceOperations interface.
 type serviceOperations struct {
-	*Client
+	*client
 }
 
 // GetAccountInfo - Returns the sku name and account kind


### PR DESCRIPTION
Added --export-client, which when set to false, will not export client
types.  Updated azblob to use this switch.
Updated minimum version of azcore in go.mod template.