### PR TITLE
Various fixes

### DIFF
--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -430,26 +430,26 @@ function generateDiscriminatedTypeUnmarshaller(obj: ObjectSchema, structDef: Str
   unmarshaller += '\tif err := json.Unmarshal(data, &rawMsg); err != nil {\n';
   unmarshaller += '\t\treturn err\n';
   unmarshaller += '\t}\n';
-  unmarshaller += '\tfor k, v := range rawMsg {\n';
+  unmarshaller += '\tfor key, val := range rawMsg {\n';
   unmarshaller += '\t\tvar err error\n';
-  unmarshaller += '\t\tswitch k {\n';
+  unmarshaller += '\t\tswitch key {\n';
   // unmarshal each field one by one
   for (const prop of values(structDef.Properties)) {
     if (prop.language.go!.isAdditionalProperties) {
       continue;
     }
     unmarshaller += `\t\tcase "${prop.serializedName}":\n`;
-    unmarshaller += '\t\t\tif v != nil {\n';
+    unmarshaller += '\t\t\tif val != nil {\n';
     if (prop.schema.language.go!.discriminatorInterface) {
-      unmarshaller += `\t\t\t\t${receiver}.${prop.language.go!.name}, err = unmarshal${prop.schema.language.go!.discriminatorInterface}(*v)\n`;
+      unmarshaller += `\t\t\t\t${receiver}.${prop.language.go!.name}, err = unmarshal${prop.schema.language.go!.discriminatorInterface}(*val)\n`;
     } else if (isArraySchema(prop.schema) && prop.schema.elementType.language.go!.discriminatorInterface) {
-      unmarshaller += `\t\t\t\t${receiver}.${prop.language.go!.name}, err = unmarshal${prop.schema.elementType.language.go!.discriminatorInterface}Array(*v)\n`;
+      unmarshaller += `\t\t\t\t${receiver}.${prop.language.go!.name}, err = unmarshal${prop.schema.elementType.language.go!.discriminatorInterface}Array(*val)\n`;
     } else if (prop.schema.language.go!.internalTimeType) {
       unmarshaller += `\t\t\t\tvar aux ${prop.schema.language.go!.internalTimeType}\n`;
-      unmarshaller += '\t\t\t\terr = json.Unmarshal(*v, &aux)\n';
+      unmarshaller += '\t\t\t\terr = json.Unmarshal(*val, &aux)\n';
       unmarshaller += `\t\t\t\t${receiver}.${prop.language.go!.name} = (*time.Time)(&aux)\n`;
     } else {
-      unmarshaller += `\t\t\t\terr = json.Unmarshal(*v, &${receiver}.${prop.language.go!.name})\n`;
+      unmarshaller += `\t\t\t\terr = json.Unmarshal(*val, &${receiver}.${prop.language.go!.name})\n`;
     }
     unmarshaller += '\t\t\t}\n';
   }
@@ -589,8 +589,8 @@ function generateAdditionalPropertiesMarshaller(structDef: StructDef, parentType
     marshaller += emitMarshaller(prop);
   }
   marshaller += `\tif ${receiver}.AdditionalProperties != nil {\n`;
-  marshaller += `\t\tfor k, v := range *${receiver}.AdditionalProperties {\n`;
-  marshaller += '\t\t\tobjectMap[k] = v\n';
+  marshaller += `\t\tfor key, val := range *${receiver}.AdditionalProperties {\n`;
+  marshaller += '\t\t\tobjectMap[key] = val\n';
   marshaller += '\t\t}\n';;
   marshaller += '\t}\n';
   marshaller += '\treturn json.Marshal(objectMap)\n';
@@ -607,13 +607,13 @@ function generateAdditionalPropertiesUnmarshaller(structDef: StructDef, elementT
   unmarshaller += '\tif err := json.Unmarshal(data, &rawMsg); err != nil {\n';
   unmarshaller += '\t\treturn err\n';
   unmarshaller += '\t}\n';
-  unmarshaller += '\tfor k, v := range rawMsg {\n';
+  unmarshaller += '\tfor key, val := range rawMsg {\n';
   unmarshaller += '\t\tvar err error\n';
-  unmarshaller += '\t\tswitch k {\n';
+  unmarshaller += '\t\tswitch key {\n';
   const emitUnmarshaller = function (prop: Property): string {
     let text = `\t\tcase "${prop.serializedName}":\n`;
-    text += '\t\t\tif v != nil {\n';
-    text += `\t\t\t\terr = json.Unmarshal(*v, &${receiver}.${prop.language.go!.name})\n`;
+    text += '\t\t\tif val != nil {\n';
+    text += `\t\t\t\terr = json.Unmarshal(*val, &${receiver}.${prop.language.go!.name})\n`;
     text += '\t\t\t}\n';
     return text;
   }
@@ -634,10 +634,10 @@ function generateAdditionalPropertiesUnmarshaller(structDef: StructDef, elementT
   unmarshaller += `\t\t\tif ${receiver}.AdditionalProperties == nil {\n`;
   unmarshaller += `\t\t\t\t${receiver}.AdditionalProperties = &map[string]${elementType.language.go!.name}{}\n`;
   unmarshaller += '\t\t\t}\n';
-  unmarshaller += '\t\t\tif v != nil {\n';
+  unmarshaller += '\t\t\tif val != nil {\n';
   unmarshaller += `\t\t\t\tvar aux ${elementType.language.go!.name}\n`;
-  unmarshaller += '\t\t\t\terr = json.Unmarshal(*v, &aux)\n';
-  unmarshaller += `\t\t\t\t(*${receiver}.AdditionalProperties)[k] = aux\n`;
+  unmarshaller += '\t\t\t\terr = json.Unmarshal(*val, &aux)\n';
+  unmarshaller += `\t\t\t\t(*${receiver}.AdditionalProperties)[key] = aux\n`;
   unmarshaller += '\t\t\t}\n';
   unmarshaller += '\t\t}\n';
   unmarshaller += '\t\tif err != nil {\n';

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -951,6 +951,8 @@ function formatStatusCode(statusCode: string): string {
       return 'http.StatusFound';
     case '303':
       return 'http.StatusSeeOther';
+    case '304':
+      return 'http.StatusNotModified';
     case '307':
       return 'http.StatusTemporaryRedirect';
     case '400':

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -842,6 +842,11 @@ function getRootDiscriminator(obj: ObjectSchema): ObjectSchema {
       if (isObjectSchema(parent) && parent.discriminator) {
         root.language.go!.discriminatorParent = parent.language.go!.discriminatorInterface;
         root = parent;
+        // update obj with the new root.  this enables us to detect the case
+        // where the parent of the new root isn't a discriminator.  consider
+        // the case of child <- parent <- non-discriminator parent.  without
+        // updating obj we can't detect the parent's non-discriminator as
+        // root would always !== obj so the below check is always false.
         obj = root;
       }
     }

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -842,6 +842,7 @@ function getRootDiscriminator(obj: ObjectSchema): ObjectSchema {
       if (isObjectSchema(parent) && parent.discriminator) {
         root.language.go!.discriminatorParent = parent.language.go!.discriminatorInterface;
         root = parent;
+        obj = root;
       }
     }
     if (root === obj) {

--- a/test/autorest/generated/additionalpropsgroup/models.go
+++ b/test/autorest/generated/additionalpropsgroup/models.go
@@ -32,8 +32,8 @@ func (c CatApTrue) MarshalJSON() ([]byte, error) {
 		objectMap["friendly"] = c.Friendly
 	}
 	if c.AdditionalProperties != nil {
-		for k, v := range *c.AdditionalProperties {
-			objectMap[k] = v
+		for key, val := range *c.AdditionalProperties {
+			objectMap[key] = val
 		}
 	}
 	return json.Marshal(objectMap)
@@ -45,33 +45,33 @@ func (c *CatApTrue) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "id":
-			if v != nil {
-				err = json.Unmarshal(*v, &c.ID)
+			if val != nil {
+				err = json.Unmarshal(*val, &c.ID)
 			}
 		case "name":
-			if v != nil {
-				err = json.Unmarshal(*v, &c.Name)
+			if val != nil {
+				err = json.Unmarshal(*val, &c.Name)
 			}
 		case "status":
-			if v != nil {
-				err = json.Unmarshal(*v, &c.Status)
+			if val != nil {
+				err = json.Unmarshal(*val, &c.Status)
 			}
 		case "friendly":
-			if v != nil {
-				err = json.Unmarshal(*v, &c.Friendly)
+			if val != nil {
+				err = json.Unmarshal(*val, &c.Friendly)
 			}
 		default:
 			if c.AdditionalProperties == nil {
 				c.AdditionalProperties = &map[string]interface{}{}
 			}
-			if v != nil {
+			if val != nil {
 				var aux interface{}
-				err = json.Unmarshal(*v, &aux)
-				(*c.AdditionalProperties)[k] = aux
+				err = json.Unmarshal(*val, &aux)
+				(*c.AdditionalProperties)[key] = aux
 			}
 		}
 		if err != nil {
@@ -156,8 +156,8 @@ func (p PetApInPropertiesWithApstring) MarshalJSON() ([]byte, error) {
 		objectMap["status"] = p.Status
 	}
 	if p.AdditionalProperties != nil {
-		for k, v := range *p.AdditionalProperties {
-			objectMap[k] = v
+		for key, val := range *p.AdditionalProperties {
+			objectMap[key] = val
 		}
 	}
 	return json.Marshal(objectMap)
@@ -169,37 +169,37 @@ func (p *PetApInPropertiesWithApstring) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "additionalProperties":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.AdditionalProperties1)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.AdditionalProperties1)
 			}
 		case "id":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.ID)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.ID)
 			}
 		case "name":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.Name)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.Name)
 			}
 		case "@odata.location":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.OdataLocation)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.OdataLocation)
 			}
 		case "status":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.Status)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.Status)
 			}
 		default:
 			if p.AdditionalProperties == nil {
 				p.AdditionalProperties = &map[string]string{}
 			}
