### PR TITLE
Fix references to client.u

### DIFF
--- a/src/generator/client.ts
+++ b/src/generator/client.ts
@@ -48,7 +48,7 @@ export async function generateClient(session: Session<CodeModel>): Promise<strin
     clientOptions = 'clientOptions';
     defaultClientOptions = 'defaultClientOptions';
   }
-  text += `// ClientOptions contains configuration settings for the default client's pipeline.\n`;
+  text += `// ${clientOptions} contains configuration settings for the default client's pipeline.\n`;
   text += `type ${clientOptions} struct {\n`;
   text += '\t// HTTPClient sets the transport for making HTTP requests.\n';
   text += '\tHTTPClient azcore.Transport\n';
@@ -76,7 +76,7 @@ export async function generateClient(session: Session<CodeModel>): Promise<strin
   text += '\t}\n';
   text += '}\n\n';
 
-  text += 'func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {\n';
+  text += `func (c *${clientOptions}) telemetryOptions() azcore.TelemetryOptions {\n`;
   text += '\tt := telemetryInfo\n';
   text += '\tif c.ApplicationID != "" {\n';
   text += '\t\ta := strings.ReplaceAll(c.ApplicationID, " ", "/")\n';
@@ -165,7 +165,7 @@ export async function generateClient(session: Session<CodeModel>): Promise<strin
       passClientOnlyParams += `${param.language.go!.name}, `;
     }
   } else {
-    text += `\t${urlVar} url.URL\n`;
+    text += `\t${urlVar} *url.URL\n`;
   }
   text += `\t${pipelineVar} azcore.Pipeline\n`;
   text += '}\n\n';
@@ -245,7 +245,7 @@ export async function generateClient(session: Session<CodeModel>): Promise<strin
     text += `\tif ${urlVar}.Scheme == "" {\n`;
     text += '\t\treturn nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)\n';
     text += '\t}\n';
