### PR TITLE
Fixing path parsing to include previously set path on client url

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -397,7 +397,8 @@ function createProtocolRequest(client: string, op: Operation, group: OperationGr
     text += '\t\treturn nil, err\n';
     text += '\t}\n';
   } else if (includeParse) {
-    text += `\tu, err := client.u.Parse(${parseVar})\n`;
+    imports.add('path');
+    text += `\tu, err := client.u.Parse(path.Join(client.u.Path, ${parseVar}))\n`;
     text += '\tif err != nil {\n';
     text += '\t\treturn nil, err\n';
     text += '\t}\n';

--- a/test/autorest/generated/additionalpropsgroup/pets.go
+++ b/test/autorest/generated/additionalpropsgroup/pets.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // PetsOperations contains the methods for the Pets group.
@@ -52,7 +53,7 @@ func (client *petsOperations) CreateApInProperties(ctx context.Context, createPa
 // createApInPropertiesCreateRequest creates the CreateApInProperties request.
 func (client *petsOperations) createApInPropertiesCreateRequest(createParameters PetApInProperties) (*azcore.Request, error) {
 	urlPath := "/additionalProperties/in/properties"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +99,7 @@ func (client *petsOperations) CreateApInPropertiesWithApstring(ctx context.Conte
 // createApInPropertiesWithApstringCreateRequest creates the CreateApInPropertiesWithApstring request.
 func (client *petsOperations) createApInPropertiesWithApstringCreateRequest(createParameters PetApInPropertiesWithApstring) (*azcore.Request, error) {
 	urlPath := "/additionalProperties/in/properties/with/additionalProperties/string"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +145,7 @@ func (client *petsOperations) CreateApObject(ctx context.Context, createParamete
 // createApObjectCreateRequest creates the CreateApObject request.
 func (client *petsOperations) createApObjectCreateRequest(createParameters PetApObject) (*azcore.Request, error) {
 	urlPath := "/additionalProperties/type/object"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +191,7 @@ func (client *petsOperations) CreateApString(ctx context.Context, createParamete
 // createApStringCreateRequest creates the CreateApString request.
 func (client *petsOperations) createApStringCreateRequest(createParameters PetApString) (*azcore.Request, error) {
 	urlPath := "/additionalProperties/type/string"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +237,7 @@ func (client *petsOperations) CreateApTrue(ctx context.Context, createParameters
 // createApTrueCreateRequest creates the CreateApTrue request.
 func (client *petsOperations) createApTrueCreateRequest(createParameters PetApTrue) (*azcore.Request, error) {
 	urlPath := "/additionalProperties/true"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +283,7 @@ func (client *petsOperations) CreateCatApTrue(ctx context.Context, createParamet
 // createCatApTrueCreateRequest creates the CreateCatApTrue request.
 func (client *petsOperations) createCatApTrueCreateRequest(createParameters CatApTrue) (*azcore.Request, error) {
 	urlPath := "/additionalProperties/true-subclass"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/arraygroup/array.go
+++ b/test/autorest/generated/arraygroup/array.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -179,7 +180,7 @@ func (client *arrayOperations) GetArrayEmpty(ctx context.Context) (*StringArrayA
 // getArrayEmptyCreateRequest creates the GetArrayEmpty request.
 func (client *arrayOperations) getArrayEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/array/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +226,7 @@ func (client *arrayOperations) GetArrayItemEmpty(ctx context.Context) (*StringAr
 // getArrayItemEmptyCreateRequest creates the GetArrayItemEmpty request.
 func (client *arrayOperations) getArrayItemEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/array/itemempty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *arrayOperations) GetArrayItemNull(ctx context.Context) (*StringArr
 // getArrayItemNullCreateRequest creates the GetArrayItemNull request.
 func (client *arrayOperations) getArrayItemNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/array/itemnull"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +318,7 @@ func (client *arrayOperations) GetArrayNull(ctx context.Context) (*StringArrayAr
 // getArrayNullCreateRequest creates the GetArrayNull request.
 func (client *arrayOperations) getArrayNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/array/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +364,7 @@ func (client *arrayOperations) GetArrayValid(ctx context.Context) (*StringArrayA
 // getArrayValidCreateRequest creates the GetArrayValid request.
 func (client *arrayOperations) getArrayValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/array/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -409,7 +410,7 @@ func (client *arrayOperations) GetBase64URL(ctx context.Context) (*ByteArrayArra
 // getBase64UrlCreateRequest creates the GetBase64URL request.
 func (client *arrayOperations) getBase64UrlCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/base64url/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -455,7 +456,7 @@ func (client *arrayOperations) GetBooleanInvalidNull(ctx context.Context) (*Bool
 // getBooleanInvalidNullCreateRequest creates the GetBooleanInvalidNull request.
 func (client *arrayOperations) getBooleanInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/boolean/true.null.false"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -501,7 +502,7 @@ func (client *arrayOperations) GetBooleanInvalidString(ctx context.Context) (*Bo
 // getBooleanInvalidStringCreateRequest creates the GetBooleanInvalidString request.
 func (client *arrayOperations) getBooleanInvalidStringCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/boolean/true.boolean.false"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -547,7 +548,7 @@ func (client *arrayOperations) GetBooleanTfft(ctx context.Context) (*BoolArrayRe
 // getBooleanTfftCreateRequest creates the GetBooleanTfft request.
 func (client *arrayOperations) getBooleanTfftCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/boolean/tfft"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -593,7 +594,7 @@ func (client *arrayOperations) GetByteInvalidNull(ctx context.Context) (*ByteArr
 // getByteInvalidNullCreateRequest creates the GetByteInvalidNull request.
 func (client *arrayOperations) getByteInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/byte/invalidnull"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -639,7 +640,7 @@ func (client *arrayOperations) GetByteValid(ctx context.Context) (*ByteArrayArra
 // getByteValidCreateRequest creates the GetByteValid request.
 func (client *arrayOperations) getByteValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/byte/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -685,7 +686,7 @@ func (client *arrayOperations) GetComplexEmpty(ctx context.Context) (*ProductArr
 // getComplexEmptyCreateRequest creates the GetComplexEmpty request.
 func (client *arrayOperations) getComplexEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/complex/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -731,7 +732,7 @@ func (client *arrayOperations) GetComplexItemEmpty(ctx context.Context) (*Produc
 // getComplexItemEmptyCreateRequest creates the GetComplexItemEmpty request.
 func (client *arrayOperations) getComplexItemEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/complex/itemempty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -777,7 +778,7 @@ func (client *arrayOperations) GetComplexItemNull(ctx context.Context) (*Product
 // getComplexItemNullCreateRequest creates the GetComplexItemNull request.
 func (client *arrayOperations) getComplexItemNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/complex/itemnull"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -823,7 +824,7 @@ func (client *arrayOperations) GetComplexNull(ctx context.Context) (*ProductArra
 // getComplexNullCreateRequest creates the GetComplexNull request.
 func (client *arrayOperations) getComplexNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/complex/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -869,7 +870,7 @@ func (client *arrayOperations) GetComplexValid(ctx context.Context) (*ProductArr
 // getComplexValidCreateRequest creates the GetComplexValid request.
 func (client *arrayOperations) getComplexValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/complex/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -915,7 +916,7 @@ func (client *arrayOperations) GetDateInvalidChars(ctx context.Context) (*TimeAr
 // getDateInvalidCharsCreateRequest creates the GetDateInvalidChars request.
 func (client *arrayOperations) getDateInvalidCharsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/date/invalidchars"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -961,7 +962,7 @@ func (client *arrayOperations) GetDateInvalidNull(ctx context.Context) (*TimeArr
 // getDateInvalidNullCreateRequest creates the GetDateInvalidNull request.
 func (client *arrayOperations) getDateInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/date/invalidnull"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1007,7 +1008,7 @@ func (client *arrayOperations) GetDateTimeInvalidChars(ctx context.Context) (*Ti
 // getDateTimeInvalidCharsCreateRequest creates the GetDateTimeInvalidChars request.
 func (client *arrayOperations) getDateTimeInvalidCharsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/date-time/invalidchars"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1060,7 +1061,7 @@ func (client *arrayOperations) GetDateTimeInvalidNull(ctx context.Context) (*Tim
 // getDateTimeInvalidNullCreateRequest creates the GetDateTimeInvalidNull request.
 func (client *arrayOperations) getDateTimeInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/date-time/invalidnull"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1113,7 +1114,7 @@ func (client *arrayOperations) GetDateTimeRFC1123Valid(ctx context.Context) (*Ti
 // getDateTimeRfc1123ValidCreateRequest creates the GetDateTimeRFC1123Valid request.
 func (client *arrayOperations) getDateTimeRfc1123ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/date-time-rfc1123/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1166,7 +1167,7 @@ func (client *arrayOperations) GetDateTimeValid(ctx context.Context) (*TimeArray
 // getDateTimeValidCreateRequest creates the GetDateTimeValid request.
 func (client *arrayOperations) getDateTimeValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/date-time/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1219,7 +1220,7 @@ func (client *arrayOperations) GetDateValid(ctx context.Context) (*TimeArrayResp
 // getDateValidCreateRequest creates the GetDateValid request.
 func (client *arrayOperations) getDateValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/date/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1265,7 +1266,7 @@ func (client *arrayOperations) GetDictionaryEmpty(ctx context.Context) (*MapOfSt
 // getDictionaryEmptyCreateRequest creates the GetDictionaryEmpty request.
 func (client *arrayOperations) getDictionaryEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/dictionary/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1311,7 +1312,7 @@ func (client *arrayOperations) GetDictionaryItemEmpty(ctx context.Context) (*Map
 // getDictionaryItemEmptyCreateRequest creates the GetDictionaryItemEmpty request.
 func (client *arrayOperations) getDictionaryItemEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/dictionary/itemempty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1357,7 +1358,7 @@ func (client *arrayOperations) GetDictionaryItemNull(ctx context.Context) (*MapO
 // getDictionaryItemNullCreateRequest creates the GetDictionaryItemNull request.
 func (client *arrayOperations) getDictionaryItemNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/dictionary/itemnull"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1403,7 +1404,7 @@ func (client *arrayOperations) GetDictionaryNull(ctx context.Context) (*MapOfStr
 // getDictionaryNullCreateRequest creates the GetDictionaryNull request.
 func (client *arrayOperations) getDictionaryNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/dictionary/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1449,7 +1450,7 @@ func (client *arrayOperations) GetDictionaryValid(ctx context.Context) (*MapOfSt
 // getDictionaryValidCreateRequest creates the GetDictionaryValid request.
 func (client *arrayOperations) getDictionaryValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/dictionary/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1495,7 +1496,7 @@ func (client *arrayOperations) GetDoubleInvalidNull(ctx context.Context) (*Float
 // getDoubleInvalidNullCreateRequest creates the GetDoubleInvalidNull request.
 func (client *arrayOperations) getDoubleInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/double/0.0-null-1.2e20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1541,7 +1542,7 @@ func (client *arrayOperations) GetDoubleInvalidString(ctx context.Context) (*Flo
 // getDoubleInvalidStringCreateRequest creates the GetDoubleInvalidString request.
 func (client *arrayOperations) getDoubleInvalidStringCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/double/1.number.0"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1587,7 +1588,7 @@ func (client *arrayOperations) GetDoubleValid(ctx context.Context) (*Float64Arra
 // getDoubleValidCreateRequest creates the GetDoubleValid request.
 func (client *arrayOperations) getDoubleValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/double/0--0.01-1.2e20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1633,7 +1634,7 @@ func (client *arrayOperations) GetDurationValid(ctx context.Context) (*DurationA
 // getDurationValidCreateRequest creates the GetDurationValid request.
 func (client *arrayOperations) getDurationValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/duration/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1679,7 +1680,7 @@ func (client *arrayOperations) GetEmpty(ctx context.Context) (*Int32ArrayRespons
 // getEmptyCreateRequest creates the GetEmpty request.
 func (client *arrayOperations) getEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1725,7 +1726,7 @@ func (client *arrayOperations) GetEnumValid(ctx context.Context) (*FooEnumArrayR
 // getEnumValidCreateRequest creates the GetEnumValid request.
 func (client *arrayOperations) getEnumValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/enum/foo1.foo2.foo3"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1771,7 +1772,7 @@ func (client *arrayOperations) GetFloatInvalidNull(ctx context.Context) (*Float3
 // getFloatInvalidNullCreateRequest creates the GetFloatInvalidNull request.
 func (client *arrayOperations) getFloatInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/float/0.0-null-1.2e20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1817,7 +1818,7 @@ func (client *arrayOperations) GetFloatInvalidString(ctx context.Context) (*Floa
 // getFloatInvalidStringCreateRequest creates the GetFloatInvalidString request.
 func (client *arrayOperations) getFloatInvalidStringCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/float/1.number.0"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1863,7 +1864,7 @@ func (client *arrayOperations) GetFloatValid(ctx context.Context) (*Float32Array
 // getFloatValidCreateRequest creates the GetFloatValid request.
 func (client *arrayOperations) getFloatValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/float/0--0.01-1.2e20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1909,7 +1910,7 @@ func (client *arrayOperations) GetIntInvalidNull(ctx context.Context) (*Int32Arr
 // getIntInvalidNullCreateRequest creates the GetIntInvalidNull request.
 func (client *arrayOperations) getIntInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/integer/1.null.zero"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1955,7 +1956,7 @@ func (client *arrayOperations) GetIntInvalidString(ctx context.Context) (*Int32A
 // getIntInvalidStringCreateRequest creates the GetIntInvalidString request.
 func (client *arrayOperations) getIntInvalidStringCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/integer/1.integer.0"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2001,7 +2002,7 @@ func (client *arrayOperations) GetIntegerValid(ctx context.Context) (*Int32Array
 // getIntegerValidCreateRequest creates the GetIntegerValid request.
 func (client *arrayOperations) getIntegerValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/integer/1.-1.3.300"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2047,7 +2048,7 @@ func (client *arrayOperations) GetInvalid(ctx context.Context) (*Int32ArrayRespo
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *arrayOperations) getInvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/invalid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2093,7 +2094,7 @@ func (client *arrayOperations) GetLongInvalidNull(ctx context.Context) (*Int64Ar
 // getLongInvalidNullCreateRequest creates the GetLongInvalidNull request.
 func (client *arrayOperations) getLongInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/long/1.null.zero"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2139,7 +2140,7 @@ func (client *arrayOperations) GetLongInvalidString(ctx context.Context) (*Int64
 // getLongInvalidStringCreateRequest creates the GetLongInvalidString request.
 func (client *arrayOperations) getLongInvalidStringCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/long/1.integer.0"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2185,7 +2186,7 @@ func (client *arrayOperations) GetLongValid(ctx context.Context) (*Int64ArrayRes
 // getLongValidCreateRequest creates the GetLongValid request.
 func (client *arrayOperations) getLongValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/long/1.-1.3.300"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2231,7 +2232,7 @@ func (client *arrayOperations) GetNull(ctx context.Context) (*Int32ArrayResponse
 // getNullCreateRequest creates the GetNull request.
 func (client *arrayOperations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2277,7 +2278,7 @@ func (client *arrayOperations) GetStringEnumValid(ctx context.Context) (*Enum0Ar
 // getStringEnumValidCreateRequest creates the GetStringEnumValid request.
 func (client *arrayOperations) getStringEnumValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/string-enum/foo1.foo2.foo3"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2323,7 +2324,7 @@ func (client *arrayOperations) GetStringValid(ctx context.Context) (*StringArray
 // getStringValidCreateRequest creates the GetStringValid request.
 func (client *arrayOperations) getStringValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/string/foo1.foo2.foo3"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2369,7 +2370,7 @@ func (client *arrayOperations) GetStringWithInvalid(ctx context.Context) (*Strin
 // getStringWithInvalidCreateRequest creates the GetStringWithInvalid request.
 func (client *arrayOperations) getStringWithInvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/string/foo.123.foo2"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2415,7 +2416,7 @@ func (client *arrayOperations) GetStringWithNull(ctx context.Context) (*StringAr
 // getStringWithNullCreateRequest creates the GetStringWithNull request.
 func (client *arrayOperations) getStringWithNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/string/foo.null.foo2"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2461,7 +2462,7 @@ func (client *arrayOperations) GetUUIDInvalidChars(ctx context.Context) (*String
 // getUuidInvalidCharsCreateRequest creates the GetUUIDInvalidChars request.
 func (client *arrayOperations) getUuidInvalidCharsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/uuid/invalidchars"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2507,7 +2508,7 @@ func (client *arrayOperations) GetUUIDValid(ctx context.Context) (*StringArrayRe
 // getUuidValidCreateRequest creates the GetUUIDValid request.
 func (client *arrayOperations) getUuidValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/array/prim/uuid/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2553,7 +2554,7 @@ func (client *arrayOperations) PutArrayValid(ctx context.Context, arrayBody [][]
 // putArrayValidCreateRequest creates the PutArrayValid request.
 func (client *arrayOperations) putArrayValidCreateRequest(arrayBody [][]string) (*azcore.Request, error) {
 	urlPath := "/array/array/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2598,7 +2599,7 @@ func (client *arrayOperations) PutBooleanTfft(ctx context.Context, arrayBody []b
 // putBooleanTfftCreateRequest creates the PutBooleanTfft request.
 func (client *arrayOperations) putBooleanTfftCreateRequest(arrayBody []bool) (*azcore.Request, error) {
 	urlPath := "/array/prim/boolean/tfft"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2643,7 +2644,7 @@ func (client *arrayOperations) PutByteValid(ctx context.Context, arrayBody [][]b
 // putByteValidCreateRequest creates the PutByteValid request.
 func (client *arrayOperations) putByteValidCreateRequest(arrayBody [][]byte) (*azcore.Request, error) {
 	urlPath := "/array/prim/byte/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2688,7 +2689,7 @@ func (client *arrayOperations) PutComplexValid(ctx context.Context, arrayBody []
 // putComplexValidCreateRequest creates the PutComplexValid request.
 func (client *arrayOperations) putComplexValidCreateRequest(arrayBody []Product) (*azcore.Request, error) {
 	urlPath := "/array/complex/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2733,7 +2734,7 @@ func (client *arrayOperations) PutDateTimeRFC1123Valid(ctx context.Context, arra
 // putDateTimeRfc1123ValidCreateRequest creates the PutDateTimeRFC1123Valid request.
 func (client *arrayOperations) putDateTimeRfc1123ValidCreateRequest(arrayBody []time.Time) (*azcore.Request, error) {
 	urlPath := "/array/prim/date-time-rfc1123/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2782,7 +2783,7 @@ func (client *arrayOperations) PutDateTimeValid(ctx context.Context, arrayBody [
 // putDateTimeValidCreateRequest creates the PutDateTimeValid request.
 func (client *arrayOperations) putDateTimeValidCreateRequest(arrayBody []time.Time) (*azcore.Request, error) {
 	urlPath := "/array/prim/date-time/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2827,7 +2828,7 @@ func (client *arrayOperations) PutDateValid(ctx context.Context, arrayBody []tim
 // putDateValidCreateRequest creates the PutDateValid request.
 func (client *arrayOperations) putDateValidCreateRequest(arrayBody []time.Time) (*azcore.Request, error) {
 	urlPath := "/array/prim/date/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2872,7 +2873,7 @@ func (client *arrayOperations) PutDictionaryValid(ctx context.Context, arrayBody
 // putDictionaryValidCreateRequest creates the PutDictionaryValid request.
 func (client *arrayOperations) putDictionaryValidCreateRequest(arrayBody []map[string]string) (*azcore.Request, error) {
 	urlPath := "/array/dictionary/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2917,7 +2918,7 @@ func (client *arrayOperations) PutDoubleValid(ctx context.Context, arrayBody []f
 // putDoubleValidCreateRequest creates the PutDoubleValid request.
 func (client *arrayOperations) putDoubleValidCreateRequest(arrayBody []float64) (*azcore.Request, error) {
 	urlPath := "/array/prim/double/0--0.01-1.2e20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2962,7 +2963,7 @@ func (client *arrayOperations) PutDurationValid(ctx context.Context, arrayBody [
 // putDurationValidCreateRequest creates the PutDurationValid request.
 func (client *arrayOperations) putDurationValidCreateRequest(arrayBody []time.Duration) (*azcore.Request, error) {
 	urlPath := "/array/prim/duration/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3007,7 +3008,7 @@ func (client *arrayOperations) PutEmpty(ctx context.Context, arrayBody []string)
 // putEmptyCreateRequest creates the PutEmpty request.
 func (client *arrayOperations) putEmptyCreateRequest(arrayBody []string) (*azcore.Request, error) {
 	urlPath := "/array/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3052,7 +3053,7 @@ func (client *arrayOperations) PutEnumValid(ctx context.Context, arrayBody []Foo
 // putEnumValidCreateRequest creates the PutEnumValid request.
 func (client *arrayOperations) putEnumValidCreateRequest(arrayBody []FooEnum) (*azcore.Request, error) {
 	urlPath := "/array/prim/enum/foo1.foo2.foo3"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3097,7 +3098,7 @@ func (client *arrayOperations) PutFloatValid(ctx context.Context, arrayBody []fl
 // putFloatValidCreateRequest creates the PutFloatValid request.
 func (client *arrayOperations) putFloatValidCreateRequest(arrayBody []float32) (*azcore.Request, error) {
 	urlPath := "/array/prim/float/0--0.01-1.2e20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3142,7 +3143,7 @@ func (client *arrayOperations) PutIntegerValid(ctx context.Context, arrayBody []
 // putIntegerValidCreateRequest creates the PutIntegerValid request.
 func (client *arrayOperations) putIntegerValidCreateRequest(arrayBody []int32) (*azcore.Request, error) {
 	urlPath := "/array/prim/integer/1.-1.3.300"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3187,7 +3188,7 @@ func (client *arrayOperations) PutLongValid(ctx context.Context, arrayBody []int
 // putLongValidCreateRequest creates the PutLongValid request.
 func (client *arrayOperations) putLongValidCreateRequest(arrayBody []int64) (*azcore.Request, error) {
 	urlPath := "/array/prim/long/1.-1.3.300"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3232,7 +3233,7 @@ func (client *arrayOperations) PutStringEnumValid(ctx context.Context, arrayBody
 // putStringEnumValidCreateRequest creates the PutStringEnumValid request.
 func (client *arrayOperations) putStringEnumValidCreateRequest(arrayBody []Enum1) (*azcore.Request, error) {
 	urlPath := "/array/prim/string-enum/foo1.foo2.foo3"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3277,7 +3278,7 @@ func (client *arrayOperations) PutStringValid(ctx context.Context, arrayBody []s
 // putStringValidCreateRequest creates the PutStringValid request.
 func (client *arrayOperations) putStringValidCreateRequest(arrayBody []string) (*azcore.Request, error) {
 	urlPath := "/array/prim/string/foo1.foo2.foo3"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3322,7 +3323,7 @@ func (client *arrayOperations) PutUUIDValid(ctx context.Context, arrayBody []str
 // putUuidValidCreateRequest creates the PutUUIDValid request.
 func (client *arrayOperations) putUuidValidCreateRequest(arrayBody []string) (*azcore.Request, error) {
 	urlPath := "/array/prim/uuid/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurereportgroup/autorestreportserviceforazure.go
+++ b/test/autorest/generated/azurereportgroup/autorestreportserviceforazure.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // AutoRestReportServiceForAzureOperations contains the methods for the AutoRestReportServiceForAzure group.
@@ -42,7 +43,7 @@ func (client *autoRestReportServiceForAzureOperations) GetReport(ctx context.Con
 // getReportCreateRequest creates the GetReport request.
 func (client *autoRestReportServiceForAzureOperations) getReportCreateRequest(autoRestReportServiceForAzureGetReportOptions *AutoRestReportServiceForAzureGetReportOptions) (*azcore.Request, error) {
 	urlPath := "/report/azure"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/apiversiondefault.go
+++ b/test/autorest/generated/azurespecialsgroup/apiversiondefault.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // APIVersionDefaultOperations contains the methods for the APIVersionDefault group.
@@ -48,7 +49,7 @@ func (client *apiVersionDefaultOperations) GetMethodGlobalNotProvidedValid(ctx c
 // getMethodGlobalNotProvidedValidCreateRequest creates the GetMethodGlobalNotProvidedValid request.
 func (client *apiVersionDefaultOperations) getMethodGlobalNotProvidedValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +97,7 @@ func (client *apiVersionDefaultOperations) GetMethodGlobalValid(ctx context.Cont
 // getMethodGlobalValidCreateRequest creates the GetMethodGlobalValid request.
 func (client *apiVersionDefaultOperations) getMethodGlobalValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +145,7 @@ func (client *apiVersionDefaultOperations) GetPathGlobalValid(ctx context.Contex
 // getPathGlobalValidCreateRequest creates the GetPathGlobalValid request.
 func (client *apiVersionDefaultOperations) getPathGlobalValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +193,7 @@ func (client *apiVersionDefaultOperations) GetSwaggerGlobalValid(ctx context.Con
 // getSwaggerGlobalValidCreateRequest creates the GetSwaggerGlobalValid request.
 func (client *apiVersionDefaultOperations) getSwaggerGlobalValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/apiversionlocal.go
+++ b/test/autorest/generated/azurespecialsgroup/apiversionlocal.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // APIVersionLocalOperations contains the methods for the APIVersionLocal group.
@@ -48,7 +49,7 @@ func (client *apiVersionLocalOperations) GetMethodLocalNull(ctx context.Context,
 // getMethodLocalNullCreateRequest creates the GetMethodLocalNull request.
 func (client *apiVersionLocalOperations) getMethodLocalNullCreateRequest(apiVersionLocalGetMethodLocalNullOptions *APIVersionLocalGetMethodLocalNullOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/local/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +99,7 @@ func (client *apiVersionLocalOperations) GetMethodLocalValid(ctx context.Context
 // getMethodLocalValidCreateRequest creates the GetMethodLocalValid request.
 func (client *apiVersionLocalOperations) getMethodLocalValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/local/2.0"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +147,7 @@ func (client *apiVersionLocalOperations) GetPathLocalValid(ctx context.Context) 
 // getPathLocalValidCreateRequest creates the GetPathLocalValid request.
 func (client *apiVersionLocalOperations) getPathLocalValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/path/string/none/query/local/2.0"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +195,7 @@ func (client *apiVersionLocalOperations) GetSwaggerLocalValid(ctx context.Contex
 // getSwaggerLocalValidCreateRequest creates the GetSwaggerLocalValid request.
 func (client *apiVersionLocalOperations) getSwaggerLocalValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/swagger/string/none/query/local/2.0"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/header.go
+++ b/test/autorest/generated/azurespecialsgroup/header.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // HeaderOperations contains the methods for the Header group.
@@ -46,7 +47,7 @@ func (client *headerOperations) CustomNamedRequestID(ctx context.Context, fooCli
 // customNamedRequestIdCreateRequest creates the CustomNamedRequestID request.
 func (client *headerOperations) customNamedRequestIdCreateRequest(fooClientRequestId string) (*azcore.Request, error) {
 	urlPath := "/azurespecials/customNamedRequestId"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +97,7 @@ func (client *headerOperations) CustomNamedRequestIDHead(ctx context.Context, fo
 // customNamedRequestIdHeadCreateRequest creates the CustomNamedRequestIDHead request.
 func (client *headerOperations) customNamedRequestIdHeadCreateRequest(fooClientRequestId string) (*azcore.Request, error) {
 	urlPath := "/azurespecials/customNamedRequestIdHead"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +147,7 @@ func (client *headerOperations) CustomNamedRequestIDParamGrouping(ctx context.Co
 // customNamedRequestIdParamGroupingCreateRequest creates the CustomNamedRequestIDParamGrouping request.
 func (client *headerOperations) customNamedRequestIdParamGroupingCreateRequest(headerCustomNamedRequestIdParamGroupingParameters HeaderCustomNamedRequestIDParamGroupingParameters) (*azcore.Request, error) {
 	urlPath := "/azurespecials/customNamedRequestIdParamGrouping"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/odata.go
+++ b/test/autorest/generated/azurespecialsgroup/odata.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 	"strconv"
 )
 
@@ -43,7 +44,7 @@ func (client *odataOperations) GetWithFilter(ctx context.Context, odataGetWithFi
 // getWithFilterCreateRequest creates the GetWithFilter request.
 func (client *odataOperations) getWithFilterCreateRequest(odataGetWithFilterOptions *OdataGetWithFilterOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/odata/filter"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/skipurlencoding.go
+++ b/test/autorest/generated/azurespecialsgroup/skipurlencoding.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 	"strings"
 )
 
@@ -56,7 +57,7 @@ func (client *skipUrlEncodingOperations) GetMethodPathValid(ctx context.Context,
 func (client *skipUrlEncodingOperations) getMethodPathValidCreateRequest(unencodedPathParam string) (*azcore.Request, error) {
 	urlPath := "/azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}"
 	urlPath = strings.ReplaceAll(urlPath, "{unencodedPathParam}", unencodedPathParam)
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +102,7 @@ func (client *skipUrlEncodingOperations) GetMethodQueryNull(ctx context.Context,
 // getMethodQueryNullCreateRequest creates the GetMethodQueryNull request.
 func (client *skipUrlEncodingOperations) getMethodQueryNullCreateRequest(skipUrlEncodingGetMethodQueryNullOptions *SkipURLEncodingGetMethodQueryNullOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/skipUrlEncoding/method/query/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +152,7 @@ func (client *skipUrlEncodingOperations) GetMethodQueryValid(ctx context.Context
 // getMethodQueryValidCreateRequest creates the GetMethodQueryValid request.
 func (client *skipUrlEncodingOperations) getMethodQueryValidCreateRequest(q1 string) (*azcore.Request, error) {
 	urlPath := "/azurespecials/skipUrlEncoding/method/query/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +200,7 @@ func (client *skipUrlEncodingOperations) GetPathQueryValid(ctx context.Context, 
 // getPathQueryValidCreateRequest creates the GetPathQueryValid request.
 func (client *skipUrlEncodingOperations) getPathQueryValidCreateRequest(q1 string) (*azcore.Request, error) {
 	urlPath := "/azurespecials/skipUrlEncoding/path/query/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +249,7 @@ func (client *skipUrlEncodingOperations) GetPathValid(ctx context.Context, unenc
 func (client *skipUrlEncodingOperations) getPathValidCreateRequest(unencodedPathParam string) (*azcore.Request, error) {
 	urlPath := "/azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}"
 	urlPath = strings.ReplaceAll(urlPath, "{unencodedPathParam}", unencodedPathParam)
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +295,7 @@ func (client *skipUrlEncodingOperations) GetSwaggerPathValid(ctx context.Context
 func (client *skipUrlEncodingOperations) getSwaggerPathValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}"
 	urlPath = strings.ReplaceAll(urlPath, "{unencodedPathParam}", "path1/path2/path3")
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +340,7 @@ func (client *skipUrlEncodingOperations) GetSwaggerQueryValid(ctx context.Contex
 // getSwaggerQueryValidCreateRequest creates the GetSwaggerQueryValid request.
 func (client *skipUrlEncodingOperations) getSwaggerQueryValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/azurespecials/skipUrlEncoding/swagger/query/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/subscriptionincredentials.go
+++ b/test/autorest/generated/azurespecialsgroup/subscriptionincredentials.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -54,7 +55,7 @@ func (client *subscriptionInCredentialsOperations) PostMethodGlobalNotProvidedVa
 func (client *subscriptionInCredentialsOperations) postMethodGlobalNotProvidedValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +104,7 @@ func (client *subscriptionInCredentialsOperations) PostMethodGlobalNull(ctx cont
 func (client *subscriptionInCredentialsOperations) postMethodGlobalNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +150,7 @@ func (client *subscriptionInCredentialsOperations) PostMethodGlobalValid(ctx con
 func (client *subscriptionInCredentialsOperations) postMethodGlobalValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +196,7 @@ func (client *subscriptionInCredentialsOperations) PostPathGlobalValid(ctx conte
 func (client *subscriptionInCredentialsOperations) postPathGlobalValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +242,7 @@ func (client *subscriptionInCredentialsOperations) PostSwaggerGlobalValid(ctx co
 func (client *subscriptionInCredentialsOperations) postSwaggerGlobalValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/subscriptioninmethod.go
+++ b/test/autorest/generated/azurespecialsgroup/subscriptioninmethod.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -51,7 +52,7 @@ func (client *subscriptionInMethodOperations) PostMethodLocalNull(ctx context.Co
 func (client *subscriptionInMethodOperations) postMethodLocalNullCreateRequest(subscriptionId string) (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +98,7 @@ func (client *subscriptionInMethodOperations) PostMethodLocalValid(ctx context.C
 func (client *subscriptionInMethodOperations) postMethodLocalValidCreateRequest(subscriptionId string) (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +144,7 @@ func (client *subscriptionInMethodOperations) PostPathLocalValid(ctx context.Con
 func (client *subscriptionInMethodOperations) postPathLocalValidCreateRequest(subscriptionId string) (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +190,7 @@ func (client *subscriptionInMethodOperations) PostSwaggerLocalValid(ctx context.
 func (client *subscriptionInMethodOperations) postSwaggerLocalValidCreateRequest(subscriptionId string) (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/xmsclientrequestid.go
+++ b/test/autorest/generated/azurespecialsgroup/xmsclientrequestid.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"io/ioutil"
 	"net/http"
+	"path"
 )
 
 // XMSClientRequestIDOperations contains the methods for the XMSClientRequestID group.
@@ -47,7 +48,7 @@ func (client *xmsClientRequestIdoperations) Get(ctx context.Context) (*http.Resp
 // getCreateRequest creates the Get request.
 func (client *xmsClientRequestIdoperations) getCreateRequest() (*azcore.Request, error) {
 	urlPath := "/azurespecials/overwrite/x-ms-client-request-id/method/"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +96,7 @@ func (client *xmsClientRequestIdoperations) ParamGet(ctx context.Context, xMSCli
 // paramGetCreateRequest creates the ParamGet request.
 func (client *xmsClientRequestIdoperations) paramGetCreateRequest(xMSClientRequestId string) (*azcore.Request, error) {
 	urlPath := "/azurespecials/overwrite/x-ms-client-request-id/via-param/method/"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/booleangroup/bool.go
+++ b/test/autorest/generated/booleangroup/bool.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // BoolOperations contains the methods for the Bool group.
@@ -52,7 +53,7 @@ func (client *boolOperations) GetFalse(ctx context.Context) (*BoolResponse, erro
 // getFalseCreateRequest creates the GetFalse request.
 func (client *boolOperations) getFalseCreateRequest() (*azcore.Request, error) {
 	urlPath := "/bool/false"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +99,7 @@ func (client *boolOperations) GetInvalid(ctx context.Context) (*BoolResponse, er
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *boolOperations) getInvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/bool/invalid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +145,7 @@ func (client *boolOperations) GetNull(ctx context.Context) (*BoolResponse, error
 // getNullCreateRequest creates the GetNull request.
 func (client *boolOperations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/bool/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +191,7 @@ func (client *boolOperations) GetTrue(ctx context.Context) (*BoolResponse, error
 // getTrueCreateRequest creates the GetTrue request.
 func (client *boolOperations) getTrueCreateRequest() (*azcore.Request, error) {
 	urlPath := "/bool/true"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +237,7 @@ func (client *boolOperations) PutFalse(ctx context.Context) (*http.Response, err
 // putFalseCreateRequest creates the PutFalse request.
 func (client *boolOperations) putFalseCreateRequest() (*azcore.Request, error) {
 	urlPath := "/bool/false"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +282,7 @@ func (client *boolOperations) PutTrue(ctx context.Context) (*http.Response, erro
 // putTrueCreateRequest creates the PutTrue request.
 func (client *boolOperations) putTrueCreateRequest() (*azcore.Request, error) {
 	urlPath := "/bool/true"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/bytegroup/byte.go
+++ b/test/autorest/generated/bytegroup/byte.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // ByteOperations contains the methods for the Byte group.
@@ -50,7 +51,7 @@ func (client *byteOperations) GetEmpty(ctx context.Context) (*ByteArrayResponse,
 // getEmptyCreateRequest creates the GetEmpty request.
 func (client *byteOperations) getEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/byte/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +97,7 @@ func (client *byteOperations) GetInvalid(ctx context.Context) (*ByteArrayRespons
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *byteOperations) getInvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/byte/invalid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +143,7 @@ func (client *byteOperations) GetNonASCII(ctx context.Context) (*ByteArrayRespon
 // getNonAsciiCreateRequest creates the GetNonASCII request.
 func (client *byteOperations) getNonAsciiCreateRequest() (*azcore.Request, error) {
 	urlPath := "/byte/nonAscii"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +189,7 @@ func (client *byteOperations) GetNull(ctx context.Context) (*ByteArrayResponse, 
 // getNullCreateRequest creates the GetNull request.
 func (client *byteOperations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/byte/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +235,7 @@ func (client *byteOperations) PutNonASCII(ctx context.Context, byteBody []byte) 
 // putNonAsciiCreateRequest creates the PutNonASCII request.
 func (client *byteOperations) putNonAsciiCreateRequest(byteBody []byte) (*azcore.Request, error) {
 	urlPath := "/byte/nonAscii"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/array.go
+++ b/test/autorest/generated/complexgroup/array.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // ArrayOperations contains the methods for the Array group.
@@ -50,7 +51,7 @@ func (client *arrayOperations) GetEmpty(ctx context.Context) (*ArrayWrapperRespo
 // getEmptyCreateRequest creates the GetEmpty request.
 func (client *arrayOperations) getEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/array/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +97,7 @@ func (client *arrayOperations) GetNotProvided(ctx context.Context) (*ArrayWrappe
 // getNotProvidedCreateRequest creates the GetNotProvided request.
 func (client *arrayOperations) getNotProvidedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/array/notprovided"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +143,7 @@ func (client *arrayOperations) GetValid(ctx context.Context) (*ArrayWrapperRespo
 // getValidCreateRequest creates the GetValid request.
 func (client *arrayOperations) getValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/array/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +189,7 @@ func (client *arrayOperations) PutEmpty(ctx context.Context, complexBody ArrayWr
 // putEmptyCreateRequest creates the PutEmpty request.
 func (client *arrayOperations) putEmptyCreateRequest(complexBody ArrayWrapper) (*azcore.Request, error) {
 	urlPath := "/complex/array/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +234,7 @@ func (client *arrayOperations) PutValid(ctx context.Context, complexBody ArrayWr
 // putValidCreateRequest creates the PutValid request.
 func (client *arrayOperations) putValidCreateRequest(complexBody ArrayWrapper) (*azcore.Request, error) {
 	urlPath := "/complex/array/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/basic.go
+++ b/test/autorest/generated/complexgroup/basic.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // BasicOperations contains the methods for the Basic group.
@@ -52,7 +53,7 @@ func (client *basicOperations) GetEmpty(ctx context.Context) (*BasicResponse, er
 // getEmptyCreateRequest creates the GetEmpty request.
 func (client *basicOperations) getEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/basic/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +99,7 @@ func (client *basicOperations) GetInvalid(ctx context.Context) (*BasicResponse, 
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *basicOperations) getInvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/basic/invalid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +145,7 @@ func (client *basicOperations) GetNotProvided(ctx context.Context) (*BasicRespon
 // getNotProvidedCreateRequest creates the GetNotProvided request.
 func (client *basicOperations) getNotProvidedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/basic/notprovided"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +191,7 @@ func (client *basicOperations) GetNull(ctx context.Context) (*BasicResponse, err
 // getNullCreateRequest creates the GetNull request.
 func (client *basicOperations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/basic/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +237,7 @@ func (client *basicOperations) GetValid(ctx context.Context) (*BasicResponse, er
 // getValidCreateRequest creates the GetValid request.
 func (client *basicOperations) getValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/basic/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +283,7 @@ func (client *basicOperations) PutValid(ctx context.Context, complexBody Basic) 
 // putValidCreateRequest creates the PutValid request.
 func (client *basicOperations) putValidCreateRequest(complexBody Basic) (*azcore.Request, error) {
 	urlPath := "/complex/basic/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/dictionary.go
+++ b/test/autorest/generated/complexgroup/dictionary.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // DictionaryOperations contains the methods for the Dictionary group.
@@ -52,7 +53,7 @@ func (client *dictionaryOperations) GetEmpty(ctx context.Context) (*DictionaryWr
 // getEmptyCreateRequest creates the GetEmpty request.
 func (client *dictionaryOperations) getEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/dictionary/typed/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +99,7 @@ func (client *dictionaryOperations) GetNotProvided(ctx context.Context) (*Dictio
 // getNotProvidedCreateRequest creates the GetNotProvided request.
 func (client *dictionaryOperations) getNotProvidedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/dictionary/typed/notprovided"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +145,7 @@ func (client *dictionaryOperations) GetNull(ctx context.Context) (*DictionaryWra
 // getNullCreateRequest creates the GetNull request.
 func (client *dictionaryOperations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/dictionary/typed/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +191,7 @@ func (client *dictionaryOperations) GetValid(ctx context.Context) (*DictionaryWr
 // getValidCreateRequest creates the GetValid request.
 func (client *dictionaryOperations) getValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/dictionary/typed/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +237,7 @@ func (client *dictionaryOperations) PutEmpty(ctx context.Context, complexBody Di
 // putEmptyCreateRequest creates the PutEmpty request.
 func (client *dictionaryOperations) putEmptyCreateRequest(complexBody DictionaryWrapper) (*azcore.Request, error) {
 	urlPath := "/complex/dictionary/typed/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +282,7 @@ func (client *dictionaryOperations) PutValid(ctx context.Context, complexBody Di
 // putValidCreateRequest creates the PutValid request.
 func (client *dictionaryOperations) putValidCreateRequest(complexBody DictionaryWrapper) (*azcore.Request, error) {
 	urlPath := "/complex/dictionary/typed/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/flattencomplex.go
+++ b/test/autorest/generated/complexgroup/flattencomplex.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"io/ioutil"
 	"net/http"
+	"path"
 )
 
 // FlattencomplexOperations contains the methods for the Flattencomplex group.
@@ -43,7 +44,7 @@ func (client *flattencomplexOperations) GetValid(ctx context.Context) (*MyBaseTy
 // getValidCreateRequest creates the GetValid request.
 func (client *flattencomplexOperations) getValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/flatten/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/inheritance.go
+++ b/test/autorest/generated/complexgroup/inheritance.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // InheritanceOperations contains the methods for the Inheritance group.
@@ -44,7 +45,7 @@ func (client *inheritanceOperations) GetValid(ctx context.Context) (*SiameseResp
 // getValidCreateRequest creates the GetValid request.
 func (client *inheritanceOperations) getValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/inheritance/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +91,7 @@ func (client *inheritanceOperations) PutValid(ctx context.Context, complexBody S
 // putValidCreateRequest creates the PutValid request.
 func (client *inheritanceOperations) putValidCreateRequest(complexBody Siamese) (*azcore.Request, error) {
 	urlPath := "/complex/inheritance/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/polymorphicrecursive.go
+++ b/test/autorest/generated/complexgroup/polymorphicrecursive.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // PolymorphicrecursiveOperations contains the methods for the Polymorphicrecursive group.
@@ -44,7 +45,7 @@ func (client *polymorphicrecursiveOperations) GetValid(ctx context.Context) (*Fi
 // getValidCreateRequest creates the GetValid request.
 func (client *polymorphicrecursiveOperations) getValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/polymorphicrecursive/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +91,7 @@ func (client *polymorphicrecursiveOperations) PutValid(ctx context.Context, comp
 // putValidCreateRequest creates the PutValid request.
 func (client *polymorphicrecursiveOperations) putValidCreateRequest(complexBody FishClassification) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphicrecursive/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/polymorphism.go
+++ b/test/autorest/generated/complexgroup/polymorphism.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // PolymorphismOperations contains the methods for the Polymorphism group.
@@ -58,7 +59,7 @@ func (client *polymorphismOperations) GetComplicated(ctx context.Context) (*Salm
 // getComplicatedCreateRequest creates the GetComplicated request.
 func (client *polymorphismOperations) getComplicatedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/complicated"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +105,7 @@ func (client *polymorphismOperations) GetComposedWithDiscriminator(ctx context.C
 // getComposedWithDiscriminatorCreateRequest creates the GetComposedWithDiscriminator request.
 func (client *polymorphismOperations) getComposedWithDiscriminatorCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/composedWithDiscriminator"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +151,7 @@ func (client *polymorphismOperations) GetComposedWithoutDiscriminator(ctx contex
 // getComposedWithoutDiscriminatorCreateRequest creates the GetComposedWithoutDiscriminator request.
 func (client *polymorphismOperations) getComposedWithoutDiscriminatorCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/composedWithoutDiscriminator"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +197,7 @@ func (client *polymorphismOperations) GetDotSyntax(ctx context.Context) (*DotFis
 // getDotSyntaxCreateRequest creates the GetDotSyntax request.
 func (client *polymorphismOperations) getDotSyntaxCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/dotsyntax"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +243,7 @@ func (client *polymorphismOperations) GetValid(ctx context.Context) (*FishRespon
 // getValidCreateRequest creates the GetValid request.
 func (client *polymorphismOperations) getValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *polymorphismOperations) PutComplicated(ctx context.Context, comple
 // putComplicatedCreateRequest creates the PutComplicated request.
 func (client *polymorphismOperations) putComplicatedCreateRequest(complexBody SalmonClassification) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/complicated"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -333,7 +334,7 @@ func (client *polymorphismOperations) PutMissingDiscriminator(ctx context.Contex
 // putMissingDiscriminatorCreateRequest creates the PutMissingDiscriminator request.
 func (client *polymorphismOperations) putMissingDiscriminatorCreateRequest(complexBody SalmonClassification) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/missingdiscriminator"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +380,7 @@ func (client *polymorphismOperations) PutValid(ctx context.Context, complexBody 
 // putValidCreateRequest creates the PutValid request.
 func (client *polymorphismOperations) putValidCreateRequest(complexBody FishClassification) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -424,7 +425,7 @@ func (client *polymorphismOperations) PutValidMissingRequired(ctx context.Contex
 // putValidMissingRequiredCreateRequest creates the PutValidMissingRequired request.
 func (client *polymorphismOperations) putValidMissingRequiredCreateRequest(complexBody FishClassification) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/missingrequired/invalid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/primitive.go
+++ b/test/autorest/generated/complexgroup/primitive.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // PrimitiveOperations contains the methods for the Primitive group.
@@ -84,7 +85,7 @@ func (client *primitiveOperations) GetBool(ctx context.Context) (*BooleanWrapper
 // getBoolCreateRequest creates the GetBool request.
 func (client *primitiveOperations) getBoolCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/primitive/bool"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +131,7 @@ func (client *primitiveOperations) GetByte(ctx context.Context) (*ByteWrapperRes
 // getByteCreateRequest creates the GetByte request.
 func (client *primitiveOperations) getByteCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/primitive/byte"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +177,7 @@ func (client *primitiveOperations) GetDate(ctx context.Context) (*DateWrapperRes
 // getDateCreateRequest creates the GetDate request.
 func (client *primitiveOperations) getDateCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/primitive/date"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +223,7 @@ func (client *primitiveOperations) GetDateTime(ctx context.Context) (*DatetimeWr
 // getDateTimeCreateRequest creates the GetDateTime request.
 func (client *primitiveOperations) getDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/primitive/datetime"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +269,7 @@ func (client *primitiveOperations) GetDateTimeRFC1123(ctx context.Context) (*Dat
 // getDateTimeRfc1123CreateRequest creates the GetDateTimeRFC1123 request.
 func (client *primitiveOperations) getDateTimeRfc1123CreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/primitive/datetimerfc1123"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +315,7 @@ func (client *primitiveOperations) GetDouble(ctx context.Context) (*DoubleWrappe
 // getDoubleCreateRequest creates the GetDouble request.
 func (client *primitiveOperations) getDoubleCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/primitive/double"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +361,7 @@ func (client *primitiveOperations) GetDuration(ctx context.Context) (*DurationWr
 // getDurationCreateRequest creates the GetDuration request.
 func (client *primitiveOperations) getDurationCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/primitive/duration"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -406,7 +407,7 @@ func (client *primitiveOperations) GetFloat(ctx context.Context) (*FloatWrapperR
 // getFloatCreateRequest creates the GetFloat request.
 func (client *primitiveOperations) getFloatCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/primitive/float"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -452,7 +453,7 @@ func (client *primitiveOperations) GetInt(ctx context.Context) (*IntWrapperRespo
 // getIntCreateRequest creates the GetInt request.
 func (client *primitiveOperations) getIntCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/primitive/integer"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -498,7 +499,7 @@ func (client *primitiveOperations) GetLong(ctx context.Context) (*LongWrapperRes
 // getLongCreateRequest creates the GetLong request.
 func (client *primitiveOperations) getLongCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/primitive/long"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -544,7 +545,7 @@ func (client *primitiveOperations) GetString(ctx context.Context) (*StringWrappe
 // getStringCreateRequest creates the GetString request.
 func (client *primitiveOperations) getStringCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/primitive/string"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -590,7 +591,7 @@ func (client *primitiveOperations) PutBool(ctx context.Context, complexBody Bool
 // putBoolCreateRequest creates the PutBool request.
 func (client *primitiveOperations) putBoolCreateRequest(complexBody BooleanWrapper) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/bool"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -635,7 +636,7 @@ func (client *primitiveOperations) PutByte(ctx context.Context, complexBody Byte
 // putByteCreateRequest creates the PutByte request.
 func (client *primitiveOperations) putByteCreateRequest(complexBody ByteWrapper) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/byte"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -680,7 +681,7 @@ func (client *primitiveOperations) PutDate(ctx context.Context, complexBody Date
 // putDateCreateRequest creates the PutDate request.
 func (client *primitiveOperations) putDateCreateRequest(complexBody DateWrapper) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/date"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -725,7 +726,7 @@ func (client *primitiveOperations) PutDateTime(ctx context.Context, complexBody 
 // putDateTimeCreateRequest creates the PutDateTime request.
 func (client *primitiveOperations) putDateTimeCreateRequest(complexBody DatetimeWrapper) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/datetime"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -770,7 +771,7 @@ func (client *primitiveOperations) PutDateTimeRFC1123(ctx context.Context, compl
 // putDateTimeRfc1123CreateRequest creates the PutDateTimeRFC1123 request.
 func (client *primitiveOperations) putDateTimeRfc1123CreateRequest(complexBody Datetimerfc1123Wrapper) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/datetimerfc1123"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -815,7 +816,7 @@ func (client *primitiveOperations) PutDouble(ctx context.Context, complexBody Do
 // putDoubleCreateRequest creates the PutDouble request.
 func (client *primitiveOperations) putDoubleCreateRequest(complexBody DoubleWrapper) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/double"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -860,7 +861,7 @@ func (client *primitiveOperations) PutDuration(ctx context.Context, complexBody 
 // putDurationCreateRequest creates the PutDuration request.
 func (client *primitiveOperations) putDurationCreateRequest(complexBody DurationWrapper) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/duration"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -905,7 +906,7 @@ func (client *primitiveOperations) PutFloat(ctx context.Context, complexBody Flo
 // putFloatCreateRequest creates the PutFloat request.
 func (client *primitiveOperations) putFloatCreateRequest(complexBody FloatWrapper) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/float"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -950,7 +951,7 @@ func (client *primitiveOperations) PutInt(ctx context.Context, complexBody IntWr
 // putIntCreateRequest creates the PutInt request.
 func (client *primitiveOperations) putIntCreateRequest(complexBody IntWrapper) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/integer"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -995,7 +996,7 @@ func (client *primitiveOperations) PutLong(ctx context.Context, complexBody Long
 // putLongCreateRequest creates the PutLong request.
 func (client *primitiveOperations) putLongCreateRequest(complexBody LongWrapper) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/long"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1040,7 +1041,7 @@ func (client *primitiveOperations) PutString(ctx context.Context, complexBody St
 // putStringCreateRequest creates the PutString request.
 func (client *primitiveOperations) putStringCreateRequest(complexBody StringWrapper) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/string"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/readonlyproperty.go
+++ b/test/autorest/generated/complexgroup/readonlyproperty.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // ReadonlypropertyOperations contains the methods for the Readonlyproperty group.
@@ -44,7 +45,7 @@ func (client *readonlypropertyOperations) GetValid(ctx context.Context) (*Readon
 // getValidCreateRequest creates the GetValid request.
 func (client *readonlypropertyOperations) getValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/complex/readonlyproperty/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +91,7 @@ func (client *readonlypropertyOperations) PutValid(ctx context.Context, complexB
 // putValidCreateRequest creates the PutValid request.
 func (client *readonlypropertyOperations) putValidCreateRequest(complexBody ReadonlyObj) (*azcore.Request, error) {
 	urlPath := "/complex/readonlyproperty/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexmodelgroup/complexmodelclient.go
+++ b/test/autorest/generated/complexmodelgroup/complexmodelclient.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -50,7 +51,7 @@ func (client *complexModelClientOperations) createCreateRequest(subscriptionId s
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +102,7 @@ func (client *complexModelClientOperations) listCreateRequest(resourceGroupName 
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape("123456"))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +153,7 @@ func (client *complexModelClientOperations) updateCreateRequest(subscriptionId s
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/datetimegroup/datetime.go
+++ b/test/autorest/generated/datetimegroup/datetime.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -85,7 +86,7 @@ func (client *datetimeOperations) GetInvalid(ctx context.Context) (*TimeResponse
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *datetimeOperations) getInvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/invalid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +133,7 @@ func (client *datetimeOperations) GetLocalNegativeOffsetLowercaseMaxDateTime(ctx
 // getLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest creates the GetLocalNegativeOffsetLowercaseMaxDateTime request.
 func (client *datetimeOperations) getLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/max/localnegativeoffset/lowercase"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +180,7 @@ func (client *datetimeOperations) GetLocalNegativeOffsetMinDateTime(ctx context.
 // getLocalNegativeOffsetMinDateTimeCreateRequest creates the GetLocalNegativeOffsetMinDateTime request.
 func (client *datetimeOperations) getLocalNegativeOffsetMinDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/min/localnegativeoffset"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *datetimeOperations) GetLocalNegativeOffsetUppercaseMaxDateTime(ctx
 // getLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest creates the GetLocalNegativeOffsetUppercaseMaxDateTime request.
 func (client *datetimeOperations) getLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/max/localnegativeoffset/uppercase"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +274,7 @@ func (client *datetimeOperations) GetLocalNoOffsetMinDateTime(ctx context.Contex
 // getLocalNoOffsetMinDateTimeCreateRequest creates the GetLocalNoOffsetMinDateTime request.
 func (client *datetimeOperations) getLocalNoOffsetMinDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/min/localnooffset"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +321,7 @@ func (client *datetimeOperations) GetLocalPositiveOffsetLowercaseMaxDateTime(ctx
 // getLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest creates the GetLocalPositiveOffsetLowercaseMaxDateTime request.
 func (client *datetimeOperations) getLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/max/localpositiveoffset/lowercase"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -367,7 +368,7 @@ func (client *datetimeOperations) GetLocalPositiveOffsetMinDateTime(ctx context.
 // getLocalPositiveOffsetMinDateTimeCreateRequest creates the GetLocalPositiveOffsetMinDateTime request.
 func (client *datetimeOperations) getLocalPositiveOffsetMinDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/min/localpositiveoffset"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -414,7 +415,7 @@ func (client *datetimeOperations) GetLocalPositiveOffsetUppercaseMaxDateTime(ctx
 // getLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest creates the GetLocalPositiveOffsetUppercaseMaxDateTime request.
 func (client *datetimeOperations) getLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/max/localpositiveoffset/uppercase"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -461,7 +462,7 @@ func (client *datetimeOperations) GetNull(ctx context.Context) (*TimeResponse, e
 // getNullCreateRequest creates the GetNull request.
 func (client *datetimeOperations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -508,7 +509,7 @@ func (client *datetimeOperations) GetOverflow(ctx context.Context) (*TimeRespons
 // getOverflowCreateRequest creates the GetOverflow request.
 func (client *datetimeOperations) getOverflowCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/overflow"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -555,7 +556,7 @@ func (client *datetimeOperations) GetUTCLowercaseMaxDateTime(ctx context.Context
 // getUtcLowercaseMaxDateTimeCreateRequest creates the GetUTCLowercaseMaxDateTime request.
 func (client *datetimeOperations) getUtcLowercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/max/utc/lowercase"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -602,7 +603,7 @@ func (client *datetimeOperations) GetUTCMinDateTime(ctx context.Context) (*TimeR
 // getUtcMinDateTimeCreateRequest creates the GetUTCMinDateTime request.
 func (client *datetimeOperations) getUtcMinDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/min/utc"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -649,7 +650,7 @@ func (client *datetimeOperations) GetUTCUppercaseMaxDateTime(ctx context.Context
 // getUtcUppercaseMaxDateTimeCreateRequest creates the GetUTCUppercaseMaxDateTime request.
 func (client *datetimeOperations) getUtcUppercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/max/utc/uppercase"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -696,7 +697,7 @@ func (client *datetimeOperations) GetUTCUppercaseMaxDateTime7Digits(ctx context.
 // getUtcUppercaseMaxDateTime7DigitsCreateRequest creates the GetUTCUppercaseMaxDateTime7Digits request.
 func (client *datetimeOperations) getUtcUppercaseMaxDateTime7DigitsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/max/utc7ms/uppercase"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -743,7 +744,7 @@ func (client *datetimeOperations) GetUnderflow(ctx context.Context) (*TimeRespon
 // getUnderflowCreateRequest creates the GetUnderflow request.
 func (client *datetimeOperations) getUnderflowCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetime/underflow"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -790,7 +791,7 @@ func (client *datetimeOperations) PutLocalNegativeOffsetMaxDateTime(ctx context.
 // putLocalNegativeOffsetMaxDateTimeCreateRequest creates the PutLocalNegativeOffsetMaxDateTime request.
 func (client *datetimeOperations) putLocalNegativeOffsetMaxDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetime/max/localnegativeoffset"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -835,7 +836,7 @@ func (client *datetimeOperations) PutLocalNegativeOffsetMinDateTime(ctx context.
 // putLocalNegativeOffsetMinDateTimeCreateRequest creates the PutLocalNegativeOffsetMinDateTime request.
 func (client *datetimeOperations) putLocalNegativeOffsetMinDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetime/min/localnegativeoffset"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -880,7 +881,7 @@ func (client *datetimeOperations) PutLocalPositiveOffsetMaxDateTime(ctx context.
 // putLocalPositiveOffsetMaxDateTimeCreateRequest creates the PutLocalPositiveOffsetMaxDateTime request.
 func (client *datetimeOperations) putLocalPositiveOffsetMaxDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetime/max/localpositiveoffset"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -925,7 +926,7 @@ func (client *datetimeOperations) PutLocalPositiveOffsetMinDateTime(ctx context.
 // putLocalPositiveOffsetMinDateTimeCreateRequest creates the PutLocalPositiveOffsetMinDateTime request.
 func (client *datetimeOperations) putLocalPositiveOffsetMinDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetime/min/localpositiveoffset"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -970,7 +971,7 @@ func (client *datetimeOperations) PutUTCMaxDateTime(ctx context.Context, datetim
 // putUtcMaxDateTimeCreateRequest creates the PutUTCMaxDateTime request.
 func (client *datetimeOperations) putUtcMaxDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetime/max/utc"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1015,7 +1016,7 @@ func (client *datetimeOperations) PutUTCMaxDateTime7Digits(ctx context.Context, 
 // putUtcMaxDateTime7DigitsCreateRequest creates the PutUTCMaxDateTime7Digits request.
 func (client *datetimeOperations) putUtcMaxDateTime7DigitsCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetime/max/utc7ms"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1060,7 +1061,7 @@ func (client *datetimeOperations) PutUTCMinDateTime(ctx context.Context, datetim
 // putUtcMinDateTimeCreateRequest creates the PutUTCMinDateTime request.
 func (client *datetimeOperations) putUtcMinDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetime/min/utc"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
+++ b/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -59,7 +60,7 @@ func (client *datetimerfc1123Operations) GetInvalid(ctx context.Context) (*TimeR
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *datetimerfc1123Operations) getInvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/invalid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +107,7 @@ func (client *datetimerfc1123Operations) GetNull(ctx context.Context) (*TimeResp
 // getNullCreateRequest creates the GetNull request.
 func (client *datetimerfc1123Operations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +154,7 @@ func (client *datetimerfc1123Operations) GetOverflow(ctx context.Context) (*Time
 // getOverflowCreateRequest creates the GetOverflow request.
 func (client *datetimerfc1123Operations) getOverflowCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/overflow"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +201,7 @@ func (client *datetimerfc1123Operations) GetUTCLowercaseMaxDateTime(ctx context.
 // getUtcLowercaseMaxDateTimeCreateRequest creates the GetUTCLowercaseMaxDateTime request.
 func (client *datetimerfc1123Operations) getUtcLowercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/max/lowercase"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +248,7 @@ func (client *datetimerfc1123Operations) GetUTCMinDateTime(ctx context.Context) 
 // getUtcMinDateTimeCreateRequest creates the GetUTCMinDateTime request.
 func (client *datetimerfc1123Operations) getUtcMinDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/min"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +295,7 @@ func (client *datetimerfc1123Operations) GetUTCUppercaseMaxDateTime(ctx context.
 // getUtcUppercaseMaxDateTimeCreateRequest creates the GetUTCUppercaseMaxDateTime request.
 func (client *datetimerfc1123Operations) getUtcUppercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/max/uppercase"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +342,7 @@ func (client *datetimerfc1123Operations) GetUnderflow(ctx context.Context) (*Tim
 // getUnderflowCreateRequest creates the GetUnderflow request.
 func (client *datetimerfc1123Operations) getUnderflowCreateRequest() (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/underflow"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +389,7 @@ func (client *datetimerfc1123Operations) PutUTCMaxDateTime(ctx context.Context, 
 // putUtcMaxDateTimeCreateRequest creates the PutUTCMaxDateTime request.
 func (client *datetimerfc1123Operations) putUtcMaxDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/max"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -434,7 +435,7 @@ func (client *datetimerfc1123Operations) PutUTCMinDateTime(ctx context.Context, 
 // putUtcMinDateTimeCreateRequest creates the PutUTCMinDateTime request.
 func (client *datetimerfc1123Operations) putUtcMinDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/min"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/dictionarygroup/dictionary.go
+++ b/test/autorest/generated/dictionarygroup/dictionary.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -171,7 +172,7 @@ func (client *dictionaryOperations) GetArrayEmpty(ctx context.Context) (*MapOfSt
 // getArrayEmptyCreateRequest creates the GetArrayEmpty request.
 func (client *dictionaryOperations) getArrayEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/array/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +218,7 @@ func (client *dictionaryOperations) GetArrayItemEmpty(ctx context.Context) (*Map
 // getArrayItemEmptyCreateRequest creates the GetArrayItemEmpty request.
 func (client *dictionaryOperations) getArrayItemEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/array/itemempty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +264,7 @@ func (client *dictionaryOperations) GetArrayItemNull(ctx context.Context) (*MapO
 // getArrayItemNullCreateRequest creates the GetArrayItemNull request.
 func (client *dictionaryOperations) getArrayItemNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/array/itemnull"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +310,7 @@ func (client *dictionaryOperations) GetArrayNull(ctx context.Context) (*MapOfStr
 // getArrayNullCreateRequest creates the GetArrayNull request.
 func (client *dictionaryOperations) getArrayNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/array/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +356,7 @@ func (client *dictionaryOperations) GetArrayValid(ctx context.Context) (*MapOfSt
 // getArrayValidCreateRequest creates the GetArrayValid request.
 func (client *dictionaryOperations) getArrayValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/array/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +402,7 @@ func (client *dictionaryOperations) GetBase64URL(ctx context.Context) (*MapOfByt
 // getBase64UrlCreateRequest creates the GetBase64URL request.
 func (client *dictionaryOperations) getBase64UrlCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/base64url/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +448,7 @@ func (client *dictionaryOperations) GetBooleanInvalidNull(ctx context.Context) (
 // getBooleanInvalidNullCreateRequest creates the GetBooleanInvalidNull request.
 func (client *dictionaryOperations) getBooleanInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/boolean/true.null.false"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -493,7 +494,7 @@ func (client *dictionaryOperations) GetBooleanInvalidString(ctx context.Context)
 // getBooleanInvalidStringCreateRequest creates the GetBooleanInvalidString request.
 func (client *dictionaryOperations) getBooleanInvalidStringCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/boolean/true.boolean.false"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -539,7 +540,7 @@ func (client *dictionaryOperations) GetBooleanTfft(ctx context.Context) (*MapOfB
 // getBooleanTfftCreateRequest creates the GetBooleanTfft request.
 func (client *dictionaryOperations) getBooleanTfftCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/boolean/tfft"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -585,7 +586,7 @@ func (client *dictionaryOperations) GetByteInvalidNull(ctx context.Context) (*Ma
 // getByteInvalidNullCreateRequest creates the GetByteInvalidNull request.
 func (client *dictionaryOperations) getByteInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/byte/invalidnull"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -631,7 +632,7 @@ func (client *dictionaryOperations) GetByteValid(ctx context.Context) (*MapOfByt
 // getByteValidCreateRequest creates the GetByteValid request.
 func (client *dictionaryOperations) getByteValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/byte/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -677,7 +678,7 @@ func (client *dictionaryOperations) GetComplexEmpty(ctx context.Context) (*MapOf
 // getComplexEmptyCreateRequest creates the GetComplexEmpty request.
 func (client *dictionaryOperations) getComplexEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/complex/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -723,7 +724,7 @@ func (client *dictionaryOperations) GetComplexItemEmpty(ctx context.Context) (*M
 // getComplexItemEmptyCreateRequest creates the GetComplexItemEmpty request.
 func (client *dictionaryOperations) getComplexItemEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/complex/itemempty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -769,7 +770,7 @@ func (client *dictionaryOperations) GetComplexItemNull(ctx context.Context) (*Ma
 // getComplexItemNullCreateRequest creates the GetComplexItemNull request.
 func (client *dictionaryOperations) getComplexItemNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/complex/itemnull"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -815,7 +816,7 @@ func (client *dictionaryOperations) GetComplexNull(ctx context.Context) (*MapOfW
 // getComplexNullCreateRequest creates the GetComplexNull request.
 func (client *dictionaryOperations) getComplexNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/complex/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -861,7 +862,7 @@ func (client *dictionaryOperations) GetComplexValid(ctx context.Context) (*MapOf
 // getComplexValidCreateRequest creates the GetComplexValid request.
 func (client *dictionaryOperations) getComplexValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/complex/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -907,7 +908,7 @@ func (client *dictionaryOperations) GetDateInvalidChars(ctx context.Context) (*M
 // getDateInvalidCharsCreateRequest creates the GetDateInvalidChars request.
 func (client *dictionaryOperations) getDateInvalidCharsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date/invalidchars"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -953,7 +954,7 @@ func (client *dictionaryOperations) GetDateInvalidNull(ctx context.Context) (*Ma
 // getDateInvalidNullCreateRequest creates the GetDateInvalidNull request.
 func (client *dictionaryOperations) getDateInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date/invalidnull"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -999,7 +1000,7 @@ func (client *dictionaryOperations) GetDateTimeInvalidChars(ctx context.Context)
 // getDateTimeInvalidCharsCreateRequest creates the GetDateTimeInvalidChars request.
 func (client *dictionaryOperations) getDateTimeInvalidCharsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date-time/invalidchars"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1052,7 +1053,7 @@ func (client *dictionaryOperations) GetDateTimeInvalidNull(ctx context.Context) 
 // getDateTimeInvalidNullCreateRequest creates the GetDateTimeInvalidNull request.
 func (client *dictionaryOperations) getDateTimeInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date-time/invalidnull"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1105,7 +1106,7 @@ func (client *dictionaryOperations) GetDateTimeRFC1123Valid(ctx context.Context)
 // getDateTimeRfc1123ValidCreateRequest creates the GetDateTimeRFC1123Valid request.
 func (client *dictionaryOperations) getDateTimeRfc1123ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date-time-rfc1123/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1158,7 +1159,7 @@ func (client *dictionaryOperations) GetDateTimeValid(ctx context.Context) (*MapO
 // getDateTimeValidCreateRequest creates the GetDateTimeValid request.
 func (client *dictionaryOperations) getDateTimeValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date-time/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1211,7 +1212,7 @@ func (client *dictionaryOperations) GetDateValid(ctx context.Context) (*MapOfTim
 // getDateValidCreateRequest creates the GetDateValid request.
 func (client *dictionaryOperations) getDateValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1257,7 +1258,7 @@ func (client *dictionaryOperations) GetDictionaryEmpty(ctx context.Context) (*Ma
 // getDictionaryEmptyCreateRequest creates the GetDictionaryEmpty request.
 func (client *dictionaryOperations) getDictionaryEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/dictionary/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1303,7 +1304,7 @@ func (client *dictionaryOperations) GetDictionaryItemEmpty(ctx context.Context) 
 // getDictionaryItemEmptyCreateRequest creates the GetDictionaryItemEmpty request.
 func (client *dictionaryOperations) getDictionaryItemEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/dictionary/itemempty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1349,7 +1350,7 @@ func (client *dictionaryOperations) GetDictionaryItemNull(ctx context.Context) (
 // getDictionaryItemNullCreateRequest creates the GetDictionaryItemNull request.
 func (client *dictionaryOperations) getDictionaryItemNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/dictionary/itemnull"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1395,7 +1396,7 @@ func (client *dictionaryOperations) GetDictionaryNull(ctx context.Context) (*Map
 // getDictionaryNullCreateRequest creates the GetDictionaryNull request.
 func (client *dictionaryOperations) getDictionaryNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/dictionary/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1441,7 +1442,7 @@ func (client *dictionaryOperations) GetDictionaryValid(ctx context.Context) (*Ma
 // getDictionaryValidCreateRequest creates the GetDictionaryValid request.
 func (client *dictionaryOperations) getDictionaryValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/dictionary/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1487,7 +1488,7 @@ func (client *dictionaryOperations) GetDoubleInvalidNull(ctx context.Context) (*
 // getDoubleInvalidNullCreateRequest creates the GetDoubleInvalidNull request.
 func (client *dictionaryOperations) getDoubleInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/double/0.0-null-1.2e20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1533,7 +1534,7 @@ func (client *dictionaryOperations) GetDoubleInvalidString(ctx context.Context) 
 // getDoubleInvalidStringCreateRequest creates the GetDoubleInvalidString request.
 func (client *dictionaryOperations) getDoubleInvalidStringCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/double/1.number.0"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1579,7 +1580,7 @@ func (client *dictionaryOperations) GetDoubleValid(ctx context.Context) (*MapOfF
 // getDoubleValidCreateRequest creates the GetDoubleValid request.
 func (client *dictionaryOperations) getDoubleValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/double/0--0.01-1.2e20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1625,7 +1626,7 @@ func (client *dictionaryOperations) GetDurationValid(ctx context.Context) (*MapO
 // getDurationValidCreateRequest creates the GetDurationValid request.
 func (client *dictionaryOperations) getDurationValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/duration/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1671,7 +1672,7 @@ func (client *dictionaryOperations) GetEmpty(ctx context.Context) (*MapOfInt32Re
 // getEmptyCreateRequest creates the GetEmpty request.
 func (client *dictionaryOperations) getEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1717,7 +1718,7 @@ func (client *dictionaryOperations) GetEmptyStringKey(ctx context.Context) (*Map
 // getEmptyStringKeyCreateRequest creates the GetEmptyStringKey request.
 func (client *dictionaryOperations) getEmptyStringKeyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/keyemptystring"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1763,7 +1764,7 @@ func (client *dictionaryOperations) GetFloatInvalidNull(ctx context.Context) (*M
 // getFloatInvalidNullCreateRequest creates the GetFloatInvalidNull request.
 func (client *dictionaryOperations) getFloatInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/float/0.0-null-1.2e20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1809,7 +1810,7 @@ func (client *dictionaryOperations) GetFloatInvalidString(ctx context.Context) (
 // getFloatInvalidStringCreateRequest creates the GetFloatInvalidString request.
 func (client *dictionaryOperations) getFloatInvalidStringCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/float/1.number.0"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1855,7 +1856,7 @@ func (client *dictionaryOperations) GetFloatValid(ctx context.Context) (*MapOfFl
 // getFloatValidCreateRequest creates the GetFloatValid request.
 func (client *dictionaryOperations) getFloatValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/float/0--0.01-1.2e20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1901,7 +1902,7 @@ func (client *dictionaryOperations) GetIntInvalidNull(ctx context.Context) (*Map
 // getIntInvalidNullCreateRequest creates the GetIntInvalidNull request.
 func (client *dictionaryOperations) getIntInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/integer/1.null.zero"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1947,7 +1948,7 @@ func (client *dictionaryOperations) GetIntInvalidString(ctx context.Context) (*M
 // getIntInvalidStringCreateRequest creates the GetIntInvalidString request.
 func (client *dictionaryOperations) getIntInvalidStringCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/integer/1.integer.0"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1993,7 +1994,7 @@ func (client *dictionaryOperations) GetIntegerValid(ctx context.Context) (*MapOf
 // getIntegerValidCreateRequest creates the GetIntegerValid request.
 func (client *dictionaryOperations) getIntegerValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/integer/1.-1.3.300"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2039,7 +2040,7 @@ func (client *dictionaryOperations) GetInvalid(ctx context.Context) (*MapOfStrin
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *dictionaryOperations) getInvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/invalid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2085,7 +2086,7 @@ func (client *dictionaryOperations) GetLongInvalidNull(ctx context.Context) (*Ma
 // getLongInvalidNullCreateRequest creates the GetLongInvalidNull request.
 func (client *dictionaryOperations) getLongInvalidNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/long/1.null.zero"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2131,7 +2132,7 @@ func (client *dictionaryOperations) GetLongInvalidString(ctx context.Context) (*
 // getLongInvalidStringCreateRequest creates the GetLongInvalidString request.
 func (client *dictionaryOperations) getLongInvalidStringCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/long/1.integer.0"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2177,7 +2178,7 @@ func (client *dictionaryOperations) GetLongValid(ctx context.Context) (*MapOfInt
 // getLongValidCreateRequest creates the GetLongValid request.
 func (client *dictionaryOperations) getLongValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/long/1.-1.3.300"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2223,7 +2224,7 @@ func (client *dictionaryOperations) GetNull(ctx context.Context) (*MapOfInt32Res
 // getNullCreateRequest creates the GetNull request.
 func (client *dictionaryOperations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2269,7 +2270,7 @@ func (client *dictionaryOperations) GetNullKey(ctx context.Context) (*MapOfStrin
 // getNullKeyCreateRequest creates the GetNullKey request.
 func (client *dictionaryOperations) getNullKeyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/nullkey"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2315,7 +2316,7 @@ func (client *dictionaryOperations) GetNullValue(ctx context.Context) (*MapOfStr
 // getNullValueCreateRequest creates the GetNullValue request.
 func (client *dictionaryOperations) getNullValueCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/nullvalue"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2361,7 +2362,7 @@ func (client *dictionaryOperations) GetStringValid(ctx context.Context) (*MapOfS
 // getStringValidCreateRequest creates the GetStringValid request.
 func (client *dictionaryOperations) getStringValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/string/foo1.foo2.foo3"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2407,7 +2408,7 @@ func (client *dictionaryOperations) GetStringWithInvalid(ctx context.Context) (*
 // getStringWithInvalidCreateRequest creates the GetStringWithInvalid request.
 func (client *dictionaryOperations) getStringWithInvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/string/foo.123.foo2"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2453,7 +2454,7 @@ func (client *dictionaryOperations) GetStringWithNull(ctx context.Context) (*Map
 // getStringWithNullCreateRequest creates the GetStringWithNull request.
 func (client *dictionaryOperations) getStringWithNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/string/foo.null.foo2"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2499,7 +2500,7 @@ func (client *dictionaryOperations) PutArrayValid(ctx context.Context, arrayBody
 // putArrayValidCreateRequest creates the PutArrayValid request.
 func (client *dictionaryOperations) putArrayValidCreateRequest(arrayBody map[string][]string) (*azcore.Request, error) {
 	urlPath := "/dictionary/array/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2544,7 +2545,7 @@ func (client *dictionaryOperations) PutBooleanTfft(ctx context.Context, arrayBod
 // putBooleanTfftCreateRequest creates the PutBooleanTfft request.
 func (client *dictionaryOperations) putBooleanTfftCreateRequest(arrayBody map[string]bool) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/boolean/tfft"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2589,7 +2590,7 @@ func (client *dictionaryOperations) PutByteValid(ctx context.Context, arrayBody 
 // putByteValidCreateRequest creates the PutByteValid request.
 func (client *dictionaryOperations) putByteValidCreateRequest(arrayBody map[string][]byte) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/byte/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2634,7 +2635,7 @@ func (client *dictionaryOperations) PutComplexValid(ctx context.Context, arrayBo
 // putComplexValidCreateRequest creates the PutComplexValid request.
 func (client *dictionaryOperations) putComplexValidCreateRequest(arrayBody map[string]Widget) (*azcore.Request, error) {
 	urlPath := "/dictionary/complex/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2679,7 +2680,7 @@ func (client *dictionaryOperations) PutDateTimeRFC1123Valid(ctx context.Context,
 // putDateTimeRfc1123ValidCreateRequest creates the PutDateTimeRFC1123Valid request.
 func (client *dictionaryOperations) putDateTimeRfc1123ValidCreateRequest(arrayBody map[string]time.Time) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date-time-rfc1123/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2728,7 +2729,7 @@ func (client *dictionaryOperations) PutDateTimeValid(ctx context.Context, arrayB
 // putDateTimeValidCreateRequest creates the PutDateTimeValid request.
 func (client *dictionaryOperations) putDateTimeValidCreateRequest(arrayBody map[string]time.Time) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date-time/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2777,7 +2778,7 @@ func (client *dictionaryOperations) PutDateValid(ctx context.Context, arrayBody 
 // putDateValidCreateRequest creates the PutDateValid request.
 func (client *dictionaryOperations) putDateValidCreateRequest(arrayBody map[string]time.Time) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2822,7 +2823,7 @@ func (client *dictionaryOperations) PutDictionaryValid(ctx context.Context, arra
 // putDictionaryValidCreateRequest creates the PutDictionaryValid request.
 func (client *dictionaryOperations) putDictionaryValidCreateRequest(arrayBody map[string]interface{}) (*azcore.Request, error) {
 	urlPath := "/dictionary/dictionary/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2867,7 +2868,7 @@ func (client *dictionaryOperations) PutDoubleValid(ctx context.Context, arrayBod
 // putDoubleValidCreateRequest creates the PutDoubleValid request.
 func (client *dictionaryOperations) putDoubleValidCreateRequest(arrayBody map[string]float64) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/double/0--0.01-1.2e20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2912,7 +2913,7 @@ func (client *dictionaryOperations) PutDurationValid(ctx context.Context, arrayB
 // putDurationValidCreateRequest creates the PutDurationValid request.
 func (client *dictionaryOperations) putDurationValidCreateRequest(arrayBody map[string]time.Duration) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/duration/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2957,7 +2958,7 @@ func (client *dictionaryOperations) PutEmpty(ctx context.Context, arrayBody map[
 // putEmptyCreateRequest creates the PutEmpty request.
 func (client *dictionaryOperations) putEmptyCreateRequest(arrayBody map[string]string) (*azcore.Request, error) {
 	urlPath := "/dictionary/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3002,7 +3003,7 @@ func (client *dictionaryOperations) PutFloatValid(ctx context.Context, arrayBody
 // putFloatValidCreateRequest creates the PutFloatValid request.
 func (client *dictionaryOperations) putFloatValidCreateRequest(arrayBody map[string]float32) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/float/0--0.01-1.2e20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3047,7 +3048,7 @@ func (client *dictionaryOperations) PutIntegerValid(ctx context.Context, arrayBo
 // putIntegerValidCreateRequest creates the PutIntegerValid request.
 func (client *dictionaryOperations) putIntegerValidCreateRequest(arrayBody map[string]int32) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/integer/1.-1.3.300"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3092,7 +3093,7 @@ func (client *dictionaryOperations) PutLongValid(ctx context.Context, arrayBody 
 // putLongValidCreateRequest creates the PutLongValid request.
 func (client *dictionaryOperations) putLongValidCreateRequest(arrayBody map[string]int64) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/long/1.-1.3.300"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3137,7 +3138,7 @@ func (client *dictionaryOperations) PutStringValid(ctx context.Context, arrayBod
 // putStringValidCreateRequest creates the PutStringValid request.
 func (client *dictionaryOperations) putStringValidCreateRequest(arrayBody map[string]string) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/string/foo1.foo2.foo3"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/errorsgroup/pet.go
+++ b/test/autorest/generated/errorsgroup/pet.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -50,7 +51,7 @@ func (client *petOperations) DoSomething(ctx context.Context, whatAction string)
 func (client *petOperations) doSomethingCreateRequest(whatAction string) (*azcore.Request, error) {
 	urlPath := "/errorStatusCodes/Pets/doSomething/{whatAction}"
 	urlPath = strings.ReplaceAll(urlPath, "{whatAction}", url.PathEscape(whatAction))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +107,7 @@ func (client *petOperations) GetPetByID(ctx context.Context, petId string) (*Pet
 func (client *petOperations) getPetByIdCreateRequest(petId string) (*azcore.Request, error) {
 	urlPath := "/errorStatusCodes/Pets/{petId}/GetPet"
 	urlPath = strings.ReplaceAll(urlPath, "{petId}", url.PathEscape(petId))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/extenumsgroup/pet.go
+++ b/test/autorest/generated/extenumsgroup/pet.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -46,7 +47,7 @@ func (client *petOperations) AddPet(ctx context.Context, petAddPetOptions *PetAd
 // addPetCreateRequest creates the AddPet request.
 func (client *petOperations) addPetCreateRequest(petAddPetOptions *PetAddPetOptions) (*azcore.Request, error) {
 	urlPath := "/extensibleenums/pet/addPet"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +99,7 @@ func (client *petOperations) GetByPetID(ctx context.Context, petId string) (*Pet
 func (client *petOperations) getByPetIdCreateRequest(petId string) (*azcore.Request, error) {
 	urlPath := "/extensibleenums/pet/{petId}"
 	urlPath = strings.ReplaceAll(urlPath, "{petId}", url.PathEscape(petId))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/filegroup/files.go
+++ b/test/autorest/generated/filegroup/files.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // FilesOperations contains the methods for the Files group.
@@ -46,7 +47,7 @@ func (client *filesOperations) GetEmptyFile(ctx context.Context) (*http.Response
 // getEmptyFileCreateRequest creates the GetEmptyFile request.
 func (client *filesOperations) getEmptyFileCreateRequest() (*azcore.Request, error) {
 	urlPath := "/files/stream/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +93,7 @@ func (client *filesOperations) GetFile(ctx context.Context) (*http.Response, err
 // getFileCreateRequest creates the GetFile request.
 func (client *filesOperations) getFileCreateRequest() (*azcore.Request, error) {
 	urlPath := "/files/stream/nonempty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +139,7 @@ func (client *filesOperations) GetFileLarge(ctx context.Context) (*http.Response
 // getFileLargeCreateRequest creates the GetFileLarge request.
 func (client *filesOperations) getFileLargeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/files/stream/verylarge"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/headergroup/header.go
+++ b/test/autorest/generated/headergroup/header.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 	"strconv"
 	"time"
 )
@@ -101,7 +102,7 @@ func (client *headerOperations) CustomRequestID(ctx context.Context) (*http.Resp
 // customRequestIdCreateRequest creates the CustomRequestID request.
 func (client *headerOperations) customRequestIdCreateRequest() (*azcore.Request, error) {
 	urlPath := "/header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +147,7 @@ func (client *headerOperations) ParamBool(ctx context.Context, scenario string, 
 // paramBoolCreateRequest creates the ParamBool request.
 func (client *headerOperations) paramBoolCreateRequest(scenario string, value bool) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/bool"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +194,7 @@ func (client *headerOperations) ParamByte(ctx context.Context, scenario string, 
 // paramByteCreateRequest creates the ParamByte request.
 func (client *headerOperations) paramByteCreateRequest(scenario string, value []byte) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/byte"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +241,7 @@ func (client *headerOperations) ParamDate(ctx context.Context, scenario string, 
 // paramDateCreateRequest creates the ParamDate request.
 func (client *headerOperations) paramDateCreateRequest(scenario string, value time.Time) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/date"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +288,7 @@ func (client *headerOperations) ParamDatetime(ctx context.Context, scenario stri
 // paramDatetimeCreateRequest creates the ParamDatetime request.
 func (client *headerOperations) paramDatetimeCreateRequest(scenario string, value time.Time) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/datetime"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +335,7 @@ func (client *headerOperations) ParamDatetimeRFC1123(ctx context.Context, scenar
 // paramDatetimeRfc1123CreateRequest creates the ParamDatetimeRFC1123 request.
 func (client *headerOperations) paramDatetimeRfc1123CreateRequest(scenario string, headerParamDatetimeRfc1123Options *HeaderParamDatetimeRFC1123Options) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/datetimerfc1123"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -383,7 +384,7 @@ func (client *headerOperations) ParamDouble(ctx context.Context, scenario string
 // paramDoubleCreateRequest creates the ParamDouble request.
 func (client *headerOperations) paramDoubleCreateRequest(scenario string, value float64) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/double"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +431,7 @@ func (client *headerOperations) ParamDuration(ctx context.Context, scenario stri
 // paramDurationCreateRequest creates the ParamDuration request.
 func (client *headerOperations) paramDurationCreateRequest(scenario string, value time.Duration) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/duration"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -477,7 +478,7 @@ func (client *headerOperations) ParamEnum(ctx context.Context, scenario string, 
 // paramEnumCreateRequest creates the ParamEnum request.
 func (client *headerOperations) paramEnumCreateRequest(scenario string, headerParamEnumOptions *HeaderParamEnumOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/enum"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -526,7 +527,7 @@ func (client *headerOperations) ParamExistingKey(ctx context.Context, userAgent 
 // paramExistingKeyCreateRequest creates the ParamExistingKey request.
 func (client *headerOperations) paramExistingKeyCreateRequest(userAgent string) (*azcore.Request, error) {
 	urlPath := "/header/param/existingkey"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -572,7 +573,7 @@ func (client *headerOperations) ParamFloat(ctx context.Context, scenario string,
 // paramFloatCreateRequest creates the ParamFloat request.
 func (client *headerOperations) paramFloatCreateRequest(scenario string, value float32) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/float"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -619,7 +620,7 @@ func (client *headerOperations) ParamInteger(ctx context.Context, scenario strin
 // paramIntegerCreateRequest creates the ParamInteger request.
 func (client *headerOperations) paramIntegerCreateRequest(scenario string, value int32) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/integer"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -666,7 +667,7 @@ func (client *headerOperations) ParamLong(ctx context.Context, scenario string, 
 // paramLongCreateRequest creates the ParamLong request.
 func (client *headerOperations) paramLongCreateRequest(scenario string, value int64) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/long"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -713,7 +714,7 @@ func (client *headerOperations) ParamProtectedKey(ctx context.Context, contentTy
 // paramProtectedKeyCreateRequest creates the ParamProtectedKey request.
 func (client *headerOperations) paramProtectedKeyCreateRequest(contentType string) (*azcore.Request, error) {
 	urlPath := "/header/param/protectedkey"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -759,7 +760,7 @@ func (client *headerOperations) ParamString(ctx context.Context, scenario string
 // paramStringCreateRequest creates the ParamString request.
 func (client *headerOperations) paramStringCreateRequest(scenario string, headerParamStringOptions *HeaderParamStringOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/string"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -808,7 +809,7 @@ func (client *headerOperations) ResponseBool(ctx context.Context, scenario strin
 // responseBoolCreateRequest creates the ResponseBool request.
 func (client *headerOperations) responseBoolCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/bool"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -862,7 +863,7 @@ func (client *headerOperations) ResponseByte(ctx context.Context, scenario strin
 // responseByteCreateRequest creates the ResponseByte request.
 func (client *headerOperations) responseByteCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/byte"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -916,7 +917,7 @@ func (client *headerOperations) ResponseDate(ctx context.Context, scenario strin
 // responseDateCreateRequest creates the ResponseDate request.
 func (client *headerOperations) responseDateCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/date"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -970,7 +971,7 @@ func (client *headerOperations) ResponseDatetime(ctx context.Context, scenario s
 // responseDatetimeCreateRequest creates the ResponseDatetime request.
 func (client *headerOperations) responseDatetimeCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/datetime"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1024,7 +1025,7 @@ func (client *headerOperations) ResponseDatetimeRFC1123(ctx context.Context, sce
 // responseDatetimeRfc1123CreateRequest creates the ResponseDatetimeRFC1123 request.
 func (client *headerOperations) responseDatetimeRfc1123CreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/datetimerfc1123"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1078,7 +1079,7 @@ func (client *headerOperations) ResponseDouble(ctx context.Context, scenario str
 // responseDoubleCreateRequest creates the ResponseDouble request.
 func (client *headerOperations) responseDoubleCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/double"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1132,7 +1133,7 @@ func (client *headerOperations) ResponseDuration(ctx context.Context, scenario s
 // responseDurationCreateRequest creates the ResponseDuration request.
 func (client *headerOperations) responseDurationCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/duration"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1186,7 +1187,7 @@ func (client *headerOperations) ResponseEnum(ctx context.Context, scenario strin
 // responseEnumCreateRequest creates the ResponseEnum request.
 func (client *headerOperations) responseEnumCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/enum"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1236,7 +1237,7 @@ func (client *headerOperations) ResponseExistingKey(ctx context.Context) (*Heade
 // responseExistingKeyCreateRequest creates the ResponseExistingKey request.
 func (client *headerOperations) responseExistingKeyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/header/response/existingkey"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1285,7 +1286,7 @@ func (client *headerOperations) ResponseFloat(ctx context.Context, scenario stri
 // responseFloatCreateRequest creates the ResponseFloat request.
 func (client *headerOperations) responseFloatCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/float"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1340,7 +1341,7 @@ func (client *headerOperations) ResponseInteger(ctx context.Context, scenario st
 // responseIntegerCreateRequest creates the ResponseInteger request.
 func (client *headerOperations) responseIntegerCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/integer"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1395,7 +1396,7 @@ func (client *headerOperations) ResponseLong(ctx context.Context, scenario strin
 // responseLongCreateRequest creates the ResponseLong request.
 func (client *headerOperations) responseLongCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/long"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1449,7 +1450,7 @@ func (client *headerOperations) ResponseProtectedKey(ctx context.Context) (*Head
 // responseProtectedKeyCreateRequest creates the ResponseProtectedKey request.
 func (client *headerOperations) responseProtectedKeyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/header/response/protectedkey"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1498,7 +1499,7 @@ func (client *headerOperations) ResponseString(ctx context.Context, scenario str
 // responseStringCreateRequest creates the ResponseString request.
 func (client *headerOperations) responseStringCreateRequest(scenario string) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/string"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpclientfailure.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpclientfailure.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // HTTPClientFailureOperations contains the methods for the HTTPClientFailure group.
@@ -92,7 +93,7 @@ func (client *httpClientFailureOperations) Delete400(ctx context.Context) (*http
 // delete400CreateRequest creates the Delete400 request.
 func (client *httpClientFailureOperations) delete400CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +135,7 @@ func (client *httpClientFailureOperations) Delete407(ctx context.Context) (*http
 // delete407CreateRequest creates the Delete407 request.
 func (client *httpClientFailureOperations) delete407CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/407"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +177,7 @@ func (client *httpClientFailureOperations) Delete417(ctx context.Context) (*http
 // delete417CreateRequest creates the Delete417 request.
 func (client *httpClientFailureOperations) delete417CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/417"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +219,7 @@ func (client *httpClientFailureOperations) Get400(ctx context.Context) (*http.Re
 // get400CreateRequest creates the Get400 request.
 func (client *httpClientFailureOperations) get400CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +261,7 @@ func (client *httpClientFailureOperations) Get402(ctx context.Context) (*http.Re
 // get402CreateRequest creates the Get402 request.
 func (client *httpClientFailureOperations) get402CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/402"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +303,7 @@ func (client *httpClientFailureOperations) Get403(ctx context.Context) (*http.Re
 // get403CreateRequest creates the Get403 request.
 func (client *httpClientFailureOperations) get403CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/403"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +345,7 @@ func (client *httpClientFailureOperations) Get411(ctx context.Context) (*http.Re
 // get411CreateRequest creates the Get411 request.
 func (client *httpClientFailureOperations) get411CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/411"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -386,7 +387,7 @@ func (client *httpClientFailureOperations) Get412(ctx context.Context) (*http.Re
 // get412CreateRequest creates the Get412 request.
 func (client *httpClientFailureOperations) get412CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/412"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -428,7 +429,7 @@ func (client *httpClientFailureOperations) Get416(ctx context.Context) (*http.Re
 // get416CreateRequest creates the Get416 request.
 func (client *httpClientFailureOperations) get416CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/416"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -470,7 +471,7 @@ func (client *httpClientFailureOperations) Head400(ctx context.Context) (*http.R
 // head400CreateRequest creates the Head400 request.
 func (client *httpClientFailureOperations) head400CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -512,7 +513,7 @@ func (client *httpClientFailureOperations) Head401(ctx context.Context) (*http.R
 // head401CreateRequest creates the Head401 request.
 func (client *httpClientFailureOperations) head401CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/401"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -554,7 +555,7 @@ func (client *httpClientFailureOperations) Head410(ctx context.Context) (*http.R
 // head410CreateRequest creates the Head410 request.
 func (client *httpClientFailureOperations) head410CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/410"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -596,7 +597,7 @@ func (client *httpClientFailureOperations) Head429(ctx context.Context) (*http.R
 // head429CreateRequest creates the Head429 request.
 func (client *httpClientFailureOperations) head429CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/429"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -638,7 +639,7 @@ func (client *httpClientFailureOperations) Options400(ctx context.Context) (*htt
 // options400CreateRequest creates the Options400 request.
 func (client *httpClientFailureOperations) options400CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -680,7 +681,7 @@ func (client *httpClientFailureOperations) Options403(ctx context.Context) (*htt
 // options403CreateRequest creates the Options403 request.
 func (client *httpClientFailureOperations) options403CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/403"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -722,7 +723,7 @@ func (client *httpClientFailureOperations) Options412(ctx context.Context) (*htt
 // options412CreateRequest creates the Options412 request.
 func (client *httpClientFailureOperations) options412CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/412"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -764,7 +765,7 @@ func (client *httpClientFailureOperations) Patch400(ctx context.Context) (*http.
 // patch400CreateRequest creates the Patch400 request.
 func (client *httpClientFailureOperations) patch400CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -806,7 +807,7 @@ func (client *httpClientFailureOperations) Patch405(ctx context.Context) (*http.
 // patch405CreateRequest creates the Patch405 request.
 func (client *httpClientFailureOperations) patch405CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/405"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -848,7 +849,7 @@ func (client *httpClientFailureOperations) Patch414(ctx context.Context) (*http.
 // patch414CreateRequest creates the Patch414 request.
 func (client *httpClientFailureOperations) patch414CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/414"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -890,7 +891,7 @@ func (client *httpClientFailureOperations) Post400(ctx context.Context) (*http.R
 // post400CreateRequest creates the Post400 request.
 func (client *httpClientFailureOperations) post400CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -932,7 +933,7 @@ func (client *httpClientFailureOperations) Post406(ctx context.Context) (*http.R
 // post406CreateRequest creates the Post406 request.
 func (client *httpClientFailureOperations) post406CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/406"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -974,7 +975,7 @@ func (client *httpClientFailureOperations) Post415(ctx context.Context) (*http.R
 // post415CreateRequest creates the Post415 request.
 func (client *httpClientFailureOperations) post415CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/415"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1016,7 +1017,7 @@ func (client *httpClientFailureOperations) Put400(ctx context.Context) (*http.Re
 // put400CreateRequest creates the Put400 request.
 func (client *httpClientFailureOperations) put400CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1058,7 +1059,7 @@ func (client *httpClientFailureOperations) Put404(ctx context.Context) (*http.Re
 // put404CreateRequest creates the Put404 request.
 func (client *httpClientFailureOperations) put404CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/404"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1100,7 +1101,7 @@ func (client *httpClientFailureOperations) Put409(ctx context.Context) (*http.Re
 // put409CreateRequest creates the Put409 request.
 func (client *httpClientFailureOperations) put409CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/409"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1142,7 +1143,7 @@ func (client *httpClientFailureOperations) Put413(ctx context.Context) (*http.Re
 // put413CreateRequest creates the Put413 request.
 func (client *httpClientFailureOperations) put413CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/client/413"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpfailure.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpfailure.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"io/ioutil"
 	"net/http"
+	"path"
 )
 
 // HTTPFailureOperations contains the methods for the HTTPFailure group.
@@ -49,7 +50,7 @@ func (client *httpFailureOperations) GetEmptyError(ctx context.Context) (*BoolRe
 // getEmptyErrorCreateRequest creates the GetEmptyError request.
 func (client *httpFailureOperations) getEmptyErrorCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/emptybody/error"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +96,7 @@ func (client *httpFailureOperations) GetNoModelEmpty(ctx context.Context) (*Bool
 // getNoModelEmptyCreateRequest creates the GetNoModelEmpty request.
 func (client *httpFailureOperations) getNoModelEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/nomodel/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +145,7 @@ func (client *httpFailureOperations) GetNoModelError(ctx context.Context) (*Bool
 // getNoModelErrorCreateRequest creates the GetNoModelError request.
 func (client *httpFailureOperations) getNoModelErrorCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/nomodel/error"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpredirects.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpredirects.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // HTTPRedirectsOperations contains the methods for the HTTPRedirects group.
@@ -73,7 +74,7 @@ func (client *httpRedirectsOperations) Delete307(ctx context.Context) (*http.Res
 // delete307CreateRequest creates the Delete307 request.
 func (client *httpRedirectsOperations) delete307CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/307"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +120,7 @@ func (client *httpRedirectsOperations) Get300(ctx context.Context) (interface{},
 // get300CreateRequest creates the Get300 request.
 func (client *httpRedirectsOperations) get300CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/300"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +177,7 @@ func (client *httpRedirectsOperations) Get301(ctx context.Context) (*http.Respon
 // get301CreateRequest creates the Get301 request.
 func (client *httpRedirectsOperations) get301CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/301"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +222,7 @@ func (client *httpRedirectsOperations) Get302(ctx context.Context) (*http.Respon
 // get302CreateRequest creates the Get302 request.
 func (client *httpRedirectsOperations) get302CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/302"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +267,7 @@ func (client *httpRedirectsOperations) Get307(ctx context.Context) (*http.Respon
 // get307CreateRequest creates the Get307 request.
 func (client *httpRedirectsOperations) get307CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/307"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -311,7 +312,7 @@ func (client *httpRedirectsOperations) Head300(ctx context.Context) (*HTTPRedire
 // head300CreateRequest creates the Head300 request.
 func (client *httpRedirectsOperations) head300CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/300"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +361,7 @@ func (client *httpRedirectsOperations) Head301(ctx context.Context) (*http.Respo
 // head301CreateRequest creates the Head301 request.
 func (client *httpRedirectsOperations) head301CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/301"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +406,7 @@ func (client *httpRedirectsOperations) Head302(ctx context.Context) (*http.Respo
 // head302CreateRequest creates the Head302 request.
 func (client *httpRedirectsOperations) head302CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/302"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -450,7 +451,7 @@ func (client *httpRedirectsOperations) Head307(ctx context.Context) (*http.Respo
 // head307CreateRequest creates the Head307 request.
 func (client *httpRedirectsOperations) head307CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/307"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -495,7 +496,7 @@ func (client *httpRedirectsOperations) Options307(ctx context.Context) (*http.Re
 // options307CreateRequest creates the Options307 request.
 func (client *httpRedirectsOperations) options307CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/307"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -540,7 +541,7 @@ func (client *httpRedirectsOperations) Patch302(ctx context.Context) (*HTTPRedir
 // patch302CreateRequest creates the Patch302 request.
 func (client *httpRedirectsOperations) patch302CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/302"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -589,7 +590,7 @@ func (client *httpRedirectsOperations) Patch307(ctx context.Context) (*http.Resp
 // patch307CreateRequest creates the Patch307 request.
 func (client *httpRedirectsOperations) patch307CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/307"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -634,7 +635,7 @@ func (client *httpRedirectsOperations) Post303(ctx context.Context) (*HTTPRedire
 // post303CreateRequest creates the Post303 request.
 func (client *httpRedirectsOperations) post303CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/303"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -683,7 +684,7 @@ func (client *httpRedirectsOperations) Post307(ctx context.Context) (*http.Respo
 // post307CreateRequest creates the Post307 request.
 func (client *httpRedirectsOperations) post307CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/307"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -728,7 +729,7 @@ func (client *httpRedirectsOperations) Put301(ctx context.Context) (*HTTPRedirec
 // put301CreateRequest creates the Put301 request.
 func (client *httpRedirectsOperations) put301CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/301"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -777,7 +778,7 @@ func (client *httpRedirectsOperations) Put307(ctx context.Context) (*http.Respon
 // put307CreateRequest creates the Put307 request.
 func (client *httpRedirectsOperations) put307CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/redirect/307"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpretry.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpretry.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // HTTPRetryOperations contains the methods for the HTTPRetry group.
@@ -58,7 +59,7 @@ func (client *httpRetryOperations) Delete503(ctx context.Context) (*http.Respons
 // delete503CreateRequest creates the Delete503 request.
 func (client *httpRetryOperations) delete503CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/retry/503"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +104,7 @@ func (client *httpRetryOperations) Get502(ctx context.Context) (*http.Response, 
 // get502CreateRequest creates the Get502 request.
 func (client *httpRetryOperations) get502CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/retry/502"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +149,7 @@ func (client *httpRetryOperations) Head408(ctx context.Context) (*http.Response,
 // head408CreateRequest creates the Head408 request.
 func (client *httpRetryOperations) head408CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/retry/408"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +194,7 @@ func (client *httpRetryOperations) Options502(ctx context.Context) (*BoolRespons
 // options502CreateRequest creates the Options502 request.
 func (client *httpRetryOperations) options502CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/retry/502"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +240,7 @@ func (client *httpRetryOperations) Patch500(ctx context.Context) (*http.Response
 // patch500CreateRequest creates the Patch500 request.
 func (client *httpRetryOperations) patch500CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/retry/500"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +285,7 @@ func (client *httpRetryOperations) Patch504(ctx context.Context) (*http.Response
 // patch504CreateRequest creates the Patch504 request.
 func (client *httpRetryOperations) patch504CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/retry/504"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +330,7 @@ func (client *httpRetryOperations) Post503(ctx context.Context) (*http.Response,
 // post503CreateRequest creates the Post503 request.
 func (client *httpRetryOperations) post503CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/retry/503"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +375,7 @@ func (client *httpRetryOperations) Put500(ctx context.Context) (*http.Response, 
 // put500CreateRequest creates the Put500 request.
 func (client *httpRetryOperations) put500CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/retry/500"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +420,7 @@ func (client *httpRetryOperations) Put504(ctx context.Context) (*http.Response, 
 // put504CreateRequest creates the Put504 request.
 func (client *httpRetryOperations) put504CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/retry/504"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpserverfailure.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpserverfailure.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // HTTPServerFailureOperations contains the methods for the HTTPServerFailure group.
@@ -48,7 +49,7 @@ func (client *httpServerFailureOperations) Delete505(ctx context.Context) (*http
 // delete505CreateRequest creates the Delete505 request.
 func (client *httpServerFailureOperations) delete505CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/server/505"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +91,7 @@ func (client *httpServerFailureOperations) Get501(ctx context.Context) (*http.Re
 // get501CreateRequest creates the Get501 request.
 func (client *httpServerFailureOperations) get501CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/server/501"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +133,7 @@ func (client *httpServerFailureOperations) Head501(ctx context.Context) (*http.R
 // head501CreateRequest creates the Head501 request.
 func (client *httpServerFailureOperations) head501CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/server/501"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +175,7 @@ func (client *httpServerFailureOperations) Post505(ctx context.Context) (*http.R
 // post505CreateRequest creates the Post505 request.
 func (client *httpServerFailureOperations) post505CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/failure/server/505"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpsuccess.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpsuccess.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // HTTPSuccessOperations contains the methods for the HTTPSuccess group.
@@ -78,7 +79,7 @@ func (client *httpSuccessOperations) Delete200(ctx context.Context) (*http.Respo
 // delete200CreateRequest creates the Delete200 request.
 func (client *httpSuccessOperations) delete200CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +124,7 @@ func (client *httpSuccessOperations) Delete202(ctx context.Context) (*http.Respo
 // delete202CreateRequest creates the Delete202 request.
 func (client *httpSuccessOperations) delete202CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/202"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +169,7 @@ func (client *httpSuccessOperations) Delete204(ctx context.Context) (*http.Respo
 // delete204CreateRequest creates the Delete204 request.
 func (client *httpSuccessOperations) delete204CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/204"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *httpSuccessOperations) Get200(ctx context.Context) (*BoolResponse,
 // get200CreateRequest creates the Get200 request.
 func (client *httpSuccessOperations) get200CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -259,7 +260,7 @@ func (client *httpSuccessOperations) Head200(ctx context.Context) (*http.Respons
 // head200CreateRequest creates the Head200 request.
 func (client *httpSuccessOperations) head200CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +305,7 @@ func (client *httpSuccessOperations) Head204(ctx context.Context) (*http.Respons
 // head204CreateRequest creates the Head204 request.
 func (client *httpSuccessOperations) head204CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/204"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +350,7 @@ func (client *httpSuccessOperations) Head404(ctx context.Context) (*http.Respons
 // head404CreateRequest creates the Head404 request.
 func (client *httpSuccessOperations) head404CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/404"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -394,7 +395,7 @@ func (client *httpSuccessOperations) Options200(ctx context.Context) (*BoolRespo
 // options200CreateRequest creates the Options200 request.
 func (client *httpSuccessOperations) options200CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +441,7 @@ func (client *httpSuccessOperations) Patch200(ctx context.Context) (*http.Respon
 // patch200CreateRequest creates the Patch200 request.
 func (client *httpSuccessOperations) patch200CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -485,7 +486,7 @@ func (client *httpSuccessOperations) Patch202(ctx context.Context) (*http.Respon
 // patch202CreateRequest creates the Patch202 request.
 func (client *httpSuccessOperations) patch202CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/202"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -530,7 +531,7 @@ func (client *httpSuccessOperations) Patch204(ctx context.Context) (*http.Respon
 // patch204CreateRequest creates the Patch204 request.
 func (client *httpSuccessOperations) patch204CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/204"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -575,7 +576,7 @@ func (client *httpSuccessOperations) Post200(ctx context.Context) (*http.Respons
 // post200CreateRequest creates the Post200 request.
 func (client *httpSuccessOperations) post200CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -620,7 +621,7 @@ func (client *httpSuccessOperations) Post201(ctx context.Context) (*http.Respons
 // post201CreateRequest creates the Post201 request.
 func (client *httpSuccessOperations) post201CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/201"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -665,7 +666,7 @@ func (client *httpSuccessOperations) Post202(ctx context.Context) (*http.Respons
 // post202CreateRequest creates the Post202 request.
 func (client *httpSuccessOperations) post202CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/202"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -710,7 +711,7 @@ func (client *httpSuccessOperations) Post204(ctx context.Context) (*http.Respons
 // post204CreateRequest creates the Post204 request.
 func (client *httpSuccessOperations) post204CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/204"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -755,7 +756,7 @@ func (client *httpSuccessOperations) Put200(ctx context.Context) (*http.Response
 // put200CreateRequest creates the Put200 request.
 func (client *httpSuccessOperations) put200CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -800,7 +801,7 @@ func (client *httpSuccessOperations) Put201(ctx context.Context) (*http.Response
 // put201CreateRequest creates the Put201 request.
 func (client *httpSuccessOperations) put201CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/201"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -845,7 +846,7 @@ func (client *httpSuccessOperations) Put202(ctx context.Context) (*http.Response
 // put202CreateRequest creates the Put202 request.
 func (client *httpSuccessOperations) put202CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/202"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -890,7 +891,7 @@ func (client *httpSuccessOperations) Put204(ctx context.Context) (*http.Response
 // put204CreateRequest creates the Put204 request.
 func (client *httpSuccessOperations) put204CreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/success/204"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/multipleresponses.go
+++ b/test/autorest/generated/httpinfrastructuregroup/multipleresponses.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"io/ioutil"
 	"net/http"
+	"path"
 )
 
 // MultipleResponsesOperations contains the methods for the MultipleResponses group.
@@ -119,7 +120,7 @@ func (client *multipleResponsesOperations) Get200Model201ModelDefaultError200Val
 // get200Model201ModelDefaultError200ValidCreateRequest creates the Get200Model201ModelDefaultError200Valid request.
 func (client *multipleResponsesOperations) get200Model201ModelDefaultError200ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/201/B/default/Error/response/200/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +172,7 @@ func (client *multipleResponsesOperations) Get200Model201ModelDefaultError201Val
 // get200Model201ModelDefaultError201ValidCreateRequest creates the Get200Model201ModelDefaultError201Valid request.
 func (client *multipleResponsesOperations) get200Model201ModelDefaultError201ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/201/B/default/Error/response/201/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +224,7 @@ func (client *multipleResponsesOperations) Get200Model201ModelDefaultError400Val
 // get200Model201ModelDefaultError400ValidCreateRequest creates the Get200Model201ModelDefaultError400Valid request.
 func (client *multipleResponsesOperations) get200Model201ModelDefaultError400ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/201/B/default/Error/response/400/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +275,7 @@ func (client *multipleResponsesOperations) Get200Model204NoModelDefaultError200V
 // get200Model204NoModelDefaultError200ValidCreateRequest creates the Get200Model204NoModelDefaultError200Valid request.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError200ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/200/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +321,7 @@ func (client *multipleResponsesOperations) Get200Model204NoModelDefaultError201I
 // get200Model204NoModelDefaultError201InvalidCreateRequest creates the Get200Model204NoModelDefaultError201Invalid request.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError201InvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/201/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -366,7 +367,7 @@ func (client *multipleResponsesOperations) Get200Model204NoModelDefaultError202N
 // get200Model204NoModelDefaultError202NoneCreateRequest creates the Get200Model204NoModelDefaultError202None request.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError202NoneCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/202/none"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -412,7 +413,7 @@ func (client *multipleResponsesOperations) Get200Model204NoModelDefaultError204V
 // get200Model204NoModelDefaultError204ValidCreateRequest creates the Get200Model204NoModelDefaultError204Valid request.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError204ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/204/none"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +459,7 @@ func (client *multipleResponsesOperations) Get200Model204NoModelDefaultError400V
 // get200Model204NoModelDefaultError400ValidCreateRequest creates the Get200Model204NoModelDefaultError400Valid request.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError400ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/400/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -504,7 +505,7 @@ func (client *multipleResponsesOperations) Get200ModelA200Invalid(ctx context.Co
 // get200ModelA200InvalidCreateRequest creates the Get200ModelA200Invalid request.
 func (client *multipleResponsesOperations) get200ModelA200InvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/response/200/invalid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -553,7 +554,7 @@ func (client *multipleResponsesOperations) Get200ModelA200None(ctx context.Conte
 // get200ModelA200NoneCreateRequest creates the Get200ModelA200None request.
 func (client *multipleResponsesOperations) get200ModelA200NoneCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/response/200/none"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -602,7 +603,7 @@ func (client *multipleResponsesOperations) Get200ModelA200Valid(ctx context.Cont
 // get200ModelA200ValidCreateRequest creates the Get200ModelA200Valid request.
 func (client *multipleResponsesOperations) get200ModelA200ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/response/200/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -652,7 +653,7 @@ func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefault
 // get200ModelA201ModelC404ModelDDefaultError200ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError200Valid request.
 func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError200ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/200/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -707,7 +708,7 @@ func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefault
 // get200ModelA201ModelC404ModelDDefaultError201ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError201Valid request.
 func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError201ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/201/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -762,7 +763,7 @@ func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefault
 // get200ModelA201ModelC404ModelDDefaultError400ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError400Valid request.
 func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError400ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/400/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -817,7 +818,7 @@ func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefault
 // get200ModelA201ModelC404ModelDDefaultError404ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError404Valid request.
 func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError404ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/404/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -871,7 +872,7 @@ func (client *multipleResponsesOperations) Get200ModelA202Valid(ctx context.Cont
 // get200ModelA202ValidCreateRequest creates the Get200ModelA202Valid request.
 func (client *multipleResponsesOperations) get200ModelA202ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/response/202/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -920,7 +921,7 @@ func (client *multipleResponsesOperations) Get200ModelA400Invalid(ctx context.Co
 // get200ModelA400InvalidCreateRequest creates the Get200ModelA400Invalid request.
 func (client *multipleResponsesOperations) get200ModelA400InvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/response/400/invalid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -969,7 +970,7 @@ func (client *multipleResponsesOperations) Get200ModelA400None(ctx context.Conte
 // get200ModelA400NoneCreateRequest creates the Get200ModelA400None request.
 func (client *multipleResponsesOperations) get200ModelA400NoneCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/response/400/none"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1018,7 +1019,7 @@ func (client *multipleResponsesOperations) Get200ModelA400Valid(ctx context.Cont
 // get200ModelA400ValidCreateRequest creates the Get200ModelA400Valid request.
 func (client *multipleResponsesOperations) get200ModelA400ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/response/400/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1067,7 +1068,7 @@ func (client *multipleResponsesOperations) Get202None204NoneDefaultError202None(
 // get202None204NoneDefaultError202NoneCreateRequest creates the Get202None204NoneDefaultError202None request.
 func (client *multipleResponsesOperations) get202None204NoneDefaultError202NoneCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/202/none/204/none/default/Error/response/202/none"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1112,7 +1113,7 @@ func (client *multipleResponsesOperations) Get202None204NoneDefaultError204None(
 // get202None204NoneDefaultError204NoneCreateRequest creates the Get202None204NoneDefaultError204None request.
 func (client *multipleResponsesOperations) get202None204NoneDefaultError204NoneCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/202/none/204/none/default/Error/response/204/none"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1157,7 +1158,7 @@ func (client *multipleResponsesOperations) Get202None204NoneDefaultError400Valid
 // get202None204NoneDefaultError400ValidCreateRequest creates the Get202None204NoneDefaultError400Valid request.
 func (client *multipleResponsesOperations) get202None204NoneDefaultError400ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/202/none/204/none/default/Error/response/400/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1202,7 +1203,7 @@ func (client *multipleResponsesOperations) Get202None204NoneDefaultNone202Invali
 // get202None204NoneDefaultNone202InvalidCreateRequest creates the Get202None204NoneDefaultNone202Invalid request.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone202InvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/202/invalid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1250,7 +1251,7 @@ func (client *multipleResponsesOperations) Get202None204NoneDefaultNone204None(c
 // get202None204NoneDefaultNone204NoneCreateRequest creates the Get202None204NoneDefaultNone204None request.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone204NoneCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/204/none"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1298,7 +1299,7 @@ func (client *multipleResponsesOperations) Get202None204NoneDefaultNone400Invali
 // get202None204NoneDefaultNone400InvalidCreateRequest creates the Get202None204NoneDefaultNone400Invalid request.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone400InvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/400/invalid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1346,7 +1347,7 @@ func (client *multipleResponsesOperations) Get202None204NoneDefaultNone400None(c
 // get202None204NoneDefaultNone400NoneCreateRequest creates the Get202None204NoneDefaultNone400None request.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone400NoneCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/400/none"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1394,7 +1395,7 @@ func (client *multipleResponsesOperations) GetDefaultModelA200None(ctx context.C
 // getDefaultModelA200NoneCreateRequest creates the GetDefaultModelA200None request.
 func (client *multipleResponsesOperations) getDefaultModelA200NoneCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/A/response/200/none"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1443,7 +1444,7 @@ func (client *multipleResponsesOperations) GetDefaultModelA200Valid(ctx context.
 // getDefaultModelA200ValidCreateRequest creates the GetDefaultModelA200Valid request.
 func (client *multipleResponsesOperations) getDefaultModelA200ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/A/response/200/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1492,7 +1493,7 @@ func (client *multipleResponsesOperations) GetDefaultModelA400None(ctx context.C
 // getDefaultModelA400NoneCreateRequest creates the GetDefaultModelA400None request.
 func (client *multipleResponsesOperations) getDefaultModelA400NoneCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/A/response/400/none"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1537,7 +1538,7 @@ func (client *multipleResponsesOperations) GetDefaultModelA400Valid(ctx context.
 // getDefaultModelA400ValidCreateRequest creates the GetDefaultModelA400Valid request.
 func (client *multipleResponsesOperations) getDefaultModelA400ValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/A/response/400/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1582,7 +1583,7 @@ func (client *multipleResponsesOperations) GetDefaultNone200Invalid(ctx context.
 // getDefaultNone200InvalidCreateRequest creates the GetDefaultNone200Invalid request.
 func (client *multipleResponsesOperations) getDefaultNone200InvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/none/response/200/invalid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1630,7 +1631,7 @@ func (client *multipleResponsesOperations) GetDefaultNone200None(ctx context.Con
 // getDefaultNone200NoneCreateRequest creates the GetDefaultNone200None request.
 func (client *multipleResponsesOperations) getDefaultNone200NoneCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/none/response/200/none"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1678,7 +1679,7 @@ func (client *multipleResponsesOperations) GetDefaultNone400Invalid(ctx context.
 // getDefaultNone400InvalidCreateRequest creates the GetDefaultNone400Invalid request.
 func (client *multipleResponsesOperations) getDefaultNone400InvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/none/response/400/invalid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1726,7 +1727,7 @@ func (client *multipleResponsesOperations) GetDefaultNone400None(ctx context.Con
 // getDefaultNone400NoneCreateRequest creates the GetDefaultNone400None request.
 func (client *multipleResponsesOperations) getDefaultNone400NoneCreateRequest() (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/none/response/400/none"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/integergroup/int.go
+++ b/test/autorest/generated/integergroup/int.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -69,7 +70,7 @@ func (client *intOperations) GetInvalid(ctx context.Context) (*Int32Response, er
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *intOperations) getInvalidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/int/invalid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +116,7 @@ func (client *intOperations) GetInvalidUnixTime(ctx context.Context) (*TimeRespo
 // getInvalidUnixTimeCreateRequest creates the GetInvalidUnixTime request.
 func (client *intOperations) getInvalidUnixTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/int/invalidunixtime"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +163,7 @@ func (client *intOperations) GetNull(ctx context.Context) (*Int32Response, error
 // getNullCreateRequest creates the GetNull request.
 func (client *intOperations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/int/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +209,7 @@ func (client *intOperations) GetNullUnixTime(ctx context.Context) (*TimeResponse
 // getNullUnixTimeCreateRequest creates the GetNullUnixTime request.
 func (client *intOperations) getNullUnixTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/int/nullunixtime"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +256,7 @@ func (client *intOperations) GetOverflowInt32(ctx context.Context) (*Int32Respon
 // getOverflowInt32CreateRequest creates the GetOverflowInt32 request.
 func (client *intOperations) getOverflowInt32CreateRequest() (*azcore.Request, error) {
 	urlPath := "/int/overflowint32"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +302,7 @@ func (client *intOperations) GetOverflowInt64(ctx context.Context) (*Int64Respon
 // getOverflowInt64CreateRequest creates the GetOverflowInt64 request.
 func (client *intOperations) getOverflowInt64CreateRequest() (*azcore.Request, error) {
 	urlPath := "/int/overflowint64"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -347,7 +348,7 @@ func (client *intOperations) GetUnderflowInt32(ctx context.Context) (*Int32Respo
 // getUnderflowInt32CreateRequest creates the GetUnderflowInt32 request.
 func (client *intOperations) getUnderflowInt32CreateRequest() (*azcore.Request, error) {
 	urlPath := "/int/underflowint32"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -393,7 +394,7 @@ func (client *intOperations) GetUnderflowInt64(ctx context.Context) (*Int64Respo
 // getUnderflowInt64CreateRequest creates the GetUnderflowInt64 request.
 func (client *intOperations) getUnderflowInt64CreateRequest() (*azcore.Request, error) {
 	urlPath := "/int/underflowint64"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -439,7 +440,7 @@ func (client *intOperations) GetUnixTime(ctx context.Context) (*TimeResponse, er
 // getUnixTimeCreateRequest creates the GetUnixTime request.
 func (client *intOperations) getUnixTimeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/int/unixtime"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -486,7 +487,7 @@ func (client *intOperations) PutMax32(ctx context.Context, intBody int32) (*http
 // putMax32CreateRequest creates the PutMax32 request.
 func (client *intOperations) putMax32CreateRequest(intBody int32) (*azcore.Request, error) {
 	urlPath := "/int/max/32"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -531,7 +532,7 @@ func (client *intOperations) PutMax64(ctx context.Context, intBody int64) (*http
 // putMax64CreateRequest creates the PutMax64 request.
 func (client *intOperations) putMax64CreateRequest(intBody int64) (*azcore.Request, error) {
 	urlPath := "/int/max/64"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -576,7 +577,7 @@ func (client *intOperations) PutMin32(ctx context.Context, intBody int32) (*http
 // putMin32CreateRequest creates the PutMin32 request.
 func (client *intOperations) putMin32CreateRequest(intBody int32) (*azcore.Request, error) {
 	urlPath := "/int/min/32"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -621,7 +622,7 @@ func (client *intOperations) PutMin64(ctx context.Context, intBody int64) (*http
 // putMin64CreateRequest creates the PutMin64 request.
 func (client *intOperations) putMin64CreateRequest(intBody int64) (*azcore.Request, error) {
 	urlPath := "/int/min/64"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -666,7 +667,7 @@ func (client *intOperations) PutUnixTimeDate(ctx context.Context, intBody time.T
 // putUnixTimeDateCreateRequest creates the PutUnixTimeDate request.
 func (client *intOperations) putUnixTimeDateCreateRequest(intBody time.Time) (*azcore.Request, error) {
 	urlPath := "/int/unixtime"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lroretrys.go
+++ b/test/autorest/generated/lrogroup/lroretrys.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -93,7 +94,7 @@ func (client *lroRetrysOperations) ResumeDelete202Retry200(token string) (HTTPPo
 // delete202Retry200CreateRequest creates the Delete202Retry200 request.
 func (client *lroRetrysOperations) delete202Retry200CreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/retryerror/delete/202/retry/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +163,7 @@ func (client *lroRetrysOperations) ResumeDeleteAsyncRelativeRetrySucceeded(token
 // deleteAsyncRelativeRetrySucceededCreateRequest creates the DeleteAsyncRelativeRetrySucceeded request.
 func (client *lroRetrysOperations) deleteAsyncRelativeRetrySucceededCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/retryerror/deleteasync/retry/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +232,7 @@ func (client *lroRetrysOperations) ResumeDeleteProvisioning202Accepted200Succeed
 // deleteProvisioning202Accepted200SucceededCreateRequest creates the DeleteProvisioning202Accepted200Succeeded request.
 func (client *lroRetrysOperations) deleteProvisioning202Accepted200SucceededCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/retryerror/delete/provisioning/202/accepted/200/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +301,7 @@ func (client *lroRetrysOperations) ResumePost202Retry200(token string) (HTTPPoll
 // post202Retry200CreateRequest creates the Post202Retry200 request.
 func (client *lroRetrysOperations) post202Retry200CreateRequest(lroRetrysPost202Retry200Options *LroRetrysPost202Retry200Options) (*azcore.Request, error) {
 	urlPath := "/lro/retryerror/post/202/retry/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -372,7 +373,7 @@ func (client *lroRetrysOperations) ResumePostAsyncRelativeRetrySucceeded(token s
 // postAsyncRelativeRetrySucceededCreateRequest creates the PostAsyncRelativeRetrySucceeded request.
 func (client *lroRetrysOperations) postAsyncRelativeRetrySucceededCreateRequest(lroRetrysPostAsyncRelativeRetrySucceededOptions *LroRetrysPostAsyncRelativeRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/retryerror/postasync/retry/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -444,7 +445,7 @@ func (client *lroRetrysOperations) ResumePut201CreatingSucceeded200(token string
 // put201CreatingSucceeded200CreateRequest creates the Put201CreatingSucceeded200 request.
 func (client *lroRetrysOperations) put201CreatingSucceeded200CreateRequest(lroRetrysPut201CreatingSucceeded200Options *LroRetrysPut201CreatingSucceeded200Options) (*azcore.Request, error) {
 	urlPath := "/lro/retryerror/put/201/creating/succeeded/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -516,7 +517,7 @@ func (client *lroRetrysOperations) ResumePutAsyncRelativeRetrySucceeded(token st
 // putAsyncRelativeRetrySucceededCreateRequest creates the PutAsyncRelativeRetrySucceeded request.
 func (client *lroRetrysOperations) putAsyncRelativeRetrySucceededCreateRequest(lroRetrysPutAsyncRelativeRetrySucceededOptions *LroRetrysPutAsyncRelativeRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/retryerror/putasync/retry/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lros.go
+++ b/test/autorest/generated/lrogroup/lros.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -229,7 +230,7 @@ func (client *lrOSOperations) ResumeDelete202NoRetry204(token string) (ProductPo
 // delete202NoRetry204CreateRequest creates the Delete202NoRetry204 request.
 func (client *lrOSOperations) delete202NoRetry204CreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/delete/202/noretry/204"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +299,7 @@ func (client *lrOSOperations) ResumeDelete202Retry200(token string) (ProductPoll
 // delete202Retry200CreateRequest creates the Delete202Retry200 request.
 func (client *lrOSOperations) delete202Retry200CreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/delete/202/retry/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -367,7 +368,7 @@ func (client *lrOSOperations) ResumeDelete204Succeeded(token string) (HTTPPoller
 // delete204SucceededCreateRequest creates the Delete204Succeeded request.
 func (client *lrOSOperations) delete204SucceededCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/delete/204/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -436,7 +437,7 @@ func (client *lrOSOperations) ResumeDeleteAsyncNoHeaderInRetry(token string) (HT
 // deleteAsyncNoHeaderInRetryCreateRequest creates the DeleteAsyncNoHeaderInRetry request.
 func (client *lrOSOperations) deleteAsyncNoHeaderInRetryCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/deleteasync/noheader/202/204"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -505,7 +506,7 @@ func (client *lrOSOperations) ResumeDeleteAsyncNoRetrySucceeded(token string) (H
 // deleteAsyncNoRetrySucceededCreateRequest creates the DeleteAsyncNoRetrySucceeded request.
 func (client *lrOSOperations) deleteAsyncNoRetrySucceededCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/deleteasync/noretry/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -574,7 +575,7 @@ func (client *lrOSOperations) ResumeDeleteAsyncRetryFailed(token string) (HTTPPo
 // deleteAsyncRetryFailedCreateRequest creates the DeleteAsyncRetryFailed request.
 func (client *lrOSOperations) deleteAsyncRetryFailedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/deleteasync/retry/failed"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -643,7 +644,7 @@ func (client *lrOSOperations) ResumeDeleteAsyncRetrySucceeded(token string) (HTT
 // deleteAsyncRetrySucceededCreateRequest creates the DeleteAsyncRetrySucceeded request.
 func (client *lrOSOperations) deleteAsyncRetrySucceededCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/deleteasync/retry/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -712,7 +713,7 @@ func (client *lrOSOperations) ResumeDeleteAsyncRetrycanceled(token string) (HTTP
 // deleteAsyncRetrycanceledCreateRequest creates the DeleteAsyncRetrycanceled request.
 func (client *lrOSOperations) deleteAsyncRetrycanceledCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/deleteasync/retry/canceled"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -781,7 +782,7 @@ func (client *lrOSOperations) ResumeDeleteNoHeaderInRetry(token string) (HTTPPol
 // deleteNoHeaderInRetryCreateRequest creates the DeleteNoHeaderInRetry request.
 func (client *lrOSOperations) deleteNoHeaderInRetryCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/delete/noheader"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -850,7 +851,7 @@ func (client *lrOSOperations) ResumeDeleteProvisioning202Accepted200Succeeded(to
 // deleteProvisioning202Accepted200SucceededCreateRequest creates the DeleteProvisioning202Accepted200Succeeded request.
 func (client *lrOSOperations) deleteProvisioning202Accepted200SucceededCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/delete/provisioning/202/accepted/200/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -919,7 +920,7 @@ func (client *lrOSOperations) ResumeDeleteProvisioning202DeletingFailed200(token
 // deleteProvisioning202DeletingFailed200CreateRequest creates the DeleteProvisioning202DeletingFailed200 request.
 func (client *lrOSOperations) deleteProvisioning202DeletingFailed200CreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/delete/provisioning/202/deleting/200/failed"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -988,7 +989,7 @@ func (client *lrOSOperations) ResumeDeleteProvisioning202Deletingcanceled200(tok
 // deleteProvisioning202Deletingcanceled200CreateRequest creates the DeleteProvisioning202Deletingcanceled200 request.
 func (client *lrOSOperations) deleteProvisioning202Deletingcanceled200CreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/delete/provisioning/202/deleting/200/canceled"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1057,7 +1058,7 @@ func (client *lrOSOperations) ResumePost200WithPayload(token string) (SkuPoller,
 // post200WithPayloadCreateRequest creates the Post200WithPayload request.
 func (client *lrOSOperations) post200WithPayloadCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/post/payload/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1126,7 +1127,7 @@ func (client *lrOSOperations) ResumePost202List(token string) (ProductArrayPolle
 // post202ListCreateRequest creates the Post202List request.
 func (client *lrOSOperations) post202ListCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/list"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1195,7 +1196,7 @@ func (client *lrOSOperations) ResumePost202NoRetry204(token string) (ProductPoll
 // post202NoRetry204CreateRequest creates the Post202NoRetry204 request.
 func (client *lrOSOperations) post202NoRetry204CreateRequest(lrOSPost202NoRetry204Options *LrOSPost202NoRetry204Options) (*azcore.Request, error) {
 	urlPath := "/lro/post/202/noretry/204"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1267,7 +1268,7 @@ func (client *lrOSOperations) ResumePost202Retry200(token string) (HTTPPoller, e
 // post202Retry200CreateRequest creates the Post202Retry200 request.
 func (client *lrOSOperations) post202Retry200CreateRequest(lrOSPost202Retry200Options *LrOSPost202Retry200Options) (*azcore.Request, error) {
 	urlPath := "/lro/post/202/retry/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1339,7 +1340,7 @@ func (client *lrOSOperations) ResumePostAsyncNoRetrySucceeded(token string) (Pro
 // postAsyncNoRetrySucceededCreateRequest creates the PostAsyncNoRetrySucceeded request.
 func (client *lrOSOperations) postAsyncNoRetrySucceededCreateRequest(lrOSPostAsyncNoRetrySucceededOptions *LrOSPostAsyncNoRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/postasync/noretry/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1411,7 +1412,7 @@ func (client *lrOSOperations) ResumePostAsyncRetryFailed(token string) (HTTPPoll
 // postAsyncRetryFailedCreateRequest creates the PostAsyncRetryFailed request.
 func (client *lrOSOperations) postAsyncRetryFailedCreateRequest(lrOSPostAsyncRetryFailedOptions *LrOSPostAsyncRetryFailedOptions) (*azcore.Request, error) {
 	urlPath := "/lro/postasync/retry/failed"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1483,7 +1484,7 @@ func (client *lrOSOperations) ResumePostAsyncRetrySucceeded(token string) (Produ
 // postAsyncRetrySucceededCreateRequest creates the PostAsyncRetrySucceeded request.
 func (client *lrOSOperations) postAsyncRetrySucceededCreateRequest(lrOSPostAsyncRetrySucceededOptions *LrOSPostAsyncRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/postasync/retry/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1555,7 +1556,7 @@ func (client *lrOSOperations) ResumePostAsyncRetrycanceled(token string) (HTTPPo
 // postAsyncRetrycanceledCreateRequest creates the PostAsyncRetrycanceled request.
 func (client *lrOSOperations) postAsyncRetrycanceledCreateRequest(lrOSPostAsyncRetrycanceledOptions *LrOSPostAsyncRetrycanceledOptions) (*azcore.Request, error) {
 	urlPath := "/lro/postasync/retry/canceled"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1627,7 +1628,7 @@ func (client *lrOSOperations) ResumePostDoubleHeadersFinalAzureHeaderGet(token s
 // postDoubleHeadersFinalAzureHeaderGetCreateRequest creates the PostDoubleHeadersFinalAzureHeaderGet request.
 func (client *lrOSOperations) postDoubleHeadersFinalAzureHeaderGetCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/LROPostDoubleHeadersFinalAzureHeaderGet"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1696,7 +1697,7 @@ func (client *lrOSOperations) ResumePostDoubleHeadersFinalAzureHeaderGetDefault(
 // postDoubleHeadersFinalAzureHeaderGetDefaultCreateRequest creates the PostDoubleHeadersFinalAzureHeaderGetDefault request.
 func (client *lrOSOperations) postDoubleHeadersFinalAzureHeaderGetDefaultCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/LROPostDoubleHeadersFinalAzureHeaderGetDefault"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1765,7 +1766,7 @@ func (client *lrOSOperations) ResumePostDoubleHeadersFinalLocationGet(token stri
 // postDoubleHeadersFinalLocationGetCreateRequest creates the PostDoubleHeadersFinalLocationGet request.
 func (client *lrOSOperations) postDoubleHeadersFinalLocationGetCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/LROPostDoubleHeadersFinalLocationGet"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1834,7 +1835,7 @@ func (client *lrOSOperations) ResumePut200Acceptedcanceled200(token string) (Pro
 // put200Acceptedcanceled200CreateRequest creates the Put200Acceptedcanceled200 request.
 func (client *lrOSOperations) put200Acceptedcanceled200CreateRequest(lrOSPut200Acceptedcanceled200Options *LrOSPut200Acceptedcanceled200Options) (*azcore.Request, error) {
 	urlPath := "/lro/put/200/accepted/canceled/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1906,7 +1907,7 @@ func (client *lrOSOperations) ResumePut200Succeeded(token string) (ProductPoller
 // put200SucceededCreateRequest creates the Put200Succeeded request.
 func (client *lrOSOperations) put200SucceededCreateRequest(lrOSPut200SucceededOptions *LrOSPut200SucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/put/200/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1978,7 +1979,7 @@ func (client *lrOSOperations) ResumePut200SucceededNoState(token string) (Produc
 // put200SucceededNoStateCreateRequest creates the Put200SucceededNoState request.
 func (client *lrOSOperations) put200SucceededNoStateCreateRequest(lrOSPut200SucceededNoStateOptions *LrOSPut200SucceededNoStateOptions) (*azcore.Request, error) {
 	urlPath := "/lro/put/200/succeeded/nostate"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2050,7 +2051,7 @@ func (client *lrOSOperations) ResumePut200UpdatingSucceeded204(token string) (Pr
 // put200UpdatingSucceeded204CreateRequest creates the Put200UpdatingSucceeded204 request.
 func (client *lrOSOperations) put200UpdatingSucceeded204CreateRequest(lrOSPut200UpdatingSucceeded204Options *LrOSPut200UpdatingSucceeded204Options) (*azcore.Request, error) {
 	urlPath := "/lro/put/200/updating/succeeded/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2122,7 +2123,7 @@ func (client *lrOSOperations) ResumePut201CreatingFailed200(token string) (Produ
 // put201CreatingFailed200CreateRequest creates the Put201CreatingFailed200 request.
 func (client *lrOSOperations) put201CreatingFailed200CreateRequest(lrOSPut201CreatingFailed200Options *LrOSPut201CreatingFailed200Options) (*azcore.Request, error) {
 	urlPath := "/lro/put/201/created/failed/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2194,7 +2195,7 @@ func (client *lrOSOperations) ResumePut201CreatingSucceeded200(token string) (Pr
 // put201CreatingSucceeded200CreateRequest creates the Put201CreatingSucceeded200 request.
 func (client *lrOSOperations) put201CreatingSucceeded200CreateRequest(lrOSPut201CreatingSucceeded200Options *LrOSPut201CreatingSucceeded200Options) (*azcore.Request, error) {
 	urlPath := "/lro/put/201/creating/succeeded/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2266,7 +2267,7 @@ func (client *lrOSOperations) ResumePut201Succeeded(token string) (ProductPoller
 // put201SucceededCreateRequest creates the Put201Succeeded request.
 func (client *lrOSOperations) put201SucceededCreateRequest(lrOSPut201SucceededOptions *LrOSPut201SucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/put/201/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2338,7 +2339,7 @@ func (client *lrOSOperations) ResumePut202Retry200(token string) (ProductPoller,
 // put202Retry200CreateRequest creates the Put202Retry200 request.
 func (client *lrOSOperations) put202Retry200CreateRequest(lrOSPut202Retry200Options *LrOSPut202Retry200Options) (*azcore.Request, error) {
 	urlPath := "/lro/put/202/retry/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2410,7 +2411,7 @@ func (client *lrOSOperations) ResumePutAsyncNoHeaderInRetry(token string) (Produ
 // putAsyncNoHeaderInRetryCreateRequest creates the PutAsyncNoHeaderInRetry request.
 func (client *lrOSOperations) putAsyncNoHeaderInRetryCreateRequest(lrOSPutAsyncNoHeaderInRetryOptions *LrOSPutAsyncNoHeaderInRetryOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putasync/noheader/201/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2482,7 +2483,7 @@ func (client *lrOSOperations) ResumePutAsyncNoRetrySucceeded(token string) (Prod
 // putAsyncNoRetrySucceededCreateRequest creates the PutAsyncNoRetrySucceeded request.
 func (client *lrOSOperations) putAsyncNoRetrySucceededCreateRequest(lrOSPutAsyncNoRetrySucceededOptions *LrOSPutAsyncNoRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putasync/noretry/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2554,7 +2555,7 @@ func (client *lrOSOperations) ResumePutAsyncNoRetrycanceled(token string) (Produ
 // putAsyncNoRetrycanceledCreateRequest creates the PutAsyncNoRetrycanceled request.
 func (client *lrOSOperations) putAsyncNoRetrycanceledCreateRequest(lrOSPutAsyncNoRetrycanceledOptions *LrOSPutAsyncNoRetrycanceledOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putasync/noretry/canceled"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2626,7 +2627,7 @@ func (client *lrOSOperations) ResumePutAsyncNonResource(token string) (SkuPoller
 // putAsyncNonResourceCreateRequest creates the PutAsyncNonResource request.
 func (client *lrOSOperations) putAsyncNonResourceCreateRequest(lrOSPutAsyncNonResourceOptions *LrOSPutAsyncNonResourceOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putnonresourceasync/202/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2698,7 +2699,7 @@ func (client *lrOSOperations) ResumePutAsyncRetryFailed(token string) (ProductPo
 // putAsyncRetryFailedCreateRequest creates the PutAsyncRetryFailed request.
 func (client *lrOSOperations) putAsyncRetryFailedCreateRequest(lrOSPutAsyncRetryFailedOptions *LrOSPutAsyncRetryFailedOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putasync/retry/failed"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2770,7 +2771,7 @@ func (client *lrOSOperations) ResumePutAsyncRetrySucceeded(token string) (Produc
 // putAsyncRetrySucceededCreateRequest creates the PutAsyncRetrySucceeded request.
 func (client *lrOSOperations) putAsyncRetrySucceededCreateRequest(lrOSPutAsyncRetrySucceededOptions *LrOSPutAsyncRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putasync/retry/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2842,7 +2843,7 @@ func (client *lrOSOperations) ResumePutAsyncSubResource(token string) (SubProduc
 // putAsyncSubResourceCreateRequest creates the PutAsyncSubResource request.
 func (client *lrOSOperations) putAsyncSubResourceCreateRequest(lrOSPutAsyncSubResourceOptions *LrOSPutAsyncSubResourceOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putsubresourceasync/202/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2914,7 +2915,7 @@ func (client *lrOSOperations) ResumePutNoHeaderInRetry(token string) (ProductPol
 // putNoHeaderInRetryCreateRequest creates the PutNoHeaderInRetry request.
 func (client *lrOSOperations) putNoHeaderInRetryCreateRequest(lrOSPutNoHeaderInRetryOptions *LrOSPutNoHeaderInRetryOptions) (*azcore.Request, error) {
 	urlPath := "/lro/put/noheader/202/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2986,7 +2987,7 @@ func (client *lrOSOperations) ResumePutNonResource(token string) (SkuPoller, err
 // putNonResourceCreateRequest creates the PutNonResource request.
 func (client *lrOSOperations) putNonResourceCreateRequest(lrOSPutNonResourceOptions *LrOSPutNonResourceOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putnonresource/202/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3058,7 +3059,7 @@ func (client *lrOSOperations) ResumePutSubResource(token string) (SubProductPoll
 // putSubResourceCreateRequest creates the PutSubResource request.
 func (client *lrOSOperations) putSubResourceCreateRequest(lrOSPutSubResourceOptions *LrOSPutSubResourceOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putsubresource/202/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lrosads.go
+++ b/test/autorest/generated/lrogroup/lrosads.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -169,7 +170,7 @@ func (client *lrosaDsOperations) ResumeDelete202NonRetry400(token string) (HTTPP
 // delete202NonRetry400CreateRequest creates the Delete202NonRetry400 request.
 func (client *lrosaDsOperations) delete202NonRetry400CreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/delete/202/retry/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +239,7 @@ func (client *lrosaDsOperations) ResumeDelete202RetryInvalidHeader(token string)
 // delete202RetryInvalidHeaderCreateRequest creates the Delete202RetryInvalidHeader request.
 func (client *lrosaDsOperations) delete202RetryInvalidHeaderCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/error/delete/202/retry/invalidheader"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +308,7 @@ func (client *lrosaDsOperations) ResumeDelete204Succeeded(token string) (HTTPPol
 // delete204SucceededCreateRequest creates the Delete204Succeeded request.
 func (client *lrosaDsOperations) delete204SucceededCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/error/delete/204/nolocation"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +377,7 @@ func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetry400(token string)
 // deleteAsyncRelativeRetry400CreateRequest creates the DeleteAsyncRelativeRetry400 request.
 func (client *lrosaDsOperations) deleteAsyncRelativeRetry400CreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/deleteasync/retry/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -445,7 +446,7 @@ func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetryInvalidHeader(tok
 // deleteAsyncRelativeRetryInvalidHeaderCreateRequest creates the DeleteAsyncRelativeRetryInvalidHeader request.
 func (client *lrosaDsOperations) deleteAsyncRelativeRetryInvalidHeaderCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/error/deleteasync/retry/invalidheader"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +515,7 @@ func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetryInvalidJSONPollin
 // deleteAsyncRelativeRetryInvalidJsonPollingCreateRequest creates the DeleteAsyncRelativeRetryInvalidJSONPolling request.
 func (client *lrosaDsOperations) deleteAsyncRelativeRetryInvalidJsonPollingCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/error/deleteasync/retry/invalidjsonpolling"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -583,7 +584,7 @@ func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetryNoStatus(token st
 // deleteAsyncRelativeRetryNoStatusCreateRequest creates the DeleteAsyncRelativeRetryNoStatus request.
 func (client *lrosaDsOperations) deleteAsyncRelativeRetryNoStatusCreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/error/deleteasync/retry/nostatus"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -652,7 +653,7 @@ func (client *lrosaDsOperations) ResumeDeleteNonRetry400(token string) (HTTPPoll
 // deleteNonRetry400CreateRequest creates the DeleteNonRetry400 request.
 func (client *lrosaDsOperations) deleteNonRetry400CreateRequest() (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/delete/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -721,7 +722,7 @@ func (client *lrosaDsOperations) ResumePost202NoLocation(token string) (HTTPPoll
 // post202NoLocationCreateRequest creates the Post202NoLocation request.
 func (client *lrosaDsOperations) post202NoLocationCreateRequest(lrosaDsPost202NoLocationOptions *LrosaDsPost202NoLocationOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/post/202/nolocation"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -793,7 +794,7 @@ func (client *lrosaDsOperations) ResumePost202NonRetry400(token string) (HTTPPol
 // post202NonRetry400CreateRequest creates the Post202NonRetry400 request.
 func (client *lrosaDsOperations) post202NonRetry400CreateRequest(lrosaDsPost202NonRetry400Options *LrosaDsPost202NonRetry400Options) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/post/202/retry/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -865,7 +866,7 @@ func (client *lrosaDsOperations) ResumePost202RetryInvalidHeader(token string) (
 // post202RetryInvalidHeaderCreateRequest creates the Post202RetryInvalidHeader request.
 func (client *lrosaDsOperations) post202RetryInvalidHeaderCreateRequest(lrosaDsPost202RetryInvalidHeaderOptions *LrosaDsPost202RetryInvalidHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/post/202/retry/invalidheader"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -937,7 +938,7 @@ func (client *lrosaDsOperations) ResumePostAsyncRelativeRetry400(token string) (
 // postAsyncRelativeRetry400CreateRequest creates the PostAsyncRelativeRetry400 request.
 func (client *lrosaDsOperations) postAsyncRelativeRetry400CreateRequest(lrosaDsPostAsyncRelativeRetry400Options *LrosaDsPostAsyncRelativeRetry400Options) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/postasync/retry/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1009,7 +1010,7 @@ func (client *lrosaDsOperations) ResumePostAsyncRelativeRetryInvalidHeader(token
 // postAsyncRelativeRetryInvalidHeaderCreateRequest creates the PostAsyncRelativeRetryInvalidHeader request.
 func (client *lrosaDsOperations) postAsyncRelativeRetryInvalidHeaderCreateRequest(lrosaDsPostAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPostAsyncRelativeRetryInvalidHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/postasync/retry/invalidheader"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1081,7 +1082,7 @@ func (client *lrosaDsOperations) ResumePostAsyncRelativeRetryInvalidJSONPolling(
 // postAsyncRelativeRetryInvalidJsonPollingCreateRequest creates the PostAsyncRelativeRetryInvalidJSONPolling request.
 func (client *lrosaDsOperations) postAsyncRelativeRetryInvalidJsonPollingCreateRequest(lrosaDsPostAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPostAsyncRelativeRetryInvalidJSONPollingOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/postasync/retry/invalidjsonpolling"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1153,7 +1154,7 @@ func (client *lrosaDsOperations) ResumePostAsyncRelativeRetryNoPayload(token str
 // postAsyncRelativeRetryNoPayloadCreateRequest creates the PostAsyncRelativeRetryNoPayload request.
 func (client *lrosaDsOperations) postAsyncRelativeRetryNoPayloadCreateRequest(lrosaDsPostAsyncRelativeRetryNoPayloadOptions *LrosaDsPostAsyncRelativeRetryNoPayloadOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/postasync/retry/nopayload"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1225,7 +1226,7 @@ func (client *lrosaDsOperations) ResumePostNonRetry400(token string) (HTTPPoller
 // postNonRetry400CreateRequest creates the PostNonRetry400 request.
 func (client *lrosaDsOperations) postNonRetry400CreateRequest(lrosaDsPostNonRetry400Options *LrosaDsPostNonRetry400Options) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/post/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1297,7 +1298,7 @@ func (client *lrosaDsOperations) ResumePut200InvalidJSON(token string) (ProductP
 // put200InvalidJsonCreateRequest creates the Put200InvalidJSON request.
 func (client *lrosaDsOperations) put200InvalidJsonCreateRequest(lrosaDsPut200InvalidJsonOptions *LrosaDsPut200InvalidJSONOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/put/200/invalidjson"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1369,7 +1370,7 @@ func (client *lrosaDsOperations) ResumePutAsyncRelativeRetry400(token string) (P
 // putAsyncRelativeRetry400CreateRequest creates the PutAsyncRelativeRetry400 request.
 func (client *lrosaDsOperations) putAsyncRelativeRetry400CreateRequest(lrosaDsPutAsyncRelativeRetry400Options *LrosaDsPutAsyncRelativeRetry400Options) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/putasync/retry/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1441,7 +1442,7 @@ func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryInvalidHeader(token 
 // putAsyncRelativeRetryInvalidHeaderCreateRequest creates the PutAsyncRelativeRetryInvalidHeader request.
 func (client *lrosaDsOperations) putAsyncRelativeRetryInvalidHeaderCreateRequest(lrosaDsPutAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPutAsyncRelativeRetryInvalidHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/putasync/retry/invalidheader"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1513,7 +1514,7 @@ func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryInvalidJSONPolling(t
 // putAsyncRelativeRetryInvalidJsonPollingCreateRequest creates the PutAsyncRelativeRetryInvalidJSONPolling request.
 func (client *lrosaDsOperations) putAsyncRelativeRetryInvalidJsonPollingCreateRequest(lrosaDsPutAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPutAsyncRelativeRetryInvalidJSONPollingOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/putasync/retry/invalidjsonpolling"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1585,7 +1586,7 @@ func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryNoStatus(token strin
 // putAsyncRelativeRetryNoStatusCreateRequest creates the PutAsyncRelativeRetryNoStatus request.
 func (client *lrosaDsOperations) putAsyncRelativeRetryNoStatusCreateRequest(lrosaDsPutAsyncRelativeRetryNoStatusOptions *LrosaDsPutAsyncRelativeRetryNoStatusOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/putasync/retry/nostatus"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1657,7 +1658,7 @@ func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryNoStatusPayload(toke
 // putAsyncRelativeRetryNoStatusPayloadCreateRequest creates the PutAsyncRelativeRetryNoStatusPayload request.
 func (client *lrosaDsOperations) putAsyncRelativeRetryNoStatusPayloadCreateRequest(lrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions *LrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/putasync/retry/nostatuspayload"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1729,7 +1730,7 @@ func (client *lrosaDsOperations) ResumePutError201NoProvisioningStatePayload(tok
 // putError201NoProvisioningStatePayloadCreateRequest creates the PutError201NoProvisioningStatePayload request.
 func (client *lrosaDsOperations) putError201NoProvisioningStatePayloadCreateRequest(lrosaDsPutError201NoProvisioningStatePayloadOptions *LrosaDsPutError201NoProvisioningStatePayloadOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/put/201/noprovisioningstatepayload"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1801,7 +1802,7 @@ func (client *lrosaDsOperations) ResumePutNonRetry201Creating400(token string) (
 // putNonRetry201Creating400CreateRequest creates the PutNonRetry201Creating400 request.
 func (client *lrosaDsOperations) putNonRetry201Creating400CreateRequest(lrosaDsPutNonRetry201Creating400Options *LrosaDsPutNonRetry201Creating400Options) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/put/201/creating/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1873,7 +1874,7 @@ func (client *lrosaDsOperations) ResumePutNonRetry201Creating400InvalidJSON(toke
 // putNonRetry201Creating400InvalidJsonCreateRequest creates the PutNonRetry201Creating400InvalidJSON request.
 func (client *lrosaDsOperations) putNonRetry201Creating400InvalidJsonCreateRequest(lrosaDsPutNonRetry201Creating400InvalidJsonOptions *LrosaDsPutNonRetry201Creating400InvalidJSONOptions) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/put/201/creating/400/invalidjson"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1945,7 +1946,7 @@ func (client *lrosaDsOperations) ResumePutNonRetry400(token string) (ProductPoll
 // putNonRetry400CreateRequest creates the PutNonRetry400 request.
 func (client *lrosaDsOperations) putNonRetry400CreateRequest(lrosaDsPutNonRetry400Options *LrosaDsPutNonRetry400Options) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/put/400"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lroscustomheader.go
+++ b/test/autorest/generated/lrogroup/lroscustomheader.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 	"time"
 )
 
@@ -81,7 +82,7 @@ func (client *lrOSCustomHeaderOperations) ResumePost202Retry200(token string) (H
 // post202Retry200CreateRequest creates the Post202Retry200 request.
 func (client *lrOSCustomHeaderOperations) post202Retry200CreateRequest(lrOSCustomHeaderPost202Retry200Options *LrOSCustomHeaderPost202Retry200Options) (*azcore.Request, error) {
 	urlPath := "/lro/customheader/post/202/retry/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +154,7 @@ func (client *lrOSCustomHeaderOperations) ResumePostAsyncRetrySucceeded(token st
 // postAsyncRetrySucceededCreateRequest creates the PostAsyncRetrySucceeded request.
 func (client *lrOSCustomHeaderOperations) postAsyncRetrySucceededCreateRequest(lrOSCustomHeaderPostAsyncRetrySucceededOptions *LrOSCustomHeaderPostAsyncRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/customheader/postasync/retry/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +226,7 @@ func (client *lrOSCustomHeaderOperations) ResumePut201CreatingSucceeded200(token
 // put201CreatingSucceeded200CreateRequest creates the Put201CreatingSucceeded200 request.
 func (client *lrOSCustomHeaderOperations) put201CreatingSucceeded200CreateRequest(lrOSCustomHeaderPut201CreatingSucceeded200Options *LrOSCustomHeaderPut201CreatingSucceeded200Options) (*azcore.Request, error) {
 	urlPath := "/lro/customheader/put/201/creating/succeeded/200"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +298,7 @@ func (client *lrOSCustomHeaderOperations) ResumePutAsyncRetrySucceeded(token str
 // putAsyncRetrySucceededCreateRequest creates the PutAsyncRetrySucceeded request.
 func (client *lrOSCustomHeaderOperations) putAsyncRetrySucceededCreateRequest(lrOSCustomHeaderPutAsyncRetrySucceededOptions *LrOSCustomHeaderPutAsyncRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/customheader/putasync/retry/succeeded"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/migroup/multipleinheritanceserviceclient.go
+++ b/test/autorest/generated/migroup/multipleinheritanceserviceclient.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"io/ioutil"
 	"net/http"
+	"path"
 )
 
 // MultipleInheritanceServiceClientOperations contains the methods for the MultipleInheritanceServiceClient group.
@@ -63,7 +64,7 @@ func (client *multipleInheritanceServiceClientOperations) GetCat(ctx context.Con
 // getCatCreateRequest creates the GetCat request.
 func (client *multipleInheritanceServiceClientOperations) getCatCreateRequest() (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/cat"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +110,7 @@ func (client *multipleInheritanceServiceClientOperations) GetFeline(ctx context.
 // getFelineCreateRequest creates the GetFeline request.
 func (client *multipleInheritanceServiceClientOperations) getFelineCreateRequest() (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/feline"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +156,7 @@ func (client *multipleInheritanceServiceClientOperations) GetHorse(ctx context.C
 // getHorseCreateRequest creates the GetHorse request.
 func (client *multipleInheritanceServiceClientOperations) getHorseCreateRequest() (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/horse"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +202,7 @@ func (client *multipleInheritanceServiceClientOperations) GetKitten(ctx context.
 // getKittenCreateRequest creates the GetKitten request.
 func (client *multipleInheritanceServiceClientOperations) getKittenCreateRequest() (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/kitten"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +248,7 @@ func (client *multipleInheritanceServiceClientOperations) GetPet(ctx context.Con
 // getPetCreateRequest creates the GetPet request.
 func (client *multipleInheritanceServiceClientOperations) getPetCreateRequest() (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/pet"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +294,7 @@ func (client *multipleInheritanceServiceClientOperations) PutCat(ctx context.Con
 // putCatCreateRequest creates the PutCat request.
 func (client *multipleInheritanceServiceClientOperations) putCatCreateRequest(cat Cat) (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/cat"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +343,7 @@ func (client *multipleInheritanceServiceClientOperations) PutFeline(ctx context.
 // putFelineCreateRequest creates the PutFeline request.
 func (client *multipleInheritanceServiceClientOperations) putFelineCreateRequest(feline Feline) (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/feline"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +392,7 @@ func (client *multipleInheritanceServiceClientOperations) PutHorse(ctx context.C
 // putHorseCreateRequest creates the PutHorse request.
 func (client *multipleInheritanceServiceClientOperations) putHorseCreateRequest(horse Horse) (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/horse"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +441,7 @@ func (client *multipleInheritanceServiceClientOperations) PutKitten(ctx context.
 // putKittenCreateRequest creates the PutKitten request.
 func (client *multipleInheritanceServiceClientOperations) putKittenCreateRequest(kitten Kitten) (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/kitten"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -489,7 +490,7 @@ func (client *multipleInheritanceServiceClientOperations) PutPet(ctx context.Con
 // putPetCreateRequest creates the PutPet request.
 func (client *multipleInheritanceServiceClientOperations) putPetCreateRequest(pet Pet) (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/pet"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/numbergroup/number.go
+++ b/test/autorest/generated/numbergroup/number.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // NumberOperations contains the methods for the Number group.
@@ -88,7 +89,7 @@ func (client *numberOperations) GetBigDecimal(ctx context.Context) (*Float64Resp
 // getBigDecimalCreateRequest creates the GetBigDecimal request.
 func (client *numberOperations) getBigDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/2.5976931e+101"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +135,7 @@ func (client *numberOperations) GetBigDecimalNegativeDecimal(ctx context.Context
 // getBigDecimalNegativeDecimalCreateRequest creates the GetBigDecimalNegativeDecimal request.
 func (client *numberOperations) getBigDecimalNegativeDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/-99999999.99"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +181,7 @@ func (client *numberOperations) GetBigDecimalPositiveDecimal(ctx context.Context
 // getBigDecimalPositiveDecimalCreateRequest creates the GetBigDecimalPositiveDecimal request.
 func (client *numberOperations) getBigDecimalPositiveDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/99999999.99"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *numberOperations) GetBigDouble(ctx context.Context) (*Float64Respo
 // getBigDoubleCreateRequest creates the GetBigDouble request.
 func (client *numberOperations) getBigDoubleCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/double/2.5976931e+101"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +273,7 @@ func (client *numberOperations) GetBigDoubleNegativeDecimal(ctx context.Context)
 // getBigDoubleNegativeDecimalCreateRequest creates the GetBigDoubleNegativeDecimal request.
 func (client *numberOperations) getBigDoubleNegativeDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/double/-99999999.99"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +319,7 @@ func (client *numberOperations) GetBigDoublePositiveDecimal(ctx context.Context)
 // getBigDoublePositiveDecimalCreateRequest creates the GetBigDoublePositiveDecimal request.
 func (client *numberOperations) getBigDoublePositiveDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/double/99999999.99"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +365,7 @@ func (client *numberOperations) GetBigFloat(ctx context.Context) (*Float32Respon
 // getBigFloatCreateRequest creates the GetBigFloat request.
 func (client *numberOperations) getBigFloatCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/float/3.402823e+20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -410,7 +411,7 @@ func (client *numberOperations) GetInvalidDecimal(ctx context.Context) (*Float64
 // getInvalidDecimalCreateRequest creates the GetInvalidDecimal request.
 func (client *numberOperations) getInvalidDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/invaliddecimal"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +457,7 @@ func (client *numberOperations) GetInvalidDouble(ctx context.Context) (*Float64R
 // getInvalidDoubleCreateRequest creates the GetInvalidDouble request.
 func (client *numberOperations) getInvalidDoubleCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/invaliddouble"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -502,7 +503,7 @@ func (client *numberOperations) GetInvalidFloat(ctx context.Context) (*Float32Re
 // getInvalidFloatCreateRequest creates the GetInvalidFloat request.
 func (client *numberOperations) getInvalidFloatCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/invalidfloat"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -548,7 +549,7 @@ func (client *numberOperations) GetNull(ctx context.Context) (*Float32Response, 
 // getNullCreateRequest creates the GetNull request.
 func (client *numberOperations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -594,7 +595,7 @@ func (client *numberOperations) GetSmallDecimal(ctx context.Context) (*Float64Re
 // getSmallDecimalCreateRequest creates the GetSmallDecimal request.
 func (client *numberOperations) getSmallDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/small/decimal/2.5976931e-101"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -640,7 +641,7 @@ func (client *numberOperations) GetSmallDouble(ctx context.Context) (*Float64Res
 // getSmallDoubleCreateRequest creates the GetSmallDouble request.
 func (client *numberOperations) getSmallDoubleCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/small/double/2.5976931e-101"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -686,7 +687,7 @@ func (client *numberOperations) GetSmallFloat(ctx context.Context) (*Float64Resp
 // getSmallFloatCreateRequest creates the GetSmallFloat request.
 func (client *numberOperations) getSmallFloatCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/small/float/3.402823e-20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -732,7 +733,7 @@ func (client *numberOperations) PutBigDecimal(ctx context.Context, numberBody fl
 // putBigDecimalCreateRequest creates the PutBigDecimal request.
 func (client *numberOperations) putBigDecimalCreateRequest(numberBody float64) (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/2.5976931e+101"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -777,7 +778,7 @@ func (client *numberOperations) PutBigDecimalNegativeDecimal(ctx context.Context
 // putBigDecimalNegativeDecimalCreateRequest creates the PutBigDecimalNegativeDecimal request.
 func (client *numberOperations) putBigDecimalNegativeDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/-99999999.99"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -822,7 +823,7 @@ func (client *numberOperations) PutBigDecimalPositiveDecimal(ctx context.Context
 // putBigDecimalPositiveDecimalCreateRequest creates the PutBigDecimalPositiveDecimal request.
 func (client *numberOperations) putBigDecimalPositiveDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/99999999.99"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -867,7 +868,7 @@ func (client *numberOperations) PutBigDouble(ctx context.Context, numberBody flo
 // putBigDoubleCreateRequest creates the PutBigDouble request.
 func (client *numberOperations) putBigDoubleCreateRequest(numberBody float64) (*azcore.Request, error) {
 	urlPath := "/number/big/double/2.5976931e+101"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -912,7 +913,7 @@ func (client *numberOperations) PutBigDoubleNegativeDecimal(ctx context.Context)
 // putBigDoubleNegativeDecimalCreateRequest creates the PutBigDoubleNegativeDecimal request.
 func (client *numberOperations) putBigDoubleNegativeDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/double/-99999999.99"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -957,7 +958,7 @@ func (client *numberOperations) PutBigDoublePositiveDecimal(ctx context.Context)
 // putBigDoublePositiveDecimalCreateRequest creates the PutBigDoublePositiveDecimal request.
 func (client *numberOperations) putBigDoublePositiveDecimalCreateRequest() (*azcore.Request, error) {
 	urlPath := "/number/big/double/99999999.99"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1002,7 +1003,7 @@ func (client *numberOperations) PutBigFloat(ctx context.Context, numberBody floa
 // putBigFloatCreateRequest creates the PutBigFloat request.
 func (client *numberOperations) putBigFloatCreateRequest(numberBody float32) (*azcore.Request, error) {
 	urlPath := "/number/big/float/3.402823e+20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1047,7 +1048,7 @@ func (client *numberOperations) PutSmallDecimal(ctx context.Context, numberBody 
 // putSmallDecimalCreateRequest creates the PutSmallDecimal request.
 func (client *numberOperations) putSmallDecimalCreateRequest(numberBody float64) (*azcore.Request, error) {
 	urlPath := "/number/small/decimal/2.5976931e-101"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1092,7 +1093,7 @@ func (client *numberOperations) PutSmallDouble(ctx context.Context, numberBody f
 // putSmallDoubleCreateRequest creates the PutSmallDouble request.
 func (client *numberOperations) putSmallDoubleCreateRequest(numberBody float64) (*azcore.Request, error) {
 	urlPath := "/number/small/double/2.5976931e-101"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1137,7 +1138,7 @@ func (client *numberOperations) PutSmallFloat(ctx context.Context, numberBody fl
 // putSmallFloatCreateRequest creates the PutSmallFloat request.
 func (client *numberOperations) putSmallFloatCreateRequest(numberBody float32) (*azcore.Request, error) {
 	urlPath := "/number/small/float/3.402823e-20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/optionalgroup/explicit.go
+++ b/test/autorest/generated/optionalgroup/explicit.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 	"strconv"
 	"strings"
 )
@@ -86,7 +87,7 @@ func (client *explicitOperations) PostOptionalArrayHeader(ctx context.Context, e
 // postOptionalArrayHeaderCreateRequest creates the PostOptionalArrayHeader request.
 func (client *explicitOperations) postOptionalArrayHeaderCreateRequest(explicitPostOptionalArrayHeaderOptions *ExplicitPostOptionalArrayHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/array/header"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +135,7 @@ func (client *explicitOperations) PostOptionalArrayParameter(ctx context.Context
 // postOptionalArrayParameterCreateRequest creates the PostOptionalArrayParameter request.
 func (client *explicitOperations) postOptionalArrayParameterCreateRequest(explicitPostOptionalArrayParameterOptions *ExplicitPostOptionalArrayParameterOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/array/parameter"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +183,7 @@ func (client *explicitOperations) PostOptionalArrayProperty(ctx context.Context,
 // postOptionalArrayPropertyCreateRequest creates the PostOptionalArrayProperty request.
 func (client *explicitOperations) postOptionalArrayPropertyCreateRequest(explicitPostOptionalArrayPropertyOptions *ExplicitPostOptionalArrayPropertyOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/array/property"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +231,7 @@ func (client *explicitOperations) PostOptionalClassParameter(ctx context.Context
 // postOptionalClassParameterCreateRequest creates the PostOptionalClassParameter request.
 func (client *explicitOperations) postOptionalClassParameterCreateRequest(explicitPostOptionalClassParameterOptions *ExplicitPostOptionalClassParameterOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/class/parameter"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +279,7 @@ func (client *explicitOperations) PostOptionalClassProperty(ctx context.Context,
 // postOptionalClassPropertyCreateRequest creates the PostOptionalClassProperty request.
 func (client *explicitOperations) postOptionalClassPropertyCreateRequest(explicitPostOptionalClassPropertyOptions *ExplicitPostOptionalClassPropertyOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/class/property"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +327,7 @@ func (client *explicitOperations) PostOptionalIntegerHeader(ctx context.Context,
 // postOptionalIntegerHeaderCreateRequest creates the PostOptionalIntegerHeader request.
 func (client *explicitOperations) postOptionalIntegerHeaderCreateRequest(explicitPostOptionalIntegerHeaderOptions *ExplicitPostOptionalIntegerHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/integer/header"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +375,7 @@ func (client *explicitOperations) PostOptionalIntegerParameter(ctx context.Conte
 // postOptionalIntegerParameterCreateRequest creates the PostOptionalIntegerParameter request.
 func (client *explicitOperations) postOptionalIntegerParameterCreateRequest(explicitPostOptionalIntegerParameterOptions *ExplicitPostOptionalIntegerParameterOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/integer/parameter"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -422,7 +423,7 @@ func (client *explicitOperations) PostOptionalIntegerProperty(ctx context.Contex
 // postOptionalIntegerPropertyCreateRequest creates the PostOptionalIntegerProperty request.
 func (client *explicitOperations) postOptionalIntegerPropertyCreateRequest(explicitPostOptionalIntegerPropertyOptions *ExplicitPostOptionalIntegerPropertyOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/integer/property"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -470,7 +471,7 @@ func (client *explicitOperations) PostOptionalStringHeader(ctx context.Context, 
 // postOptionalStringHeaderCreateRequest creates the PostOptionalStringHeader request.
 func (client *explicitOperations) postOptionalStringHeaderCreateRequest(explicitPostOptionalStringHeaderOptions *ExplicitPostOptionalStringHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/string/header"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -518,7 +519,7 @@ func (client *explicitOperations) PostOptionalStringParameter(ctx context.Contex
 // postOptionalStringParameterCreateRequest creates the PostOptionalStringParameter request.
 func (client *explicitOperations) postOptionalStringParameterCreateRequest(explicitPostOptionalStringParameterOptions *ExplicitPostOptionalStringParameterOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/string/parameter"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -566,7 +567,7 @@ func (client *explicitOperations) PostOptionalStringProperty(ctx context.Context
 // postOptionalStringPropertyCreateRequest creates the PostOptionalStringProperty request.
 func (client *explicitOperations) postOptionalStringPropertyCreateRequest(explicitPostOptionalStringPropertyOptions *ExplicitPostOptionalStringPropertyOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/string/property"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -614,7 +615,7 @@ func (client *explicitOperations) PostRequiredArrayHeader(ctx context.Context, h
 // postRequiredArrayHeaderCreateRequest creates the PostRequiredArrayHeader request.
 func (client *explicitOperations) postRequiredArrayHeaderCreateRequest(headerParameter []string) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/array/header"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -660,7 +661,7 @@ func (client *explicitOperations) PostRequiredArrayParameter(ctx context.Context
 // postRequiredArrayParameterCreateRequest creates the PostRequiredArrayParameter request.
 func (client *explicitOperations) postRequiredArrayParameterCreateRequest(bodyParameter []string) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/array/parameter"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -705,7 +706,7 @@ func (client *explicitOperations) PostRequiredArrayProperty(ctx context.Context,
 // postRequiredArrayPropertyCreateRequest creates the PostRequiredArrayProperty request.
 func (client *explicitOperations) postRequiredArrayPropertyCreateRequest(bodyParameter ArrayWrapper) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/array/property"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -750,7 +751,7 @@ func (client *explicitOperations) PostRequiredClassParameter(ctx context.Context
 // postRequiredClassParameterCreateRequest creates the PostRequiredClassParameter request.
 func (client *explicitOperations) postRequiredClassParameterCreateRequest(bodyParameter Product) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/class/parameter"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -795,7 +796,7 @@ func (client *explicitOperations) PostRequiredClassProperty(ctx context.Context,
 // postRequiredClassPropertyCreateRequest creates the PostRequiredClassProperty request.
 func (client *explicitOperations) postRequiredClassPropertyCreateRequest(bodyParameter ClassWrapper) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/class/property"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -840,7 +841,7 @@ func (client *explicitOperations) PostRequiredIntegerHeader(ctx context.Context,
 // postRequiredIntegerHeaderCreateRequest creates the PostRequiredIntegerHeader request.
 func (client *explicitOperations) postRequiredIntegerHeaderCreateRequest(headerParameter int32) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/integer/header"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -886,7 +887,7 @@ func (client *explicitOperations) PostRequiredIntegerParameter(ctx context.Conte
 // postRequiredIntegerParameterCreateRequest creates the PostRequiredIntegerParameter request.
 func (client *explicitOperations) postRequiredIntegerParameterCreateRequest(bodyParameter int32) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/integer/parameter"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -931,7 +932,7 @@ func (client *explicitOperations) PostRequiredIntegerProperty(ctx context.Contex
 // postRequiredIntegerPropertyCreateRequest creates the PostRequiredIntegerProperty request.
 func (client *explicitOperations) postRequiredIntegerPropertyCreateRequest(bodyParameter IntWrapper) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/integer/property"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -976,7 +977,7 @@ func (client *explicitOperations) PostRequiredStringHeader(ctx context.Context, 
 // postRequiredStringHeaderCreateRequest creates the PostRequiredStringHeader request.
 func (client *explicitOperations) postRequiredStringHeaderCreateRequest(headerParameter string) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/string/header"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1022,7 +1023,7 @@ func (client *explicitOperations) PostRequiredStringParameter(ctx context.Contex
 // postRequiredStringParameterCreateRequest creates the PostRequiredStringParameter request.
 func (client *explicitOperations) postRequiredStringParameterCreateRequest(bodyParameter string) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/string/parameter"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1067,7 +1068,7 @@ func (client *explicitOperations) PostRequiredStringProperty(ctx context.Context
 // postRequiredStringPropertyCreateRequest creates the PostRequiredStringProperty request.
 func (client *explicitOperations) postRequiredStringPropertyCreateRequest(bodyParameter StringWrapper) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/string/property"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/optionalgroup/implicit.go
+++ b/test/autorest/generated/optionalgroup/implicit.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 )
@@ -60,7 +61,7 @@ func (client *implicitOperations) GetOptionalGlobalQuery(ctx context.Context) (*
 // getOptionalGlobalQueryCreateRequest creates the GetOptionalGlobalQuery request.
 func (client *implicitOperations) getOptionalGlobalQueryCreateRequest() (*azcore.Request, error) {
 	urlPath := "/reqopt/global/optional/query"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +112,7 @@ func (client *implicitOperations) GetRequiredGlobalPath(ctx context.Context) (*h
 func (client *implicitOperations) getRequiredGlobalPathCreateRequest() (*azcore.Request, error) {
 	urlPath := "/reqopt/global/required/path/{required-global-path}"
 	urlPath = strings.ReplaceAll(urlPath, "{required-global-path}", url.PathEscape(client.requiredGlobalPath))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +157,7 @@ func (client *implicitOperations) GetRequiredGlobalQuery(ctx context.Context) (*
 // getRequiredGlobalQueryCreateRequest creates the GetRequiredGlobalQuery request.
 func (client *implicitOperations) getRequiredGlobalQueryCreateRequest() (*azcore.Request, error) {
 	urlPath := "/reqopt/global/required/query"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +206,7 @@ func (client *implicitOperations) GetRequiredPath(ctx context.Context, pathParam
 func (client *implicitOperations) getRequiredPathCreateRequest(pathParameter string) (*azcore.Request, error) {
 	urlPath := "/reqopt/implicit/required/path/{pathParameter}"
 	urlPath = strings.ReplaceAll(urlPath, "{pathParameter}", url.PathEscape(pathParameter))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +251,7 @@ func (client *implicitOperations) PutOptionalBody(ctx context.Context, implicitP
 // putOptionalBodyCreateRequest creates the PutOptionalBody request.
 func (client *implicitOperations) putOptionalBodyCreateRequest(implicitPutOptionalBodyOptions *ImplicitPutOptionalBodyOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/implicit/optional/body"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +299,7 @@ func (client *implicitOperations) PutOptionalHeader(ctx context.Context, implici
 // putOptionalHeaderCreateRequest creates the PutOptionalHeader request.
 func (client *implicitOperations) putOptionalHeaderCreateRequest(implicitPutOptionalHeaderOptions *ImplicitPutOptionalHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/implicit/optional/header"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -346,7 +347,7 @@ func (client *implicitOperations) PutOptionalQuery(ctx context.Context, implicit
 // putOptionalQueryCreateRequest creates the PutOptionalQuery request.
 func (client *implicitOperations) putOptionalQueryCreateRequest(implicitPutOptionalQueryOptions *ImplicitPutOptionalQueryOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/implicit/optional/query"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/paginggroup/paging.go
+++ b/test/autorest/generated/paginggroup/paging.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -87,7 +88,7 @@ func (client *pagingOperations) GetMultiplePages(pagingGetMultiplePagesOptions *
 // getMultiplePagesCreateRequest creates the GetMultiplePages request.
 func (client *pagingOperations) getMultiplePagesCreateRequest(pagingGetMultiplePagesOptions *PagingGetMultiplePagesOptions) (*azcore.Request, error) {
 	urlPath := "/paging/multiple"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +152,7 @@ func (client *pagingOperations) GetMultiplePagesFailure() (ProductResultPager, e
 // getMultiplePagesFailureCreateRequest creates the GetMultiplePagesFailure request.
 func (client *pagingOperations) getMultiplePagesFailureCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paging/multiple/failure"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +207,7 @@ func (client *pagingOperations) GetMultiplePagesFailureURI() (ProductResultPager
 // getMultiplePagesFailureUriCreateRequest creates the GetMultiplePagesFailureURI request.
 func (client *pagingOperations) getMultiplePagesFailureUriCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paging/multiple/failureuri"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +256,7 @@ func (client *pagingOperations) GetMultiplePagesFragmentNextLink(apiVersion stri
 func (client *pagingOperations) getMultiplePagesFragmentNextLinkCreateRequest(apiVersion string, tenant string) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/fragment/{tenant}"
 	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(tenant))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +308,7 @@ func (client *pagingOperations) GetMultiplePagesFragmentWithGroupingNextLink(cus
 func (client *pagingOperations) getMultiplePagesFragmentWithGroupingNextLinkCreateRequest(customParameterGroup CustomParameterGroup) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/fragmentwithgrouping/{tenant}"
 	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(customParameterGroup.Tenant))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -384,7 +385,7 @@ func (client *pagingOperations) ResumeGetMultiplePagesLro(token string) (Product
 // getMultiplePagesLroCreateRequest creates the GetMultiplePagesLro request.
 func (client *pagingOperations) getMultiplePagesLroCreateRequest(pagingGetMultiplePagesLroOptions *PagingGetMultiplePagesLroOptions) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/lro"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +457,7 @@ func (client *pagingOperations) GetMultiplePagesRetryFirst() (ProductResultPager
 // getMultiplePagesRetryFirstCreateRequest creates the GetMultiplePagesRetryFirst request.
 func (client *pagingOperations) getMultiplePagesRetryFirstCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paging/multiple/retryfirst"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -511,7 +512,7 @@ func (client *pagingOperations) GetMultiplePagesRetrySecond() (ProductResultPage
 // getMultiplePagesRetrySecondCreateRequest creates the GetMultiplePagesRetrySecond request.
 func (client *pagingOperations) getMultiplePagesRetrySecondCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paging/multiple/retrysecond"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -567,7 +568,7 @@ func (client *pagingOperations) GetMultiplePagesWithOffset(pagingGetMultiplePage
 func (client *pagingOperations) getMultiplePagesWithOffsetCreateRequest(pagingGetMultiplePagesWithOffsetOptions PagingGetMultiplePagesWithOffsetOptions) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/withpath/{offset}"
 	urlPath = strings.ReplaceAll(urlPath, "{offset}", url.PathEscape(strconv.FormatInt(int64(pagingGetMultiplePagesWithOffsetOptions.Offset), 10)))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -631,7 +632,7 @@ func (client *pagingOperations) GetNoItemNamePages() (ProductResultValuePager, e
 // getNoItemNamePagesCreateRequest creates the GetNoItemNamePages request.
 func (client *pagingOperations) getNoItemNamePagesCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paging/noitemname"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -680,7 +681,7 @@ func (client *pagingOperations) GetNullNextLinkNamePages(ctx context.Context) (*
 // getNullNextLinkNamePagesCreateRequest creates the GetNullNextLinkNamePages request.
 func (client *pagingOperations) getNullNextLinkNamePagesCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paging/nullnextlink"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -735,7 +736,7 @@ func (client *pagingOperations) GetOdataMultiplePages(pagingGetOdataMultiplePage
 // getOdataMultiplePagesCreateRequest creates the GetOdataMultiplePages request.
 func (client *pagingOperations) getOdataMultiplePagesCreateRequest(pagingGetOdataMultiplePagesOptions *PagingGetOdataMultiplePagesOptions) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/odata"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -799,7 +800,7 @@ func (client *pagingOperations) GetPagingModelWithItemNameWithXmsClientName() (P
 // getPagingModelWithItemNameWithXmsClientNameCreateRequest creates the GetPagingModelWithItemNameWithXmsClientName request.
 func (client *pagingOperations) getPagingModelWithItemNameWithXmsClientNameCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paging/itemNameWithXMSClientName"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -854,7 +855,7 @@ func (client *pagingOperations) GetSinglePages() (ProductResultPager, error) {
 // getSinglePagesCreateRequest creates the GetSinglePages request.
 func (client *pagingOperations) getSinglePagesCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paging/single"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -909,7 +910,7 @@ func (client *pagingOperations) GetSinglePagesFailure() (ProductResultPager, err
 // getSinglePagesFailureCreateRequest creates the GetSinglePagesFailure request.
 func (client *pagingOperations) getSinglePagesFailureCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paging/single/failure"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -957,7 +958,7 @@ func (client *pagingOperations) GetWithQueryParams(requiredQueryParameter int32)
 // getWithQueryParamsCreateRequest creates the GetWithQueryParams request.
 func (client *pagingOperations) getWithQueryParamsCreateRequest(requiredQueryParameter int32) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/getWithQueryParams"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -995,7 +996,7 @@ func (client *pagingOperations) nextFragmentCreateRequest(apiVersion string, ten
 	urlPath := "/paging/multiple/fragment/{tenant}/{nextLink}"
 	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(tenant))
 	urlPath = strings.ReplaceAll(urlPath, "{nextLink}", nextLink)
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1032,7 +1033,7 @@ func (client *pagingOperations) nextFragmentWithGroupingCreateRequest(nextLink s
 	urlPath := "/paging/multiple/fragmentwithgrouping/{tenant}/{nextLink}"
 	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(customParameterGroup.Tenant))
 	urlPath = strings.ReplaceAll(urlPath, "{nextLink}", nextLink)
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1067,7 +1068,7 @@ func (client *pagingOperations) nextFragmentWithGroupingHandleError(resp *azcore
 // nextOperationWithQueryParamsCreateRequest creates the NextOperationWithQueryParams request.
 func (client *pagingOperations) nextOperationWithQueryParamsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paging/multiple/nextOperationWithQueryParams"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/paramgroupinggroup/parametergrouping.go
+++ b/test/autorest/generated/paramgroupinggroup/parametergrouping.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 )
@@ -51,7 +52,7 @@ func (client *parameterGroupingOperations) PostMultiParamGroups(ctx context.Cont
 // postMultiParamGroupsCreateRequest creates the PostMultiParamGroups request.
 func (client *parameterGroupingOperations) postMultiParamGroupsCreateRequest(firstParameterGroup *FirstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup *ParameterGroupingPostMultiParamGroupsSecondParamGroup) (*azcore.Request, error) {
 	urlPath := "/parameterGrouping/postMultipleParameterGroups"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (client *parameterGroupingOperations) PostOptional(ctx context.Context, par
 // postOptionalCreateRequest creates the PostOptional request.
 func (client *parameterGroupingOperations) postOptionalCreateRequest(parameterGroupingPostOptionalParameters *ParameterGroupingPostOptionalParameters) (*azcore.Request, error) {
 	urlPath := "/parameterGrouping/postOptional"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +165,7 @@ func (client *parameterGroupingOperations) PostRequired(ctx context.Context, par
 func (client *parameterGroupingOperations) postRequiredCreateRequest(parameterGroupingPostRequiredParameters ParameterGroupingPostRequiredParameters) (*azcore.Request, error) {
 	urlPath := "/parameterGrouping/postRequired/{path}"
 	urlPath = strings.ReplaceAll(urlPath, "{path}", url.PathEscape(parameterGroupingPostRequiredParameters.PathParameter))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +218,7 @@ func (client *parameterGroupingOperations) PostSharedParameterGroupObject(ctx co
 // postSharedParameterGroupObjectCreateRequest creates the PostSharedParameterGroupObject request.
 func (client *parameterGroupingOperations) postSharedParameterGroupObjectCreateRequest(firstParameterGroup *FirstParameterGroup) (*azcore.Request, error) {
 	urlPath := "/parameterGrouping/sharedParameterGroupObject"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/reportgroup/autorestreportservice.go
+++ b/test/autorest/generated/reportgroup/autorestreportservice.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // AutoRestReportServiceOperations contains the methods for the AutoRestReportService group.
@@ -44,7 +45,7 @@ func (client *autoRestReportServiceOperations) GetOptionalReport(ctx context.Con
 // getOptionalReportCreateRequest creates the GetOptionalReport request.
 func (client *autoRestReportServiceOperations) getOptionalReportCreateRequest(autoRestReportServiceGetOptionalReportOptions *AutoRestReportServiceGetOptionalReportOptions) (*azcore.Request, error) {
 	urlPath := "/report/optional"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +96,7 @@ func (client *autoRestReportServiceOperations) GetReport(ctx context.Context, au
 // getReportCreateRequest creates the GetReport request.
 func (client *autoRestReportServiceOperations) getReportCreateRequest(autoRestReportServiceGetReportOptions *AutoRestReportServiceGetReportOptions) (*azcore.Request, error) {
 	urlPath := "/report"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/stringgroup/enum.go
+++ b/test/autorest/generated/stringgroup/enum.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // EnumOperations contains the methods for the Enum group.
@@ -52,7 +53,7 @@ func (client *enumOperations) GetNotExpandable(ctx context.Context) (*ColorsResp
 // getNotExpandableCreateRequest creates the GetNotExpandable request.
 func (client *enumOperations) getNotExpandableCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/enum/notExpandable"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +99,7 @@ func (client *enumOperations) GetReferenced(ctx context.Context) (*ColorsRespons
 // getReferencedCreateRequest creates the GetReferenced request.
 func (client *enumOperations) getReferencedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/enum/Referenced"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +145,7 @@ func (client *enumOperations) GetReferencedConstant(ctx context.Context) (*RefCo
 // getReferencedConstantCreateRequest creates the GetReferencedConstant request.
 func (client *enumOperations) getReferencedConstantCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/enum/ReferencedConstant"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +191,7 @@ func (client *enumOperations) PutNotExpandable(ctx context.Context, stringBody C
 // putNotExpandableCreateRequest creates the PutNotExpandable request.
 func (client *enumOperations) putNotExpandableCreateRequest(stringBody Colors) (*azcore.Request, error) {
 	urlPath := "/string/enum/notExpandable"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +236,7 @@ func (client *enumOperations) PutReferenced(ctx context.Context, enumStringBody 
 // putReferencedCreateRequest creates the PutReferenced request.
 func (client *enumOperations) putReferencedCreateRequest(enumStringBody Colors) (*azcore.Request, error) {
 	urlPath := "/string/enum/Referenced"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +281,7 @@ func (client *enumOperations) PutReferencedConstant(ctx context.Context, enumStr
 // putReferencedConstantCreateRequest creates the PutReferencedConstant request.
 func (client *enumOperations) putReferencedConstantCreateRequest(enumStringBody RefColorConstant) (*azcore.Request, error) {
 	urlPath := "/string/enum/ReferencedConstant"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/stringgroup/string.go
+++ b/test/autorest/generated/stringgroup/string.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 )
 
 // StringOperations contains the methods for the String group.
@@ -66,7 +67,7 @@ func (client *stringOperations) GetBase64Encoded(ctx context.Context) (*ByteArra
 // getBase64EncodedCreateRequest creates the GetBase64Encoded request.
 func (client *stringOperations) getBase64EncodedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/base64Encoding"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +113,7 @@ func (client *stringOperations) GetBase64URLEncoded(ctx context.Context) (*ByteA
 // getBase64UrlEncodedCreateRequest creates the GetBase64URLEncoded request.
 func (client *stringOperations) getBase64UrlEncodedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/base64UrlEncoding"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +159,7 @@ func (client *stringOperations) GetEmpty(ctx context.Context) (*StringResponse, 
 // getEmptyCreateRequest creates the GetEmpty request.
 func (client *stringOperations) getEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +205,7 @@ func (client *stringOperations) GetMBCS(ctx context.Context) (*StringResponse, e
 // getMbcsCreateRequest creates the GetMBCS request.
 func (client *stringOperations) getMbcsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/mbcs"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +251,7 @@ func (client *stringOperations) GetNotProvided(ctx context.Context) (*StringResp
 // getNotProvidedCreateRequest creates the GetNotProvided request.
 func (client *stringOperations) getNotProvidedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/notProvided"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +297,7 @@ func (client *stringOperations) GetNull(ctx context.Context) (*StringResponse, e
 // getNullCreateRequest creates the GetNull request.
 func (client *stringOperations) getNullCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +343,7 @@ func (client *stringOperations) GetNullBase64URLEncoded(ctx context.Context) (*B
 // getNullBase64UrlEncodedCreateRequest creates the GetNullBase64URLEncoded request.
 func (client *stringOperations) getNullBase64UrlEncodedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/nullBase64UrlEncoding"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +389,7 @@ func (client *stringOperations) GetWhitespace(ctx context.Context) (*StringRespo
 // getWhitespaceCreateRequest creates the GetWhitespace request.
 func (client *stringOperations) getWhitespaceCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/whitespace"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -434,7 +435,7 @@ func (client *stringOperations) PutBase64URLEncoded(ctx context.Context, stringB
 // putBase64UrlEncodedCreateRequest creates the PutBase64URLEncoded request.
 func (client *stringOperations) putBase64UrlEncodedCreateRequest(stringBody []byte) (*azcore.Request, error) {
 	urlPath := "/string/base64UrlEncoding"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -479,7 +480,7 @@ func (client *stringOperations) PutEmpty(ctx context.Context) (*http.Response, e
 // putEmptyCreateRequest creates the PutEmpty request.
 func (client *stringOperations) putEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -524,7 +525,7 @@ func (client *stringOperations) PutMBCS(ctx context.Context) (*http.Response, er
 // putMbcsCreateRequest creates the PutMBCS request.
 func (client *stringOperations) putMbcsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/mbcs"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -569,7 +570,7 @@ func (client *stringOperations) PutNull(ctx context.Context, stringPutNullOption
 // putNullCreateRequest creates the PutNull request.
 func (client *stringOperations) putNullCreateRequest(stringPutNullOptions *StringPutNullOptions) (*azcore.Request, error) {
 	urlPath := "/string/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -617,7 +618,7 @@ func (client *stringOperations) PutWhitespace(ctx context.Context) (*http.Respon
 // putWhitespaceCreateRequest creates the PutWhitespace request.
 func (client *stringOperations) putWhitespaceCreateRequest() (*azcore.Request, error) {
 	urlPath := "/string/whitespace"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/urlgroup/pathitems.go
+++ b/test/autorest/generated/urlgroup/pathitems.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -55,7 +56,7 @@ func (client *pathItemsOperations) getAllWithValuesCreateRequest(pathItemStringP
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +115,7 @@ func (client *pathItemsOperations) getGlobalAndLocalQueryNullCreateRequest(pathI
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +174,7 @@ func (client *pathItemsOperations) getGlobalQueryNullCreateRequest(pathItemStrin
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +233,7 @@ func (client *pathItemsOperations) getLocalPathItemQueryNullCreateRequest(pathIt
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/urlgroup/paths.go
+++ b/test/autorest/generated/urlgroup/paths.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -99,7 +100,7 @@ func (client *pathsOperations) ArrayCSVInPath(ctx context.Context, arrayPath []s
 func (client *pathsOperations) arrayCsvInPathCreateRequest(arrayPath []string) (*azcore.Request, error) {
 	urlPath := "/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{arrayPath}", url.PathEscape(strings.Join(arrayPath, ",")))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +146,7 @@ func (client *pathsOperations) Base64URL(ctx context.Context, base64UrlPath []by
 func (client *pathsOperations) base64UrlCreateRequest(base64UrlPath []byte) (*azcore.Request, error) {
 	urlPath := "/paths/string/bG9yZW0/{base64UrlPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{base64UrlPath}", url.PathEscape(base64.RawURLEncoding.EncodeToString(base64UrlPath)))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +192,7 @@ func (client *pathsOperations) ByteEmpty(ctx context.Context) (*http.Response, e
 func (client *pathsOperations) byteEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/byte/empty/{bytePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(""))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +238,7 @@ func (client *pathsOperations) ByteMultiByte(ctx context.Context, bytePath []byt
 func (client *pathsOperations) byteMultiByteCreateRequest(bytePath []byte) (*azcore.Request, error) {
 	urlPath := "/paths/byte/multibyte/{bytePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(base64.StdEncoding.EncodeToString(bytePath)))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +284,7 @@ func (client *pathsOperations) ByteNull(ctx context.Context, bytePath []byte) (*
 func (client *pathsOperations) byteNullCreateRequest(bytePath []byte) (*azcore.Request, error) {
 	urlPath := "/paths/byte/null/{bytePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(base64.StdEncoding.EncodeToString(bytePath)))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +330,7 @@ func (client *pathsOperations) DateNull(ctx context.Context, datePath time.Time)
 func (client *pathsOperations) dateNullCreateRequest(datePath time.Time) (*azcore.Request, error) {
 	urlPath := "/paths/date/null/{datePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{datePath}", url.PathEscape(datePath.Format("2006-01-02")))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -375,7 +376,7 @@ func (client *pathsOperations) DateTimeNull(ctx context.Context, dateTimePath ti
 func (client *pathsOperations) dateTimeNullCreateRequest(dateTimePath time.Time) (*azcore.Request, error) {
 	urlPath := "/paths/datetime/null/{dateTimePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{dateTimePath}", url.PathEscape(dateTimePath.Format(time.RFC3339)))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -421,7 +422,7 @@ func (client *pathsOperations) DateTimeValid(ctx context.Context) (*http.Respons
 func (client *pathsOperations) dateTimeValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{dateTimePath}", url.PathEscape("2012-01-01T01:01:01Z"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -467,7 +468,7 @@ func (client *pathsOperations) DateValid(ctx context.Context) (*http.Response, e
 func (client *pathsOperations) dateValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/date/2012-01-01/{datePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{datePath}", url.PathEscape("2012-01-01"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -513,7 +514,7 @@ func (client *pathsOperations) DoubleDecimalNegative(ctx context.Context) (*http
 func (client *pathsOperations) doubleDecimalNegativeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/double/-9999999.999/{doublePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{doublePath}", url.PathEscape("-9999999.999"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -559,7 +560,7 @@ func (client *pathsOperations) DoubleDecimalPositive(ctx context.Context) (*http
 func (client *pathsOperations) doubleDecimalPositiveCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/double/9999999.999/{doublePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{doublePath}", url.PathEscape("9999999.999"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -605,7 +606,7 @@ func (client *pathsOperations) EnumNull(ctx context.Context, enumPath UriColor) 
 func (client *pathsOperations) enumNullCreateRequest(enumPath UriColor) (*azcore.Request, error) {
 	urlPath := "/paths/string/null/{enumPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{enumPath}", url.PathEscape(string(enumPath)))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -651,7 +652,7 @@ func (client *pathsOperations) EnumValid(ctx context.Context, enumPath UriColor)
 func (client *pathsOperations) enumValidCreateRequest(enumPath UriColor) (*azcore.Request, error) {
 	urlPath := "/paths/enum/green%20color/{enumPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{enumPath}", url.PathEscape(string(enumPath)))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -697,7 +698,7 @@ func (client *pathsOperations) FloatScientificNegative(ctx context.Context) (*ht
 func (client *pathsOperations) floatScientificNegativeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/float/-1.034E-20/{floatPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{floatPath}", url.PathEscape("-1.034e-20"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -743,7 +744,7 @@ func (client *pathsOperations) FloatScientificPositive(ctx context.Context) (*ht
 func (client *pathsOperations) floatScientificPositiveCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/float/1.034E+20/{floatPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{floatPath}", url.PathEscape("103400000000000000000"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -789,7 +790,7 @@ func (client *pathsOperations) GetBooleanFalse(ctx context.Context) (*http.Respo
 func (client *pathsOperations) getBooleanFalseCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/bool/false/{boolPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{boolPath}", url.PathEscape("false"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -835,7 +836,7 @@ func (client *pathsOperations) GetBooleanTrue(ctx context.Context) (*http.Respon
 func (client *pathsOperations) getBooleanTrueCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/bool/true/{boolPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{boolPath}", url.PathEscape("true"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -881,7 +882,7 @@ func (client *pathsOperations) GetIntNegativeOneMillion(ctx context.Context) (*h
 func (client *pathsOperations) getIntNegativeOneMillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/int/-1000000/{intPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{intPath}", url.PathEscape("-1000000"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -927,7 +928,7 @@ func (client *pathsOperations) GetIntOneMillion(ctx context.Context) (*http.Resp
 func (client *pathsOperations) getIntOneMillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/int/1000000/{intPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{intPath}", url.PathEscape("1000000"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -973,7 +974,7 @@ func (client *pathsOperations) GetNegativeTenBillion(ctx context.Context) (*http
 func (client *pathsOperations) getNegativeTenBillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/long/-10000000000/{longPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{longPath}", url.PathEscape("-10000000000"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1019,7 +1020,7 @@ func (client *pathsOperations) GetTenBillion(ctx context.Context) (*http.Respons
 func (client *pathsOperations) getTenBillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/long/10000000000/{longPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{longPath}", url.PathEscape("10000000000"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1065,7 +1066,7 @@ func (client *pathsOperations) StringEmpty(ctx context.Context) (*http.Response,
 func (client *pathsOperations) stringEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/string/empty/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape(""))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1111,7 +1112,7 @@ func (client *pathsOperations) StringNull(ctx context.Context, stringPath string
 func (client *pathsOperations) stringNullCreateRequest(stringPath string) (*azcore.Request, error) {
 	urlPath := "/paths/string/null/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape(stringPath))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1157,7 +1158,7 @@ func (client *pathsOperations) StringURLEncoded(ctx context.Context) (*http.Resp
 func (client *pathsOperations) stringUrlEncodedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape("begin!*'();:@ &=+$,/?#[]end"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1203,7 +1204,7 @@ func (client *pathsOperations) StringURLNonEncoded(ctx context.Context) (*http.R
 func (client *pathsOperations) stringUrlNonEncodedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/string/begin!*'();:@&=+$,end/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", "begin!*'();:@&=+$,end")
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1249,7 +1250,7 @@ func (client *pathsOperations) StringUnicode(ctx context.Context) (*http.Respons
 func (client *pathsOperations) stringUnicodeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/paths/string/unicode/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape("啊齄丂狛狜隣郎隣兀﨩"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1295,7 +1296,7 @@ func (client *pathsOperations) UnixTimeURL(ctx context.Context, unixTimeUrlPath 
 func (client *pathsOperations) unixTimeUrlCreateRequest(unixTimeUrlPath time.Time) (*azcore.Request, error) {
 	urlPath := "/paths/int/1460505600/{unixTimeUrlPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{unixTimeUrlPath}", url.PathEscape(timeUnix(unixTimeUrlPath).String()))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/urlgroup/queries.go
+++ b/test/autorest/generated/urlgroup/queries.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -112,7 +113,7 @@ func (client *queriesOperations) ArrayStringCSVEmpty(ctx context.Context, querie
 // arrayStringCsvEmptyCreateRequest creates the ArrayStringCSVEmpty request.
 func (client *queriesOperations) arrayStringCsvEmptyCreateRequest(queriesArrayStringCsvEmptyOptions *QueriesArrayStringCSVEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/csv/string/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +163,7 @@ func (client *queriesOperations) ArrayStringCSVNull(ctx context.Context, queries
 // arrayStringCsvNullCreateRequest creates the ArrayStringCSVNull request.
 func (client *queriesOperations) arrayStringCsvNullCreateRequest(queriesArrayStringCsvNullOptions *QueriesArrayStringCSVNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/csv/string/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +213,7 @@ func (client *queriesOperations) ArrayStringCSVValid(ctx context.Context, querie
 // arrayStringCsvValidCreateRequest creates the ArrayStringCSVValid request.
 func (client *queriesOperations) arrayStringCsvValidCreateRequest(queriesArrayStringCsvValidOptions *QueriesArrayStringCSVValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/csv/string/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +263,7 @@ func (client *queriesOperations) ArrayStringPipesValid(ctx context.Context, quer
 // arrayStringPipesValidCreateRequest creates the ArrayStringPipesValid request.
 func (client *queriesOperations) arrayStringPipesValidCreateRequest(queriesArrayStringPipesValidOptions *QueriesArrayStringPipesValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/pipes/string/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +313,7 @@ func (client *queriesOperations) ArrayStringSsvValid(ctx context.Context, querie
 // arrayStringSsvValidCreateRequest creates the ArrayStringSsvValid request.
 func (client *queriesOperations) arrayStringSsvValidCreateRequest(queriesArrayStringSsvValidOptions *QueriesArrayStringSsvValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/ssv/string/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -362,7 +363,7 @@ func (client *queriesOperations) ArrayStringTsvValid(ctx context.Context, querie
 // arrayStringTsvValidCreateRequest creates the ArrayStringTsvValid request.
 func (client *queriesOperations) arrayStringTsvValidCreateRequest(queriesArrayStringTsvValidOptions *QueriesArrayStringTsvValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/tsv/string/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -412,7 +413,7 @@ func (client *queriesOperations) ByteEmpty(ctx context.Context) (*http.Response,
 // byteEmptyCreateRequest creates the ByteEmpty request.
 func (client *queriesOperations) byteEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/byte/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -460,7 +461,7 @@ func (client *queriesOperations) ByteMultiByte(ctx context.Context, queriesByteM
 // byteMultiByteCreateRequest creates the ByteMultiByte request.
 func (client *queriesOperations) byteMultiByteCreateRequest(queriesByteMultiByteOptions *QueriesByteMultiByteOptions) (*azcore.Request, error) {
 	urlPath := "/queries/byte/multibyte"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -510,7 +511,7 @@ func (client *queriesOperations) ByteNull(ctx context.Context, queriesByteNullOp
 // byteNullCreateRequest creates the ByteNull request.
 func (client *queriesOperations) byteNullCreateRequest(queriesByteNullOptions *QueriesByteNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/byte/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +561,7 @@ func (client *queriesOperations) DateNull(ctx context.Context, queriesDateNullOp
 // dateNullCreateRequest creates the DateNull request.
 func (client *queriesOperations) dateNullCreateRequest(queriesDateNullOptions *QueriesDateNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/date/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -610,7 +611,7 @@ func (client *queriesOperations) DateTimeNull(ctx context.Context, queriesDateTi
 // dateTimeNullCreateRequest creates the DateTimeNull request.
 func (client *queriesOperations) dateTimeNullCreateRequest(queriesDateTimeNullOptions *QueriesDateTimeNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/datetime/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -660,7 +661,7 @@ func (client *queriesOperations) DateTimeValid(ctx context.Context) (*http.Respo
 // dateTimeValidCreateRequest creates the DateTimeValid request.
 func (client *queriesOperations) dateTimeValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/datetime/2012-01-01T01%3A01%3A01Z"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -708,7 +709,7 @@ func (client *queriesOperations) DateValid(ctx context.Context) (*http.Response,
 // dateValidCreateRequest creates the DateValid request.
 func (client *queriesOperations) dateValidCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/date/2012-01-01"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -756,7 +757,7 @@ func (client *queriesOperations) DoubleDecimalNegative(ctx context.Context) (*ht
 // doubleDecimalNegativeCreateRequest creates the DoubleDecimalNegative request.
 func (client *queriesOperations) doubleDecimalNegativeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/double/-9999999.999"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -804,7 +805,7 @@ func (client *queriesOperations) DoubleDecimalPositive(ctx context.Context) (*ht
 // doubleDecimalPositiveCreateRequest creates the DoubleDecimalPositive request.
 func (client *queriesOperations) doubleDecimalPositiveCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/double/9999999.999"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -852,7 +853,7 @@ func (client *queriesOperations) DoubleNull(ctx context.Context, queriesDoubleNu
 // doubleNullCreateRequest creates the DoubleNull request.
 func (client *queriesOperations) doubleNullCreateRequest(queriesDoubleNullOptions *QueriesDoubleNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/double/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -902,7 +903,7 @@ func (client *queriesOperations) EnumNull(ctx context.Context, queriesEnumNullOp
 // enumNullCreateRequest creates the EnumNull request.
 func (client *queriesOperations) enumNullCreateRequest(queriesEnumNullOptions *QueriesEnumNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/enum/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -952,7 +953,7 @@ func (client *queriesOperations) EnumValid(ctx context.Context, queriesEnumValid
 // enumValidCreateRequest creates the EnumValid request.
 func (client *queriesOperations) enumValidCreateRequest(queriesEnumValidOptions *QueriesEnumValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/enum/green%20color"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1002,7 +1003,7 @@ func (client *queriesOperations) FloatNull(ctx context.Context, queriesFloatNull
 // floatNullCreateRequest creates the FloatNull request.
 func (client *queriesOperations) floatNullCreateRequest(queriesFloatNullOptions *QueriesFloatNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/float/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1052,7 +1053,7 @@ func (client *queriesOperations) FloatScientificNegative(ctx context.Context) (*
 // floatScientificNegativeCreateRequest creates the FloatScientificNegative request.
 func (client *queriesOperations) floatScientificNegativeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/float/-1.034E-20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1100,7 +1101,7 @@ func (client *queriesOperations) FloatScientificPositive(ctx context.Context) (*
 // floatScientificPositiveCreateRequest creates the FloatScientificPositive request.
 func (client *queriesOperations) floatScientificPositiveCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/float/1.034E+20"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1148,7 +1149,7 @@ func (client *queriesOperations) GetBooleanFalse(ctx context.Context) (*http.Res
 // getBooleanFalseCreateRequest creates the GetBooleanFalse request.
 func (client *queriesOperations) getBooleanFalseCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/bool/false"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1196,7 +1197,7 @@ func (client *queriesOperations) GetBooleanNull(ctx context.Context, queriesGetB
 // getBooleanNullCreateRequest creates the GetBooleanNull request.
 func (client *queriesOperations) getBooleanNullCreateRequest(queriesGetBooleanNullOptions *QueriesGetBooleanNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/bool/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1246,7 +1247,7 @@ func (client *queriesOperations) GetBooleanTrue(ctx context.Context) (*http.Resp
 // getBooleanTrueCreateRequest creates the GetBooleanTrue request.
 func (client *queriesOperations) getBooleanTrueCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/bool/true"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1294,7 +1295,7 @@ func (client *queriesOperations) GetIntNegativeOneMillion(ctx context.Context) (
 // getIntNegativeOneMillionCreateRequest creates the GetIntNegativeOneMillion request.
 func (client *queriesOperations) getIntNegativeOneMillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/int/-1000000"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1342,7 +1343,7 @@ func (client *queriesOperations) GetIntNull(ctx context.Context, queriesGetIntNu
 // getIntNullCreateRequest creates the GetIntNull request.
 func (client *queriesOperations) getIntNullCreateRequest(queriesGetIntNullOptions *QueriesGetIntNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/int/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1392,7 +1393,7 @@ func (client *queriesOperations) GetIntOneMillion(ctx context.Context) (*http.Re
 // getIntOneMillionCreateRequest creates the GetIntOneMillion request.
 func (client *queriesOperations) getIntOneMillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/int/1000000"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1440,7 +1441,7 @@ func (client *queriesOperations) GetLongNull(ctx context.Context, queriesGetLong
 // getLongNullCreateRequest creates the GetLongNull request.
 func (client *queriesOperations) getLongNullCreateRequest(queriesGetLongNullOptions *QueriesGetLongNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/long/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1490,7 +1491,7 @@ func (client *queriesOperations) GetNegativeTenBillion(ctx context.Context) (*ht
 // getNegativeTenBillionCreateRequest creates the GetNegativeTenBillion request.
 func (client *queriesOperations) getNegativeTenBillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/long/-10000000000"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1538,7 +1539,7 @@ func (client *queriesOperations) GetTenBillion(ctx context.Context) (*http.Respo
 // getTenBillionCreateRequest creates the GetTenBillion request.
 func (client *queriesOperations) getTenBillionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/long/10000000000"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1586,7 +1587,7 @@ func (client *queriesOperations) StringEmpty(ctx context.Context) (*http.Respons
 // stringEmptyCreateRequest creates the StringEmpty request.
 func (client *queriesOperations) stringEmptyCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/string/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1634,7 +1635,7 @@ func (client *queriesOperations) StringNull(ctx context.Context, queriesStringNu
 // stringNullCreateRequest creates the StringNull request.
 func (client *queriesOperations) stringNullCreateRequest(queriesStringNullOptions *QueriesStringNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/string/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1684,7 +1685,7 @@ func (client *queriesOperations) StringURLEncoded(ctx context.Context) (*http.Re
 // stringUrlEncodedCreateRequest creates the StringURLEncoded request.
 func (client *queriesOperations) stringUrlEncodedCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1732,7 +1733,7 @@ func (client *queriesOperations) StringUnicode(ctx context.Context) (*http.Respo
 // stringUnicodeCreateRequest creates the StringUnicode request.
 func (client *queriesOperations) stringUnicodeCreateRequest() (*azcore.Request, error) {
 	urlPath := "/queries/string/unicode/"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/urlmultigroup/queries.go
+++ b/test/autorest/generated/urlmultigroup/queries.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"path"
 	"strings"
 )
 
@@ -47,7 +48,7 @@ func (client *queriesOperations) ArrayStringMultiEmpty(ctx context.Context, quer
 // arrayStringMultiEmptyCreateRequest creates the ArrayStringMultiEmpty request.
 func (client *queriesOperations) arrayStringMultiEmptyCreateRequest(queriesArrayStringMultiEmptyOptions *QueriesArrayStringMultiEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/multi/string/empty"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +98,7 @@ func (client *queriesOperations) ArrayStringMultiNull(ctx context.Context, queri
 // arrayStringMultiNullCreateRequest creates the ArrayStringMultiNull request.
 func (client *queriesOperations) arrayStringMultiNullCreateRequest(queriesArrayStringMultiNullOptions *QueriesArrayStringMultiNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/multi/string/null"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +148,7 @@ func (client *queriesOperations) ArrayStringMultiValid(ctx context.Context, quer
 // arrayStringMultiValidCreateRequest creates the ArrayStringMultiValid request.
 func (client *queriesOperations) arrayStringMultiValidCreateRequest(queriesArrayStringMultiValidOptions *QueriesArrayStringMultiValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/multi/string/valid"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/validationgroup/autorestvalidationtest.go
+++ b/test/autorest/generated/validationgroup/autorestvalidationtest.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 )
@@ -53,7 +54,7 @@ func (client *autoRestValidationTestOperations) GetWithConstantInPath(ctx contex
 func (client *autoRestValidationTestOperations) getWithConstantInPathCreateRequest() (*azcore.Request, error) {
 	urlPath := "/validation/constantsInPath/{constantParam}/value"
 	urlPath = strings.ReplaceAll(urlPath, "{constantParam}", url.PathEscape("constant"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +102,7 @@ func (client *autoRestValidationTestOperations) PostWithConstantInBody(ctx conte
 func (client *autoRestValidationTestOperations) postWithConstantInBodyCreateRequest(autoRestValidationTestPostWithConstantInBodyOptions *AutoRestValidationTestPostWithConstantInBodyOptions) (*azcore.Request, error) {
 	urlPath := "/validation/constantsInPath/{constantParam}/value"
 	urlPath = strings.ReplaceAll(urlPath, "{constantParam}", url.PathEscape("constant"))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +157,7 @@ func (client *autoRestValidationTestOperations) validationOfBodyCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{id}", url.PathEscape(strconv.FormatInt(int64(id), 10)))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +212,7 @@ func (client *autoRestValidationTestOperations) validationOfMethodParametersCrea
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{id}", url.PathEscape(strconv.FormatInt(int64(id), 10)))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/xmlgroup/xml.go
+++ b/test/autorest/generated/xmlgroup/xml.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"io/ioutil"
 	"net/http"
+	"path"
 )
 
 // XMLOperations contains the methods for the XML group.
@@ -102,7 +103,7 @@ func (client *xmlOperations) GetACLs(ctx context.Context) (*SignedIDentifierArra
 // getAcLsCreateRequest creates the GetACLs request.
 func (client *xmlOperations) getAcLsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/mycontainer"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +156,7 @@ func (client *xmlOperations) GetComplexTypeRefNoMeta(ctx context.Context) (*Root
 // getComplexTypeRefNoMetaCreateRequest creates the GetComplexTypeRefNoMeta request.
 func (client *xmlOperations) getComplexTypeRefNoMetaCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/complex-type-ref-no-meta"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +205,7 @@ func (client *xmlOperations) GetComplexTypeRefWithMeta(ctx context.Context) (*Ro
 // getComplexTypeRefWithMetaCreateRequest creates the GetComplexTypeRefWithMeta request.
 func (client *xmlOperations) getComplexTypeRefWithMetaCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/complex-type-ref-with-meta"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +254,7 @@ func (client *xmlOperations) GetEmptyChildElement(ctx context.Context) (*BananaR
 // getEmptyChildElementCreateRequest creates the GetEmptyChildElement request.
 func (client *xmlOperations) getEmptyChildElementCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/empty-child-element"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +303,7 @@ func (client *xmlOperations) GetEmptyList(ctx context.Context) (*SlideshowRespon
 // getEmptyListCreateRequest creates the GetEmptyList request.
 func (client *xmlOperations) getEmptyListCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/empty-list"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +352,7 @@ func (client *xmlOperations) GetEmptyRootList(ctx context.Context) (*BananaArray
 // getEmptyRootListCreateRequest creates the GetEmptyRootList request.
 func (client *xmlOperations) getEmptyRootListCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/empty-root-list"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -400,7 +401,7 @@ func (client *xmlOperations) GetEmptyWrappedLists(ctx context.Context) (*AppleBa
 // getEmptyWrappedListsCreateRequest creates the GetEmptyWrappedLists request.
 func (client *xmlOperations) getEmptyWrappedListsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/empty-wrapped-lists"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -449,7 +450,7 @@ func (client *xmlOperations) GetHeaders(ctx context.Context) (*XMLGetHeadersResp
 // getHeadersCreateRequest creates the GetHeaders request.
 func (client *xmlOperations) getHeadersCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/headers"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -501,7 +502,7 @@ func (client *xmlOperations) GetRootList(ctx context.Context) (*BananaArrayRespo
 // getRootListCreateRequest creates the GetRootList request.
 func (client *xmlOperations) getRootListCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/root-list"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -550,7 +551,7 @@ func (client *xmlOperations) GetRootListSingleItem(ctx context.Context) (*Banana
 // getRootListSingleItemCreateRequest creates the GetRootListSingleItem request.
 func (client *xmlOperations) getRootListSingleItemCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/root-list-single-item"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -599,7 +600,7 @@ func (client *xmlOperations) GetServiceProperties(ctx context.Context) (*Storage
 // getServicePropertiesCreateRequest creates the GetServiceProperties request.
 func (client *xmlOperations) getServicePropertiesCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -652,7 +653,7 @@ func (client *xmlOperations) GetSimple(ctx context.Context) (*SlideshowResponse,
 // getSimpleCreateRequest creates the GetSimple request.
 func (client *xmlOperations) getSimpleCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/simple"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -698,7 +699,7 @@ func (client *xmlOperations) GetWrappedLists(ctx context.Context) (*AppleBarrelR
 // getWrappedListsCreateRequest creates the GetWrappedLists request.
 func (client *xmlOperations) getWrappedListsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/wrapped-lists"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -747,7 +748,7 @@ func (client *xmlOperations) JSONInput(ctx context.Context, properties JSONInput
 // jsonInputCreateRequest creates the JSONInput request.
 func (client *xmlOperations) jsonInputCreateRequest(properties JSONInput) (*azcore.Request, error) {
 	urlPath := "/xml/jsoninput"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -795,7 +796,7 @@ func (client *xmlOperations) JSONOutput(ctx context.Context) (*JSONOutputRespons
 // jsonOutputCreateRequest creates the JSONOutput request.
 func (client *xmlOperations) jsonOutputCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/jsonoutput"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -844,7 +845,7 @@ func (client *xmlOperations) ListBlobs(ctx context.Context) (*ListBlobsResponseR
 // listBlobsCreateRequest creates the ListBlobs request.
 func (client *xmlOperations) listBlobsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/mycontainer"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -897,7 +898,7 @@ func (client *xmlOperations) ListContainers(ctx context.Context) (*ListContainer
 // listContainersCreateRequest creates the ListContainers request.
 func (client *xmlOperations) listContainersCreateRequest() (*azcore.Request, error) {
 	urlPath := "/xml/"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -949,7 +950,7 @@ func (client *xmlOperations) PutACLs(ctx context.Context, properties []SignedIDe
 // putAcLsCreateRequest creates the PutACLs request.
 func (client *xmlOperations) putAcLsCreateRequest(properties []SignedIDentifier) (*azcore.Request, error) {
 	urlPath := "/xml/mycontainer"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1005,7 +1006,7 @@ func (client *xmlOperations) PutComplexTypeRefNoMeta(ctx context.Context, model 
 // putComplexTypeRefNoMetaCreateRequest creates the PutComplexTypeRefNoMeta request.
 func (client *xmlOperations) putComplexTypeRefNoMetaCreateRequest(model RootWithRefAndNoMeta) (*azcore.Request, error) {
 	urlPath := "/xml/complex-type-ref-no-meta"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1053,7 +1054,7 @@ func (client *xmlOperations) PutComplexTypeRefWithMeta(ctx context.Context, mode
 // putComplexTypeRefWithMetaCreateRequest creates the PutComplexTypeRefWithMeta request.
 func (client *xmlOperations) putComplexTypeRefWithMetaCreateRequest(model RootWithRefAndMeta) (*azcore.Request, error) {
 	urlPath := "/xml/complex-type-ref-with-meta"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1101,7 +1102,7 @@ func (client *xmlOperations) PutEmptyChildElement(ctx context.Context, banana Ba
 // putEmptyChildElementCreateRequest creates the PutEmptyChildElement request.
 func (client *xmlOperations) putEmptyChildElementCreateRequest(banana Banana) (*azcore.Request, error) {
 	urlPath := "/xml/empty-child-element"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1149,7 +1150,7 @@ func (client *xmlOperations) PutEmptyList(ctx context.Context, slideshow Slidesh
 // putEmptyListCreateRequest creates the PutEmptyList request.
 func (client *xmlOperations) putEmptyListCreateRequest(slideshow Slideshow) (*azcore.Request, error) {
 	urlPath := "/xml/empty-list"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1197,7 +1198,7 @@ func (client *xmlOperations) PutEmptyRootList(ctx context.Context, bananas []Ban
 // putEmptyRootListCreateRequest creates the PutEmptyRootList request.
 func (client *xmlOperations) putEmptyRootListCreateRequest(bananas []Banana) (*azcore.Request, error) {
 	urlPath := "/xml/empty-root-list"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1249,7 +1250,7 @@ func (client *xmlOperations) PutEmptyWrappedLists(ctx context.Context, appleBarr
 // putEmptyWrappedListsCreateRequest creates the PutEmptyWrappedLists request.
 func (client *xmlOperations) putEmptyWrappedListsCreateRequest(appleBarrel AppleBarrel) (*azcore.Request, error) {
 	urlPath := "/xml/empty-wrapped-lists"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1297,7 +1298,7 @@ func (client *xmlOperations) PutRootList(ctx context.Context, bananas []Banana) 
 // putRootListCreateRequest creates the PutRootList request.
 func (client *xmlOperations) putRootListCreateRequest(bananas []Banana) (*azcore.Request, error) {
 	urlPath := "/xml/root-list"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1349,7 +1350,7 @@ func (client *xmlOperations) PutRootListSingleItem(ctx context.Context, bananas 
 // putRootListSingleItemCreateRequest creates the PutRootListSingleItem request.
 func (client *xmlOperations) putRootListSingleItemCreateRequest(bananas []Banana) (*azcore.Request, error) {
 	urlPath := "/xml/root-list-single-item"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1401,7 +1402,7 @@ func (client *xmlOperations) PutServiceProperties(ctx context.Context, propertie
 // putServicePropertiesCreateRequest creates the PutServiceProperties request.
 func (client *xmlOperations) putServicePropertiesCreateRequest(properties StorageServiceProperties) (*azcore.Request, error) {
 	urlPath := "/xml/"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1453,7 +1454,7 @@ func (client *xmlOperations) PutSimple(ctx context.Context, slideshow Slideshow)
 // putSimpleCreateRequest creates the PutSimple request.
 func (client *xmlOperations) putSimpleCreateRequest(slideshow Slideshow) (*azcore.Request, error) {
 	urlPath := "/xml/simple"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1498,7 +1499,7 @@ func (client *xmlOperations) PutWrappedLists(ctx context.Context, wrappedLists A
 // putWrappedListsCreateRequest creates the PutWrappedLists request.
 func (client *xmlOperations) putWrappedListsCreateRequest(wrappedLists AppleBarrel) (*azcore.Request, error) {
 	urlPath := "/xml/wrapped-lists"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/applicationgateways.go
+++ b/test/network/2020-03-01/armnetwork/applicationgateways.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -118,7 +119,7 @@ func (client *applicationGatewaysOperations) backendHealthCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +197,7 @@ func (client *applicationGatewaysOperations) backendHealthOnDemandCreateRequest(
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +275,7 @@ func (client *applicationGatewaysOperations) createOrUpdateCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +350,7 @@ func (client *applicationGatewaysOperations) deleteCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -400,7 +401,7 @@ func (client *applicationGatewaysOperations) getCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -451,7 +452,7 @@ func (client *applicationGatewaysOperations) getSslPredefinedPolicyCreateRequest
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default/predefinedPolicies/{predefinedPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{predefinedPolicyName}", url.PathEscape(predefinedPolicyName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -508,7 +509,7 @@ func (client *applicationGatewaysOperations) listCreateRequest(resourceGroupName
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -564,7 +565,7 @@ func (client *applicationGatewaysOperations) ListAll() (ApplicationGatewayListRe
 func (client *applicationGatewaysOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -614,7 +615,7 @@ func (client *applicationGatewaysOperations) ListAvailableRequestHeaders(ctx con
 func (client *applicationGatewaysOperations) listAvailableRequestHeadersCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableRequestHeaders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -664,7 +665,7 @@ func (client *applicationGatewaysOperations) ListAvailableResponseHeaders(ctx co
 func (client *applicationGatewaysOperations) listAvailableResponseHeadersCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableResponseHeaders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -714,7 +715,7 @@ func (client *applicationGatewaysOperations) ListAvailableServerVariables(ctx co
 func (client *applicationGatewaysOperations) listAvailableServerVariablesCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableServerVariables"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -764,7 +765,7 @@ func (client *applicationGatewaysOperations) ListAvailableSslOptions(ctx context
 func (client *applicationGatewaysOperations) listAvailableSslOptionsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -820,7 +821,7 @@ func (client *applicationGatewaysOperations) ListAvailableSslPredefinedPolicies(
 func (client *applicationGatewaysOperations) listAvailableSslPredefinedPoliciesCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default/predefinedPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -870,7 +871,7 @@ func (client *applicationGatewaysOperations) ListAvailableWafRuleSets(ctx contex
 func (client *applicationGatewaysOperations) listAvailableWafRuleSetsCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableWafRuleSets"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -946,7 +947,7 @@ func (client *applicationGatewaysOperations) startCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1021,7 +1022,7 @@ func (client *applicationGatewaysOperations) stopCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1072,7 +1073,7 @@ func (client *applicationGatewaysOperations) updateTagsCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/applicationsecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/applicationsecuritygroups.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *applicationSecurityGroupsOperations) createOrUpdateCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *applicationSecurityGroupsOperations) deleteCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *applicationSecurityGroupsOperations) getCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *applicationSecurityGroupsOperations) listCreateRequest(resourceGro
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +328,7 @@ func (client *applicationSecurityGroupsOperations) ListAll() (ApplicationSecurit
 func (client *applicationSecurityGroupsOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +380,7 @@ func (client *applicationSecurityGroupsOperations) updateTagsCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/availabledelegations.go
+++ b/test/network/2020-03-01/armnetwork/availabledelegations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -53,7 +54,7 @@ func (client *availableDelegationsOperations) listCreateRequest(location string)
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/availableDelegations"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/availableendpointservices.go
+++ b/test/network/2020-03-01/armnetwork/availableendpointservices.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -53,7 +54,7 @@ func (client *availableEndpointServicesOperations) listCreateRequest(location st
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/virtualNetworkAvailableEndpointServices"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/availableprivateendpointtypes.go
+++ b/test/network/2020-03-01/armnetwork/availableprivateendpointtypes.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -55,7 +56,7 @@ func (client *availablePrivateEndpointTypesOperations) listCreateRequest(locatio
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/availablePrivateEndpointTypes"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +114,7 @@ func (client *availablePrivateEndpointTypesOperations) listByResourceGroupCreate
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/availableresourcegroupdelegations.go
+++ b/test/network/2020-03-01/armnetwork/availableresourcegroupdelegations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -54,7 +55,7 @@ func (client *availableResourceGroupDelegationsOperations) listCreateRequest(loc
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/availableservicealiases.go
+++ b/test/network/2020-03-01/armnetwork/availableservicealiases.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -55,7 +56,7 @@ func (client *availableServiceAliasesOperations) listCreateRequest(location stri
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/availableServiceAliases"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +114,7 @@ func (client *availableServiceAliasesOperations) listByResourceGroupCreateReques
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/azurefirewallfqdntags.go
+++ b/test/network/2020-03-01/armnetwork/azurefirewallfqdntags.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -52,7 +53,7 @@ func (client *azureFirewallFqdnTagsOperations) ListAll() (AzureFirewallFqdnTagLi
 func (client *azureFirewallFqdnTagsOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewallFqdnTags"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/azurefirewalls.go
+++ b/test/network/2020-03-01/armnetwork/azurefirewalls.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *azureFirewallsOperations) createOrUpdateCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +166,7 @@ func (client *azureFirewallsOperations) deleteCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +217,7 @@ func (client *azureFirewallsOperations) getCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +274,7 @@ func (client *azureFirewallsOperations) listCreateRequest(resourceGroupName stri
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +330,7 @@ func (client *azureFirewallsOperations) ListAll() (AzureFirewallListResultPager,
 func (client *azureFirewallsOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +406,7 @@ func (client *azureFirewallsOperations) updateTagsCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/bastionhosts.go
+++ b/test/network/2020-03-01/armnetwork/bastionhosts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -86,7 +87,7 @@ func (client *bastionHostsOperations) createOrUpdateCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *bastionHostsOperations) deleteCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +213,7 @@ func (client *bastionHostsOperations) getCreateRequest(resourceGroupName string,
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +269,7 @@ func (client *bastionHostsOperations) List() (BastionHostListResultPager, error)
 func (client *bastionHostsOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/bastionHosts"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -325,7 +326,7 @@ func (client *bastionHostsOperations) listByResourceGroupCreateRequest(resourceG
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/bgpservicecommunities.go
+++ b/test/network/2020-03-01/armnetwork/bgpservicecommunities.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -52,7 +53,7 @@ func (client *bgpServiceCommunitiesOperations) List() (BgpServiceCommunityListRe
 func (client *bgpServiceCommunitiesOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/bgpServiceCommunities"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/connectionmonitors.go
+++ b/test/network/2020-03-01/armnetwork/connectionmonitors.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -98,7 +99,7 @@ func (client *connectionMonitorsOperations) createOrUpdateCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +175,7 @@ func (client *connectionMonitorsOperations) deleteCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *connectionMonitorsOperations) getCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +279,7 @@ func (client *connectionMonitorsOperations) listCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +356,7 @@ func (client *connectionMonitorsOperations) queryCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -431,7 +432,7 @@ func (client *connectionMonitorsOperations) startCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -507,7 +508,7 @@ func (client *connectionMonitorsOperations) stopCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -559,7 +560,7 @@ func (client *connectionMonitorsOperations) updateTagsCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/ddoscustompolicies.go
+++ b/test/network/2020-03-01/armnetwork/ddoscustompolicies.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -83,7 +84,7 @@ func (client *ddosCustomPoliciesOperations) createOrUpdateCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +159,7 @@ func (client *ddosCustomPoliciesOperations) deleteCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +210,7 @@ func (client *ddosCustomPoliciesOperations) getCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +262,7 @@ func (client *ddosCustomPoliciesOperations) updateTagsCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/ddosprotectionplans.go
+++ b/test/network/2020-03-01/armnetwork/ddosprotectionplans.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *ddosProtectionPlansOperations) createOrUpdateCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *ddosProtectionPlansOperations) deleteCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *ddosProtectionPlansOperations) getCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +271,7 @@ func (client *ddosProtectionPlansOperations) List() (DdosProtectionPlanListResul
 func (client *ddosProtectionPlansOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ddosProtectionPlans"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +328,7 @@ func (client *ddosProtectionPlansOperations) listByResourceGroupCreateRequest(re
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +380,7 @@ func (client *ddosProtectionPlansOperations) updateTagsCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/defaultsecurityrules.go
+++ b/test/network/2020-03-01/armnetwork/defaultsecurityrules.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -52,7 +53,7 @@ func (client *defaultSecurityRulesOperations) getCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{defaultSecurityRuleName}", url.PathEscape(defaultSecurityRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (client *defaultSecurityRulesOperations) listCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecircuitauthorizations.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecircuitauthorizations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *expressRouteCircuitAuthorizationsOperations) createOrUpdateCreateR
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{authorizationName}", url.PathEscape(authorizationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *expressRouteCircuitAuthorizationsOperations) deleteCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{authorizationName}", url.PathEscape(authorizationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *expressRouteCircuitAuthorizationsOperations) getCreateRequest(reso
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{authorizationName}", url.PathEscape(authorizationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *expressRouteCircuitAuthorizationsOperations) listCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecircuitconnections.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -86,7 +87,7 @@ func (client *expressRouteCircuitConnectionsOperations) createOrUpdateCreateRequ
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *expressRouteCircuitConnectionsOperations) deleteCreateRequest(reso
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +217,7 @@ func (client *expressRouteCircuitConnectionsOperations) getCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +276,7 @@ func (client *expressRouteCircuitConnectionsOperations) listCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecircuitpeerings.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecircuitpeerings.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *expressRouteCircuitPeeringsOperations) createOrUpdateCreateRequest
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *expressRouteCircuitPeeringsOperations) deleteCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *expressRouteCircuitPeeringsOperations) getCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *expressRouteCircuitPeeringsOperations) listCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecircuits.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecircuits.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -104,7 +105,7 @@ func (client *expressRouteCircuitsOperations) createOrUpdateCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +180,7 @@ func (client *expressRouteCircuitsOperations) deleteCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +231,7 @@ func (client *expressRouteCircuitsOperations) getCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +284,7 @@ func (client *expressRouteCircuitsOperations) getPeeringStatsCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +336,7 @@ func (client *expressRouteCircuitsOperations) getStatsCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -392,7 +393,7 @@ func (client *expressRouteCircuitsOperations) listCreateRequest(resourceGroupNam
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -448,7 +449,7 @@ func (client *expressRouteCircuitsOperations) ListAll() (ExpressRouteCircuitList
 func (client *expressRouteCircuitsOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteCircuits"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -526,7 +527,7 @@ func (client *expressRouteCircuitsOperations) listArpTableCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -603,7 +604,7 @@ func (client *expressRouteCircuitsOperations) listRoutesTableCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -680,7 +681,7 @@ func (client *expressRouteCircuitsOperations) listRoutesTableSummaryCreateReques
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -731,7 +732,7 @@ func (client *expressRouteCircuitsOperations) updateTagsCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressrouteconnections.go
+++ b/test/network/2020-03-01/armnetwork/expressrouteconnections.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -84,7 +85,7 @@ func (client *expressRouteConnectionsOperations) createOrUpdateCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +161,7 @@ func (client *expressRouteConnectionsOperations) deleteCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +213,7 @@ func (client *expressRouteConnectionsOperations) getCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +265,7 @@ func (client *expressRouteConnectionsOperations) listCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecrossconnectionpeerings.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecrossconnectionpeerings.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *expressRouteCrossConnectionPeeringsOperations) createOrUpdateCreat
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *expressRouteCrossConnectionPeeringsOperations) deleteCreateRequest
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *expressRouteCrossConnectionPeeringsOperations) getCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *expressRouteCrossConnectionPeeringsOperations) listCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecrossconnections.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecrossconnections.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -96,7 +97,7 @@ func (client *expressRouteCrossConnectionsOperations) createOrUpdateCreateReques
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +148,7 @@ func (client *expressRouteCrossConnectionsOperations) getCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +204,7 @@ func (client *expressRouteCrossConnectionsOperations) List() (ExpressRouteCrossC
 func (client *expressRouteCrossConnectionsOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteCrossConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +282,7 @@ func (client *expressRouteCrossConnectionsOperations) listArpTableCreateRequest(
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +338,7 @@ func (client *expressRouteCrossConnectionsOperations) listByResourceGroupCreateR
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -415,7 +416,7 @@ func (client *expressRouteCrossConnectionsOperations) listRoutesTableCreateReque
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -492,7 +493,7 @@ func (client *expressRouteCrossConnectionsOperations) listRoutesTableSummaryCrea
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -543,7 +544,7 @@ func (client *expressRouteCrossConnectionsOperations) updateTagsCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutegateways.go
+++ b/test/network/2020-03-01/armnetwork/expressroutegateways.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *expressRouteGatewaysOperations) createOrUpdateCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +161,7 @@ func (client *expressRouteGatewaysOperations) deleteCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +212,7 @@ func (client *expressRouteGatewaysOperations) getCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +263,7 @@ func (client *expressRouteGatewaysOperations) listByResourceGroupCreateRequest(r
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +313,7 @@ func (client *expressRouteGatewaysOperations) ListBySubscription(ctx context.Con
 func (client *expressRouteGatewaysOperations) listBySubscriptionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutelinks.go
+++ b/test/network/2020-03-01/armnetwork/expressroutelinks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -52,7 +53,7 @@ func (client *expressRouteLinksOperations) getCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
 	urlPath = strings.ReplaceAll(urlPath, "{linkName}", url.PathEscape(linkName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (client *expressRouteLinksOperations) listCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressrouteports.go
+++ b/test/network/2020-03-01/armnetwork/expressrouteports.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *expressRoutePortsOperations) createOrUpdateCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *expressRoutePortsOperations) deleteCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *expressRoutePortsOperations) getCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +271,7 @@ func (client *expressRoutePortsOperations) List() (ExpressRoutePortListResultPag
 func (client *expressRoutePortsOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ExpressRoutePorts"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +328,7 @@ func (client *expressRoutePortsOperations) listByResourceGroupCreateRequest(reso
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +380,7 @@ func (client *expressRoutePortsOperations) updateTagsCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressrouteportslocations.go
+++ b/test/network/2020-03-01/armnetwork/expressrouteportslocations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -50,7 +51,7 @@ func (client *expressRoutePortsLocationsOperations) getCreateRequest(locationNam
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ExpressRoutePortsLocations/{locationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{locationName}", url.PathEscape(locationName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +107,7 @@ func (client *expressRoutePortsLocationsOperations) List() (ExpressRoutePortsLoc
 func (client *expressRoutePortsLocationsOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ExpressRoutePortsLocations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressrouteserviceproviders.go
+++ b/test/network/2020-03-01/armnetwork/expressrouteserviceproviders.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -52,7 +53,7 @@ func (client *expressRouteServiceProvidersOperations) List() (ExpressRouteServic
 func (client *expressRouteServiceProvidersOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteServiceProviders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/firewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/firewallpolicies.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -86,7 +87,7 @@ func (client *firewallPoliciesOperations) createOrUpdateCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *firewallPoliciesOperations) deleteCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +213,7 @@ func (client *firewallPoliciesOperations) getCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +273,7 @@ func (client *firewallPoliciesOperations) listCreateRequest(resourceGroupName st
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +329,7 @@ func (client *firewallPoliciesOperations) ListAll() (FirewallPolicyListResultPag
 func (client *firewallPoliciesOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/firewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/firewallpolicyrulegroups.go
+++ b/test/network/2020-03-01/armnetwork/firewallpolicyrulegroups.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *firewallPolicyRuleGroupsOperations) createOrUpdateCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleGroupName}", url.PathEscape(ruleGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *firewallPolicyRuleGroupsOperations) deleteCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleGroupName}", url.PathEscape(ruleGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *firewallPolicyRuleGroupsOperations) getCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleGroupName}", url.PathEscape(ruleGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *firewallPolicyRuleGroupsOperations) listCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/flowlogs.go
+++ b/test/network/2020-03-01/armnetwork/flowlogs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *flowLogsOperations) createOrUpdateCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{flowLogName}", url.PathEscape(flowLogName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *flowLogsOperations) deleteCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{flowLogName}", url.PathEscape(flowLogName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *flowLogsOperations) getCreateRequest(resourceGroupName string, net
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{flowLogName}", url.PathEscape(flowLogName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *flowLogsOperations) listCreateRequest(resourceGroupName string, ne
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/hubvirtualnetworkconnections.go
+++ b/test/network/2020-03-01/armnetwork/hubvirtualnetworkconnections.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -52,7 +53,7 @@ func (client *hubVirtualNetworkConnectionsOperations) getCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (client *hubVirtualNetworkConnectionsOperations) listCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/inboundnatrules.go
+++ b/test/network/2020-03-01/armnetwork/inboundnatrules.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *inboundNatRulesOperations) createOrUpdateCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{inboundNatRuleName}", url.PathEscape(inboundNatRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *inboundNatRulesOperations) deleteCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{inboundNatRuleName}", url.PathEscape(inboundNatRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *inboundNatRulesOperations) getCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{inboundNatRuleName}", url.PathEscape(inboundNatRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +275,7 @@ func (client *inboundNatRulesOperations) listCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/ipallocations.go
+++ b/test/network/2020-03-01/armnetwork/ipallocations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *ipAllocationsOperations) createOrUpdateCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *ipAllocationsOperations) deleteCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *ipAllocationsOperations) getCreateRequest(resourceGroupName string
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +274,7 @@ func (client *ipAllocationsOperations) List() (IPAllocationListResultPager, erro
 func (client *ipAllocationsOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/IpAllocations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +331,7 @@ func (client *ipAllocationsOperations) listByResourceGroupCreateRequest(resource
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +383,7 @@ func (client *ipAllocationsOperations) updateTagsCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/ipgroups.go
+++ b/test/network/2020-03-01/armnetwork/ipgroups.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *ipGroupsOperations) createOrUpdateCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *ipGroupsOperations) deleteCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *ipGroupsOperations) getCreateRequest(resourceGroupName string, ipG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +274,7 @@ func (client *ipGroupsOperations) List() (IPGroupListResultPager, error) {
 func (client *ipGroupsOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ipGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +331,7 @@ func (client *ipGroupsOperations) listByResourceGroupCreateRequest(resourceGroup
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +383,7 @@ func (client *ipGroupsOperations) updateGroupsCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancerbackendaddresspools.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancerbackendaddresspools.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -52,7 +53,7 @@ func (client *loadBalancerBackendAddressPoolsOperations) getCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{backendAddressPoolName}", url.PathEscape(backendAddressPoolName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (client *loadBalancerBackendAddressPoolsOperations) listCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancerfrontendipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancerfrontendipconfigurations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -52,7 +53,7 @@ func (client *loadBalancerFrontendIPConfigurationsOperations) getCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{frontendIPConfigurationName}", url.PathEscape(frontendIPConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (client *loadBalancerFrontendIPConfigurationsOperations) listCreateRequest(
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancerloadbalancingrules.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancerloadbalancingrules.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -52,7 +53,7 @@ func (client *loadBalancerLoadBalancingRulesOperations) getCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancingRuleName}", url.PathEscape(loadBalancingRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (client *loadBalancerLoadBalancingRulesOperations) listCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancernetworkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancernetworkinterfaces.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -54,7 +55,7 @@ func (client *loadBalancerNetworkInterfacesOperations) listCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalanceroutboundrules.go
+++ b/test/network/2020-03-01/armnetwork/loadbalanceroutboundrules.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -52,7 +53,7 @@ func (client *loadBalancerOutboundRulesOperations) getCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{outboundRuleName}", url.PathEscape(outboundRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (client *loadBalancerOutboundRulesOperations) listCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancerprobes.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancerprobes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -52,7 +53,7 @@ func (client *loadBalancerProbesOperations) getCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{probeName}", url.PathEscape(probeName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (client *loadBalancerProbesOperations) listCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *loadBalancersOperations) createOrUpdateCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *loadBalancersOperations) deleteCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *loadBalancersOperations) getCreateRequest(resourceGroupName string
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +275,7 @@ func (client *loadBalancersOperations) listCreateRequest(resourceGroupName strin
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +331,7 @@ func (client *loadBalancersOperations) ListAll() (LoadBalancerListResultPager, e
 func (client *loadBalancersOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/loadBalancers"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +383,7 @@ func (client *loadBalancersOperations) updateTagsCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/localnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/localnetworkgateways.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -86,7 +87,7 @@ func (client *localNetworkGatewaysOperations) createOrUpdateCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *localNetworkGatewaysOperations) deleteCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +213,7 @@ func (client *localNetworkGatewaysOperations) getCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +270,7 @@ func (client *localNetworkGatewaysOperations) listCreateRequest(resourceGroupNam
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +322,7 @@ func (client *localNetworkGatewaysOperations) updateTagsCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/natgateways.go
+++ b/test/network/2020-03-01/armnetwork/natgateways.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *natGatewaysOperations) createOrUpdateCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *natGatewaysOperations) deleteCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *natGatewaysOperations) getCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +275,7 @@ func (client *natGatewaysOperations) listCreateRequest(resourceGroupName string)
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +331,7 @@ func (client *natGatewaysOperations) ListAll() (NatGatewayListResultPager, error
 func (client *natGatewaysOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/natGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +383,7 @@ func (client *natGatewaysOperations) updateTagsCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkinterfaceipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/networkinterfaceipconfigurations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -52,7 +53,7 @@ func (client *networkInterfaceIPConfigurationsOperations) getCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipConfigurationName}", url.PathEscape(ipConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (client *networkInterfaceIPConfigurationsOperations) listCreateRequest(reso
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkinterfaceloadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/networkinterfaceloadbalancers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -54,7 +55,7 @@ func (client *networkInterfaceLoadBalancersOperations) listCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/networkinterfaces.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -106,7 +107,7 @@ func (client *networkInterfacesOperations) createOrUpdateCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +182,7 @@ func (client *networkInterfacesOperations) deleteCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +233,7 @@ func (client *networkInterfacesOperations) getCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -311,7 +312,7 @@ func (client *networkInterfacesOperations) getEffectiveRouteTableCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +366,7 @@ func (client *networkInterfacesOperations) getVirtualMachineScaleSetIPConfigurat
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipConfigurationName}", url.PathEscape(ipConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -422,7 +423,7 @@ func (client *networkInterfacesOperations) getVirtualMachineScaleSetNetworkInter
 	urlPath = strings.ReplaceAll(urlPath, "{virtualmachineIndex}", url.PathEscape(virtualmachineIndex))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -482,7 +483,7 @@ func (client *networkInterfacesOperations) listCreateRequest(resourceGroupName s
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -538,7 +539,7 @@ func (client *networkInterfacesOperations) ListAll() (NetworkInterfaceListResult
 func (client *networkInterfacesOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkInterfaces"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -614,7 +615,7 @@ func (client *networkInterfacesOperations) listEffectiveNetworkSecurityGroupsCre
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -673,7 +674,7 @@ func (client *networkInterfacesOperations) listVirtualMachineScaleSetIPConfigura
 	urlPath = strings.ReplaceAll(urlPath, "{virtualmachineIndex}", url.PathEscape(virtualmachineIndex))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -734,7 +735,7 @@ func (client *networkInterfacesOperations) listVirtualMachineScaleSetNetworkInte
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -793,7 +794,7 @@ func (client *networkInterfacesOperations) listVirtualMachineScaleSetVMNetworkIn
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualmachineIndex}", url.PathEscape(virtualmachineIndex))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -845,7 +846,7 @@ func (client *networkInterfacesOperations) updateTagsCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkinterfacetapconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/networkinterfacetapconfigurations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *networkInterfaceTapConfigurationsOperations) createOrUpdateCreateR
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapConfigurationName}", url.PathEscape(tapConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *networkInterfaceTapConfigurationsOperations) deleteCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapConfigurationName}", url.PathEscape(tapConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *networkInterfaceTapConfigurationsOperations) getCreateRequest(reso
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapConfigurationName}", url.PathEscape(tapConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *networkInterfaceTapConfigurationsOperations) listCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkmanagementclient.go
+++ b/test/network/2020-03-01/armnetwork/networkmanagementclient.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -71,7 +72,7 @@ func (client *networkManagementClientOperations) checkDnsNameAvailabilityCreateR
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/CheckDnsNameAvailability"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +149,7 @@ func (client *networkManagementClientOperations) deleteBastionShareableLinkCreat
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +206,7 @@ func (client *networkManagementClientOperations) disconnectActiveSessionsCreateR
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +282,7 @@ func (client *networkManagementClientOperations) generatevirtualwanvpnserverconf
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWanName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +358,7 @@ func (client *networkManagementClientOperations) getActiveSessionsCreateRequest(
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -423,7 +424,7 @@ func (client *networkManagementClientOperations) getBastionShareableLinkCreateRe
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -500,7 +501,7 @@ func (client *networkManagementClientOperations) putBastionShareableLinkCreateRe
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +561,7 @@ func (client *networkManagementClientOperations) supportedSecurityProvidersCreat
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWanName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkprofiles.go
+++ b/test/network/2020-03-01/armnetwork/networkprofiles.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -62,7 +63,7 @@ func (client *networkProfilesOperations) createOrUpdateCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +139,7 @@ func (client *networkProfilesOperations) deleteCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +190,7 @@ func (client *networkProfilesOperations) getCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +250,7 @@ func (client *networkProfilesOperations) listCreateRequest(resourceGroupName str
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +306,7 @@ func (client *networkProfilesOperations) ListAll() (NetworkProfileListResultPage
 func (client *networkProfilesOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkProfiles"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +358,7 @@ func (client *networkProfilesOperations) updateTagsCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networksecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/networksecuritygroups.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *networkSecurityGroupsOperations) createOrUpdateCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *networkSecurityGroupsOperations) deleteCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *networkSecurityGroupsOperations) getCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +275,7 @@ func (client *networkSecurityGroupsOperations) listCreateRequest(resourceGroupNa
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +331,7 @@ func (client *networkSecurityGroupsOperations) ListAll() (NetworkSecurityGroupLi
 func (client *networkSecurityGroupsOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +383,7 @@ func (client *networkSecurityGroupsOperations) updateTagsCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkvirtualappliances.go
+++ b/test/network/2020-03-01/armnetwork/networkvirtualappliances.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *networkVirtualAppliancesOperations) createOrUpdateCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *networkVirtualAppliancesOperations) deleteCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *networkVirtualAppliancesOperations) getCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +274,7 @@ func (client *networkVirtualAppliancesOperations) List() (NetworkVirtualApplianc
 func (client *networkVirtualAppliancesOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkVirtualAppliances"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +331,7 @@ func (client *networkVirtualAppliancesOperations) listByResourceGroupCreateReque
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +383,7 @@ func (client *networkVirtualAppliancesOperations) updateTagsCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkwatchers.go
+++ b/test/network/2020-03-01/armnetwork/networkwatchers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -131,7 +132,7 @@ func (client *networkWatchersOperations) checkConnectivityCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +183,7 @@ func (client *networkWatchersOperations) createOrUpdateCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +259,7 @@ func (client *networkWatchersOperations) deleteCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +310,7 @@ func (client *networkWatchersOperations) getCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -385,7 +386,7 @@ func (client *networkWatchersOperations) getAzureReachabilityReportCreateRequest
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -460,7 +461,7 @@ func (client *networkWatchersOperations) getFlowLogStatusCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -535,7 +536,7 @@ func (client *networkWatchersOperations) getNetworkConfigurationDiagnosticCreate
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -610,7 +611,7 @@ func (client *networkWatchersOperations) getNextHopCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -661,7 +662,7 @@ func (client *networkWatchersOperations) getTopologyCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -737,7 +738,7 @@ func (client *networkWatchersOperations) getTroubleshootingCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -812,7 +813,7 @@ func (client *networkWatchersOperations) getTroubleshootingResultCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -887,7 +888,7 @@ func (client *networkWatchersOperations) getVMSecurityRulesCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -937,7 +938,7 @@ func (client *networkWatchersOperations) listCreateRequest(resourceGroupName str
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -987,7 +988,7 @@ func (client *networkWatchersOperations) ListAll(ctx context.Context) (*NetworkW
 func (client *networkWatchersOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkWatchers"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1063,7 +1064,7 @@ func (client *networkWatchersOperations) listAvailableProvidersCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1138,7 +1139,7 @@ func (client *networkWatchersOperations) setFlowLogConfigurationCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1189,7 +1190,7 @@ func (client *networkWatchersOperations) updateTagsCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1265,7 +1266,7 @@ func (client *networkWatchersOperations) verifyIPFlowCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/operations.go
+++ b/test/network/2020-03-01/armnetwork/operations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // Operations contains the methods for the Operations group.
@@ -49,7 +50,7 @@ func (client *operations) List() (OperationListResultPager, error) {
 // listCreateRequest creates the List request.
 func (client *operations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/providers/Microsoft.Network/operations"
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/p2svpngateways.go
+++ b/test/network/2020-03-01/armnetwork/p2svpngateways.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -104,7 +105,7 @@ func (client *p2SVpnGatewaysOperations) createOrUpdateCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +180,7 @@ func (client *p2SVpnGatewaysOperations) deleteCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +255,7 @@ func (client *p2SVpnGatewaysOperations) disconnectP2SVpnConnectionsCreateRequest
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{p2sVpnGatewayName}", url.PathEscape(p2SVpnGatewayName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +330,7 @@ func (client *p2SVpnGatewaysOperations) generateVpnProfileCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +381,7 @@ func (client *p2SVpnGatewaysOperations) getCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +457,7 @@ func (client *p2SVpnGatewaysOperations) getP2SVpnConnectionHealthCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -531,7 +532,7 @@ func (client *p2SVpnGatewaysOperations) getP2SVpnConnectionHealthDetailedCreateR
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +587,7 @@ func (client *p2SVpnGatewaysOperations) List() (ListP2SVpnGatewaysResultPager, e
 func (client *p2SVpnGatewaysOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/p2svpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -643,7 +644,7 @@ func (client *p2SVpnGatewaysOperations) listByResourceGroupCreateRequest(resourc
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -695,7 +696,7 @@ func (client *p2SVpnGatewaysOperations) updateTagsCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/packetcaptures.go
+++ b/test/network/2020-03-01/armnetwork/packetcaptures.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -92,7 +93,7 @@ func (client *packetCapturesOperations) createCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{packetCaptureName}", url.PathEscape(packetCaptureName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +169,7 @@ func (client *packetCapturesOperations) deleteCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{packetCaptureName}", url.PathEscape(packetCaptureName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +221,7 @@ func (client *packetCapturesOperations) getCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{packetCaptureName}", url.PathEscape(packetCaptureName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +298,7 @@ func (client *packetCapturesOperations) getStatusCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{packetCaptureName}", url.PathEscape(packetCaptureName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +349,7 @@ func (client *packetCapturesOperations) listCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -425,7 +426,7 @@ func (client *packetCapturesOperations) stopCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{packetCaptureName}", url.PathEscape(packetCaptureName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/peerexpressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/peerexpressroutecircuitconnections.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -53,7 +54,7 @@ func (client *peerExpressRouteCircuitConnectionsOperations) getCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +113,7 @@ func (client *peerExpressRouteCircuitConnectionsOperations) listCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/privatednszonegroups.go
+++ b/test/network/2020-03-01/armnetwork/privatednszonegroups.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *privateDnsZoneGroupsOperations) createOrUpdateCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateDnsZoneGroupName}", url.PathEscape(privateDnsZoneGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *privateDnsZoneGroupsOperations) deleteCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateDnsZoneGroupName}", url.PathEscape(privateDnsZoneGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *privateDnsZoneGroupsOperations) getCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateDnsZoneGroupName}", url.PathEscape(privateDnsZoneGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *privateDnsZoneGroupsOperations) listCreateRequest(privateEndpointN
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/privateendpoints.go
+++ b/test/network/2020-03-01/armnetwork/privateendpoints.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -86,7 +87,7 @@ func (client *privateEndpointsOperations) createOrUpdateCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *privateEndpointsOperations) deleteCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +213,7 @@ func (client *privateEndpointsOperations) getCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +273,7 @@ func (client *privateEndpointsOperations) listCreateRequest(resourceGroupName st
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +329,7 @@ func (client *privateEndpointsOperations) ListBySubscription() (PrivateEndpointL
 func (client *privateEndpointsOperations) listBySubscriptionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/privateEndpoints"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/privatelinkservices.go
+++ b/test/network/2020-03-01/armnetwork/privatelinkservices.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -107,7 +108,7 @@ func (client *privateLinkServicesOperations) checkPrivateLinkServiceVisibilityCr
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/checkPrivateLinkServiceVisibility"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +183,7 @@ func (client *privateLinkServicesOperations) checkPrivateLinkServiceVisibilityBy
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +258,7 @@ func (client *privateLinkServicesOperations) createOrUpdateCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +333,7 @@ func (client *privateLinkServicesOperations) deleteCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -408,7 +409,7 @@ func (client *privateLinkServicesOperations) deletePrivateEndpointConnectionCrea
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{peConnectionName}", url.PathEscape(peConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -459,7 +460,7 @@ func (client *privateLinkServicesOperations) getCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -515,7 +516,7 @@ func (client *privateLinkServicesOperations) getPrivateEndpointConnectionCreateR
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{peConnectionName}", url.PathEscape(peConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -575,7 +576,7 @@ func (client *privateLinkServicesOperations) listCreateRequest(resourceGroupName
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -632,7 +633,7 @@ func (client *privateLinkServicesOperations) listAutoApprovedPrivateLinkServices
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/autoApprovedPrivateLinkServices"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -690,7 +691,7 @@ func (client *privateLinkServicesOperations) listAutoApprovedPrivateLinkServices
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -746,7 +747,7 @@ func (client *privateLinkServicesOperations) ListBySubscription() (PrivateLinkSe
 func (client *privateLinkServicesOperations) listBySubscriptionCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/privateLinkServices"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -804,7 +805,7 @@ func (client *privateLinkServicesOperations) listPrivateEndpointConnectionsCreat
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -857,7 +858,7 @@ func (client *privateLinkServicesOperations) updatePrivateEndpointConnectionCrea
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{peConnectionName}", url.PathEscape(peConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/publicipaddresses.go
+++ b/test/network/2020-03-01/armnetwork/publicipaddresses.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -94,7 +95,7 @@ func (client *publicIPAddressesOperations) createOrUpdateCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +170,7 @@ func (client *publicIPAddressesOperations) deleteCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +221,7 @@ func (client *publicIPAddressesOperations) getCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +280,7 @@ func (client *publicIPAddressesOperations) getVirtualMachineScaleSetPublicIPAddr
 	urlPath = strings.ReplaceAll(urlPath, "{ipConfigurationName}", url.PathEscape(ipConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +340,7 @@ func (client *publicIPAddressesOperations) listCreateRequest(resourceGroupName s
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -395,7 +396,7 @@ func (client *publicIPAddressesOperations) ListAll() (PublicIPAddressListResultP
 func (client *publicIPAddressesOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/publicIPAddresses"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -453,7 +454,7 @@ func (client *publicIPAddressesOperations) listVirtualMachineScaleSetPublicIPAdd
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +515,7 @@ func (client *publicIPAddressesOperations) listVirtualMachineScaleSetVMPublicIpa
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipConfigurationName}", url.PathEscape(ipConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -566,7 +567,7 @@ func (client *publicIPAddressesOperations) updateTagsCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/publicipprefixes.go
+++ b/test/network/2020-03-01/armnetwork/publicipprefixes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *publicIPPrefixesOperations) createOrUpdateCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *publicIPPrefixesOperations) deleteCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *publicIPPrefixesOperations) getCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +275,7 @@ func (client *publicIPPrefixesOperations) listCreateRequest(resourceGroupName st
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +331,7 @@ func (client *publicIPPrefixesOperations) ListAll() (PublicIPPrefixListResultPag
 func (client *publicIPPrefixesOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/publicIPPrefixes"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +383,7 @@ func (client *publicIPPrefixesOperations) updateTagsCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/resourcenavigationlinks.go
+++ b/test/network/2020-03-01/armnetwork/resourcenavigationlinks.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -49,7 +50,7 @@ func (client *resourceNavigationLinksOperations) listCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/routefilterrules.go
+++ b/test/network/2020-03-01/armnetwork/routefilterrules.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *routeFilterRulesOperations) createOrUpdateCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleName}", url.PathEscape(ruleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *routeFilterRulesOperations) deleteCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleName}", url.PathEscape(ruleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *routeFilterRulesOperations) getCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleName}", url.PathEscape(ruleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *routeFilterRulesOperations) listByRouteFilterCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/routefilters.go
+++ b/test/network/2020-03-01/armnetwork/routefilters.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *routeFiltersOperations) createOrUpdateCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *routeFiltersOperations) deleteCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *routeFiltersOperations) getCreateRequest(resourceGroupName string,
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +274,7 @@ func (client *routeFiltersOperations) List() (RouteFilterListResultPager, error)
 func (client *routeFiltersOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/routeFilters"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +331,7 @@ func (client *routeFiltersOperations) listByResourceGroupCreateRequest(resourceG
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +383,7 @@ func (client *routeFiltersOperations) updateTagsCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/routes.go
+++ b/test/network/2020-03-01/armnetwork/routes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *routesOperations) createOrUpdateCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeName}", url.PathEscape(routeName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *routesOperations) deleteCreateRequest(resourceGroupName string, ro
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeName}", url.PathEscape(routeName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *routesOperations) getCreateRequest(resourceGroupName string, route
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeName}", url.PathEscape(routeName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *routesOperations) listCreateRequest(resourceGroupName string, rout
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/routetables.go
+++ b/test/network/2020-03-01/armnetwork/routetables.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *routeTablesOperations) createOrUpdateCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *routeTablesOperations) deleteCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *routeTablesOperations) getCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +275,7 @@ func (client *routeTablesOperations) listCreateRequest(resourceGroupName string)
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +331,7 @@ func (client *routeTablesOperations) ListAll() (RouteTableListResultPager, error
 func (client *routeTablesOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/routeTables"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +383,7 @@ func (client *routeTablesOperations) updateTagsCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/securitypartnerproviders.go
+++ b/test/network/2020-03-01/armnetwork/securitypartnerproviders.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *securityPartnerProvidersOperations) createOrUpdateCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *securityPartnerProvidersOperations) deleteCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *securityPartnerProvidersOperations) getCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +271,7 @@ func (client *securityPartnerProvidersOperations) List() (SecurityPartnerProvide
 func (client *securityPartnerProvidersOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/securityPartnerProviders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +328,7 @@ func (client *securityPartnerProvidersOperations) listByResourceGroupCreateReque
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +380,7 @@ func (client *securityPartnerProvidersOperations) updateTagsCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/securityrules.go
+++ b/test/network/2020-03-01/armnetwork/securityrules.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *securityRulesOperations) createOrUpdateCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityRuleName}", url.PathEscape(securityRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *securityRulesOperations) deleteCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityRuleName}", url.PathEscape(securityRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *securityRulesOperations) getCreateRequest(resourceGroupName string
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityRuleName}", url.PathEscape(securityRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *securityRulesOperations) listCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/serviceassociationlinks.go
+++ b/test/network/2020-03-01/armnetwork/serviceassociationlinks.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -49,7 +50,7 @@ func (client *serviceAssociationLinksOperations) listCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/serviceendpointpolicies.go
+++ b/test/network/2020-03-01/armnetwork/serviceendpointpolicies.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *serviceEndpointPoliciesOperations) createOrUpdateCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *serviceEndpointPoliciesOperations) deleteCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *serviceEndpointPoliciesOperations) getCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +274,7 @@ func (client *serviceEndpointPoliciesOperations) List() (ServiceEndpointPolicyLi
 func (client *serviceEndpointPoliciesOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ServiceEndpointPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +331,7 @@ func (client *serviceEndpointPoliciesOperations) listByResourceGroupCreateReques
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +383,7 @@ func (client *serviceEndpointPoliciesOperations) updateTagsCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/serviceendpointpolicydefinitions.go
+++ b/test/network/2020-03-01/armnetwork/serviceendpointpolicydefinitions.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *serviceEndpointPolicyDefinitionsOperations) createOrUpdateCreateRe
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyDefinitionName}", url.PathEscape(serviceEndpointPolicyDefinitionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *serviceEndpointPolicyDefinitionsOperations) deleteCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyDefinitionName}", url.PathEscape(serviceEndpointPolicyDefinitionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *serviceEndpointPolicyDefinitionsOperations) getCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyDefinitionName}", url.PathEscape(serviceEndpointPolicyDefinitionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *serviceEndpointPolicyDefinitionsOperations) listByResourceGroupCre
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/servicetags.go
+++ b/test/network/2020-03-01/armnetwork/servicetags.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -47,7 +48,7 @@ func (client *serviceTagsOperations) listCreateRequest(location string) (*azcore
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/serviceTags"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/subnets.go
+++ b/test/network/2020-03-01/armnetwork/subnets.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *subnetsOperations) createOrUpdateCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +170,7 @@ func (client *subnetsOperations) deleteCreateRequest(resourceGroupName string, v
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +222,7 @@ func (client *subnetsOperations) getCreateRequest(resourceGroupName string, virt
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +283,7 @@ func (client *subnetsOperations) listCreateRequest(resourceGroupName string, vir
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +360,7 @@ func (client *subnetsOperations) prepareNetworkPoliciesCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +436,7 @@ func (client *subnetsOperations) unprepareNetworkPoliciesCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/usages.go
+++ b/test/network/2020-03-01/armnetwork/usages.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -53,7 +54,7 @@ func (client *usagesOperations) listCreateRequest(location string) (*azcore.Requ
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/usages"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualhubroutetablev2s.go
+++ b/test/network/2020-03-01/armnetwork/virtualhubroutetablev2s.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *virtualHubRouteTableV2SOperations) createOrUpdateCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *virtualHubRouteTableV2SOperations) deleteCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *virtualHubRouteTableV2SOperations) getCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *virtualHubRouteTableV2SOperations) listCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualhubs.go
+++ b/test/network/2020-03-01/armnetwork/virtualhubs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *virtualHubsOperations) createOrUpdateCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *virtualHubsOperations) deleteCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *virtualHubsOperations) getCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +271,7 @@ func (client *virtualHubsOperations) List() (ListVirtualHubsResultPager, error) 
 func (client *virtualHubsOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualHubs"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +328,7 @@ func (client *virtualHubsOperations) listByResourceGroupCreateRequest(resourceGr
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +380,7 @@ func (client *virtualHubsOperations) updateTagsCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualnetworkgatewayconnections.go
+++ b/test/network/2020-03-01/armnetwork/virtualnetworkgatewayconnections.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -106,7 +107,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) createOrUpdateCreateRe
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +182,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) deleteCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +233,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) getCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +285,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) getSharedKeyCreateRequ
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +342,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) listCreateRequest(reso
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -417,7 +418,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) resetSharedKeyCreateRe
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -492,7 +493,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) setSharedKeyCreateRequ
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -567,7 +568,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) startPacketCaptureCrea
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -645,7 +646,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) stopPacketCaptureCreat
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -720,7 +721,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) updateTagsCreateReques
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/virtualnetworkgateways.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -150,7 +151,7 @@ func (client *virtualNetworkGatewaysOperations) createOrUpdateCreateRequest(reso
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +226,7 @@ func (client *virtualNetworkGatewaysOperations) deleteCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +301,7 @@ func (client *virtualNetworkGatewaysOperations) disconnectVirtualNetworkGatewayV
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -375,7 +376,7 @@ func (client *virtualNetworkGatewaysOperations) generateVpnProfileCreateRequest(
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -450,7 +451,7 @@ func (client *virtualNetworkGatewaysOperations) generatevpnclientpackageCreateRe
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -501,7 +502,7 @@ func (client *virtualNetworkGatewaysOperations) getCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -577,7 +578,7 @@ func (client *virtualNetworkGatewaysOperations) getAdvertisedRoutesCreateRequest
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -653,7 +654,7 @@ func (client *virtualNetworkGatewaysOperations) getBgpPeerStatusCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -731,7 +732,7 @@ func (client *virtualNetworkGatewaysOperations) getLearnedRoutesCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -806,7 +807,7 @@ func (client *virtualNetworkGatewaysOperations) getVpnProfilePackageUrlCreateReq
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -881,7 +882,7 @@ func (client *virtualNetworkGatewaysOperations) getVpnclientConnectionHealthCrea
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -956,7 +957,7 @@ func (client *virtualNetworkGatewaysOperations) getVpnclientIPsecParametersCreat
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1012,7 +1013,7 @@ func (client *virtualNetworkGatewaysOperations) listCreateRequest(resourceGroupN
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1070,7 +1071,7 @@ func (client *virtualNetworkGatewaysOperations) listConnectionsCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1146,7 +1147,7 @@ func (client *virtualNetworkGatewaysOperations) resetCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1224,7 +1225,7 @@ func (client *virtualNetworkGatewaysOperations) resetVpnClientSharedKeyCreateReq
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1299,7 +1300,7 @@ func (client *virtualNetworkGatewaysOperations) setVpnclientIPsecParametersCreat
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1374,7 +1375,7 @@ func (client *virtualNetworkGatewaysOperations) startPacketCaptureCreateRequest(
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1452,7 +1453,7 @@ func (client *virtualNetworkGatewaysOperations) stopPacketCaptureCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1503,7 +1504,7 @@ func (client *virtualNetworkGatewaysOperations) supportedVpnDevicesCreateRequest
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1579,7 +1580,7 @@ func (client *virtualNetworkGatewaysOperations) updateTagsCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1630,7 +1631,7 @@ func (client *virtualNetworkGatewaysOperations) vpnDeviceConfigurationScriptCrea
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualnetworkpeerings.go
+++ b/test/network/2020-03-01/armnetwork/virtualnetworkpeerings.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *virtualNetworkPeeringsOperations) createOrUpdateCreateRequest(reso
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkPeeringName}", url.PathEscape(virtualNetworkPeeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *virtualNetworkPeeringsOperations) deleteCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkPeeringName}", url.PathEscape(virtualNetworkPeeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *virtualNetworkPeeringsOperations) getCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkPeeringName}", url.PathEscape(virtualNetworkPeeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *virtualNetworkPeeringsOperations) listCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualnetworks.go
+++ b/test/network/2020-03-01/armnetwork/virtualnetworks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -68,7 +69,7 @@ func (client *virtualNetworksOperations) checkIPAddressAvailabilityCreateRequest
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +146,7 @@ func (client *virtualNetworksOperations) createOrUpdateCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +221,7 @@ func (client *virtualNetworksOperations) deleteCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *virtualNetworksOperations) getCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +332,7 @@ func (client *virtualNetworksOperations) listCreateRequest(resourceGroupName str
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +388,7 @@ func (client *virtualNetworksOperations) ListAll() (VirtualNetworkListResultPage
 func (client *virtualNetworksOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworks"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -445,7 +446,7 @@ func (client *virtualNetworksOperations) listUsageCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -497,7 +498,7 @@ func (client *virtualNetworksOperations) updateTagsCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualnetworktaps.go
+++ b/test/network/2020-03-01/armnetwork/virtualnetworktaps.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *virtualNetworkTapsOperations) createOrUpdateCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *virtualNetworkTapsOperations) deleteCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *virtualNetworkTapsOperations) getCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +271,7 @@ func (client *virtualNetworkTapsOperations) ListAll() (VirtualNetworkTapListResu
 func (client *virtualNetworkTapsOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworkTaps"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +328,7 @@ func (client *virtualNetworkTapsOperations) listByResourceGroupCreateRequest(res
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +380,7 @@ func (client *virtualNetworkTapsOperations) updateTagsCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualrouterpeerings.go
+++ b/test/network/2020-03-01/armnetwork/virtualrouterpeerings.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *virtualRouterPeeringsOperations) createOrUpdateCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *virtualRouterPeeringsOperations) deleteCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *virtualRouterPeeringsOperations) getCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *virtualRouterPeeringsOperations) listCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualrouters.go
+++ b/test/network/2020-03-01/armnetwork/virtualrouters.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -86,7 +87,7 @@ func (client *virtualRoutersOperations) createOrUpdateCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *virtualRoutersOperations) deleteCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +213,7 @@ func (client *virtualRoutersOperations) getCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *virtualRoutersOperations) List() (VirtualRouterListResultPager, er
 func (client *virtualRoutersOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualRouters"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +329,7 @@ func (client *virtualRoutersOperations) listByResourceGroupCreateRequest(resourc
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualwans.go
+++ b/test/network/2020-03-01/armnetwork/virtualwans.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *virtualWansOperations) createOrUpdateCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWanName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *virtualWansOperations) deleteCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWanName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *virtualWansOperations) getCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWanName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +271,7 @@ func (client *virtualWansOperations) List() (ListVirtualWaNsResultPager, error) 
 func (client *virtualWansOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualWans"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +328,7 @@ func (client *virtualWansOperations) listByResourceGroupCreateRequest(resourceGr
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +380,7 @@ func (client *virtualWansOperations) updateTagsCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWanName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnconnections.go
+++ b/test/network/2020-03-01/armnetwork/vpnconnections.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -85,7 +86,7 @@ func (client *vpnConnectionsOperations) createOrUpdateCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *vpnConnectionsOperations) deleteCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *vpnConnectionsOperations) getCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *vpnConnectionsOperations) listByVpnGatewayCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpngateways.go
+++ b/test/network/2020-03-01/armnetwork/vpngateways.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -92,7 +93,7 @@ func (client *vpnGatewaysOperations) createOrUpdateCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +168,7 @@ func (client *vpnGatewaysOperations) deleteCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +219,7 @@ func (client *vpnGatewaysOperations) getCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +275,7 @@ func (client *vpnGatewaysOperations) List() (ListVpnGatewaysResultPager, error) 
 func (client *vpnGatewaysOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +332,7 @@ func (client *vpnGatewaysOperations) listByResourceGroupCreateRequest(resourceGr
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +408,7 @@ func (client *vpnGatewaysOperations) resetCreateRequest(resourceGroupName string
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +459,7 @@ func (client *vpnGatewaysOperations) updateTagsCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnlinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/vpnlinkconnections.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -55,7 +56,7 @@ func (client *vpnLinkConnectionsOperations) listByVpnConnectionCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnserverconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/vpnserverconfigurations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *vpnServerConfigurationsOperations) createOrUpdateCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *vpnServerConfigurationsOperations) deleteCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *vpnServerConfigurationsOperations) getCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +271,7 @@ func (client *vpnServerConfigurationsOperations) List() (ListVpnServerConfigurat
 func (client *vpnServerConfigurationsOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnServerConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +328,7 @@ func (client *vpnServerConfigurationsOperations) listByResourceGroupCreateReques
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +380,7 @@ func (client *vpnServerConfigurationsOperations) updateTagsCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnserverconfigurationsassociatedwithvirtualwan.go
+++ b/test/network/2020-03-01/armnetwork/vpnserverconfigurationsassociatedwithvirtualwan.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -75,7 +76,7 @@ func (client *vpnServerConfigurationsAssociatedWithVirtualWanOperations) listCre
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWanName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnsitelinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/vpnsitelinkconnections.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -50,7 +51,7 @@ func (client *vpnSiteLinkConnectionsOperations) getCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{linkConnectionName}", url.PathEscape(linkConnectionName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnsitelinks.go
+++ b/test/network/2020-03-01/armnetwork/vpnsitelinks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -52,7 +53,7 @@ func (client *vpnSiteLinksOperations) getCreateRequest(resourceGroupName string,
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteLinkName}", url.PathEscape(vpnSiteLinkName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (client *vpnSiteLinksOperations) listByVpnSiteCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnsites.go
+++ b/test/network/2020-03-01/armnetwork/vpnsites.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *vpnSitesOperations) createOrUpdateCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *vpnSitesOperations) deleteCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (client *vpnSitesOperations) getCreateRequest(resourceGroupName string, vpn
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +271,7 @@ func (client *vpnSitesOperations) List() (ListVpnSitesResultPager, error) {
 func (client *vpnSitesOperations) listCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnSites"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +328,7 @@ func (client *vpnSitesOperations) listByResourceGroupCreateRequest(resourceGroup
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +380,7 @@ func (client *vpnSitesOperations) updateTagsCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnsitesconfiguration.go
+++ b/test/network/2020-03-01/armnetwork/vpnsitesconfiguration.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -75,7 +76,7 @@ func (client *vpnSitesConfigurationOperations) downloadCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWanName))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/webapplicationfirewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/webapplicationfirewallpolicies.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -60,7 +61,7 @@ func (client *webApplicationFirewallPoliciesOperations) createOrUpdateCreateRequ
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{policyName}", url.PathEscape(policyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +137,7 @@ func (client *webApplicationFirewallPoliciesOperations) deleteCreateRequest(reso
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{policyName}", url.PathEscape(policyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +188,7 @@ func (client *webApplicationFirewallPoliciesOperations) getCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{policyName}", url.PathEscape(policyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +245,7 @@ func (client *webApplicationFirewallPoliciesOperations) listCreateRequest(resour
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +301,7 @@ func (client *webApplicationFirewallPoliciesOperations) ListAll() (WebApplicatio
 func (client *webApplicationFirewallPoliciesOperations) listAllCreateRequest() (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(urlPath)
+	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR fixes path parsing, so that new paths are appended to previously declared paths on the endpoint url. 

This helps ensure proper functioning for cases where the host is declared as: `{endpoint}/foo` so that the `/foo` is not lost upon request creation.