-			if v != nil {
+			if val != nil {
 				var aux string
-				err = json.Unmarshal(*v, &aux)
-				(*p.AdditionalProperties)[k] = aux
+				err = json.Unmarshal(*val, &aux)
+				(*p.AdditionalProperties)[key] = aux
 			}
 		}
 		if err != nil {
@@ -239,8 +239,8 @@ func (p PetApObject) MarshalJSON() ([]byte, error) {
 		objectMap["status"] = p.Status
 	}
 	if p.AdditionalProperties != nil {
-		for k, v := range *p.AdditionalProperties {
-			objectMap[k] = v
+		for key, val := range *p.AdditionalProperties {
+			objectMap[key] = val
 		}
 	}
 	return json.Marshal(objectMap)
@@ -252,29 +252,29 @@ func (p *PetApObject) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "id":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.ID)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.ID)
 			}
 		case "name":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.Name)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.Name)
 			}
 		case "status":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.Status)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.Status)
 			}
 		default:
 			if p.AdditionalProperties == nil {
 				p.AdditionalProperties = &map[string]interface{}{}
 			}
-			if v != nil {
+			if val != nil {
 				var aux interface{}
-				err = json.Unmarshal(*v, &aux)
-				(*p.AdditionalProperties)[k] = aux
+				err = json.Unmarshal(*val, &aux)
+				(*p.AdditionalProperties)[key] = aux
 			}
 		}
 		if err != nil {
@@ -313,8 +313,8 @@ func (p PetApString) MarshalJSON() ([]byte, error) {
 		objectMap["status"] = p.Status
 	}
 	if p.AdditionalProperties != nil {
-		for k, v := range *p.AdditionalProperties {
-			objectMap[k] = v
+		for key, val := range *p.AdditionalProperties {
+			objectMap[key] = val
 		}
 	}
 	return json.Marshal(objectMap)
@@ -326,29 +326,29 @@ func (p *PetApString) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "id":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.ID)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.ID)
 			}
 		case "name":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.Name)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.Name)
 			}
 		case "status":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.Status)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.Status)
 			}
 		default:
 			if p.AdditionalProperties == nil {
 				p.AdditionalProperties = &map[string]string{}
 			}