-    text += `\treturn &${client}{${urlVar}: *${urlVar}, ${pipelineVar}: ${pipelineVar}}, nil\n`;
+    text += `\treturn &${client}{${urlVar}: ${urlVar}, ${pipelineVar}: ${pipelineVar}}, nil\n`;
   } else if (paramHostInfo.urlOnClient) {
     const op = session.model.operationGroups[0].operations[0];
     const group = session.model.operationGroups[0];

--- a/test/autorest/generated/additionalpropsgroup/client.go
+++ b/test/autorest/generated/additionalpropsgroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // PetsOperations returns the PetsOperations associated with this client.

--- a/test/autorest/generated/arraygroup/client.go
+++ b/test/autorest/generated/arraygroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest Swagger BAT
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // ArrayOperations returns the ArrayOperations associated with this client.

--- a/test/autorest/generated/azurereportgroup/client.go
+++ b/test/autorest/generated/azurereportgroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // AutoRestReportServiceForAzureOperations returns the AutoRestReportServiceForAzureOperations associated with this client.

--- a/test/autorest/generated/azurespecialsgroup/client.go
+++ b/test/autorest/generated/azurespecialsgroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // XMSClientRequestIDOperations returns the XMSClientRequestIDOperations associated with this client.

--- a/test/autorest/generated/booleangroup/client.go
+++ b/test/autorest/generated/booleangroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // BoolOperations returns the BoolOperations associated with this client.

--- a/test/autorest/generated/bytegroup/client.go
+++ b/test/autorest/generated/bytegroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest Swagger BAT
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // ByteOperations returns the ByteOperations associated with this client.

--- a/test/autorest/generated/complexgroup/client.go
+++ b/test/autorest/generated/complexgroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // BasicOperations returns the BasicOperations associated with this client.

--- a/test/autorest/generated/complexmodelgroup/client.go
+++ b/test/autorest/generated/complexmodelgroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Some cool documentation.
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // ComplexModelClientOperations returns the ComplexModelClientOperations associated with this client.

--- a/test/autorest/generated/datetimegroup/client.go
+++ b/test/autorest/generated/datetimegroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // DatetimeOperations returns the DatetimeOperations associated with this client.

--- a/test/autorest/generated/datetimerfc1123group/client.go
+++ b/test/autorest/generated/datetimerfc1123group/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // Datetimerfc1123Operations returns the Datetimerfc1123Operations associated with this client.

--- a/test/autorest/generated/dictionarygroup/client.go
+++ b/test/autorest/generated/dictionarygroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest Swagger BAT
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // DictionaryOperations returns the DictionaryOperations associated with this client.

--- a/test/autorest/generated/errorsgroup/client.go
+++ b/test/autorest/generated/errorsgroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - XMS Error Response Extensions
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // PetOperations returns the PetOperations associated with this client.

--- a/test/autorest/generated/extenumsgroup/client.go
+++ b/test/autorest/generated/extenumsgroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - PetStore
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // PetOperations returns the PetOperations associated with this client.

--- a/test/autorest/generated/filegroup/client.go
+++ b/test/autorest/generated/filegroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest Swagger BAT
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // FilesOperations returns the FilesOperations associated with this client.

--- a/test/autorest/generated/headergroup/client.go
+++ b/test/autorest/generated/headergroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // HeaderOperations returns the HeaderOperations associated with this client.

--- a/test/autorest/generated/httpinfrastructuregroup/client.go
+++ b/test/autorest/generated/httpinfrastructuregroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // HTTPFailureOperations returns the HTTPFailureOperations associated with this client.

--- a/test/autorest/generated/integergroup/client.go
+++ b/test/autorest/generated/integergroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // IntOperations returns the IntOperations associated with this client.

--- a/test/autorest/generated/lrogroup/client.go
+++ b/test/autorest/generated/lrogroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Long-running Operation for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // LrOSOperations returns the LrOSOperations associated with this client.

--- a/test/autorest/generated/migroup/client.go
+++ b/test/autorest/generated/migroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Service client for multiinheritance client testing
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // MultipleInheritanceServiceClientOperations returns the MultipleInheritanceServiceClientOperations associated with this client.

--- a/test/autorest/generated/numbergroup/client.go
+++ b/test/autorest/generated/numbergroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // NumberOperations returns the NumberOperations associated with this client.

--- a/test/autorest/generated/optionalgroup/client.go
+++ b/test/autorest/generated/optionalgroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // ImplicitOperations returns the ImplicitOperations associated with this client.

--- a/test/autorest/generated/paginggroup/client.go
+++ b/test/autorest/generated/paginggroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Long-running Operation for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // PagingOperations returns the PagingOperations associated with this client.

--- a/test/autorest/generated/paramgroupinggroup/client.go
+++ b/test/autorest/generated/paramgroupinggroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // ParameterGroupingOperations returns the ParameterGroupingOperations associated with this client.

--- a/test/autorest/generated/reportgroup/client.go
+++ b/test/autorest/generated/reportgroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // AutoRestReportServiceOperations returns the AutoRestReportServiceOperations associated with this client.

--- a/test/autorest/generated/stringgroup/client.go
+++ b/test/autorest/generated/stringgroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest Swagger BAT
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // StringOperations returns the StringOperations associated with this client.

--- a/test/autorest/generated/urlgroup/client.go
+++ b/test/autorest/generated/urlgroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // PathsOperations returns the PathsOperations associated with this client.

--- a/test/autorest/generated/urlmultigroup/client.go
+++ b/test/autorest/generated/urlmultigroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // QueriesOperations returns the QueriesOperations associated with this client.

--- a/test/autorest/generated/validationgroup/client.go
+++ b/test/autorest/generated/validationgroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest. No server backend exists for these tests.
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // AutoRestValidationTestOperations returns the AutoRestValidationTestOperations associated with this client.

--- a/test/autorest/generated/xmlgroup/client.go
+++ b/test/autorest/generated/xmlgroup/client.go
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest Swagger BAT
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -89,7 +89,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // XMLOperations returns the XMLOperations associated with this client.

--- a/test/go.mod
+++ b/test/go.mod
@@ -3,6 +3,13 @@ module generatortests
 go 1.13
 
 require (
+	armnetwork v0.0.0-00010101000000-000000000000
+	azblob v0.0.0-00010101000000-000000000000
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.0
 	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.0
+)
+
+replace (
+	armnetwork => ./network/2020-03-01/armnetwork
+	azblob => ./storage/2019-07-07/azblob
 )

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,3 +1,5 @@
+github.com/Azure/azure-sdk-for-go/sdk/armcore v0.1.0 h1:i4/txgB7gpzLa3YBBPnSSXnRB5+oOd+79M3EhlaaEHM=
+github.com/Azure/azure-sdk-for-go/sdk/armcore v0.1.0/go.mod h1:/cH2D+NpD2KRgnop4cU+S5P2On5mP6KWgpWq48+Bt/M=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.0 h1:VdhfbVpQ3dkhXYOx/Wj1+utikcZkZSZSmpqmXWwaNJY=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.0/go.mod h1:hL9TGc07RkJVzDIBxsYXC/r0M+YiRkvl4z1elXCD+8s=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.0 h1:cLpVMIkXC/umSP9DMz9I6FttDWJAsmvhpaB6MlkagGY=

--- a/test/network/2020-03-01/armnetwork/client.go
+++ b/test/network/2020-03-01/armnetwork/client.go
@@ -60,7 +60,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Network Client
 type Client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -106,7 +106,7 @@ func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &Client{u: *u, p: p}, nil
+	return &Client{u: u, p: p}, nil
 }
 
 // ApplicationGatewaysOperations returns the ApplicationGatewaysOperations associated with this client.

--- a/test/other_mods.go
+++ b/test/other_mods.go
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package generatortests
+
+import (
+	_ "armnetwork"
+	_ "azblob"
+)

