### PR TITLE
Adding LRO retry after fix for initial response delay 

### DIFF
--- a/test/autorest/generated/lrogroup/pollers.go
+++ b/test/autorest/generated/lrogroup/pollers.go
@@ -62,11 +62,9 @@ func (p *httpPoller) ResumeToken() (string, error) {
 func (p *httpPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*http.Response, error) {
 	// initial check for a retry-after header existing on the initial response
 	if retryAfter := azcore.RetryAfter(p.pt.latestResponse().Response); retryAfter > 0 {
-		select {
-		case <-time.After(retryAfter):
-			// do nothing
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		err := delay(ctx, retryAfter)
+		if err != nil {
+			return nil, err
 		}
 	}
 	// begin polling the endpoint until a terminal state is reached
@@ -78,15 +76,13 @@ func (p *httpPoller) pollUntilDone(ctx context.Context, frequency time.Duration)
 		if p.Done() {
 			break
 		}
-		delay := frequency
+		d := frequency
 		if retryAfter := azcore.RetryAfter(resp); retryAfter > 0 {
-			delay = retryAfter
+			d = retryAfter
 		}
-		select {
-		case <-time.After(delay):
-			// do nothing
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		err = delay(ctx, d)
+		if err != nil {
+			return nil, err
 		}
 	}
 	return p.FinalResponse(), nil
@@ -182,11 +178,9 @@ func (p *productArrayPoller) ResumeToken() (string, error) {
 func (p *productArrayPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*ProductArrayResponse, error) {
 	// initial check for a retry-after header existing on the initial response
 	if retryAfter := azcore.RetryAfter(p.pt.latestResponse().Response); retryAfter > 0 {
-		select {
-		case <-time.After(retryAfter):
-			// do nothing
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		err := delay(ctx, retryAfter)
+		if err != nil {
+			return nil, err
 		}
 	}
 	// begin polling the endpoint until a terminal state is reached
@@ -198,15 +192,13 @@ func (p *productArrayPoller) pollUntilDone(ctx context.Context, frequency time.D
 		if p.Done() {
 			break
 		}
-		delay := frequency
+		d := frequency
 		if retryAfter := azcore.RetryAfter(resp); retryAfter > 0 {
-			delay = retryAfter
+			d = retryAfter
 		}
-		select {
-		case <-time.After(delay):
-			// do nothing
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		err = delay(ctx, d)
+		if err != nil {
+			return nil, err
 		}
 	}
 	return p.FinalResponse(ctx)
@@ -313,11 +305,9 @@ func (p *productPoller) ResumeToken() (string, error) {
 func (p *productPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
 	// initial check for a retry-after header existing on the initial response
 	if retryAfter := azcore.RetryAfter(p.pt.latestResponse().Response); retryAfter > 0 {
-		select {
-		case <-time.After(retryAfter):
-			// do nothing
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		err := delay(ctx, retryAfter)
+		if err != nil {
+			return nil, err
 		}
 	}
 	// begin polling the endpoint until a terminal state is reached
@@ -329,15 +319,13 @@ func (p *productPoller) pollUntilDone(ctx context.Context, frequency time.Durati
 		if p.Done() {
 			break
 		}
-		delay := frequency
+		d := frequency
 		if retryAfter := azcore.RetryAfter(resp); retryAfter > 0 {
-			delay = retryAfter
+			d = retryAfter
 		}
-		select {
-		case <-time.After(delay):
-			// do nothing
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		err = delay(ctx, d)
+		if err != nil {
+			return nil, err
 		}
 	}
 	return p.FinalResponse(ctx)
@@ -444,11 +432,9 @@ func (p *skuPoller) ResumeToken() (string, error) {
 func (p *skuPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*SkuResponse, error) {
 	// initial check for a retry-after header existing on the initial response
 	if retryAfter := azcore.RetryAfter(p.pt.latestResponse().Response); retryAfter > 0 {
-		select {
-		case <-time.After(retryAfter):
-			// do nothing
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		err := delay(ctx, retryAfter)
+		if err != nil {
+			return nil, err
 		}
 	}
 	// begin polling the endpoint until a terminal state is reached
@@ -460,15 +446,13 @@ func (p *skuPoller) pollUntilDone(ctx context.Context, frequency time.Duration) 
 		if p.Done() {
 			break
 		}
-		delay := frequency
+		d := frequency
 		if retryAfter := azcore.RetryAfter(resp); retryAfter > 0 {
-			delay = retryAfter
+			d = retryAfter
 		}
-		select {
-		case <-time.After(delay):
-			// do nothing
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		err = delay(ctx, d)
+		if err != nil {
+			return nil, err
 		}
 	}
 	return p.FinalResponse(ctx)
@@ -575,11 +559,9 @@ func (p *subProductPoller) ResumeToken() (string, error) {
 func (p *subProductPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*SubProductResponse, error) {
 	// initial check for a retry-after header existing on the initial response
 	if retryAfter := azcore.RetryAfter(p.pt.latestResponse().Response); retryAfter > 0 {
-		select {
-		case <-time.After(retryAfter):
-			// do nothing
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		err := delay(ctx, retryAfter)
+		if err != nil {
+			return nil, err
 		}
 	}
 	// begin polling the endpoint until a terminal state is reached
@@ -591,15 +573,13 @@ func (p *subProductPoller) pollUntilDone(ctx context.Context, frequency time.Dur
 		if p.Done() {
 			break
 		}
-		delay := frequency
+		d := frequency
 		if retryAfter := azcore.RetryAfter(resp); retryAfter > 0 {
-			delay = retryAfter
+			d = retryAfter
 		}
-		select {
-		case <-time.After(delay):
-			// do nothing
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		err = delay(ctx, d)
+		if err != nil {
+			return nil, err
 		}
 	}
 	return p.FinalResponse(ctx)
@@ -614,4 +594,13 @@ func (p *subProductPoller) handleResponse(resp *azcore.Response) (*SubProductRes
 		return nil, p.pt.handleError(resp)
 	}
 	return &result, resp.UnmarshalAsJSON(&result.SubProduct)
+}
+
+func delay(ctx context.Context, delay time.Duration) error {
+	select {
+	case <-time.After(delay):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/test/autorest/generated/lrogroup/pollers.go
+++ b/test/autorest/generated/lrogroup/pollers.go
@@ -60,6 +60,16 @@ func (p *httpPoller) ResumeToken() (string, error) {
 }
 
 func (p *httpPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+	// initial check for a retry-after header existing on the initial response
+	if retryAfter := azcore.RetryAfter(p.pt.latestResponse().Response); retryAfter > 0 {
+		select {
+		case <-time.After(retryAfter):
+			// do nothing
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	// begin polling the endpoint until a terminal state is reached
 	for {
 		resp, err := p.Poll(ctx)
 		if err != nil {
@@ -68,10 +78,15 @@ func (p *httpPoller) pollUntilDone(ctx context.Context, frequency time.Duration)
 		if p.Done() {
 			break
 		}
-		if delay := azcore.RetryAfter(resp); delay > 0 {
-			time.Sleep(delay)
-		} else {
-			time.Sleep(frequency)
+		delay := frequency
+		if retryAfter := azcore.RetryAfter(resp); retryAfter > 0 {
+			delay = retryAfter
+		}
+		select {
+		case <-time.After(delay):
+			// do nothing
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
 	}
 	return p.FinalResponse(), nil
@@ -165,6 +180,16 @@ func (p *productArrayPoller) ResumeToken() (string, error) {
 }
 
 func (p *productArrayPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*ProductArrayResponse, error) {
+	// initial check for a retry-after header existing on the initial response
+	if retryAfter := azcore.RetryAfter(p.pt.latestResponse().Response); retryAfter > 0 {
+		select {
+		case <-time.After(retryAfter):
+			// do nothing
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	// begin polling the endpoint until a terminal state is reached
 	for {
 		resp, err := p.Poll(ctx)
 		if err != nil {
@@ -173,10 +198,15 @@ func (p *productArrayPoller) pollUntilDone(ctx context.Context, frequency time.D
 		if p.Done() {
 			break
 		}
-		if delay := azcore.RetryAfter(resp); delay > 0 {
-			time.Sleep(delay)
-		} else {
-			time.Sleep(frequency)
+		delay := frequency
+		if retryAfter := azcore.RetryAfter(resp); retryAfter > 0 {
+			delay = retryAfter
+		}
+		select {
+		case <-time.After(delay):
+			// do nothing
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
 	}
 	return p.FinalResponse(ctx)
@@ -281,6 +311,16 @@ func (p *productPoller) ResumeToken() (string, error) {
 }
 
 func (p *productPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*ProductResponse, error) {
+	// initial check for a retry-after header existing on the initial response
+	if retryAfter := azcore.RetryAfter(p.pt.latestResponse().Response); retryAfter > 0 {
+		select {
+		case <-time.After(retryAfter):
+			// do nothing
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	// begin polling the endpoint until a terminal state is reached
 	for {
 		resp, err := p.Poll(ctx)
 		if err != nil {
@@ -289,10 +329,15 @@ func (p *productPoller) pollUntilDone(ctx context.Context, frequency time.Durati
 		if p.Done() {
 			break
 		}
-		if delay := azcore.RetryAfter(resp); delay > 0 {
-			time.Sleep(delay)
-		} else {
-			time.Sleep(frequency)
+		delay := frequency
+		if retryAfter := azcore.RetryAfter(resp); retryAfter > 0 {
+			delay = retryAfter
+		}
+		select {
+		case <-time.After(delay):
+			// do nothing
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
 	}
 	return p.FinalResponse(ctx)
@@ -397,6 +442,16 @@ func (p *skuPoller) ResumeToken() (string, error) {
 }
 
 func (p *skuPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*SkuResponse, error) {
+	// initial check for a retry-after header existing on the initial response
+	if retryAfter := azcore.RetryAfter(p.pt.latestResponse().Response); retryAfter > 0 {
+		select {
+		case <-time.After(retryAfter):
+			// do nothing
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	// begin polling the endpoint until a terminal state is reached
 	for {
 		resp, err := p.Poll(ctx)
 		if err != nil {
@@ -405,10 +460,15 @@ func (p *skuPoller) pollUntilDone(ctx context.Context, frequency time.Duration) 
 		if p.Done() {
 			break
 		}
-		if delay := azcore.RetryAfter(resp); delay > 0 {
-			time.Sleep(delay)
-		} else {
-			time.Sleep(frequency)
+		delay := frequency
+		if retryAfter := azcore.RetryAfter(resp); retryAfter > 0 {
+			delay = retryAfter
+		}
+		select {
+		case <-time.After(delay):
+			// do nothing
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
 	}
 	return p.FinalResponse(ctx)
@@ -513,6 +573,16 @@ func (p *subProductPoller) ResumeToken() (string, error) {
 }
 
 func (p *subProductPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*SubProductResponse, error) {
+	// initial check for a retry-after header existing on the initial response
+	if retryAfter := azcore.RetryAfter(p.pt.latestResponse().Response); retryAfter > 0 {
+		select {
+		case <-time.After(retryAfter):
+			// do nothing
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	// begin polling the endpoint until a terminal state is reached
 	for {
 		resp, err := p.Poll(ctx)
 		if err != nil {
@@ -521,10 +591,15 @@ func (p *subProductPoller) pollUntilDone(ctx context.Context, frequency time.Dur
 		if p.Done() {
 			break
 		}
-		if delay := azcore.RetryAfter(resp); delay > 0 {
-			time.Sleep(delay)
-		} else {
-			time.Sleep(frequency)
+		delay := frequency
+		if retryAfter := azcore.RetryAfter(resp); retryAfter > 0 {
+			delay = retryAfter
+		}
+		select {
+		case <-time.After(delay):
+			// do nothing
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
 	}
 	return p.FinalResponse(ctx)


### PR DESCRIPTION
This PR includes a fix to consider retry-after headers in the initial response from the endpoing for LROs. Also adds consideration for ctx time out.