-			if v != nil {
+			if val != nil {
 				var aux string
-				err = json.Unmarshal(*v, &aux)
-				(*p.AdditionalProperties)[k] = aux
+				err = json.Unmarshal(*val, &aux)
+				(*p.AdditionalProperties)[key] = aux
 			}
 		}
 		if err != nil {
@@ -387,8 +387,8 @@ func (p PetApTrue) MarshalJSON() ([]byte, error) {
 		objectMap["status"] = p.Status
 	}
 	if p.AdditionalProperties != nil {
-		for k, v := range *p.AdditionalProperties {
-			objectMap[k] = v
+		for key, val := range *p.AdditionalProperties {
+			objectMap[key] = val
 		}
 	}
 	return json.Marshal(objectMap)
@@ -400,29 +400,29 @@ func (p *PetApTrue) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "id":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.ID)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.ID)
 			}
 		case "name":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.Name)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.Name)
 			}
 		case "status":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.Status)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.Status)
 			}
 		default:
 			if p.AdditionalProperties == nil {
 				p.AdditionalProperties = &map[string]interface{}{}
 			}
-			if v != nil {
+			if val != nil {
 				var aux interface{}
-				err = json.Unmarshal(*v, &aux)
-				(*p.AdditionalProperties)[k] = aux
+				err = json.Unmarshal(*val, &aux)
+				(*p.AdditionalProperties)[key] = aux
 			}
 		}
 		if err != nil {

--- a/test/autorest/generated/complexgroup/models.go
+++ b/test/autorest/generated/complexgroup/models.go
@@ -225,16 +225,16 @@ func (d *DotFish) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "fish.type":
-			if v != nil {
-				err = json.Unmarshal(*v, &d.FishType)
+			if val != nil {
+				err = json.Unmarshal(*val, &d.FishType)
 			}
 		case "species":
-			if v != nil {
-				err = json.Unmarshal(*v, &d.Species)
+			if val != nil {
+				err = json.Unmarshal(*val, &d.Species)
 			}
 		}
 		if err != nil {
@@ -267,24 +267,24 @@ func (d *DotFishMarket) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "fishes":
-			if v != nil {
-				d.Fishes, err = unmarshalDotFishClassificationArray(*v)
+			if val != nil {
+				d.Fishes, err = unmarshalDotFishClassificationArray(*val)
 			}
 		case "salmons":
-			if v != nil {
-				err = json.Unmarshal(*v, &d.Salmons)
+			if val != nil {
+				err = json.Unmarshal(*val, &d.Salmons)
 			}
 		case "sampleFish":
-			if v != nil {
-				d.SampleFish, err = unmarshalDotFishClassification(*v)
+			if val != nil {
+				d.SampleFish, err = unmarshalDotFishClassification(*val)
 			}
 		case "sampleSalmon":
-			if v != nil {
-				err = json.Unmarshal(*v, &d.SampleSalmon)
+			if val != nil {
+				err = json.Unmarshal(*val, &d.SampleSalmon)
 			}
 		}
 		if err != nil {
@@ -344,16 +344,16 @@ func (d *DotSalmon) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "iswild":
-			if v != nil {
-				err = json.Unmarshal(*v, &d.Iswild)
+			if val != nil {
+				err = json.Unmarshal(*val, &d.Iswild)
 			}
 		case "location":
-			if v != nil {
-				err = json.Unmarshal(*v, &d.Location)
+			if val != nil {
+				err = json.Unmarshal(*val, &d.Location)
 			}
 		}
 		if err != nil {
@@ -429,24 +429,24 @@ func (f *Fish) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "fishtype":
-			if v != nil {
-				err = json.Unmarshal(*v, &f.Fishtype)
+			if val != nil {
+				err = json.Unmarshal(*val, &f.Fishtype)
 			}
 		case "length":
-			if v != nil {
-				err = json.Unmarshal(*v, &f.Length)
+			if val != nil {
+				err = json.Unmarshal(*val, &f.Length)
 			}
 		case "siblings":
-			if v != nil {
-				f.Siblings, err = unmarshalFishClassificationArray(*v)
+			if val != nil {
+				f.Siblings, err = unmarshalFishClassificationArray(*val)
 			}
 		case "species":
-			if v != nil {
-				err = json.Unmarshal(*v, &f.Species)
+			if val != nil {
+				err = json.Unmarshal(*val, &f.Species)
 			}
 		}
 		if err != nil {
@@ -528,16 +528,16 @@ func (g *Goblinshark) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "color":
-			if v != nil {
-				err = json.Unmarshal(*v, &g.Color)
+			if val != nil {
+				err = json.Unmarshal(*val, &g.Color)
 			}
 		case "jawsize":
-			if v != nil {
-				err = json.Unmarshal(*v, &g.Jawsize)
+			if val != nil {
+				err = json.Unmarshal(*val, &g.Jawsize)
 			}
 		}
 		if err != nil {
@@ -597,20 +597,20 @@ func (m *MyBaseType) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "helper":
-			if v != nil {
-				err = json.Unmarshal(*v, &m.Helper)
+			if val != nil {
+				err = json.Unmarshal(*val, &m.Helper)
 			}
 		case "kind":
-			if v != nil {
-				err = json.Unmarshal(*v, &m.Kind)
+			if val != nil {
+				err = json.Unmarshal(*val, &m.Kind)
 			}
 		case "propB1":
-			if v != nil {
-				err = json.Unmarshal(*v, &m.PropB1)
+			if val != nil {
+				err = json.Unmarshal(*val, &m.PropB1)
 			}
 		}
 		if err != nil {
@@ -671,12 +671,12 @@ func (m *MyDerivedType) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "propD1":
-			if v != nil {
-				err = json.Unmarshal(*v, &m.PropD1)
+			if val != nil {
+				err = json.Unmarshal(*val, &m.PropD1)
 			}
 		}
 		if err != nil {
@@ -736,16 +736,16 @@ func (s *Salmon) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "iswild":
-			if v != nil {
-				err = json.Unmarshal(*v, &s.Iswild)
+			if val != nil {
+				err = json.Unmarshal(*val, &s.Iswild)
 			}
 		case "location":
-			if v != nil {
-				err = json.Unmarshal(*v, &s.Location)
+			if val != nil {
+				err = json.Unmarshal(*val, &s.Location)
 			}
 		}
 		if err != nil {
@@ -803,12 +803,12 @@ func (s *Sawshark) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "picture":
-			if v != nil {
-				err = json.Unmarshal(*v, &s.Picture)
+			if val != nil {
+				err = json.Unmarshal(*val, &s.Picture)
 			}
 		}
 		if err != nil {
@@ -851,17 +851,17 @@ func (s *Shark) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "age":
-			if v != nil {
-				err = json.Unmarshal(*v, &s.Age)
+			if val != nil {
+				err = json.Unmarshal(*val, &s.Age)
 			}
 		case "birthday":
-			if v != nil {
+			if val != nil {
 				var aux timeRFC3339
-				err = json.Unmarshal(*v, &aux)
+				err = json.Unmarshal(*val, &aux)
 				s.Birthday = (*time.Time)(&aux)
 			}
 		}
@@ -917,12 +917,12 @@ func (s *SmartSalmon) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "college_degree":
-			if v != nil {
-				err = json.Unmarshal(*v, &s.CollegeDegree)
+			if val != nil {
+				err = json.Unmarshal(*val, &s.CollegeDegree)
 			}
 		}
 		if err != nil {

--- a/test/autorest/generated/errorsgroup/models.go
+++ b/test/autorest/generated/errorsgroup/models.go
@@ -26,12 +26,12 @@ func (a *AnimalNotFound) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "name":
-			if v != nil {
-				err = json.Unmarshal(*v, &a.Name)
+			if val != nil {
+				err = json.Unmarshal(*val, &a.Name)
 			}
 		}
 		if err != nil {
@@ -56,12 +56,12 @@ func (l *LinkNotFound) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "whatSubAddress":
-			if v != nil {
-				err = json.Unmarshal(*v, &l.WhatSubAddress)
+			if val != nil {
+				err = json.Unmarshal(*val, &l.WhatSubAddress)
 			}
 		}
 		if err != nil {
@@ -107,16 +107,16 @@ func (n *NotFoundErrorBase) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "reason":
-			if v != nil {
-				err = json.Unmarshal(*v, &n.Reason)
+			if val != nil {
+				err = json.Unmarshal(*val, &n.Reason)
 			}
 		case "whatNotFound":
-			if v != nil {
-				err = json.Unmarshal(*v, &n.WhatNotFound)
+			if val != nil {
+				err = json.Unmarshal(*val, &n.WhatNotFound)
 			}
 		}
 		if err != nil {
@@ -173,16 +173,16 @@ func (p *PetActionError) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "errorMessage":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.ErrorMessage)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.ErrorMessage)
 			}
 		case "errorType":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.ErrorType)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.ErrorType)
 			}
 		}
 		if err != nil {
@@ -212,12 +212,12 @@ func (p *PetHungryOrThirstyError) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "hungryOrThirsty":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.HungryOrThirsty)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.HungryOrThirsty)
 			}
 		}
 		if err != nil {
@@ -256,12 +256,12 @@ func (p *PetSadError) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for k, v := range rawMsg {
+	for key, val := range rawMsg {
 		var err error
-		switch k {
+		switch key {
 		case "reason":
-			if v != nil {
-				err = json.Unmarshal(*v, &p.Reason)
+			if val != nil {
+				err = json.Unmarshal(*val, &p.Reason)
 			}
 		}
 		if err != nil {


### PR DESCRIPTION
Fixed infinite loop when walking discriminators hierarchy.
Renamed "k, v" locals to "key, val" to avoid clashing with receivers.
Added 304 to list of HTTP status codes.