### PR TITLE
Emit header collections as a map

### DIFF
--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -134,6 +134,21 @@ export function getMethodParameters(op: Operation): Parameter[] {
   return params;
 }
 
+export function getParamName(param: Parameter, onClient: boolean): string {
+  let paramName = param.language.go!.name;
+  if (onClient) {
+    paramName = `client.Client.${paramName}`;
+  } else if (param.implementation === ImplementationLocation.Client) {
+    paramName = `client.${paramName}`;
+  } else if (param.language.go!.paramGroup) {
+    paramName = `${camelCase(param.language.go!.paramGroup.language.go!.name)}.${pascalCase(paramName)}`;
+  }
+  if (param.required !== true) {
+    paramName = `*${paramName}`;
+  }
+  return paramName;
+}
+
 export function formatParamValue(param: Parameter, imports: ImportManager, onClient: boolean): string {
   let separator = ',';
   switch (param.protocol.http?.style) {
@@ -147,17 +162,7 @@ export function formatParamValue(param: Parameter, imports: ImportManager, onCli
       separator = '\\t';
       break;
   }
-  let paramName = param.language.go!.name;
-  if (onClient) {
-    paramName = `client.Client.${paramName}`;
-  } else if (param.implementation === ImplementationLocation.Client) {
-    paramName = `client.${paramName}`;
-  } else if (param.language.go!.paramGroup) {
-    paramName = `${camelCase(param.language.go!.paramGroup.language.go!.name)}.${pascalCase(paramName)}`;
-  }
-  if (param.required !== true) {
-    paramName = `*${paramName}`;
-  }
+  let paramName = getParamName(param, onClient);
   switch (param.schema.type) {
     case SchemaType.Array:
       const arraySchema = <ArraySchema>param.schema;

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -254,6 +254,14 @@ function processOperationRequests(session: Session<CodeModel>) {
         }
         const inBody = param.protocol.http !== undefined && param.protocol.http!.in === 'body';
         param.schema.language.go!.name = schemaTypeToGoType(session.model, param.schema, inBody);
+        // check if this is a header collection
+        if (param.extensions?.['x-ms-header-collection-prefix']) {
+          // key is always string, use the specified type for the value
+          const ds = new DictionarySchema(`map[string]${param.schema.language.go!.name}`, '', param.schema);
+          ds.language.go = ds.language.default;
+          ds.language.go!.headerCollectionPrefix = param.extensions['x-ms-header-collection-prefix'];
+          param.schema = ds;
+        }
         if (param.implementation === ImplementationLocation.Client && param.schema.type !== SchemaType.Constant) {
           // add global param info to the operation group
           if (group.language.go!.clientParams === undefined) {

--- a/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
@@ -399,7 +399,9 @@ func (client *appendBlobOperations) createCreateRequest(contentLength int64, app
 		req.Header.Set("x-ms-blob-cache-control", *blobHttpHeaders.BlobCacheControl)
 	}
 	if appendBlobCreateOptions != nil && appendBlobCreateOptions.Metadata != nil {
-		req.Header.Set("x-ms-meta", *appendBlobCreateOptions.Metadata)
+		for k, v := range *appendBlobCreateOptions.Metadata {
+			req.Header.Set("x-ms-meta-"+k, v)
+		}
 	}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseId != nil {
 		req.Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseId)

--- a/test/storage/2019-07-07/azblob/zz_generated_blob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blob.go
@@ -469,7 +469,9 @@ func (client *blobOperations) copyFromUrlCreateRequest(copySource url.URL, blobC
 	req := azcore.NewRequest(http.MethodPut, *u)
 	req.Header.Set("x-ms-requires-sync", "true")
 	if blobCopyFromUrlOptions != nil && blobCopyFromUrlOptions.Metadata != nil {
-		req.Header.Set("x-ms-meta", *blobCopyFromUrlOptions.Metadata)
+		for k, v := range *blobCopyFromUrlOptions.Metadata {
+			req.Header.Set("x-ms-meta-"+k, v)
+		}
 	}
 	if blobCopyFromUrlOptions != nil && blobCopyFromUrlOptions.Tier != nil {
 		req.Header.Set("x-ms-access-tier", string(*blobCopyFromUrlOptions.Tier))
@@ -605,7 +607,9 @@ func (client *blobOperations) createSnapshotCreateRequest(blobCreateSnapshotOpti
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if blobCreateSnapshotOptions != nil && blobCreateSnapshotOptions.Metadata != nil {
-		req.Header.Set("x-ms-meta", *blobCreateSnapshotOptions.Metadata)
+		for k, v := range *blobCreateSnapshotOptions.Metadata {
+			req.Header.Set("x-ms-meta-"+k, v)
+		}
 	}
 	if cpkInfo != nil && cpkInfo.EncryptionKey != nil {
 		req.Header.Set("x-ms-encryption-key", *cpkInfo.EncryptionKey)
@@ -2002,7 +2006,9 @@ func (client *blobOperations) setMetadataCreateRequest(blobSetMetadataOptions *B
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if blobSetMetadataOptions != nil && blobSetMetadataOptions.Metadata != nil {
-		req.Header.Set("x-ms-meta", *blobSetMetadataOptions.Metadata)
+		for k, v := range *blobSetMetadataOptions.Metadata {
+			req.Header.Set("x-ms-meta-"+k, v)
+		}
 	}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseId != nil {
 		req.Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseId)
@@ -2189,7 +2195,9 @@ func (client *blobOperations) startCopyFromUrlCreateRequest(copySource url.URL, 
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if blobStartCopyFromUrlOptions != nil && blobStartCopyFromUrlOptions.Metadata != nil {
-		req.Header.Set("x-ms-meta", *blobStartCopyFromUrlOptions.Metadata)
+		for k, v := range *blobStartCopyFromUrlOptions.Metadata {
+			req.Header.Set("x-ms-meta-"+k, v)
+		}
 	}
 	if blobStartCopyFromUrlOptions != nil && blobStartCopyFromUrlOptions.Tier != nil {
 		req.Header.Set("x-ms-access-tier", string(*blobStartCopyFromUrlOptions.Tier))

--- a/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
@@ -84,7 +84,9 @@ func (client *blockBlobOperations) commitBlockListCreateRequest(blocks BlockLook
 		req.Header.Set("x-ms-content-crc64", base64.StdEncoding.EncodeToString(*blockBlobCommitBlockListOptions.TransactionalContentCrc64))
 	}
 	if blockBlobCommitBlockListOptions != nil && blockBlobCommitBlockListOptions.Metadata != nil {
-		req.Header.Set("x-ms-meta", *blockBlobCommitBlockListOptions.Metadata)
+		for k, v := range *blockBlobCommitBlockListOptions.Metadata {
+			req.Header.Set("x-ms-meta-"+k, v)
+		}
 	}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseId != nil {
 		req.Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseId)
@@ -586,7 +588,9 @@ func (client *blockBlobOperations) uploadCreateRequest(contentLength int64, body
 		req.Header.Set("x-ms-blob-cache-control", *blobHttpHeaders.BlobCacheControl)
 	}
 	if blockBlobUploadOptions != nil && blockBlobUploadOptions.Metadata != nil {
-		req.Header.Set("x-ms-meta", *blockBlobUploadOptions.Metadata)
+		for k, v := range *blockBlobUploadOptions.Metadata {
+			req.Header.Set("x-ms-meta-"+k, v)
+		}
 	}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseId != nil {
 		req.Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseId)

--- a/test/storage/2019-07-07/azblob/zz_generated_container.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_container.go
@@ -369,7 +369,9 @@ func (client *containerOperations) createCreateRequest(containerCreateOptions *C
 	u.RawQuery = query.Encode()
 	req := azcore.NewRequest(http.MethodPut, *u)
 	if containerCreateOptions != nil && containerCreateOptions.Metadata != nil {
-		req.Header.Set("x-ms-meta", *containerCreateOptions.Metadata)
+		for k, v := range *containerCreateOptions.Metadata {
+			req.Header.Set("x-ms-meta-"+k, v)
+		}
 	}
 	if containerCreateOptions != nil && containerCreateOptions.Access != nil {
 		req.Header.Set("x-ms-blob-public-access", string(*containerCreateOptions.Access))
@@ -1280,7 +1282,9 @@ func (client *containerOperations) setMetadataCreateRequest(containerSetMetadata
 		req.Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseId)
 	}
 	if containerSetMetadataOptions != nil && containerSetMetadataOptions.Metadata != nil {
-		req.Header.Set("x-ms-meta", *containerSetMetadataOptions.Metadata)
+		for k, v := range *containerSetMetadataOptions.Metadata {
+			req.Header.Set("x-ms-meta-"+k, v)
+		}
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
 		req.Header.Set("If-Modified-Since", modifiedAccessConditions.IfModifiedSince.Format(time.RFC1123))

--- a/test/storage/2019-07-07/azblob/zz_generated_models.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_models.go
@@ -184,7 +184,7 @@ type AppendBlobCreateOptions struct {
 	// are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source
 	// blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers.
 	// See Naming and Referencing Containers, Blobs, and Metadata for more information.
-	Metadata *string
+	Metadata *map[string]string
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestId *string
@@ -399,7 +399,7 @@ type BlobCopyFromURLOptions struct {
 	// are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source
 	// blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers.
 	// See Naming and Referencing Containers, Blobs, and Metadata for more information.
-	Metadata *string
+	Metadata *map[string]string
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestId *string
@@ -455,7 +455,7 @@ type BlobCreateSnapshotOptions struct {
 	// are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source
 	// blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers.
 	// See Naming and Referencing Containers, Blobs, and Metadata for more information.
-	Metadata *string
+	Metadata *map[string]string
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestId *string
@@ -1202,7 +1202,7 @@ type BlobSetMetadataOptions struct {
 	// are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source
 	// blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers.
 	// See Naming and Referencing Containers, Blobs, and Metadata for more information.
-	Metadata *string
+	Metadata *map[string]string
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestId *string
@@ -1278,7 +1278,7 @@ type BlobStartCopyFromURLOptions struct {
 	// are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source
 	// blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers.
 	// See Naming and Referencing Containers, Blobs, and Metadata for more information.
-	Metadata *string
+	Metadata *map[string]string
 	// Optional: Indicates the priority with which to rehydrate an archived blob.
 	RehydratePriority *RehydratePriority
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
@@ -1365,7 +1365,7 @@ type BlockBlobCommitBlockListOptions struct {
 	// are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source
 	// blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers.
 	// See Naming and Referencing Containers, Blobs, and Metadata for more information.
-	Metadata *string
+	Metadata *map[string]string
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestId *string
@@ -1536,7 +1536,7 @@ type BlockBlobUploadOptions struct {
 	// are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source
 	// blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers.
 	// See Naming and Referencing Containers, Blobs, and Metadata for more information.
-	Metadata *string
+	Metadata *map[string]string
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestId *string
@@ -1786,7 +1786,7 @@ type ContainerCreateOptions struct {
 	// are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source
 	// blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers.
 	// See Naming and Referencing Containers, Blobs, and Metadata for more information.
-	Metadata *string
+	Metadata *map[string]string
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestId *string
@@ -2159,7 +2159,7 @@ type ContainerSetMetadataOptions struct {
 	// are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source
 	// blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers.
 	// See Naming and Referencing Containers, Blobs, and Metadata for more information.
-	Metadata *string
+	Metadata *map[string]string
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestId *string
@@ -2806,7 +2806,7 @@ type PageBlobCreateOptions struct {
 	// are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source
 	// blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers.
 	// See Naming and Referencing Containers, Blobs, and Metadata for more information.
-	Metadata *string
+	Metadata *map[string]string
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestId *string

--- a/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
@@ -326,7 +326,9 @@ func (client *pageBlobOperations) createCreateRequest(contentLength int64, blobC
 		req.Header.Set("x-ms-blob-cache-control", *blobHttpHeaders.BlobCacheControl)
 	}
 	if pageBlobCreateOptions != nil && pageBlobCreateOptions.Metadata != nil {
-		req.Header.Set("x-ms-meta", *pageBlobCreateOptions.Metadata)
+		for k, v := range *pageBlobCreateOptions.Metadata {
+			req.Header.Set("x-ms-meta-"+k, v)
+		}
 	}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseId != nil {
 		req.Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseId)


### PR DESCRIPTION
For types annotated with x-ms-header-collection-prefix, emit them as a
map[string]<value>, where <value> is the type specified in the swagger.