### PR TITLE
Add support for multiple response types

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -51,7 +51,7 @@
     "typescript": "~3.7.2",
     "@typescript-eslint/eslint-plugin": "~2.6.0",
     "@typescript-eslint/parser": "~2.6.0",
-    "@microsoft.azure/autorest.testserver": "2.10.41",
+    "@microsoft.azure/autorest.testserver": "2.10.42",
     "@autorest/autorest": "~3.0.6173",
     "eslint": "~6.6.0",
     "@azure-tools/codegen": "~2.4.263",

--- a/test/autorest/generated/azurespecialsgroup/header.go
+++ b/test/autorest/generated/azurespecialsgroup/header.go
@@ -107,7 +107,7 @@ func (client *headerOperations) customNamedRequestIdHeadCreateRequest(fooClientR
 
 // customNamedRequestIdHeadHandleResponse handles the CustomNamedRequestIDHead response.
 func (client *headerOperations) customNamedRequestIdHeadHandleResponse(resp *azcore.Response) (*HeaderCustomNamedRequestIDHeadResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusNotFound) {
 		return nil, client.customNamedRequestIdHeadHandleError(resp)
 	}
 	result := HeaderCustomNamedRequestIDHeadResponse{RawResponse: resp.Response}

--- a/test/autorest/generated/errorsgroup/pet.go
+++ b/test/autorest/generated/errorsgroup/pet.go
@@ -115,7 +115,7 @@ func (client *petOperations) getPetByIdCreateRequest(petId string) (*azcore.Requ
 
 // getPetByIdHandleResponse handles the GetPetByID response.
 func (client *petOperations) getPetByIdHandleResponse(resp *azcore.Response) (*PetResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
 		return nil, client.getPetByIdHandleError(resp)
 	}
 	result := PetResponse{RawResponse: resp.Response}

--- a/test/autorest/generated/httpinfrastructuregroup/models.go
+++ b/test/autorest/generated/httpinfrastructuregroup/models.go
@@ -15,6 +15,14 @@ type B struct {
 	TextStatusCode *string `json:"textStatusCode,omitempty"`
 }
 
+// BResponse is the response envelope for operations that return a B type.
+type BResponse struct {
+	B *B
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+}
+
 // BoolResponse is the response envelope for operations that return a bool type.
 type BoolResponse struct {
 	// RawResponse contains the underlying HTTP response.
@@ -28,8 +36,24 @@ type C struct {
 	HTTPCode *string `json:"httpCode,omitempty"`
 }
 
+// CResponse is the response envelope for operations that return a C type.
+type CResponse struct {
+	C *C
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+}
+
 type D struct {
 	HTTPStatusCode *string `json:"httpStatusCode,omitempty"`
+}
+
+// DResponse is the response envelope for operations that return a D type.
+type DResponse struct {
+	D *D
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
 }
 
 type Error struct {
@@ -51,44 +75,8 @@ func (e Error) Error() string {
 	return msg
 }
 
-// HTTPRedirectsDelete307Response contains the response from method HTTPRedirects.Delete307.
-type HTTPRedirectsDelete307Response struct {
-	// Location contains the information returned from the Location header response.
-	Location *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // HTTPRedirectsGet300Response contains the response from method HTTPRedirects.Get300.
 type HTTPRedirectsGet300Response struct {
-	// Location contains the information returned from the Location header response.
-	Location *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HTTPRedirectsGet301Response contains the response from method HTTPRedirects.Get301.
-type HTTPRedirectsGet301Response struct {
-	// Location contains the information returned from the Location header response.
-	Location *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HTTPRedirectsGet302Response contains the response from method HTTPRedirects.Get302.
-type HTTPRedirectsGet302Response struct {
-	// Location contains the information returned from the Location header response.
-	Location *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HTTPRedirectsGet307Response contains the response from method HTTPRedirects.Get307.
-type HTTPRedirectsGet307Response struct {
 	// Location contains the information returned from the Location header response.
 	Location *string
 
@@ -105,53 +93,8 @@ type HTTPRedirectsHead300Response struct {
 	RawResponse *http.Response
 }
 
-// HTTPRedirectsHead301Response contains the response from method HTTPRedirects.Head301.
-type HTTPRedirectsHead301Response struct {
-	// Location contains the information returned from the Location header response.
-	Location *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HTTPRedirectsHead302Response contains the response from method HTTPRedirects.Head302.
-type HTTPRedirectsHead302Response struct {
-	// Location contains the information returned from the Location header response.
-	Location *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HTTPRedirectsHead307Response contains the response from method HTTPRedirects.Head307.
-type HTTPRedirectsHead307Response struct {
-	// Location contains the information returned from the Location header response.
-	Location *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HTTPRedirectsOptions307Response contains the response from method HTTPRedirects.Options307.
-type HTTPRedirectsOptions307Response struct {
-	// Location contains the information returned from the Location header response.
-	Location *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // HTTPRedirectsPatch302Response contains the response from method HTTPRedirects.Patch302.
 type HTTPRedirectsPatch302Response struct {
-	// Location contains the information returned from the Location header response.
-	Location *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HTTPRedirectsPatch307Response contains the response from method HTTPRedirects.Patch307.
-type HTTPRedirectsPatch307Response struct {
 	// Location contains the information returned from the Location header response.
 	Location *string
 
@@ -168,26 +111,8 @@ type HTTPRedirectsPost303Response struct {
 	RawResponse *http.Response
 }
 
-// HTTPRedirectsPost307Response contains the response from method HTTPRedirects.Post307.
-type HTTPRedirectsPost307Response struct {
-	// Location contains the information returned from the Location header response.
-	Location *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
 // HTTPRedirectsPut301Response contains the response from method HTTPRedirects.Put301.
 type HTTPRedirectsPut301Response struct {
-	// Location contains the information returned from the Location header response.
-	Location *string
-
-	// RawResponse contains the underlying HTTP response.
-	RawResponse *http.Response
-}
-
-// HTTPRedirectsPut307Response contains the response from method HTTPRedirects.Put307.
-type HTTPRedirectsPut307Response struct {
 	// Location contains the information returned from the Location header response.
 	Location *string
 
@@ -216,4 +141,16 @@ type MyExceptionResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// StringArrayResponse is the response envelope for operations that return a []string type.
+type StringArrayResponse struct {
+	// Location contains the information returned from the Location header response.
+	Location *string
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+
+	// A list of location options for the request ['/http/success/get/200']
+	StringArray *[]string
 }

--- a/test/autorest/generated/httpinfrastructuregroup/multipleresponses.go
+++ b/test/autorest/generated/httpinfrastructuregroup/multipleresponses.go
@@ -15,11 +15,14 @@ import (
 // MultipleResponsesOperations contains the methods for the MultipleResponses group.
 type MultipleResponsesOperations interface {
 	// Get200Model201ModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
-	Get200Model201ModelDefaultError200Valid(ctx context.Context) (*MyExceptionResponse, error)
+	// Possible return types are *MyExceptionResponse, *BResponse
+	Get200Model201ModelDefaultError200Valid(ctx context.Context) (interface{}, error)
 	// Get200Model201ModelDefaultError201Valid - Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}
-	Get200Model201ModelDefaultError201Valid(ctx context.Context) (*MyExceptionResponse, error)
+	// Possible return types are *MyExceptionResponse, *BResponse
+	Get200Model201ModelDefaultError201Valid(ctx context.Context) (interface{}, error)
 	// Get200Model201ModelDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
-	Get200Model201ModelDefaultError400Valid(ctx context.Context) (*MyExceptionResponse, error)
+	// Possible return types are *MyExceptionResponse, *BResponse
+	Get200Model201ModelDefaultError400Valid(ctx context.Context) (interface{}, error)
 	// Get200Model204NoModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 	Get200Model204NoModelDefaultError200Valid(ctx context.Context) (*MyExceptionResponse, error)
 	// Get200Model204NoModelDefaultError201Invalid - Send a 201 response with valid payload: {'statusCode': '201'}
@@ -37,13 +40,17 @@ type MultipleResponsesOperations interface {
 	// Get200ModelA200Valid - Send a 200 response with payload {'statusCode': '200'}
 	Get200ModelA200Valid(ctx context.Context) (*MyExceptionResponse, error)
 	// Get200ModelA201ModelC404ModelDDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
-	Get200ModelA201ModelC404ModelDDefaultError200Valid(ctx context.Context) (*MyExceptionResponse, error)
+	// Possible return types are *MyExceptionResponse, *CResponse, *DResponse
+	Get200ModelA201ModelC404ModelDDefaultError200Valid(ctx context.Context) (interface{}, error)
 	// Get200ModelA201ModelC404ModelDDefaultError201Valid - Send a 200 response with valid payload: {'httpCode': '201'}
-	Get200ModelA201ModelC404ModelDDefaultError201Valid(ctx context.Context) (*MyExceptionResponse, error)
+	// Possible return types are *MyExceptionResponse, *CResponse, *DResponse
+	Get200ModelA201ModelC404ModelDDefaultError201Valid(ctx context.Context) (interface{}, error)
 	// Get200ModelA201ModelC404ModelDDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
-	Get200ModelA201ModelC404ModelDDefaultError400Valid(ctx context.Context) (*MyExceptionResponse, error)
+	// Possible return types are *MyExceptionResponse, *CResponse, *DResponse
+	Get200ModelA201ModelC404ModelDDefaultError400Valid(ctx context.Context) (interface{}, error)
 	// Get200ModelA201ModelC404ModelDDefaultError404Valid - Send a 200 response with valid payload: {'httpStatusCode': '404'}
-	Get200ModelA201ModelC404ModelDDefaultError404Valid(ctx context.Context) (*MyExceptionResponse, error)
+	// Possible return types are *MyExceptionResponse, *CResponse, *DResponse
+	Get200ModelA201ModelC404ModelDDefaultError404Valid(ctx context.Context) (interface{}, error)
 	// Get200ModelA202Valid - Send a 202 response with payload {'statusCode': '202'}
 	Get200ModelA202Valid(ctx context.Context) (*MyExceptionResponse, error)
 	// Get200ModelA400Invalid - Send a 200 response with invalid payload {'statusCodeInvalid': '400'}
@@ -90,7 +97,8 @@ type multipleResponsesOperations struct {
 }
 
 // Get200Model201ModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
-func (client *multipleResponsesOperations) Get200Model201ModelDefaultError200Valid(ctx context.Context) (*MyExceptionResponse, error) {
+// Possible return types are *MyExceptionResponse, *BResponse
+func (client *multipleResponsesOperations) Get200Model201ModelDefaultError200Valid(ctx context.Context) (interface{}, error) {
 	req, err := client.get200Model201ModelDefaultError200ValidCreateRequest()
 	if err != nil {
 		return nil, err
@@ -118,12 +126,17 @@ func (client *multipleResponsesOperations) get200Model201ModelDefaultError200Val
 }
 
 // get200Model201ModelDefaultError200ValidHandleResponse handles the Get200Model201ModelDefaultError200Valid response.
-func (client *multipleResponsesOperations) get200Model201ModelDefaultError200ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+func (client *multipleResponsesOperations) get200Model201ModelDefaultError200ValidHandleResponse(resp *azcore.Response) (interface{}, error) {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		result := MyExceptionResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.MyException)
+	case http.StatusCreated:
+		result := BResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.B)
+	default:
 		return nil, client.get200Model201ModelDefaultError200ValidHandleError(resp)
 	}
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // get200Model201ModelDefaultError200ValidHandleError handles the Get200Model201ModelDefaultError200Valid error response.
@@ -136,7 +149,8 @@ func (client *multipleResponsesOperations) get200Model201ModelDefaultError200Val
 }
 
 // Get200Model201ModelDefaultError201Valid - Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}
-func (client *multipleResponsesOperations) Get200Model201ModelDefaultError201Valid(ctx context.Context) (*MyExceptionResponse, error) {
+// Possible return types are *MyExceptionResponse, *BResponse
+func (client *multipleResponsesOperations) Get200Model201ModelDefaultError201Valid(ctx context.Context) (interface{}, error) {
 	req, err := client.get200Model201ModelDefaultError201ValidCreateRequest()
 	if err != nil {
 		return nil, err
@@ -164,12 +178,17 @@ func (client *multipleResponsesOperations) get200Model201ModelDefaultError201Val
 }
 
 // get200Model201ModelDefaultError201ValidHandleResponse handles the Get200Model201ModelDefaultError201Valid response.
-func (client *multipleResponsesOperations) get200Model201ModelDefaultError201ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+func (client *multipleResponsesOperations) get200Model201ModelDefaultError201ValidHandleResponse(resp *azcore.Response) (interface{}, error) {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		result := MyExceptionResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.MyException)
+	case http.StatusCreated:
+		result := BResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.B)
+	default:
 		return nil, client.get200Model201ModelDefaultError201ValidHandleError(resp)
 	}
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // get200Model201ModelDefaultError201ValidHandleError handles the Get200Model201ModelDefaultError201Valid error response.
@@ -182,7 +201,8 @@ func (client *multipleResponsesOperations) get200Model201ModelDefaultError201Val
 }
 
 // Get200Model201ModelDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
-func (client *multipleResponsesOperations) Get200Model201ModelDefaultError400Valid(ctx context.Context) (*MyExceptionResponse, error) {
+// Possible return types are *MyExceptionResponse, *BResponse
+func (client *multipleResponsesOperations) Get200Model201ModelDefaultError400Valid(ctx context.Context) (interface{}, error) {
 	req, err := client.get200Model201ModelDefaultError400ValidCreateRequest()
 	if err != nil {
 		return nil, err
@@ -210,12 +230,17 @@ func (client *multipleResponsesOperations) get200Model201ModelDefaultError400Val
 }
 
 // get200Model201ModelDefaultError400ValidHandleResponse handles the Get200Model201ModelDefaultError400Valid response.
-func (client *multipleResponsesOperations) get200Model201ModelDefaultError400ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+func (client *multipleResponsesOperations) get200Model201ModelDefaultError400ValidHandleResponse(resp *azcore.Response) (interface{}, error) {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		result := MyExceptionResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.MyException)
+	case http.StatusCreated:
+		result := BResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.B)
+	default:
 		return nil, client.get200Model201ModelDefaultError400ValidHandleError(resp)
 	}
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // get200Model201ModelDefaultError400ValidHandleError handles the Get200Model201ModelDefaultError400Valid error response.
@@ -257,7 +282,7 @@ func (client *multipleResponsesOperations) get200Model204NoModelDefaultError200V
 
 // get200Model204NoModelDefaultError200ValidHandleResponse handles the Get200Model204NoModelDefaultError200Valid response.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError200ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
 		return nil, client.get200Model204NoModelDefaultError200ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
@@ -303,7 +328,7 @@ func (client *multipleResponsesOperations) get200Model204NoModelDefaultError201I
 
 // get200Model204NoModelDefaultError201InvalidHandleResponse handles the Get200Model204NoModelDefaultError201Invalid response.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError201InvalidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
 		return nil, client.get200Model204NoModelDefaultError201InvalidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
@@ -349,7 +374,7 @@ func (client *multipleResponsesOperations) get200Model204NoModelDefaultError202N
 
 // get200Model204NoModelDefaultError202NoneHandleResponse handles the Get200Model204NoModelDefaultError202None response.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError202NoneHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
 		return nil, client.get200Model204NoModelDefaultError202NoneHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
@@ -395,7 +420,7 @@ func (client *multipleResponsesOperations) get200Model204NoModelDefaultError204V
 
 // get200Model204NoModelDefaultError204ValidHandleResponse handles the Get200Model204NoModelDefaultError204Valid response.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError204ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
 		return nil, client.get200Model204NoModelDefaultError204ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
@@ -441,7 +466,7 @@ func (client *multipleResponsesOperations) get200Model204NoModelDefaultError400V
 
 // get200Model204NoModelDefaultError400ValidHandleResponse handles the Get200Model204NoModelDefaultError400Valid response.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError400ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
 		return nil, client.get200Model204NoModelDefaultError400ValidHandleError(resp)
 	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
@@ -584,7 +609,8 @@ func (client *multipleResponsesOperations) get200ModelA200ValidHandleError(resp 
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
-func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefaultError200Valid(ctx context.Context) (*MyExceptionResponse, error) {
+// Possible return types are *MyExceptionResponse, *CResponse, *DResponse
+func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefaultError200Valid(ctx context.Context) (interface{}, error) {
 	req, err := client.get200ModelA201ModelC404ModelDDefaultError200ValidCreateRequest()
 	if err != nil {
 		return nil, err
@@ -612,12 +638,20 @@ func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefault
 }
 
 // get200ModelA201ModelC404ModelDDefaultError200ValidHandleResponse handles the Get200ModelA201ModelC404ModelDDefaultError200Valid response.
-func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError200ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError200ValidHandleResponse(resp *azcore.Response) (interface{}, error) {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		result := MyExceptionResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.MyException)
+	case http.StatusCreated:
+		result := CResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.C)
+	case http.StatusNotFound:
+		result := DResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.D)
+	default:
 		return nil, client.get200ModelA201ModelC404ModelDDefaultError200ValidHandleError(resp)
 	}
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // get200ModelA201ModelC404ModelDDefaultError200ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError200Valid error response.
@@ -630,7 +664,8 @@ func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefault
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError201Valid - Send a 200 response with valid payload: {'httpCode': '201'}
-func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefaultError201Valid(ctx context.Context) (*MyExceptionResponse, error) {
+// Possible return types are *MyExceptionResponse, *CResponse, *DResponse
+func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefaultError201Valid(ctx context.Context) (interface{}, error) {
 	req, err := client.get200ModelA201ModelC404ModelDDefaultError201ValidCreateRequest()
 	if err != nil {
 		return nil, err
@@ -658,12 +693,20 @@ func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefault
 }
 
 // get200ModelA201ModelC404ModelDDefaultError201ValidHandleResponse handles the Get200ModelA201ModelC404ModelDDefaultError201Valid response.
-func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError201ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError201ValidHandleResponse(resp *azcore.Response) (interface{}, error) {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		result := MyExceptionResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.MyException)
+	case http.StatusCreated:
+		result := CResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.C)
+	case http.StatusNotFound:
+		result := DResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.D)
+	default:
 		return nil, client.get200ModelA201ModelC404ModelDDefaultError201ValidHandleError(resp)
 	}
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // get200ModelA201ModelC404ModelDDefaultError201ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError201Valid error response.
@@ -676,7 +719,8 @@ func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefault
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
-func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefaultError400Valid(ctx context.Context) (*MyExceptionResponse, error) {
+// Possible return types are *MyExceptionResponse, *CResponse, *DResponse
+func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefaultError400Valid(ctx context.Context) (interface{}, error) {
 	req, err := client.get200ModelA201ModelC404ModelDDefaultError400ValidCreateRequest()
 	if err != nil {
 		return nil, err
@@ -704,12 +748,20 @@ func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefault
 }
 
 // get200ModelA201ModelC404ModelDDefaultError400ValidHandleResponse handles the Get200ModelA201ModelC404ModelDDefaultError400Valid response.
-func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError400ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError400ValidHandleResponse(resp *azcore.Response) (interface{}, error) {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		result := MyExceptionResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.MyException)
+	case http.StatusCreated:
+		result := CResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.C)
+	case http.StatusNotFound:
+		result := DResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.D)
+	default:
 		return nil, client.get200ModelA201ModelC404ModelDDefaultError400ValidHandleError(resp)
 	}
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // get200ModelA201ModelC404ModelDDefaultError400ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError400Valid error response.
@@ -722,7 +774,8 @@ func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefault
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError404Valid - Send a 200 response with valid payload: {'httpStatusCode': '404'}
-func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefaultError404Valid(ctx context.Context) (*MyExceptionResponse, error) {
+// Possible return types are *MyExceptionResponse, *CResponse, *DResponse
+func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefaultError404Valid(ctx context.Context) (interface{}, error) {
 	req, err := client.get200ModelA201ModelC404ModelDDefaultError404ValidCreateRequest()
 	if err != nil {
 		return nil, err
@@ -750,12 +803,20 @@ func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefault
 }
 
 // get200ModelA201ModelC404ModelDDefaultError404ValidHandleResponse handles the Get200ModelA201ModelC404ModelDDefaultError404Valid response.
-func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError404ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError404ValidHandleResponse(resp *azcore.Response) (interface{}, error) {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		result := MyExceptionResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.MyException)
+	case http.StatusCreated:
+		result := CResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.C)
+	case http.StatusNotFound:
+		result := DResponse{RawResponse: resp.Response}
+		return &result, resp.UnmarshalAsJSON(&result.D)
+	default:
 		return nil, client.get200ModelA201ModelC404ModelDDefaultError404ValidHandleError(resp)
 	}
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // get200ModelA201ModelC404ModelDDefaultError404ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError404Valid error response.

--- a/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
@@ -28,42 +28,120 @@ func TestGet200Model201ModelDefaultError200Valid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	helpers.DeepEqualOrFatal(t, result.MyException.StatusCode, to.StringPtr("200"))
+	switch x := result.(type) {
+	case *httpinfrastructuregroup.MyExceptionResponse:
+		helpers.DeepEqualOrFatal(t, x.MyException.StatusCode, to.StringPtr("200"))
+	case *httpinfrastructuregroup.BResponse:
+		helpers.VerifyStatusCode(t, x.RawResponse, http.StatusCreated)
+	default:
+		t.Fatalf("unhandled response type %v", x)
+	}
 }
 
 // Get200Model201ModelDefaultError201Valid - Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}
 func TestGet200Model201ModelDefaultError201Valid(t *testing.T) {
-	t.Skip("different return schemas NYI")
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200Model201ModelDefaultError201Valid(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, ok := result.(*httpinfrastructuregroup.BResponse)
+	if !ok {
+		t.Fatal("unexpected response type")
+	}
+	helpers.DeepEqualOrFatal(t, r.B, &httpinfrastructuregroup.B{
+		MyException: httpinfrastructuregroup.MyException{
+			StatusCode: to.StringPtr("201"),
+		},
+		TextStatusCode: to.StringPtr("Created"),
+	})
 }
 
 // Get200Model201ModelDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
 func TestGet200Model201ModelDefaultError400Valid(t *testing.T) {
-	t.Skip("different return schemas NYI")
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200Model201ModelDefaultError400Valid(context.Background())
+	r, ok := err.(httpinfrastructuregroup.Error)
+	if !ok {
+		t.Fatal("unexpected error type")
+	}
+	helpers.DeepEqualOrFatal(t, r, httpinfrastructuregroup.Error{
+		Message: to.StringPtr("client error"),
+		Status:  to.Int32Ptr(400),
+	})
+	if result != nil {
+		t.Fatal("expected nil result")
+	}
 }
 
 // Get200Model204NoModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 func TestGet200Model204NoModelDefaultError200Valid(t *testing.T) {
-	t.Skip("different return schemas NYI")
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200Model204NoModelDefaultError200Valid(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.DeepEqualOrFatal(t, result.MyException, &httpinfrastructuregroup.MyException{
+		StatusCode: to.StringPtr("200"),
+	})
 }
 
 // Get200Model204NoModelDefaultError201Invalid - Send a 201 response with valid payload: {'statusCode': '201'}
 func TestGet200Model204NoModelDefaultError201Invalid(t *testing.T) {
-	t.Skip("different return schemas NYI")
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200Model204NoModelDefaultError201Invalid(context.Background())
+	r, ok := err.(httpinfrastructuregroup.Error)
+	if !ok {
+		t.Fatal("unexpected error type")
+	}
+	helpers.DeepEqualOrFatal(t, r, httpinfrastructuregroup.Error{})
+	if result != nil {
+		t.Fatal("expected nil result")
+	}
 }
 
 // Get200Model204NoModelDefaultError202None - Send a 202 response with no payload:
 func TestGet200Model204NoModelDefaultError202None(t *testing.T) {
-	t.Skip("different return schemas NYI")
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200Model204NoModelDefaultError202None(context.Background())
+	r, ok := err.(httpinfrastructuregroup.Error)
+	if !ok {
+		t.Fatal("unexpected error type")
+	}
+	helpers.DeepEqualOrFatal(t, r, httpinfrastructuregroup.Error{})
+	if result != nil {
+		t.Fatal("expected nil result")
+	}
 }
 
 // Get200Model204NoModelDefaultError204Valid - Send a 204 response with no payload
 func TestGet200Model204NoModelDefaultError204Valid(t *testing.T) {
-	t.Skip("different return schemas NYI")
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200Model204NoModelDefaultError204Valid(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusNoContent)
+	if result.MyException != nil {
+		t.Fatal("expected nil payload")
+	}
 }
 
 // Get200Model204NoModelDefaultError400Valid - Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}
 func TestGet200Model204NoModelDefaultError400Valid(t *testing.T) {
-	t.Skip("different return schemas NYI")
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200Model204NoModelDefaultError400Valid(context.Background())
+	r, ok := err.(httpinfrastructuregroup.Error)
+	if !ok {
+		t.Fatal("unexpected error type")
+	}
+	helpers.DeepEqualOrFatal(t, r, httpinfrastructuregroup.Error{
+		Message: to.StringPtr("client error"),
+		Status:  to.Int32Ptr(400),
+	})
+	if result != nil {
+		t.Fatal("expected nil result")
+	}
 }
 
 // Get200ModelA200Invalid - Send a 200 response with invalid payload {'statusCodeInvalid': '200'}
@@ -97,22 +175,67 @@ func TestGet200ModelA200Valid(t *testing.T) {
 
 // Get200ModelA201ModelC404ModelDDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 func TestGet200ModelA201ModelC404ModelDDefaultError200Valid(t *testing.T) {
-	t.Skip("different return schemas NYI")
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200ModelA201ModelC404ModelDDefaultError200Valid(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, ok := result.(*httpinfrastructuregroup.MyExceptionResponse)
+	if !ok {
+		t.Fatal("unexpected result type")
+	}
+	helpers.DeepEqualOrFatal(t, r.MyException, &httpinfrastructuregroup.MyException{
+		StatusCode: to.StringPtr("200"),
+	})
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError201Valid - Send a 200 response with valid payload: {'httpCode': '201'}
 func TestGet200ModelA201ModelC404ModelDDefaultError201Valid(t *testing.T) {
-	t.Skip("different return schemas NYI")
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200ModelA201ModelC404ModelDDefaultError201Valid(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, ok := result.(*httpinfrastructuregroup.CResponse)
+	if !ok {
+		t.Fatal("unexpected result type")
+	}
+	helpers.DeepEqualOrFatal(t, r.C, &httpinfrastructuregroup.C{
+		HTTPCode: to.StringPtr("201"),
+	})
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
 func TestGet200ModelA201ModelC404ModelDDefaultError400Valid(t *testing.T) {
-	t.Skip("different return schemas NYI")
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200ModelA201ModelC404ModelDDefaultError400Valid(context.Background())
+	r, ok := err.(httpinfrastructuregroup.Error)
+	if !ok {
+		t.Fatal("unexpected error type")
+	}
+	helpers.DeepEqualOrFatal(t, r, httpinfrastructuregroup.Error{
+		Message: to.StringPtr("client error"),
+		Status:  to.Int32Ptr(400),
+	})
+	if result != nil {
+		t.Fatal("expected nil result")
+	}
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError404Valid - Send a 200 response with valid payload: {'httpStatusCode': '404'}
 func TestGet200ModelA201ModelC404ModelDDefaultError404Valid(t *testing.T) {
-	t.Skip("different return schemas NYI")
+	client := getMultipleResponseOperations(t)
+	result, err := client.Get200ModelA201ModelC404ModelDDefaultError404Valid(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, ok := result.(*httpinfrastructuregroup.DResponse)
+	if !ok {
+		t.Fatal("unexpected result type")
+	}
+	helpers.DeepEqualOrFatal(t, r.D, &httpinfrastructuregroup.D{
+		HTTPStatusCode: to.StringPtr("404"),
+	})
 }
 
 // Get200ModelA202Valid - Send a 202 response with payload {'statusCode': '202'}

--- a/test/autorest/httpinfrastructuregroup/httpredirects_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpredirects_test.go
@@ -25,17 +25,24 @@ func TestHTTPRedirectsDelete307(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHTTPRedirectsGet300(t *testing.T) {
-	t.Skip()
+	t.Skip("does not automatically redirect")
 	client := getHTTPRedirectsOperations(t)
 	result, err := client.Get300(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	switch x := result.(type) {
+	case *httpinfrastructuregroup.HTTPRedirectsGet300Response:
+		helpers.VerifyStatusCode(t, x.RawResponse, http.StatusOK)
+	case *httpinfrastructuregroup.StringArrayResponse:
+		helpers.VerifyStatusCode(t, x.RawResponse, http.StatusMultipleChoices)
+	default:
+		t.Fatalf("unhandled response type %v", x)
+	}
 }
 
 func TestHTTPRedirectsGet301(t *testing.T) {
@@ -44,7 +51,7 @@ func TestHTTPRedirectsGet301(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHTTPRedirectsGet302(t *testing.T) {
@@ -53,7 +60,7 @@ func TestHTTPRedirectsGet302(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHTTPRedirectsGet307(t *testing.T) {
@@ -62,11 +69,11 @@ func TestHTTPRedirectsGet307(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHTTPRedirectsHead300(t *testing.T) {
-	t.Skip()
+	t.Skip("does not automatically redirect")
 	client := getHTTPRedirectsOperations(t)
 	result, err := client.Head300(context.Background())
 	if err != nil {
@@ -81,7 +88,7 @@ func TestHTTPRedirectsHead301(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHTTPRedirectsHead302(t *testing.T) {
@@ -90,7 +97,7 @@ func TestHTTPRedirectsHead302(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHTTPRedirectsHead307(t *testing.T) {
@@ -99,21 +106,21 @@ func TestHTTPRedirectsHead307(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHTTPRedirectsOptions307(t *testing.T) {
-	t.Skip()
+	t.Skip("receive a status code of 204 which is not expected")
 	client := getHTTPRedirectsOperations(t)
 	result, err := client.Options307(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHTTPRedirectsPatch302(t *testing.T) {
-	t.Skip()
+	t.Skip("HTTP client automatically redirects, test server doesn't expect it")
 	client := getHTTPRedirectsOperations(t)
 	result, err := client.Patch302(context.Background())
 	if err != nil {
@@ -128,7 +135,7 @@ func TestHTTPRedirectsPatch307(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHTTPRedirectsPost303(t *testing.T) {
@@ -146,11 +153,11 @@ func TestHTTPRedirectsPost307(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 func TestHTTPRedirectsPut301(t *testing.T) {
-	t.Skip()
+	t.Skip("HTTP client automatically redirects, test server doesn't expect it")
 	client := getHTTPRedirectsOperations(t)
 	result, err := client.Put301(context.Background())
 	if err != nil {
@@ -165,5 +172,5 @@ func TestHTTPRedirectsPut307(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }

--- a/test/autorest/urlgroup/paths_test.go
+++ b/test/autorest/urlgroup/paths_test.go
@@ -248,9 +248,7 @@ func TestPathsStringURLNonEncoded(t *testing.T) {
 	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
-// TODO verify how to work with this type of string
 func TestPathsStringUnicode(t *testing.T) {
-	t.Skip()
 	client := getPathsOperations(t)
 	result, err := client.StringUnicode(context.Background())
 	if err != nil {

--- a/test/autorest/urlgroup/queries_test.go
+++ b/test/autorest/urlgroup/queries_test.go
@@ -122,7 +122,6 @@ func TestGetTenBillion(t *testing.T) {
 }
 
 func TestStringUnicode(t *testing.T) {
-	t.Skip("scenario NYI in test server")
 	client := getQueriesClient(t)
 	result, err := client.StringUnicode(context.Background())
 	if err != nil {

--- a/test/storage/2019-07-07/azblob/blob.go
+++ b/test/storage/2019-07-07/azblob/blob.go
@@ -843,7 +843,7 @@ func (client *blobOperations) downloadCreateRequest(blobDownloadOptions *BlobDow
 
 // downloadHandleResponse handles the Download response.
 func (client *blobOperations) downloadHandleResponse(resp *azcore.Response) (*BlobDownloadResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusPartialContent) {
 		return nil, client.downloadHandleError(resp)
 	}
 	result := BlobDownloadResponse{RawResponse: resp.Response}
@@ -2118,7 +2118,7 @@ func (client *blobOperations) setTierCreateRequest(tier AccessTier, blobSetTierO
 
 // setTierHandleResponse handles the SetTier response.
 func (client *blobOperations) setTierHandleResponse(resp *azcore.Response) (*BlobSetTierResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
 		return nil, client.setTierHandleError(resp)
 	}
 	result := BlobSetTierResponse{RawResponse: resp.Response}

--- a/test/storage/2019-07-07/azblob/models.go
+++ b/test/storage/2019-07-07/azblob/models.go
@@ -1038,7 +1038,7 @@ type BlobRenameOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestId *string
-	// A lease ID for the source path. If specified, the source path must have an active lease and the leaase ID must match.
+	// A lease ID for the source path. If specified, the source path must have an active lease and the lease ID must match.
 	SourceLeaseId *string
 	// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
 	// Timeouts for Blob Service Operations.</a>
@@ -2420,7 +2420,7 @@ type DirectoryRenameOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestId *string
-	// A lease ID for the source path. If specified, the source path must have an active lease and the leaase ID must match.
+	// A lease ID for the source path. If specified, the source path must have an active lease and the lease ID must match.
 	SourceLeaseId *string
 	// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
 	// Timeouts for Blob Service Operations.</a>


### PR DESCRIPTION
Operations that return different types depending on HTTP status code now
return interface{}.
Generate a method comment that includes the possible return types.
LROs are excluded from this conversion as it's not applicable.
Fixed response envelope generation for multi-response methods.
Remove HTTP redirect status codes for cases where the Go HTTP client
implicitly follows them and added missing tests.
Fixed codegen for checking HTTP status codes of single-response APIs.
Updated test server version which fixed a few urlgroup tests.