--- a/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
@@ -49,7 +49,8 @@ func (client *appendBlobOperations) AppendBlock(ctx context.Context, contentLeng
 
 // appendBlockCreateRequest creates the AppendBlock request.
 func (client *appendBlobOperations) appendBlockCreateRequest(contentLength int64, body azcore.ReadSeekCloser, appendBlobAppendBlockOptions *AppendBlobAppendBlockOptions, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "appendblock")
 	if appendBlobAppendBlockOptions != nil && appendBlobAppendBlockOptions.Timeout != nil {
@@ -202,7 +203,8 @@ func (client *appendBlobOperations) AppendBlockFromURL(ctx context.Context, sour
 
 // appendBlockFromUrlCreateRequest creates the AppendBlockFromURL request.
 func (client *appendBlobOperations) appendBlockFromUrlCreateRequest(sourceUrl url.URL, contentLength int64, appendBlobAppendBlockFromUrlOptions *AppendBlobAppendBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "appendblock")
 	if appendBlobAppendBlockFromUrlOptions != nil && appendBlobAppendBlockFromUrlOptions.Timeout != nil {
@@ -371,7 +373,8 @@ func (client *appendBlobOperations) Create(ctx context.Context, contentLength in
 
 // createCreateRequest creates the Create request.
 func (client *appendBlobOperations) createCreateRequest(contentLength int64, appendBlobCreateOptions *AppendBlobCreateOptions, blobHttpHeaders *BlobHttpHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	if appendBlobCreateOptions != nil && appendBlobCreateOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*appendBlobCreateOptions.Timeout), 10))

--- a/test/storage/2019-07-07/azblob/zz_generated_blob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blob.go
@@ -84,7 +84,8 @@ func (client *blobOperations) AbortCopyFromURL(ctx context.Context, copyId strin
 
 // abortCopyFromUrlCreateRequest creates the AbortCopyFromURL request.
 func (client *blobOperations) abortCopyFromUrlCreateRequest(copyId string, blobAbortCopyFromUrlOptions *BlobAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "copy")
 	query.Set("copyid", copyId)
@@ -157,7 +158,8 @@ func (client *blobOperations) AcquireLease(ctx context.Context, blobAcquireLease
 
 // acquireLeaseCreateRequest creates the AcquireLease request.
 func (client *blobOperations) acquireLeaseCreateRequest(blobAcquireLeaseOptions *BlobAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "lease")
 	if blobAcquireLeaseOptions != nil && blobAcquireLeaseOptions.Timeout != nil {
@@ -257,7 +259,8 @@ func (client *blobOperations) BreakLease(ctx context.Context, blobBreakLeaseOpti
 
 // breakLeaseCreateRequest creates the BreakLease request.
 func (client *blobOperations) breakLeaseCreateRequest(blobBreakLeaseOptions *BlobBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "lease")
 	if blobBreakLeaseOptions != nil && blobBreakLeaseOptions.Timeout != nil {
@@ -359,7 +362,8 @@ func (client *blobOperations) ChangeLease(ctx context.Context, leaseId string, p
 
 // changeLeaseCreateRequest creates the ChangeLease request.
 func (client *blobOperations) changeLeaseCreateRequest(leaseId string, proposedLeaseId string, blobChangeLeaseOptions *BlobChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "lease")
 	if blobChangeLeaseOptions != nil && blobChangeLeaseOptions.Timeout != nil {
@@ -455,7 +459,8 @@ func (client *blobOperations) CopyFromURL(ctx context.Context, copySource url.UR
 
 // copyFromUrlCreateRequest creates the CopyFromURL request.
 func (client *blobOperations) copyFromUrlCreateRequest(copySource url.URL, blobCopyFromUrlOptions *BlobCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	if blobCopyFromUrlOptions != nil && blobCopyFromUrlOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*blobCopyFromUrlOptions.Timeout), 10))
@@ -590,7 +595,8 @@ func (client *blobOperations) CreateSnapshot(ctx context.Context, blobCreateSnap
 
 // createSnapshotCreateRequest creates the CreateSnapshot request.
 func (client *blobOperations) createSnapshotCreateRequest(blobCreateSnapshotOptions *BlobCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "snapshot")
 	if blobCreateSnapshotOptions != nil && blobCreateSnapshotOptions.Timeout != nil {
@@ -705,7 +711,8 @@ func (client *blobOperations) Delete(ctx context.Context, blobDeleteOptions *Blo
 
 // deleteCreateRequest creates the Delete request.
 func (client *blobOperations) deleteCreateRequest(blobDeleteOptions *BlobDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	if blobDeleteOptions != nil && blobDeleteOptions.Snapshot != nil {
 		query.Set("snapshot", *blobDeleteOptions.Snapshot)
@@ -793,7 +800,8 @@ func (client *blobOperations) Download(ctx context.Context, blobDownloadOptions 
 
 // downloadCreateRequest creates the Download request.
 func (client *blobOperations) downloadCreateRequest(blobDownloadOptions *BlobDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	if blobDownloadOptions != nil && blobDownloadOptions.Snapshot != nil {
 		query.Set("snapshot", *blobDownloadOptions.Snapshot)
@@ -1018,7 +1026,8 @@ func (client *blobOperations) GetAccessControl(ctx context.Context, blobGetAcces
 
 // getAccessControlCreateRequest creates the GetAccessControl request.
 func (client *blobOperations) getAccessControlCreateRequest(blobGetAccessControlOptions *BlobGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("action", "getAccessControl")
 	if blobGetAccessControlOptions != nil && blobGetAccessControlOptions.Timeout != nil {
@@ -1123,7 +1132,8 @@ func (client *blobOperations) GetAccountInfo(ctx context.Context) (*BlobGetAccou
 
 // getAccountInfoCreateRequest creates the GetAccountInfo request.
 func (client *blobOperations) getAccountInfoCreateRequest() (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("restype", "account")
 	query.Set("comp", "properties")
@@ -1192,7 +1202,8 @@ func (client *blobOperations) GetProperties(ctx context.Context, blobGetProperti
 
 // getPropertiesCreateRequest creates the GetProperties request.
 func (client *blobOperations) getPropertiesCreateRequest(blobGetPropertiesOptions *BlobGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	if blobGetPropertiesOptions != nil && blobGetPropertiesOptions.Snapshot != nil {
 		query.Set("snapshot", *blobGetPropertiesOptions.Snapshot)
@@ -1427,7 +1438,8 @@ func (client *blobOperations) ReleaseLease(ctx context.Context, leaseId string, 
 
 // releaseLeaseCreateRequest creates the ReleaseLease request.
 func (client *blobOperations) releaseLeaseCreateRequest(leaseId string, blobReleaseLeaseOptions *BlobReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "lease")
 	if blobReleaseLeaseOptions != nil && blobReleaseLeaseOptions.Timeout != nil {
@@ -1519,7 +1531,8 @@ func (client *blobOperations) Rename(ctx context.Context, renameSource string, b
 
 // renameCreateRequest creates the Rename request.
 func (client *blobOperations) renameCreateRequest(renameSource string, blobRenameOptions *BlobRenameOptions, directoryHttpHeaders *DirectoryHttpHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	if blobRenameOptions != nil && blobRenameOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*blobRenameOptions.Timeout), 10))
@@ -1661,7 +1674,8 @@ func (client *blobOperations) RenewLease(ctx context.Context, leaseId string, bl
 
 // renewLeaseCreateRequest creates the RenewLease request.
 func (client *blobOperations) renewLeaseCreateRequest(leaseId string, blobRenewLeaseOptions *BlobRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "lease")
 	if blobRenewLeaseOptions != nil && blobRenewLeaseOptions.Timeout != nil {
@@ -1756,7 +1770,8 @@ func (client *blobOperations) SetAccessControl(ctx context.Context, blobSetAcces
 
 // setAccessControlCreateRequest creates the SetAccessControl request.
 func (client *blobOperations) setAccessControlCreateRequest(blobSetAccessControlOptions *BlobSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("action", "setAccessControl")
 	if blobSetAccessControlOptions != nil && blobSetAccessControlOptions.Timeout != nil {
@@ -1858,7 +1873,8 @@ func (client *blobOperations) SetHTTPHeaders(ctx context.Context, blobSetHttpHea
 
 // setHttpHeadersCreateRequest creates the SetHTTPHeaders request.
 func (client *blobOperations) setHttpHeadersCreateRequest(blobSetHttpHeadersOptions *BlobSetHTTPHeadersOptions, blobHttpHeaders *BlobHttpHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "properties")
 	if blobSetHttpHeadersOptions != nil && blobSetHttpHeadersOptions.Timeout != nil {
@@ -1976,7 +1992,8 @@ func (client *blobOperations) SetMetadata(ctx context.Context, blobSetMetadataOp
 
 // setMetadataCreateRequest creates the SetMetadata request.
 func (client *blobOperations) setMetadataCreateRequest(blobSetMetadataOptions *BlobSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "metadata")
 	if blobSetMetadataOptions != nil && blobSetMetadataOptions.Timeout != nil {
@@ -2094,7 +2111,8 @@ func (client *blobOperations) SetTier(ctx context.Context, tier AccessTier, blob
 
 // setTierCreateRequest creates the SetTier request.
 func (client *blobOperations) setTierCreateRequest(tier AccessTier, blobSetTierOptions *BlobSetTierOptions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "tier")
 	if blobSetTierOptions != nil && blobSetTierOptions.Timeout != nil {
@@ -2162,7 +2180,8 @@ func (client *blobOperations) StartCopyFromURL(ctx context.Context, copySource u
 
 // startCopyFromUrlCreateRequest creates the StartCopyFromURL request.
 func (client *blobOperations) startCopyFromUrlCreateRequest(copySource url.URL, blobStartCopyFromUrlOptions *BlobStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	if blobStartCopyFromUrlOptions != nil && blobStartCopyFromUrlOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*blobStartCopyFromUrlOptions.Timeout), 10))
@@ -2282,7 +2301,8 @@ func (client *blobOperations) Undelete(ctx context.Context, blobUndeleteOptions 
 
 // undeleteCreateRequest creates the Undelete request.
 func (client *blobOperations) undeleteCreateRequest(blobUndeleteOptions *BlobUndeleteOptions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "undelete")
 	if blobUndeleteOptions != nil && blobUndeleteOptions.Timeout != nil {

--- a/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
@@ -53,7 +53,8 @@ func (client *blockBlobOperations) CommitBlockList(ctx context.Context, blocks B
 
 // commitBlockListCreateRequest creates the CommitBlockList request.
 func (client *blockBlobOperations) commitBlockListCreateRequest(blocks BlockLookupList, blockBlobCommitBlockListOptions *BlockBlobCommitBlockListOptions, blobHttpHeaders *BlobHttpHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "blocklist")
 	if blockBlobCommitBlockListOptions != nil && blockBlobCommitBlockListOptions.Timeout != nil {
@@ -212,7 +213,8 @@ func (client *blockBlobOperations) GetBlockList(ctx context.Context, listType Bl
 
 // getBlockListCreateRequest creates the GetBlockList request.
 func (client *blockBlobOperations) getBlockListCreateRequest(listType BlockListType, blockBlobGetBlockListOptions *BlockBlobGetBlockListOptions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "blocklist")
 	if blockBlobGetBlockListOptions != nil && blockBlobGetBlockListOptions.Snapshot != nil {
@@ -307,7 +309,8 @@ func (client *blockBlobOperations) StageBlock(ctx context.Context, blockId strin
 
 // stageBlockCreateRequest creates the StageBlock request.
 func (client *blockBlobOperations) stageBlockCreateRequest(blockId string, contentLength int64, body azcore.ReadSeekCloser, blockBlobStageBlockOptions *BlockBlobStageBlockOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "block")
 	query.Set("blockid", blockId)
@@ -422,7 +425,8 @@ func (client *blockBlobOperations) StageBlockFromURL(ctx context.Context, blockI
 
 // stageBlockFromUrlCreateRequest creates the StageBlockFromURL request.
 func (client *blockBlobOperations) stageBlockFromUrlCreateRequest(blockId string, contentLength int64, sourceUrl url.URL, blockBlobStageBlockFromUrlOptions *BlockBlobStageBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "block")
 	query.Set("blockid", blockId)
@@ -553,7 +557,8 @@ func (client *blockBlobOperations) Upload(ctx context.Context, contentLength int
 
 // uploadCreateRequest creates the Upload request.
 func (client *blockBlobOperations) uploadCreateRequest(contentLength int64, body azcore.ReadSeekCloser, blockBlobUploadOptions *BlockBlobUploadOptions, blobHttpHeaders *BlobHttpHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	if blockBlobUploadOptions != nil && blockBlobUploadOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*blockBlobUploadOptions.Timeout), 10))

--- a/test/storage/2019-07-07/azblob/zz_generated_client.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_client.go
@@ -15,7 +15,7 @@ import (
 const scope = "https://storage.azure.com/.default"
 const telemetryInfo = "azsdk-go-azblob/<version>"
 
-// ClientOptions contains configuration settings for the default client's pipeline.
+// clientOptions contains configuration settings for the default client's pipeline.
 type clientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
@@ -38,7 +38,7 @@ func defaultClientOptions() clientOptions {
 	}
 }
 
-func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
+func (c *clientOptions) telemetryOptions() azcore.TelemetryOptions {
 	t := telemetryInfo
 	if c.ApplicationID != "" {
 		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
@@ -54,7 +54,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 }
 
 type client struct {
-	u url.URL
+	u *url.URL
 	p azcore.Pipeline
 }
 
@@ -82,7 +82,7 @@ func newClientWithPipeline(endpoint string, p azcore.Pipeline) (*client, error) 
 	if u.Scheme == "" {
 		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
 	}
-	return &client{u: *u, p: p}, nil
+	return &client{u: u, p: p}, nil
 }
 
 // ServiceOperations returns the ServiceOperations associated with this client.

--- a/test/storage/2019-07-07/azblob/zz_generated_container.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_container.go
@@ -73,7 +73,8 @@ func (client *containerOperations) AcquireLease(ctx context.Context, containerAc
 
 // acquireLeaseCreateRequest creates the AcquireLease request.
 func (client *containerOperations) acquireLeaseCreateRequest(containerAcquireLeaseOptions *ContainerAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "lease")
 	query.Set("restype", "container")
@@ -168,7 +169,8 @@ func (client *containerOperations) BreakLease(ctx context.Context, containerBrea
 
 // breakLeaseCreateRequest creates the BreakLease request.
 func (client *containerOperations) breakLeaseCreateRequest(containerBreakLeaseOptions *ContainerBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "lease")
 	query.Set("restype", "container")
@@ -265,7 +267,8 @@ func (client *containerOperations) ChangeLease(ctx context.Context, leaseId stri
 
 // changeLeaseCreateRequest creates the ChangeLease request.
 func (client *containerOperations) changeLeaseCreateRequest(leaseId string, proposedLeaseId string, containerChangeLeaseOptions *ContainerChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "lease")
 	query.Set("restype", "container")
@@ -356,7 +359,8 @@ func (client *containerOperations) Create(ctx context.Context, containerCreateOp
 
 // createCreateRequest creates the Create request.
 func (client *containerOperations) createCreateRequest(containerCreateOptions *ContainerCreateOptions, containerCpkScopeInfo *ContainerCpkScopeInfo) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("restype", "container")
 	if containerCreateOptions != nil && containerCreateOptions.Timeout != nil {
@@ -446,7 +450,8 @@ func (client *containerOperations) Delete(ctx context.Context, containerDeleteOp
 
 // deleteCreateRequest creates the Delete request.
 func (client *containerOperations) deleteCreateRequest(containerDeleteOptions *ContainerDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("restype", "container")
 	if containerDeleteOptions != nil && containerDeleteOptions.Timeout != nil {
@@ -523,7 +528,8 @@ func (client *containerOperations) GetAccessPolicy(ctx context.Context, containe
 
 // getAccessPolicyCreateRequest creates the GetAccessPolicy request.
 func (client *containerOperations) getAccessPolicyCreateRequest(containerGetAccessPolicyOptions *ContainerGetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("restype", "container")
 	query.Set("comp", "acl")
@@ -608,7 +614,8 @@ func (client *containerOperations) GetAccountInfo(ctx context.Context) (*Contain
 
 // getAccountInfoCreateRequest creates the GetAccountInfo request.
 func (client *containerOperations) getAccountInfoCreateRequest() (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("restype", "account")
 	query.Set("comp", "properties")
@@ -677,7 +684,8 @@ func (client *containerOperations) GetProperties(ctx context.Context, containerG
 
 // getPropertiesCreateRequest creates the GetProperties request.
 func (client *containerOperations) getPropertiesCreateRequest(containerGetPropertiesOptions *ContainerGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("restype", "container")
 	if containerGetPropertiesOptions != nil && containerGetPropertiesOptions.Timeout != nil {
@@ -803,7 +811,8 @@ func (client *containerOperations) ListBlobFlatSegment(containerListBlobFlatSegm
 
 // listBlobFlatSegmentCreateRequest creates the ListBlobFlatSegment request.
 func (client *containerOperations) listBlobFlatSegmentCreateRequest(containerListBlobFlatSegmentOptions *ContainerListBlobFlatSegmentOptions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("restype", "container")
 	query.Set("comp", "list")
@@ -893,7 +902,8 @@ func (client *containerOperations) ListBlobHierarchySegment(delimiter string, co
 
 // listBlobHierarchySegmentCreateRequest creates the ListBlobHierarchySegment request.
 func (client *containerOperations) listBlobHierarchySegmentCreateRequest(delimiter string, containerListBlobHierarchySegmentOptions *ContainerListBlobHierarchySegmentOptions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("restype", "container")
 	query.Set("comp", "list")
@@ -978,7 +988,8 @@ func (client *containerOperations) ReleaseLease(ctx context.Context, leaseId str
 
 // releaseLeaseCreateRequest creates the ReleaseLease request.
 func (client *containerOperations) releaseLeaseCreateRequest(leaseId string, containerReleaseLeaseOptions *ContainerReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "lease")
 	query.Set("restype", "container")
@@ -1065,7 +1076,8 @@ func (client *containerOperations) RenewLease(ctx context.Context, leaseId strin
 
 // renewLeaseCreateRequest creates the RenewLease request.
 func (client *containerOperations) renewLeaseCreateRequest(leaseId string, containerRenewLeaseOptions *ContainerRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "lease")
 	query.Set("restype", "container")
@@ -1155,7 +1167,8 @@ func (client *containerOperations) SetAccessPolicy(ctx context.Context, containe
 
 // setAccessPolicyCreateRequest creates the SetAccessPolicy request.
 func (client *containerOperations) setAccessPolicyCreateRequest(containerSetAccessPolicyOptions *ContainerSetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("restype", "container")
 	query.Set("comp", "acl")
@@ -1253,7 +1266,8 @@ func (client *containerOperations) SetMetadata(ctx context.Context, containerSet
 
 // setMetadataCreateRequest creates the SetMetadata request.
 func (client *containerOperations) setMetadataCreateRequest(containerSetMetadataOptions *ContainerSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("restype", "container")
 	query.Set("comp", "metadata")

--- a/test/storage/2019-07-07/azblob/zz_generated_directory.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_directory.go
@@ -52,7 +52,8 @@ func (client *directoryOperations) Create(ctx context.Context, directoryCreateOp
 
 // createCreateRequest creates the Create request.
 func (client *directoryOperations) createCreateRequest(directoryCreateOptions *DirectoryCreateOptions, directoryHttpHeaders *DirectoryHttpHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("resource", "directory")
 	if directoryCreateOptions != nil && directoryCreateOptions.Timeout != nil {
@@ -176,7 +177,8 @@ func (client *directoryOperations) Delete(ctx context.Context, recursiveDirector
 
 // deleteCreateRequest creates the Delete request.
 func (client *directoryOperations) deleteCreateRequest(recursiveDirectoryDelete bool, directoryDeleteOptions *DirectoryDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	if directoryDeleteOptions != nil && directoryDeleteOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*directoryDeleteOptions.Timeout), 10))
@@ -265,7 +267,8 @@ func (client *directoryOperations) GetAccessControl(ctx context.Context, directo
 
 // getAccessControlCreateRequest creates the GetAccessControl request.
 func (client *directoryOperations) getAccessControlCreateRequest(directoryGetAccessControlOptions *DirectoryGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("action", "getAccessControl")
 	if directoryGetAccessControlOptions != nil && directoryGetAccessControlOptions.Timeout != nil {
@@ -370,7 +373,8 @@ func (client *directoryOperations) Rename(ctx context.Context, renameSource stri
 
 // renameCreateRequest creates the Rename request.
 func (client *directoryOperations) renameCreateRequest(renameSource string, directoryRenameOptions *DirectoryRenameOptions, directoryHttpHeaders *DirectoryHttpHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	if directoryRenameOptions != nil && directoryRenameOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*directoryRenameOptions.Timeout), 10))
@@ -518,7 +522,8 @@ func (client *directoryOperations) SetAccessControl(ctx context.Context, directo
 
 // setAccessControlCreateRequest creates the SetAccessControl request.
 func (client *directoryOperations) setAccessControlCreateRequest(directorySetAccessControlOptions *DirectorySetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("action", "setAccessControl")
 	if directorySetAccessControlOptions != nil && directorySetAccessControlOptions.Timeout != nil {

--- a/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
@@ -61,7 +61,8 @@ func (client *pageBlobOperations) ClearPages(ctx context.Context, contentLength 
 
 // clearPagesCreateRequest creates the ClearPages request.
 func (client *pageBlobOperations) clearPagesCreateRequest(contentLength int64, pageBlobClearPagesOptions *PageBlobClearPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "page")
 	if pageBlobClearPagesOptions != nil && pageBlobClearPagesOptions.Timeout != nil {
@@ -198,7 +199,8 @@ func (client *pageBlobOperations) CopyIncremental(ctx context.Context, copySourc
 
 // copyIncrementalCreateRequest creates the CopyIncremental request.
 func (client *pageBlobOperations) copyIncrementalCreateRequest(copySource url.URL, pageBlobCopyIncrementalOptions *PageBlobCopyIncrementalOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "incrementalcopy")
 	if pageBlobCopyIncrementalOptions != nil && pageBlobCopyIncrementalOptions.Timeout != nil {
@@ -295,7 +297,8 @@ func (client *pageBlobOperations) Create(ctx context.Context, contentLength int6
 
 // createCreateRequest creates the Create request.
 func (client *pageBlobOperations) createCreateRequest(contentLength int64, blobContentLength int64, pageBlobCreateOptions *PageBlobCreateOptions, blobHttpHeaders *BlobHttpHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	if pageBlobCreateOptions != nil && pageBlobCreateOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*pageBlobCreateOptions.Timeout), 10))
@@ -446,7 +449,8 @@ func (client *pageBlobOperations) GetPageRanges(ctx context.Context, pageBlobGet
 
 // getPageRangesCreateRequest creates the GetPageRanges request.
 func (client *pageBlobOperations) getPageRangesCreateRequest(pageBlobGetPageRangesOptions *PageBlobGetPageRangesOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "pagelist")
 	if pageBlobGetPageRangesOptions != nil && pageBlobGetPageRangesOptions.Snapshot != nil {
@@ -552,7 +556,8 @@ func (client *pageBlobOperations) GetPageRangesDiff(ctx context.Context, pageBlo
 
 // getPageRangesDiffCreateRequest creates the GetPageRangesDiff request.
 func (client *pageBlobOperations) getPageRangesDiffCreateRequest(pageBlobGetPageRangesDiffOptions *PageBlobGetPageRangesDiffOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "pagelist")
 	if pageBlobGetPageRangesDiffOptions != nil && pageBlobGetPageRangesDiffOptions.Snapshot != nil {
@@ -664,7 +669,8 @@ func (client *pageBlobOperations) Resize(ctx context.Context, blobContentLength 
 
 // resizeCreateRequest creates the Resize request.
 func (client *pageBlobOperations) resizeCreateRequest(blobContentLength int64, pageBlobResizeOptions *PageBlobResizeOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "properties")
 	if pageBlobResizeOptions != nil && pageBlobResizeOptions.Timeout != nil {
@@ -774,7 +780,8 @@ func (client *pageBlobOperations) UpdateSequenceNumber(ctx context.Context, sequ
 
 // updateSequenceNumberCreateRequest creates the UpdateSequenceNumber request.
 func (client *pageBlobOperations) updateSequenceNumberCreateRequest(sequenceNumberAction SequenceNumberActionType, pageBlobUpdateSequenceNumberOptions *PageBlobUpdateSequenceNumberOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "properties")
 	if pageBlobUpdateSequenceNumberOptions != nil && pageBlobUpdateSequenceNumberOptions.Timeout != nil {
@@ -878,7 +885,8 @@ func (client *pageBlobOperations) UploadPages(ctx context.Context, contentLength
 
 // uploadPagesCreateRequest creates the UploadPages request.
 func (client *pageBlobOperations) uploadPagesCreateRequest(contentLength int64, body azcore.ReadSeekCloser, pageBlobUploadPagesOptions *PageBlobUploadPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "page")
 	if pageBlobUploadPagesOptions != nil && pageBlobUploadPagesOptions.Timeout != nil {
@@ -1034,7 +1042,8 @@ func (client *pageBlobOperations) UploadPagesFromURL(ctx context.Context, source
 
 // uploadPagesFromUrlCreateRequest creates the UploadPagesFromURL request.
 func (client *pageBlobOperations) uploadPagesFromUrlCreateRequest(sourceUrl url.URL, sourceRange string, contentLength int64, rangeParameter string, pageBlobUploadPagesFromUrlOptions *PageBlobUploadPagesFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "page")
 	if pageBlobUploadPagesFromUrlOptions != nil && pageBlobUploadPagesFromUrlOptions.Timeout != nil {

--- a/test/storage/2019-07-07/azblob/zz_generated_service.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_service.go
@@ -57,7 +57,8 @@ func (client *serviceOperations) GetAccountInfo(ctx context.Context) (*ServiceGe
 
 // getAccountInfoCreateRequest creates the GetAccountInfo request.
 func (client *serviceOperations) getAccountInfoCreateRequest() (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("restype", "account")
 	query.Set("comp", "properties")
@@ -126,7 +127,8 @@ func (client *serviceOperations) GetProperties(ctx context.Context, serviceGetPr
 
 // getPropertiesCreateRequest creates the GetProperties request.
 func (client *serviceOperations) getPropertiesCreateRequest(serviceGetPropertiesOptions *ServiceGetPropertiesOptions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("restype", "service")
 	query.Set("comp", "properties")
@@ -188,7 +190,8 @@ func (client *serviceOperations) GetStatistics(ctx context.Context, serviceGetSt
 
 // getStatisticsCreateRequest creates the GetStatistics request.
 func (client *serviceOperations) getStatisticsCreateRequest(serviceGetStatisticsOptions *ServiceGetStatisticsOptions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("restype", "service")
 	query.Set("comp", "stats")
@@ -257,7 +260,8 @@ func (client *serviceOperations) GetUserDelegationKey(ctx context.Context, keyIn
 
 // getUserDelegationKeyCreateRequest creates the GetUserDelegationKey request.
 func (client *serviceOperations) getUserDelegationKeyCreateRequest(keyInfo KeyInfo, serviceGetUserDelegationKeyOptions *ServiceGetUserDelegationKeyOptions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("restype", "service")
 	query.Set("comp", "userdelegationkey")
@@ -332,7 +336,8 @@ func (client *serviceOperations) ListContainersSegment(serviceListContainersSegm
 
 // listContainersSegmentCreateRequest creates the ListContainersSegment request.
 func (client *serviceOperations) listContainersSegmentCreateRequest(serviceListContainersSegmentOptions *ServiceListContainersSegmentOptions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "list")
 	if serviceListContainersSegmentOptions != nil && serviceListContainersSegmentOptions.Prefix != nil {
@@ -402,7 +407,8 @@ func (client *serviceOperations) SetProperties(ctx context.Context, storageServi
 
 // setPropertiesCreateRequest creates the SetProperties request.
 func (client *serviceOperations) setPropertiesCreateRequest(storageServiceProperties StorageServiceProperties, serviceSetPropertiesOptions *ServiceSetPropertiesOptions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("restype", "service")
 	query.Set("comp", "properties")
@@ -464,7 +470,8 @@ func (client *serviceOperations) SubmitBatch(ctx context.Context, contentLength 
 
 // submitBatchCreateRequest creates the SubmitBatch request.
 func (client *serviceOperations) submitBatchCreateRequest(contentLength int64, multipartContentType string, body azcore.ReadSeekCloser, serviceSubmitBatchOptions *ServiceSubmitBatchOptions) (*azcore.Request, error) {
-	u := client.u
+	copy := *client.u
+	u := &copy
 	query := u.Query()
 	query.Set("comp", "batch")
 	if serviceSubmitBatchOptions != nil && serviceSubmitBatchOptions.Timeout != nil {


### PR DESCRIPTION
Make a copy of client.u for operations that use a parameterized host
along with query parameters.
Fixed case for unexported client options.
Added armnetwork and azblob to test build.