### PR TITLE
Update ClientOptions with latest policy changes

### DIFF
--- a/src/generator/gomod.ts
+++ b/src/generator/gomod.ts
@@ -16,10 +16,10 @@ export async function generateGoModFile(session: Session<CodeModel>): Promise<st
   text += 'go 1.13\n\n';
   // here we specify the minimum version of armcore/azcore as required by the code generator
   // TODO: come up with a way to get the latest minor/patch versions.
-  const azcore = 'github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.4';
+  const azcore = 'github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.6';
   if (session.model.language.go!.openApiType === 'arm') {
     text += 'require (\n';
-    text += '\tgithub.com/Azure/azure-sdk-for-go/sdk/armcore v0.1.1\n';
+    text += '\tgithub.com/Azure/azure-sdk-for-go/sdk/armcore v0.2.0\n';
     text += `\t${azcore}\n`;
     text += ')\n'
   } else {

--- a/test/autorest/generated/additionalpropsgroup/client.go
+++ b/test/autorest/generated/additionalpropsgroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-additionalpropsgroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/arraygroup/client.go
+++ b/test/autorest/generated/arraygroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-arraygroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest Swagger BAT

--- a/test/autorest/generated/azurereportgroup/client.go
+++ b/test/autorest/generated/azurereportgroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-azurereportgroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/azurespecialsgroup/client.go
+++ b/test/autorest/generated/azurespecialsgroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-azurespecialsgroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/booleangroup/client.go
+++ b/test/autorest/generated/booleangroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-booleangroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/bytegroup/client.go
+++ b/test/autorest/generated/bytegroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-bytegroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest Swagger BAT

--- a/test/autorest/generated/complexgroup/client.go
+++ b/test/autorest/generated/complexgroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-complexgroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/complexmodelgroup/client.go
+++ b/test/autorest/generated/complexmodelgroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-complexmodelgroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Some cool documentation.

--- a/test/autorest/generated/custombaseurlgroup/client.go
+++ b/test/autorest/generated/custombaseurlgroup/client.go
@@ -8,7 +8,6 @@ package custombaseurlgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-custombaseurlgroup/<version>"
@@ -23,9 +22,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -37,18 +33,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/datetimegroup/client.go
+++ b/test/autorest/generated/datetimegroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-datetimegroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/datetimerfc1123group/client.go
+++ b/test/autorest/generated/datetimerfc1123group/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-datetimerfc1123group/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/dictionarygroup/client.go
+++ b/test/autorest/generated/dictionarygroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-dictionarygroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest Swagger BAT

--- a/test/autorest/generated/durationgroup/client.go
+++ b/test/autorest/generated/durationgroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-durationgroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/errorsgroup/client.go
+++ b/test/autorest/generated/errorsgroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-errorsgroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - XMS Error Response Extensions

--- a/test/autorest/generated/extenumsgroup/client.go
+++ b/test/autorest/generated/extenumsgroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-extenumsgroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - PetStore

--- a/test/autorest/generated/filegroup/client.go
+++ b/test/autorest/generated/filegroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-filegroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest Swagger BAT

--- a/test/autorest/generated/headergroup/client.go
+++ b/test/autorest/generated/headergroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-headergroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/httpinfrastructuregroup/client.go
+++ b/test/autorest/generated/httpinfrastructuregroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-httpinfrastructuregroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/integergroup/client.go
+++ b/test/autorest/generated/integergroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-integergroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/lrogroup/client.go
+++ b/test/autorest/generated/lrogroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-lrogroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Long-running Operation for AutoRest

--- a/test/autorest/generated/migroup/client.go
+++ b/test/autorest/generated/migroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-migroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Service client for multiinheritance client testing

--- a/test/autorest/generated/morecustombaseurigroup/client.go
+++ b/test/autorest/generated/morecustombaseurigroup/client.go
@@ -8,7 +8,6 @@ package morecustombaseurigroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-morecustombaseurigroup/<version>"
@@ -23,9 +22,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -37,18 +33,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/nonstringenumgroup/client.go
+++ b/test/autorest/generated/nonstringenumgroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-nonstringenumgroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Testing non-string enums.

--- a/test/autorest/generated/numbergroup/client.go
+++ b/test/autorest/generated/numbergroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-numbergroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/optionalgroup/client.go
+++ b/test/autorest/generated/optionalgroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-optionalgroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/paginggroup/client.go
+++ b/test/autorest/generated/paginggroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-paginggroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Long-running Operation for AutoRest

--- a/test/autorest/generated/paramgroupinggroup/client.go
+++ b/test/autorest/generated/paramgroupinggroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-paramgroupinggroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/reportgroup/client.go
+++ b/test/autorest/generated/reportgroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-reportgroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/stringgroup/client.go
+++ b/test/autorest/generated/stringgroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-stringgroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest Swagger BAT

--- a/test/autorest/generated/urlgroup/client.go
+++ b/test/autorest/generated/urlgroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-urlgroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/urlmultigroup/client.go
+++ b/test/autorest/generated/urlmultigroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-urlmultigroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest

--- a/test/autorest/generated/validationgroup/client.go
+++ b/test/autorest/generated/validationgroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-validationgroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest. No server backend exists for these tests.

--- a/test/autorest/generated/xmlgroup/client.go
+++ b/test/autorest/generated/xmlgroup/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const telemetryInfo = "azsdk-go-xmlgroup/<version>"
@@ -24,9 +23,6 @@ type ClientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // DefaultClientOptions creates a ClientOptions type initialized with default values.
@@ -38,18 +34,13 @@ func DefaultClientOptions() ClientOptions {
 }
 
 func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 // Client - Test Infrastructure for AutoRest Swagger BAT

--- a/test/go.mod
+++ b/test/go.mod
@@ -3,7 +3,7 @@ module generatortests
 go 1.13
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.1.1
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.4
-	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.0
+	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.6
+	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.1
 )

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,8 +1,8 @@
-github.com/Azure/azure-sdk-for-go/sdk/armcore v0.1.1 h1:o+Dh2U9YIgSVI8GXeaUrggzPzXCZsmnOCJTRDcjPl9s=
-github.com/Azure/azure-sdk-for-go/sdk/armcore v0.1.1/go.mod h1:V6UjiAAUGm10huBBJqEkKejYn7fFpWWdmzO0qRwaHwM=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.4 h1:gtFPMBq2q4k8APBCPak6gPNHDKN6vCWQ36o6ox72A3g=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.4/go.mod h1:Di5xm8E6X6yte1db/npBJSxzNliJpAMo0ZIZStGzp+4=
+github.com/Azure/azure-sdk-for-go/sdk/armcore v0.2.0 h1:lJQCCnXAhRxDqzP/31d2q6ylw30usGgpVPV9Nwi7uks=
+github.com/Azure/azure-sdk-for-go/sdk/armcore v0.2.0/go.mod h1:kkxKUdJQmQiYkoaBbA72vvWMrGRx5yA1hBqBbzDCyGg=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.6 h1:Pcqitzt/YJIZWfoa/cwB42VB/Xd0ZU+lDqzDevi+xcg=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.6/go.mod h1:Di5xm8E6X6yte1db/npBJSxzNliJpAMo0ZIZStGzp+4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.3 h1:LqwNXxJyW493jG65Ki37BSgGtWN/YJHS8U8Pa7RGwrU=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.2.3/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=
-github.com/Azure/azure-sdk-for-go/sdk/to v0.1.0 h1:5PmE4x8xzfL3onRdC5adQPrJSMDhYT2h5DwPB1uR9tA=
-github.com/Azure/azure-sdk-for-go/sdk/to v0.1.0/go.mod h1:UL/d4lvWAzSJUuX+19uKdN0ktyjoOyQhgY+HWNgtIYI=
+github.com/Azure/azure-sdk-for-go/sdk/to v0.1.1 h1:xfQtpQrdXC5By+/gOhE6rLRevCw17TLfjSWzkGkT58Y=
+github.com/Azure/azure-sdk-for-go/sdk/to v0.1.1/go.mod h1:UL/d4lvWAzSJUuX+19uKdN0ktyjoOyQhgY+HWNgtIYI=

--- a/test/network/2020-03-01/armnetwork/go.mod
+++ b/test/network/2020-03-01/armnetwork/go.mod
@@ -3,6 +3,6 @@ module armnetwork
 go 1.13
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.1.1
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.4
+	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.6
 )

--- a/test/storage/2019-07-07/azblob/go.mod
+++ b/test/storage/2019-07-07/azblob/go.mod
@@ -2,4 +2,4 @@ module azstorage
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.4
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.9.6

--- a/test/storage/2019-07-07/azblob/zz_generated_client.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/url"
-	"strings"
 )
 
 const scope = "https://storage.azure.com/.default"
@@ -25,9 +24,6 @@ type clientOptions struct {
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
 	Telemetry azcore.TelemetryOptions
-	// ApplicationID is an application-specific identification string used in telemetry.
-	// It has a maximum length of 24 characters and must not contain any spaces.
-	ApplicationID string
 }
 
 // defaultClientOptions creates a clientOptions type initialized with default values.
@@ -39,18 +35,13 @@ func defaultClientOptions() clientOptions {
 }
 
 func (c *clientOptions) telemetryOptions() azcore.TelemetryOptions {
-	t := telemetryInfo
-	if c.ApplicationID != "" {
-		a := strings.ReplaceAll(c.ApplicationID, " ", "/")
-		if len(a) > 24 {
-			a = a[:24]
-		}
-		t = fmt.Sprintf("%s %s", a, telemetryInfo)
+	to := c.Telemetry
+	if to.Value == "" {
+		to.Value = telemetryInfo
+	} else {
+		to.Value = fmt.Sprintf("%s %s", telemetryInfo, to.Value)
 	}
-	if c.Telemetry.Value == "" {
-		return azcore.TelemetryOptions{Value: t}
-	}
-	return azcore.TelemetryOptions{Value: fmt.Sprintf("%s %s", c.Telemetry.Value, t)}
+	return to
 }
 
 type client struct {


### PR DESCRIPTION
Removed ApplicationID as it's now a part of telemetry options.
Replaced DisableRPRegistration with armcore.RegistrationOptions.
Updated azcore and armcore versions to latest.