### PR TITLE
Make client constructors no-fail

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -37,6 +37,7 @@ export async function generateOperations(session: Session<CodeModel>): Promise<O
     const imports = new ImportManager();
     // add standard imorts
     imports.add('net/http');
+    imports.add('net/url');
     imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore');
 
     const clientName = camelCase(group.language.go!.clientName);
@@ -277,7 +278,6 @@ function generateOperation(clientName: string, op: Operation, imports: ImportMan
       text += '\t\t},\n';
     } else {
       imports.add('fmt');
-      imports.add('net/url');
       let resultTypeName = schemaResponse.schema.language.go!.name;
       if (schemaResponse.schema.serialization?.xml?.name) {
         // xml can specifiy its own name, prefer that if available
@@ -324,7 +324,8 @@ function createProtocolRequest(codeModel: CodeModel, client: string, op: Operati
   const returns = ['*azcore.Request', 'error'];
   let text = `${comment(name, '// ')} creates the ${info.name} request.\n`;
   text += `func (client *${client}) ${name}(${getCreateRequestParametersSig(op)}) (${returns.join(', ')}) {\n`;
-  let hasHost = false;
+  // default to host on the client
+  let hostParam = 'client.u';
   if (codeModel.language.go!.complexHostParams) {
     imports.add('strings');
     // we have a complex parameterized host
@@ -340,8 +341,12 @@ function createProtocolRequest(codeModel: CodeModel, client: string, op: Operati
         text += `\thost = strings.ReplaceAll(host, "{${param.language.go!.serializedName}}", ${param.language.go!.name})\n`;
       }
     }
-    hasHost = true;
+    hostParam = 'host';
   }
+  text += `\tu, err := url.Parse(${hostParam})\n`;
+  text += '\tif err != nil {\n';
+  text += '\t\treturn nil, err\n';
+  text += '\t}\n';
   const hasPathParams = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http!.in === 'path'; }).any();
   // storage needs the client.u to be the source-of-truth for the full path.
   // however, swagger requires that all operations specify a path, which is at odds with storage.
@@ -363,28 +368,18 @@ function createProtocolRequest(codeModel: CodeModel, client: string, op: Operati
     for (const pp of values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http!.in === 'path'; })) {
       let paramValue = formatParamValue(pp, imports);
       if (!skipURLEncoding(pp)) {
-        imports.add('net/url');
         paramValue = `url.PathEscape(${formatParamValue(pp, imports)})`;
       }
       text += `\turlPath = strings.ReplaceAll(urlPath, "{${pp.language.go!.serializedName}}", ${paramValue})\n`;
     }
   }
-  const hasQueryParams = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http!.in === 'query'; }).any();
   if (hasURLPath) {
-    if (hasHost) {
-      imports.add('net/url');
-      text += `\tu, err := url.Parse(host + urlPath)\n`;
-    } else {
-      imports.add('path');
-      text += `\tu, err := client.u.Parse(path.Join(client.u.Path, urlPath))\n`;
-    }
+    text += '\tu, err = u.Parse(urlPath)\n';
     text += '\tif err != nil {\n';
     text += '\t\treturn nil, err\n';
     text += '\t}\n';
-  } else {
-    text += '\tcopy := *client.u\n';
-    text += '\tu := &copy\n';
   }
+  const hasQueryParams = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http!.in === 'query'; }).any();
   // helper to build nil checks for param groups
   const emitParamGroupCheck = function (gp: GroupProperty, param: Parameter): string {
     const paramGroupName = camelCase(gp.language.go!.name);

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -374,7 +374,8 @@ function createProtocolRequest(codeModel: CodeModel, client: string, op: Operati
     }
   }
   if (hasURLPath) {
-    text += '\tu, err = u.Parse(urlPath)\n';
+    imports.add('path');
+    text += '\tu, err = u.Parse(path.Join(u.Path, urlPath))\n';
     text += '\tif err != nil {\n';
     text += '\t\treturn nil, err\n';
     text += '\t}\n';

--- a/test/autorest/additionalpropsgroup/additionalpropsgroup_test.go
+++ b/test/autorest/additionalpropsgroup/additionalpropsgroup_test.go
@@ -13,17 +13,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getPetsOperations(t *testing.T) additionalpropsgroup.PetsOperations {
-	client, err := additionalpropsgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.PetsOperations()
-}
-
 // CreateApInProperties - Create a Pet which contains more properties than what is defined.
 func TestCreateApInProperties(t *testing.T) {
-	client := getPetsOperations(t)
+	client := additionalpropsgroup.NewDefaultClient(nil).PetsOperations()
 	result, err := client.CreateApInProperties(context.Background(), additionalpropsgroup.PetApInProperties{
 		ID:   to.Int32Ptr(4),
 		Name: to.StringPtr("Bunny"),
@@ -50,7 +42,7 @@ func TestCreateApInProperties(t *testing.T) {
 
 // CreateApInPropertiesWithApstring - Create a Pet which contains more properties than what is defined.
 func TestCreateApInPropertiesWithApstring(t *testing.T) {
-	client := getPetsOperations(t)
+	client := additionalpropsgroup.NewDefaultClient(nil).PetsOperations()
 	result, err := client.CreateApInPropertiesWithApstring(context.Background(), additionalpropsgroup.PetApInPropertiesWithApstring{
 		ID:            to.Int32Ptr(5),
 		Name:          to.StringPtr("Funny"),
@@ -89,7 +81,7 @@ func TestCreateApInPropertiesWithApstring(t *testing.T) {
 
 // CreateApObject - Create a Pet which contains more properties than what is defined.
 func TestCreateApObject(t *testing.T) {
-	client := getPetsOperations(t)
+	client := additionalpropsgroup.NewDefaultClient(nil).PetsOperations()
 	result, err := client.CreateApObject(context.Background(), additionalpropsgroup.PetApObject{
 		ID:   to.Int32Ptr(2),
 		Name: to.StringPtr("Hira"),
@@ -132,7 +124,7 @@ func TestCreateApObject(t *testing.T) {
 
 // CreateApString - Create a Pet which contains more properties than what is defined.
 func TestCreateApString(t *testing.T) {
-	client := getPetsOperations(t)
+	client := additionalpropsgroup.NewDefaultClient(nil).PetsOperations()
 	result, err := client.CreateApString(context.Background(), additionalpropsgroup.PetApString{
 		ID:   to.Int32Ptr(3),
 		Name: to.StringPtr("Tommy"),
@@ -159,7 +151,7 @@ func TestCreateApString(t *testing.T) {
 
 // CreateApTrue - Create a Pet which contains more properties than what is defined.
 func TestCreateApTrue(t *testing.T) {
-	client := getPetsOperations(t)
+	client := additionalpropsgroup.NewDefaultClient(nil).PetsOperations()
 	result, err := client.CreateApTrue(context.Background(), additionalpropsgroup.PetApTrue{
 		ID:   to.Int32Ptr(1),
 		Name: to.StringPtr("Puppy"),
@@ -188,7 +180,7 @@ func TestCreateApTrue(t *testing.T) {
 
 // CreateCatApTrue - Create a CatAPTrue which contains more properties than what is defined.
 func TestCreateCatApTrue(t *testing.T) {
-	client := getPetsOperations(t)
+	client := additionalpropsgroup.NewDefaultClient(nil).PetsOperations()
 	result, err := client.CreateCatApTrue(context.Background(), additionalpropsgroup.CatApTrue{
 		PetApTrue: additionalpropsgroup.PetApTrue{
 			ID:   to.Int32Ptr(1),

--- a/test/autorest/arraygroup/arraygroup_test.go
+++ b/test/autorest/arraygroup/arraygroup_test.go
@@ -14,17 +14,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getArrayClient(t *testing.T) arraygroup.ArrayOperations {
-	client, err := arraygroup.NewClient("http://localhost:3000", nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.ArrayOperations()
-}
-
 // GetArrayEmpty - Get an empty array []
 func TestGetArrayEmpty(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetArrayEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -39,7 +31,7 @@ func TestGetArrayEmpty(t *testing.T) {
 
 // GetArrayItemEmpty - Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']]
 func TestGetArrayItemEmpty(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetArrayItemEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -53,7 +45,7 @@ func TestGetArrayItemEmpty(t *testing.T) {
 
 // GetArrayItemNull - Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']]
 func TestGetArrayItemNull(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetArrayItemNull(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +59,7 @@ func TestGetArrayItemNull(t *testing.T) {
 
 // GetArrayNull - Get a null array
 func TestGetArrayNull(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetArrayNull(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -79,7 +71,7 @@ func TestGetArrayNull(t *testing.T) {
 
 // GetArrayValid - Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
 func TestGetArrayValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetArrayValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -94,7 +86,7 @@ func TestGetArrayValid(t *testing.T) {
 // GetBase64URL - Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded
 func TestGetBase64URL(t *testing.T) {
 	t.Skip("decoding fails")
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetBase64URL(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -109,7 +101,7 @@ func TestGetBase64URL(t *testing.T) {
 // GetBooleanInvalidNull - Get boolean array value [true, null, false]
 func TestGetBooleanInvalidNull(t *testing.T) {
 	t.Skip("unmarshalling succeeds")
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetBooleanInvalidNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -121,7 +113,7 @@ func TestGetBooleanInvalidNull(t *testing.T) {
 
 // GetBooleanInvalidString - Get boolean array value [true, 'boolean', false]
 func TestGetBooleanInvalidString(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetBooleanInvalidString(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -133,7 +125,7 @@ func TestGetBooleanInvalidString(t *testing.T) {
 
 // GetBooleanTfft - Get boolean array value [true, false, false, true]
 func TestGetBooleanTfft(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetBooleanTfft(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -144,7 +136,7 @@ func TestGetBooleanTfft(t *testing.T) {
 // GetByteInvalidNull - Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded
 func TestGetByteInvalidNull(t *testing.T) {
 	t.Skip("needs investigation")
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetByteInvalidNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -156,7 +148,7 @@ func TestGetByteInvalidNull(t *testing.T) {
 
 // GetByteValid - Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64
 func TestGetByteValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetByteValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -170,7 +162,7 @@ func TestGetByteValid(t *testing.T) {
 
 // GetComplexEmpty - Get empty array of complex type []
 func TestGetComplexEmpty(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetComplexEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -185,7 +177,7 @@ func TestGetComplexEmpty(t *testing.T) {
 
 // GetComplexItemEmpty - Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]
 func TestGetComplexItemEmpty(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetComplexItemEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -209,7 +201,7 @@ func TestGetComplexNull(t *testing.T) {
 
 // GetComplexValid - Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
 func TestGetComplexValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetComplexValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -223,7 +215,7 @@ func TestGetComplexValid(t *testing.T) {
 
 // GetDateInvalidChars - Get date array value ['2011-03-22', 'date']
 func TestGetDateInvalidChars(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetDateInvalidChars(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -240,7 +232,7 @@ func TestGetDateInvalidNull(t *testing.T) {
 
 // GetDateTimeInvalidChars - Get date array value ['2000-12-01t00:00:01z', 'date-time']
 func TestGetDateTimeInvalidChars(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetDateTimeInvalidChars(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -252,7 +244,7 @@ func TestGetDateTimeInvalidChars(t *testing.T) {
 
 // GetDateTimeInvalidNull - Get date array value ['2000-12-01t00:00:01z', null]
 func TestGetDateTimeInvalidNull(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetDateTimeInvalidNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -264,7 +256,7 @@ func TestGetDateTimeInvalidNull(t *testing.T) {
 
 // GetDateTimeRFC1123Valid - Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
 func TestGetDateTimeRFC1123Valid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetDateTimeRFC1123Valid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -281,7 +273,7 @@ func TestGetDateTimeRFC1123Valid(t *testing.T) {
 
 // GetDateTimeValid - Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
 func TestGetDateTimeValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetDateTimeValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -299,7 +291,7 @@ func TestGetDateTimeValid(t *testing.T) {
 // GetDateValid - Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12']
 func TestGetDateValid(t *testing.T) {
 	t.Skip("needs codegen fix")
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetDateValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -313,7 +305,7 @@ func TestGetDateValid(t *testing.T) {
 
 // GetDictionaryEmpty - Get an array of Dictionaries of type <string, string> with value []
 func TestGetDictionaryEmpty(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetDictionaryEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -323,7 +315,7 @@ func TestGetDictionaryEmpty(t *testing.T) {
 
 // GetDictionaryItemEmpty - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
 func TestGetDictionaryItemEmpty(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetDictionaryItemEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -345,7 +337,7 @@ func TestGetDictionaryItemEmpty(t *testing.T) {
 
 // GetDictionaryItemNull - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}]
 func TestGetDictionaryItemNull(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetDictionaryItemNull(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -367,7 +359,7 @@ func TestGetDictionaryItemNull(t *testing.T) {
 
 // GetDictionaryNull - Get an array of Dictionaries with value null
 func TestGetDictionaryNull(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetDictionaryNull(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -379,7 +371,7 @@ func TestGetDictionaryNull(t *testing.T) {
 
 // GetDictionaryValid - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
 func TestGetDictionaryValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetDictionaryValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -406,7 +398,7 @@ func TestGetDictionaryValid(t *testing.T) {
 // GetDoubleInvalidNull - Get float array value [0.0, null, -1.2e20]
 func TestGetDoubleInvalidNull(t *testing.T) {
 	t.Skip("arrays with nil elements")
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetDoubleInvalidNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -418,7 +410,7 @@ func TestGetDoubleInvalidNull(t *testing.T) {
 
 // GetDoubleInvalidString - Get boolean array value [1.0, 'number', 0.0]
 func TestGetDoubleInvalidString(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetDoubleInvalidString(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -430,7 +422,7 @@ func TestGetDoubleInvalidString(t *testing.T) {
 
 // GetDoubleValid - Get float array value [0, -0.01, 1.2e20]
 func TestGetDoubleValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetDoubleValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -440,7 +432,7 @@ func TestGetDoubleValid(t *testing.T) {
 
 // GetDurationValid - Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S']
 func TestGetDurationValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetDurationValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -450,7 +442,7 @@ func TestGetDurationValid(t *testing.T) {
 
 // GetEmpty - Get empty array value []
 func TestGetEmpty(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -465,7 +457,7 @@ func TestGetEmpty(t *testing.T) {
 
 // GetEnumValid - Get enum array value ['foo1', 'foo2', 'foo3']
 func TestGetEnumValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetEnumValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -476,7 +468,7 @@ func TestGetEnumValid(t *testing.T) {
 // GetFloatInvalidNull - Get float array value [0.0, null, -1.2e20]
 func TestGetFloatInvalidNull(t *testing.T) {
 	t.Skip("arrays with nil elements")
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetFloatInvalidNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -488,7 +480,7 @@ func TestGetFloatInvalidNull(t *testing.T) {
 
 // GetFloatInvalidString - Get boolean array value [1.0, 'number', 0.0]
 func TestGetFloatInvalidString(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetFloatInvalidString(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -500,7 +492,7 @@ func TestGetFloatInvalidString(t *testing.T) {
 
 // GetFloatValid - Get float array value [0, -0.01, 1.2e20]
 func TestGetFloatValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetFloatValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -511,7 +503,7 @@ func TestGetFloatValid(t *testing.T) {
 // GetIntInvalidNull - Get integer array value [1, null, 0]
 func TestGetIntInvalidNull(t *testing.T) {
 	t.Skip("arrays with nil elements")
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetIntInvalidNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -523,7 +515,7 @@ func TestGetIntInvalidNull(t *testing.T) {
 
 // GetIntInvalidString - Get integer array value [1, 'integer', 0]
 func TestGetIntInvalidString(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetIntInvalidString(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -535,7 +527,7 @@ func TestGetIntInvalidString(t *testing.T) {
 
 // GetIntegerValid - Get integer array value [1, -1, 3, 300]
 func TestGetIntegerValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetIntegerValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -545,7 +537,7 @@ func TestGetIntegerValid(t *testing.T) {
 
 // GetInvalid - Get invalid array [1, 2, 3
 func TestGetInvalid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetInvalid(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -558,7 +550,7 @@ func TestGetInvalid(t *testing.T) {
 // GetLongInvalidNull - Get long array value [1, null, 0]
 func TestGetLongInvalidNull(t *testing.T) {
 	t.Skip("arrays with nil elements")
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetLongInvalidNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -570,7 +562,7 @@ func TestGetLongInvalidNull(t *testing.T) {
 
 // GetLongInvalidString - Get long array value [1, 'integer', 0]
 func TestGetLongInvalidString(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetLongInvalidString(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -582,7 +574,7 @@ func TestGetLongInvalidString(t *testing.T) {
 
 // GetLongValid - Get integer array value [1, -1, 3, 300]
 func TestGetLongValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetLongValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -592,7 +584,7 @@ func TestGetLongValid(t *testing.T) {
 
 // GetNull - Get null array value
 func TestGetNull(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetNull(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -604,7 +596,7 @@ func TestGetNull(t *testing.T) {
 
 // GetStringEnumValid - Get enum array value ['foo1', 'foo2', 'foo3']
 func TestGetStringEnumValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetStringEnumValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -614,7 +606,7 @@ func TestGetStringEnumValid(t *testing.T) {
 
 // GetStringValid - Get string array value ['foo1', 'foo2', 'foo3']
 func TestGetStringValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetStringValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -624,7 +616,7 @@ func TestGetStringValid(t *testing.T) {
 
 // GetStringWithInvalid - Get string array value ['foo', 123, 'foo2']
 func TestGetStringWithInvalid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetStringWithInvalid(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -637,7 +629,7 @@ func TestGetStringWithInvalid(t *testing.T) {
 // GetStringWithNull - Get string array value ['foo', null, 'foo2']
 func TestGetStringWithNull(t *testing.T) {
 	t.Skip("arrays with nil elements")
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetStringWithNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -654,7 +646,7 @@ func TestGetUUIDInvalidChars(t *testing.T) {
 
 // GetUUIDValid - Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
 func TestGetUUIDValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.GetUUIDValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -664,7 +656,7 @@ func TestGetUUIDValid(t *testing.T) {
 
 // PutArrayValid - Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
 func TestPutArrayValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.PutArrayValid(context.Background(), [][]string{
 		[]string{"1", "2", "3"},
 		[]string{"4", "5", "6"},
@@ -678,7 +670,7 @@ func TestPutArrayValid(t *testing.T) {
 
 // PutBooleanTfft - Set array value empty [true, false, false, true]
 func TestPutBooleanTfft(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.PutBooleanTfft(context.Background(), []bool{true, false, false, true})
 	if err != nil {
 		t.Fatal(err)
@@ -688,7 +680,7 @@ func TestPutBooleanTfft(t *testing.T) {
 
 // PutByteValid - Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64
 func TestPutByteValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.PutByteValid(context.Background(), [][]byte{
 		[]byte{0xFF, 0xFF, 0xFF, 0xFA},
 		[]byte{0x01, 0x02, 0x03},
@@ -702,7 +694,7 @@ func TestPutByteValid(t *testing.T) {
 
 // PutComplexValid - Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
 func TestPutComplexValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.PutComplexValid(context.Background(), []arraygroup.Product{
 		arraygroup.Product{Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		arraygroup.Product{Integer: to.Int32Ptr(3), String: to.StringPtr("4")},
@@ -716,7 +708,7 @@ func TestPutComplexValid(t *testing.T) {
 
 // PutDateTimeRFC1123Valid - Set array value  ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
 func TestPutDateTimeRFC1123Valid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	v1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
 	v2, _ := time.Parse(time.RFC1123, "Wed, 02 Jan 1980 00:11:35 GMT")
 	v3, _ := time.Parse(time.RFC1123, "Wed, 12 Oct 1492 10:15:01 GMT")
@@ -729,7 +721,7 @@ func TestPutDateTimeRFC1123Valid(t *testing.T) {
 
 // PutDateTimeValid - Set array value  ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
 func TestPutDateTimeValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	v1, _ := time.Parse(time.RFC3339, "2000-12-01T00:00:01Z")
 	v2, _ := time.Parse(time.RFC3339, "1980-01-02T00:11:35Z")
 	v3, _ := time.Parse(time.RFC3339, "1492-10-12T10:15:01Z")
@@ -747,7 +739,7 @@ func TestPutDateValid(t *testing.T) {
 
 // PutDictionaryValid - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
 func TestPutDictionaryValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.PutDictionaryValid(context.Background(), []map[string]string{
 		map[string]string{
 			"1": "one",
@@ -773,7 +765,7 @@ func TestPutDictionaryValid(t *testing.T) {
 
 // PutDoubleValid - Set array value [0, -0.01, 1.2e20]
 func TestPutDoubleValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.PutDoubleValid(context.Background(), []float64{0, -0.01, -1.2e20})
 	if err != nil {
 		t.Fatal(err)
@@ -783,7 +775,7 @@ func TestPutDoubleValid(t *testing.T) {
 
 // PutDurationValid - Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S']
 func TestPutDurationValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.PutDurationValid(context.Background(), []string{"P123DT22H14M12.011S", "P5DT1H"})
 	if err != nil {
 		t.Fatal(err)
@@ -793,7 +785,7 @@ func TestPutDurationValid(t *testing.T) {
 
 // PutEmpty - Set array value empty []
 func TestPutEmpty(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.PutEmpty(context.Background(), []string{})
 	if err != nil {
 		t.Fatal(err)
@@ -803,7 +795,7 @@ func TestPutEmpty(t *testing.T) {
 
 // PutEnumValid - Set array value ['foo1', 'foo2', 'foo3']
 func TestPutEnumValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.PutEnumValid(context.Background(), []arraygroup.FooEnum{arraygroup.FooEnumFoo1, arraygroup.FooEnumFoo2, arraygroup.FooEnumFoo3})
 	if err != nil {
 		t.Fatal(err)
@@ -813,7 +805,7 @@ func TestPutEnumValid(t *testing.T) {
 
 // PutFloatValid - Set array value [0, -0.01, 1.2e20]
 func TestPutFloatValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.PutFloatValid(context.Background(), []float32{0, -0.01, -1.2e20})
 	if err != nil {
 		t.Fatal(err)
@@ -823,7 +815,7 @@ func TestPutFloatValid(t *testing.T) {
 
 // PutIntegerValid - Set array value empty [1, -1, 3, 300]
 func TestPutIntegerValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.PutIntegerValid(context.Background(), []int32{1, -1, 3, 300})
 	if err != nil {
 		t.Fatal(err)
@@ -833,7 +825,7 @@ func TestPutIntegerValid(t *testing.T) {
 
 // PutLongValid - Set array value empty [1, -1, 3, 300]
 func TestPutLongValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.PutLongValid(context.Background(), []int64{1, -1, 3, 300})
 	if err != nil {
 		t.Fatal(err)
@@ -843,7 +835,7 @@ func TestPutLongValid(t *testing.T) {
 
 // PutStringEnumValid - Set array value ['foo1', 'foo2', 'foo3']
 func TestPutStringEnumValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.PutStringEnumValid(context.Background(), []arraygroup.Enum1{arraygroup.Enum1Foo1, arraygroup.Enum1Foo2, arraygroup.Enum1Foo3})
 	if err != nil {
 		t.Fatal(err)
@@ -853,7 +845,7 @@ func TestPutStringEnumValid(t *testing.T) {
 
 // PutStringValid - Set array value ['foo1', 'foo2', 'foo3']
 func TestPutStringValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.PutStringValid(context.Background(), []string{"foo1", "foo2", "foo3"})
 	if err != nil {
 		t.Fatal(err)
@@ -863,7 +855,7 @@ func TestPutStringValid(t *testing.T) {
 
 // PutUUIDValid - Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
 func TestPutUUIDValid(t *testing.T) {
-	client := getArrayClient(t)
+	client := arraygroup.NewDefaultClient(nil).ArrayOperations()
 	resp, err := client.PutUUIDValid(context.Background(), []string{"6dcc7237-45fe-45c4-8a6b-3a8a3f625652", "d1399005-30f7-40d6-8da6-dd7c89ad34db", "f42f6aa1-a5bc-4ddf-907e-5f915de43205"})
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/azurespecialsgroup/apiversiondefault_test.go
+++ b/test/autorest/azurespecialsgroup/apiversiondefault_test.go
@@ -11,17 +11,9 @@ import (
 	"testing"
 )
 
-func getAPIVersionDefaultOperations(t *testing.T) azurespecialsgroup.APIVersionDefaultOperations {
-	client, err := azurespecialsgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.APIVersionDefaultOperations()
-}
-
 // GetMethodGlobalNotProvidedValid - GET method with api-version modeled in global settings.
 func TestGetMethodGlobalNotProvidedValid(t *testing.T) {
-	client := getAPIVersionDefaultOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).APIVersionDefaultOperations()
 	result, err := client.GetMethodGlobalNotProvidedValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -31,7 +23,7 @@ func TestGetMethodGlobalNotProvidedValid(t *testing.T) {
 
 // GetMethodGlobalValid - GET method with api-version modeled in global settings.
 func TestGetMethodGlobalValid(t *testing.T) {
-	client := getAPIVersionDefaultOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).APIVersionDefaultOperations()
 	result, err := client.GetMethodGlobalValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -41,7 +33,7 @@ func TestGetMethodGlobalValid(t *testing.T) {
 
 // GetPathGlobalValid - GET method with api-version modeled in global settings.
 func TestGetPathGlobalValid(t *testing.T) {
-	client := getAPIVersionDefaultOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).APIVersionDefaultOperations()
 	result, err := client.GetPathGlobalValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -51,7 +43,7 @@ func TestGetPathGlobalValid(t *testing.T) {
 
 // GetSwaggerGlobalValid - GET method with api-version modeled in global settings.
 func TestGetSwaggerGlobalValid(t *testing.T) {
-	client := getAPIVersionDefaultOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).APIVersionDefaultOperations()
 	result, err := client.GetSwaggerGlobalValid(context.Background())
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/azurespecialsgroup/apiversionlocal_test.go
+++ b/test/autorest/azurespecialsgroup/apiversionlocal_test.go
@@ -11,17 +11,9 @@ import (
 	"testing"
 )
 
-func getAPIVersionLocalOperations(t *testing.T) azurespecialsgroup.APIVersionLocalOperations {
-	client, err := azurespecialsgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.APIVersionLocalOperations()
-}
-
 // GetMethodLocalNull - Get method with api-version modeled in the method.  pass in api-version = null to succeed
 func TestGetMethodLocalNull(t *testing.T) {
-	client := getAPIVersionLocalOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).APIVersionLocalOperations()
 	result, err := client.GetMethodLocalNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -31,7 +23,7 @@ func TestGetMethodLocalNull(t *testing.T) {
 
 // GetMethodLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
 func TestGetMethodLocalValid(t *testing.T) {
-	client := getAPIVersionLocalOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).APIVersionLocalOperations()
 	result, err := client.GetMethodLocalValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -41,7 +33,7 @@ func TestGetMethodLocalValid(t *testing.T) {
 
 // GetPathLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
 func TestGetPathLocalValid(t *testing.T) {
-	client := getAPIVersionLocalOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).APIVersionLocalOperations()
 	result, err := client.GetPathLocalValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -51,7 +43,7 @@ func TestGetPathLocalValid(t *testing.T) {
 
 // GetSwaggerLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
 func TestGetSwaggerLocalValid(t *testing.T) {
-	client := getAPIVersionLocalOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).APIVersionLocalOperations()
 	result, err := client.GetSwaggerLocalValid(context.Background())
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/azurespecialsgroup/headers_test.go
+++ b/test/autorest/azurespecialsgroup/headers_test.go
@@ -12,17 +12,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getHeaderOperations(t *testing.T) azurespecialsgroup.HeaderOperations {
-	client, err := azurespecialsgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.HeaderOperations()
-}
-
 // CustomNamedRequestID - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
 func TestCustomNamedRequestID(t *testing.T) {
-	client := getHeaderOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.CustomNamedRequestID(context.Background(), "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0")
 	if err != nil {
 		t.Fatal(err)
@@ -32,7 +24,7 @@ func TestCustomNamedRequestID(t *testing.T) {
 
 // CustomNamedRequestIDHead - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
 func TestCustomNamedRequestIDHead(t *testing.T) {
-	client := getHeaderOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.CustomNamedRequestIDHead(context.Background(), "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0")
 	if err != nil {
 		t.Fatal(err)
@@ -42,7 +34,7 @@ func TestCustomNamedRequestIDHead(t *testing.T) {
 
 // CustomNamedRequestIDParamGrouping - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group
 func TestCustomNamedRequestIDParamGrouping(t *testing.T) {
-	client := getHeaderOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.CustomNamedRequestIDParamGrouping(context.Background(), azurespecialsgroup.HeaderCustomNamedRequestIDParamGroupingParameters{
 		FooClientRequestId: "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0",
 	})

--- a/test/autorest/azurespecialsgroup/odata_test.go
+++ b/test/autorest/azurespecialsgroup/odata_test.go
@@ -13,17 +13,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getOdataOperations(t *testing.T) azurespecialsgroup.OdataOperations {
-	client, err := azurespecialsgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.OdataOperations()
-}
-
 // GetWithFilter - Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&$orderby=id&$top=10'
 func TestGetWithFilter(t *testing.T) {
-	client := getOdataOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).OdataOperations()
 	result, err := client.GetWithFilter(context.Background(), &azurespecialsgroup.OdataGetWithFilterOptions{
 		Filter:  to.StringPtr("id gt 5 and name eq 'foo'"),
 		Orderby: to.StringPtr("id"),

--- a/test/autorest/azurespecialsgroup/skipurlencoding_test.go
+++ b/test/autorest/azurespecialsgroup/skipurlencoding_test.go
@@ -11,17 +11,9 @@ import (
 	"testing"
 )
 
-func getSkipURLEncodingOperations(t *testing.T) azurespecialsgroup.SkipURLEncodingOperations {
-	client, err := azurespecialsgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.SkipURLEncodingOperations()
-}
-
 // GetMethodPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
 func TestGetMethodPathValid(t *testing.T) {
-	client := getSkipURLEncodingOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).SkipURLEncodingOperations()
 	result, err := client.GetMethodPathValid(context.Background(), "path1/path2/path3")
 	if err != nil {
 		t.Fatal(err)
@@ -31,7 +23,7 @@ func TestGetMethodPathValid(t *testing.T) {
 
 // GetMethodQueryNull - Get method with unencoded query parameter with value null
 func TestGetMethodQueryNull(t *testing.T) {
-	client := getSkipURLEncodingOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).SkipURLEncodingOperations()
 	result, err := client.GetMethodQueryNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -41,7 +33,7 @@ func TestGetMethodQueryNull(t *testing.T) {
 
 // GetMethodQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
 func TestGetMethodQueryValid(t *testing.T) {
-	client := getSkipURLEncodingOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).SkipURLEncodingOperations()
 	result, err := client.GetMethodQueryValid(context.Background(), "value1&q2=value2&q3=value3")
 	if err != nil {
 		t.Fatal(err)
@@ -51,7 +43,7 @@ func TestGetMethodQueryValid(t *testing.T) {
 
 // GetPathQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
 func TestGetPathQueryValid(t *testing.T) {
-	client := getSkipURLEncodingOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).SkipURLEncodingOperations()
 	result, err := client.GetPathQueryValid(context.Background(), "value1&q2=value2&q3=value3")
 	if err != nil {
 		t.Fatal(err)
@@ -61,7 +53,7 @@ func TestGetPathQueryValid(t *testing.T) {
 
 // GetPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
 func TestGetPathValid(t *testing.T) {
-	client := getSkipURLEncodingOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).SkipURLEncodingOperations()
 	result, err := client.GetPathValid(context.Background(), "path1/path2/path3")
 	if err != nil {
 		t.Fatal(err)
@@ -71,7 +63,7 @@ func TestGetPathValid(t *testing.T) {
 
 // GetSwaggerPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
 func TestGetSwaggerPathValid(t *testing.T) {
-	client := getSkipURLEncodingOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).SkipURLEncodingOperations()
 	result, err := client.GetSwaggerPathValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -81,7 +73,7 @@ func TestGetSwaggerPathValid(t *testing.T) {
 
 // GetSwaggerQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
 func TestGetSwaggerQueryValid(t *testing.T) {
-	client := getSkipURLEncodingOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).SkipURLEncodingOperations()
 	result, err := client.GetSwaggerQueryValid(context.Background())
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/azurespecialsgroup/subscriptionincredentials_test.go
+++ b/test/autorest/azurespecialsgroup/subscriptionincredentials_test.go
@@ -11,17 +11,9 @@ import (
 	"testing"
 )
 
-func getSubscriptionInCredentialsOperations(t *testing.T) azurespecialsgroup.SubscriptionInCredentialsOperations {
-	client, err := azurespecialsgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.SubscriptionInCredentialsOperations("1234-5678-9012-3456")
-}
-
 // PostMethodGlobalNotProvidedValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
 func TestPostMethodGlobalNotProvidedValid(t *testing.T) {
-	client := getSubscriptionInCredentialsOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).SubscriptionInCredentialsOperations("1234-5678-9012-3456")
 	result, err := client.PostMethodGlobalNotProvidedValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +28,7 @@ func TestPostMethodGlobalNull(t *testing.T) {
 
 // PostMethodGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
 func TestPostMethodGlobalValid(t *testing.T) {
-	client := getSubscriptionInCredentialsOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).SubscriptionInCredentialsOperations("1234-5678-9012-3456")
 	result, err := client.PostMethodGlobalValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -46,7 +38,7 @@ func TestPostMethodGlobalValid(t *testing.T) {
 
 // PostPathGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
 func TestPostPathGlobalValid(t *testing.T) {
-	client := getSubscriptionInCredentialsOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).SubscriptionInCredentialsOperations("1234-5678-9012-3456")
 	result, err := client.PostPathGlobalValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -56,7 +48,7 @@ func TestPostPathGlobalValid(t *testing.T) {
 
 // PostSwaggerGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
 func TestPostSwaggerGlobalValid(t *testing.T) {
-	client := getSubscriptionInCredentialsOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).SubscriptionInCredentialsOperations("1234-5678-9012-3456")
 	result, err := client.PostSwaggerGlobalValid(context.Background())
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/azurespecialsgroup/subscriptioninmethod_test.go
+++ b/test/autorest/azurespecialsgroup/subscriptioninmethod_test.go
@@ -11,14 +11,6 @@ import (
 	"testing"
 )
 
-func getSubscriptionInMethodOperations(t *testing.T) azurespecialsgroup.SubscriptionInMethodOperations {
-	client, err := azurespecialsgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.SubscriptionInMethodOperations()
-}
-
 // PostMethodLocalNull - POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call
 func TestPostMethodLocalNull(t *testing.T) {
 	t.Skip("invalid test, missing x-nullable")
@@ -26,7 +18,7 @@ func TestPostMethodLocalNull(t *testing.T) {
 
 // PostMethodLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
 func TestPostMethodLocalValid(t *testing.T) {
-	client := getSubscriptionInMethodOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).SubscriptionInMethodOperations()
 	result, err := client.PostMethodLocalValid(context.Background(), "1234-5678-9012-3456")
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +28,7 @@ func TestPostMethodLocalValid(t *testing.T) {
 
 // PostPathLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
 func TestPostPathLocalValid(t *testing.T) {
-	client := getSubscriptionInMethodOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).SubscriptionInMethodOperations()
 	result, err := client.PostPathLocalValid(context.Background(), "1234-5678-9012-3456")
 	if err != nil {
 		t.Fatal(err)
@@ -46,7 +38,7 @@ func TestPostPathLocalValid(t *testing.T) {
 
 // PostSwaggerLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
 func TestPostSwaggerLocalValid(t *testing.T) {
-	client := getSubscriptionInMethodOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).SubscriptionInMethodOperations()
 	result, err := client.PostSwaggerLocalValid(context.Background(), "1234-5678-9012-3456")
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/azurespecialsgroup/xmsclientrequestid_test.go
+++ b/test/autorest/azurespecialsgroup/xmsclientrequestid_test.go
@@ -13,17 +13,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
-func getXMSClientRequestIDOperations(t *testing.T) azurespecialsgroup.XMSClientRequestIDOperations {
-	client, err := azurespecialsgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.XMSClientRequestIDOperations()
-}
-
 // Get - Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
 func TestGet(t *testing.T) {
-	client := getXMSClientRequestIDOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).XMSClientRequestIDOperations()
 	result, err := client.Get(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -39,7 +31,7 @@ func TestGet(t *testing.T) {
 
 // ParamGet - Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
 func TestParamGet(t *testing.T) {
-	client := getXMSClientRequestIDOperations(t)
+	client := azurespecialsgroup.NewDefaultClient(nil).XMSClientRequestIDOperations()
 	result, err := client.ParamGet(context.Background(), "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0")
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/booleangroup/booleangroup_test.go
+++ b/test/autorest/booleangroup/booleangroup_test.go
@@ -11,16 +11,8 @@ import (
 	"testing"
 )
 
-func getBoolClient(t *testing.T) booleangroup.BoolOperations {
-	client, err := booleangroup.NewClient("http://localhost:3000", nil)
-	if err != nil {
-		t.Fatalf("failed to create bool client: %v", err)
-	}
-	return client.BoolOperations()
-}
-
 func TestGetTrue(t *testing.T) {
-	client := getBoolClient(t)
+	client := booleangroup.NewDefaultClient(nil).BoolOperations()
 	result, err := client.GetTrue(context.Background())
 	if err != nil {
 		t.Fatalf("GetTrue: %v", err)
@@ -31,7 +23,7 @@ func TestGetTrue(t *testing.T) {
 }
 
 func TestGetFalse(t *testing.T) {
-	client := getBoolClient(t)
+	client := booleangroup.NewDefaultClient(nil).BoolOperations()
 	result, err := client.GetFalse(context.Background())
 	if err != nil {
 		t.Fatalf("GetFalse: %v", err)
@@ -42,7 +34,7 @@ func TestGetFalse(t *testing.T) {
 }
 
 func TestGetNull(t *testing.T) {
-	client := getBoolClient(t)
+	client := booleangroup.NewDefaultClient(nil).BoolOperations()
 	result, err := client.GetNull(context.Background())
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
@@ -52,7 +44,7 @@ func TestGetNull(t *testing.T) {
 }
 
 func TestGetInvalid(t *testing.T) {
-	client := getBoolClient(t)
+	client := booleangroup.NewDefaultClient(nil).BoolOperations()
 	result, err := client.GetInvalid(context.Background())
 	// TODO: verify error response is clear and actionable
 	if err == nil {
@@ -64,7 +56,7 @@ func TestGetInvalid(t *testing.T) {
 }
 
 func TestPutTrue(t *testing.T) {
-	client := getBoolClient(t)
+	client := booleangroup.NewDefaultClient(nil).BoolOperations()
 	result, err := client.PutTrue(context.Background())
 	if err != nil {
 		t.Fatalf("PutTrue: %v", err)
@@ -73,7 +65,7 @@ func TestPutTrue(t *testing.T) {
 }
 
 func TestPutFalse(t *testing.T) {
-	client := getBoolClient(t)
+	client := booleangroup.NewDefaultClient(nil).BoolOperations()
 	result, err := client.PutFalse(context.Background())
 	if err != nil {
 		t.Fatalf("PutFalse: %v", err)

--- a/test/autorest/bytegroup/bytegroup_test.go
+++ b/test/autorest/bytegroup/bytegroup_test.go
@@ -11,16 +11,8 @@ import (
 	"testing"
 )
 
-func getByteClient(t *testing.T) bytegroup.ByteOperations {
-	client, err := bytegroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create byte client: %v", err)
-	}
-	return client.ByteOperations()
-}
-
 func TestGetEmpty(t *testing.T) {
-	client := getByteClient(t)
+	client := bytegroup.NewDefaultClient(nil).ByteOperations()
 	result, err := client.GetEmpty(context.Background())
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
@@ -30,7 +22,7 @@ func TestGetEmpty(t *testing.T) {
 }
 
 func TestGetInvalid(t *testing.T) {
-	client := getByteClient(t)
+	client := bytegroup.NewDefaultClient(nil).ByteOperations()
 	result, err := client.GetInvalid(context.Background())
 	// TODO: verify error response is clear and actionable
 	if err == nil {
@@ -42,7 +34,7 @@ func TestGetInvalid(t *testing.T) {
 }
 
 func TestGetNonASCII(t *testing.T) {
-	client := getByteClient(t)
+	client := bytegroup.NewDefaultClient(nil).ByteOperations()
 	result, err := client.GetNonASCII(context.Background())
 	if err != nil {
 		t.Fatalf("GetNonASCII: %v", err)
@@ -52,7 +44,7 @@ func TestGetNonASCII(t *testing.T) {
 }
 
 func TestGetNull(t *testing.T) {
-	client := getByteClient(t)
+	client := bytegroup.NewDefaultClient(nil).ByteOperations()
 	result, err := client.GetNull(context.Background())
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
@@ -62,7 +54,7 @@ func TestGetNull(t *testing.T) {
 }
 
 func TestPutNonASCII(t *testing.T) {
-	client := getByteClient(t)
+	client := bytegroup.NewDefaultClient(nil).ByteOperations()
 	result, err := client.PutNonASCII(context.Background(), []byte{0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9, 0xF8, 0xF7, 0xF6})
 	if err != nil {
 		t.Fatalf("PutNonASCII: %v", err)

--- a/test/autorest/complexgroup/array_test.go
+++ b/test/autorest/complexgroup/array_test.go
@@ -11,16 +11,8 @@ import (
 	"testing"
 )
 
-func getArrayOperations(t *testing.T) complexgroup.ArrayOperations {
-	client, err := complexgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create complex client: %v", err)
-	}
-	return client.ArrayOperations()
-}
-
 func TestArrayGetEmpty(t *testing.T) {
-	client := getArrayOperations(t)
+	client := complexgroup.NewDefaultClient(nil).ArrayOperations()
 	result, err := client.GetEmpty(context.Background())
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
@@ -31,7 +23,7 @@ func TestArrayGetEmpty(t *testing.T) {
 }
 
 func TestArrayGetNotProvided(t *testing.T) {
-	client := getArrayOperations(t)
+	client := complexgroup.NewDefaultClient(nil).ArrayOperations()
 	result, err := client.GetNotProvided(context.Background())
 	if err != nil {
 		t.Fatalf("GetNotProvided: %v", err)
@@ -40,7 +32,7 @@ func TestArrayGetNotProvided(t *testing.T) {
 }
 
 func TestArrayGetValid(t *testing.T) {
-	client := getArrayOperations(t)
+	client := complexgroup.NewDefaultClient(nil).ArrayOperations()
 	result, err := client.GetValid(context.Background())
 	if err != nil {
 		t.Fatalf("GetValid: %v", err)
@@ -51,7 +43,7 @@ func TestArrayGetValid(t *testing.T) {
 }
 
 func TestArrayPutEmpty(t *testing.T) {
-	client := getArrayOperations(t)
+	client := complexgroup.NewDefaultClient(nil).ArrayOperations()
 	result, err := client.PutEmpty(context.Background(), complexgroup.ArrayWrapper{Array: &[]string{}})
 	if err != nil {
 		t.Fatalf("PutEmpty: %v", err)
@@ -62,7 +54,7 @@ func TestArrayPutEmpty(t *testing.T) {
 /*
 test is currently invalid, missing x-nullable but expects null
 func TestArrayPutValid(t *testing.T) {
-	client := getArrayOperations(t)
+	client := complexgroup.NewDefaultClient(nil).ArrayOperations()
 	result, err := client.PutValid(context.Background(), complexgroup.ArrayWrapper{Array: &[]string{"1, 2, 3, 4", "", nil, "&S#$(*Y", "The quick brown fox jumps over the lazy dog"}})
 	if err != nil {
 		t.Fatalf("PutValid: %v", err)

--- a/test/autorest/complexgroup/basic_test.go
+++ b/test/autorest/complexgroup/basic_test.go
@@ -13,16 +13,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getBasicOperations(t *testing.T) complexgroup.BasicOperations {
-	client, err := complexgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create complex client: %v", err)
-	}
-	return client.BasicOperations()
-}
-
 func TestBasicGetValid(t *testing.T) {
-	client := getBasicOperations(t)
+	client := complexgroup.NewDefaultClient(nil).BasicOperations()
 	result, err := client.GetValid(context.Background())
 	if err != nil {
 		t.Fatalf("GetValid: %v", err)
@@ -31,7 +23,7 @@ func TestBasicGetValid(t *testing.T) {
 }
 
 func TestBasicPutValid(t *testing.T) {
-	client := getBasicOperations(t)
+	client := complexgroup.NewDefaultClient(nil).BasicOperations()
 	result, err := client.PutValid(context.Background(), complexgroup.Basic{
 		ID:    to.Int32Ptr(2),
 		Name:  to.StringPtr("abc"),
@@ -44,7 +36,7 @@ func TestBasicPutValid(t *testing.T) {
 }
 
 func TestBasicGetInvalid(t *testing.T) {
-	client := getBasicOperations(t)
+	client := complexgroup.NewDefaultClient(nil).BasicOperations()
 	result, err := client.GetInvalid(context.Background())
 	if err == nil {
 		t.Fatal("GetInvalid expected an error")
@@ -55,7 +47,7 @@ func TestBasicGetInvalid(t *testing.T) {
 }
 
 func TestBasicGetEmpty(t *testing.T) {
-	client := getBasicOperations(t)
+	client := complexgroup.NewDefaultClient(nil).BasicOperations()
 	result, err := client.GetEmpty(context.Background())
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
@@ -64,7 +56,7 @@ func TestBasicGetEmpty(t *testing.T) {
 }
 
 func TestBasicGetNull(t *testing.T) {
-	client := getBasicOperations(t)
+	client := complexgroup.NewDefaultClient(nil).BasicOperations()
 	result, err := client.GetNull(context.Background())
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
@@ -73,7 +65,7 @@ func TestBasicGetNull(t *testing.T) {
 }
 
 func TestBasicGetNotProvided(t *testing.T) {
-	client := getBasicOperations(t)
+	client := complexgroup.NewDefaultClient(nil).BasicOperations()
 	result, err := client.GetNotProvided(context.Background())
 	if err != nil {
 		t.Fatalf("GetNotProvided: %v", err)

--- a/test/autorest/complexgroup/dictionary_test.go
+++ b/test/autorest/complexgroup/dictionary_test.go
@@ -11,16 +11,8 @@ import (
 	"testing"
 )
 
-func getDictionaryOperations(t *testing.T) complexgroup.DictionaryOperations {
-	client, err := complexgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create complex client: %v", err)
-	}
-	return client.DictionaryOperations()
-}
-
 func TestDictionaryGetEmpty(t *testing.T) {
-	client := getDictionaryOperations(t)
+	client := complexgroup.NewDefaultClient(nil).DictionaryOperations()
 	result, err := client.GetEmpty(context.Background())
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
@@ -29,7 +21,7 @@ func TestDictionaryGetEmpty(t *testing.T) {
 }
 
 func TestDictionaryGetNotProvided(t *testing.T) {
-	client := getDictionaryOperations(t)
+	client := complexgroup.NewDefaultClient(nil).DictionaryOperations()
 	result, err := client.GetNotProvided(context.Background())
 	if err != nil {
 		t.Fatalf("GetNotProvided: %v", err)
@@ -38,7 +30,7 @@ func TestDictionaryGetNotProvided(t *testing.T) {
 }
 
 func TestDictionaryGetNull(t *testing.T) {
-	client := getDictionaryOperations(t)
+	client := complexgroup.NewDefaultClient(nil).DictionaryOperations()
 	result, err := client.GetNull(context.Background())
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
@@ -49,7 +41,7 @@ func TestDictionaryGetNull(t *testing.T) {
 /*
 test is invalid, expects null values but missing x-nullable
 func TestDictionaryGetValid(t *testing.T) {
-	client := getDictionaryOperations(t)
+	client := complexgroup.NewDefaultClient(nil).DictionaryOperations()
 	result, err := client.GetValid(context.Background())
 	if err != nil {
 		t.Fatalf("GetValid: %v", err)
@@ -60,7 +52,7 @@ func TestDictionaryGetValid(t *testing.T) {
 }*/
 
 func TestDictionaryPutEmpty(t *testing.T) {
-	client := getDictionaryOperations(t)
+	client := complexgroup.NewDefaultClient(nil).DictionaryOperations()
 	result, err := client.PutEmpty(context.Background(), complexgroup.DictionaryWrapper{DefaultProgram: &map[string]string{}})
 	if err != nil {
 		t.Fatalf("PutEmpty: %v", err)
@@ -71,7 +63,7 @@ func TestDictionaryPutEmpty(t *testing.T) {
 /*
 test is invalid, expects null values but missing x-nullable
 func TestDictionaryPutValid(t *testing.T) {
-	client := getDictionaryOperations(t)
+	client := complexgroup.NewDefaultClient(nil).DictionaryOperations()
 	s1, s2, s3, s4 := "notepad", "mspaint", "excel", ""
 	result, err := client.PutValid(context.Background(), complexgroup.DictionaryWrapper{DefaultProgram: &map[string]string{"txt": s1, "bmp": s2, "xls": s3, "exe": s4, "": nil}})
 	if err != nil {

--- a/test/autorest/complexgroup/inheritance_test.go
+++ b/test/autorest/complexgroup/inheritance_test.go
@@ -13,16 +13,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getInheritanceOperations(t *testing.T) complexgroup.InheritanceOperations {
-	client, err := complexgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create complex client: %v", err)
-	}
-	return client.InheritanceOperations()
-}
-
 func TestInheritanceGetValid(t *testing.T) {
-	client := getInheritanceOperations(t)
+	client := complexgroup.NewDefaultClient(nil).InheritanceOperations()
 	result, err := client.GetValid(context.Background())
 	if err != nil {
 		t.Fatalf("GetValid: %v", err)
@@ -56,7 +48,7 @@ func TestInheritanceGetValid(t *testing.T) {
 }
 
 func TestInheritancePutValid(t *testing.T) {
-	client := getInheritanceOperations(t)
+	client := complexgroup.NewDefaultClient(nil).InheritanceOperations()
 	result, err := client.PutValid(context.Background(), complexgroup.Siamese{
 		Cat: complexgroup.Cat{
 			Pet: complexgroup.Pet{

--- a/test/autorest/complexgroup/polymorphicrecursive_test.go
+++ b/test/autorest/complexgroup/polymorphicrecursive_test.go
@@ -14,17 +14,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getPolymorphicrecursiveOperations(t *testing.T) complexgroup.PolymorphicrecursiveOperations {
-	client, err := complexgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create complex client: %v", err)
-	}
-	return client.PolymorphicrecursiveOperations()
-}
-
 // GetValid - Get complex types that are polymorphic and have recursive references
 func TestGetValid(t *testing.T) {
-	client := getPolymorphicrecursiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PolymorphicrecursiveOperations()
 	result, err := client.GetValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -115,7 +107,7 @@ func TestGetValid(t *testing.T) {
 
 // PutValid - Put complex types that are polymorphic and have recursive references
 func TestPutValid(t *testing.T) {
-	client := getPolymorphicrecursiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PolymorphicrecursiveOperations()
 	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
 	sharkBday := time.Date(2012, time.January, 5, 1, 0, 0, 0, time.UTC)
 	result, err := client.PutValid(context.Background(), &complexgroup.Salmon{

--- a/test/autorest/complexgroup/polymorphism_test.go
+++ b/test/autorest/complexgroup/polymorphism_test.go
@@ -14,17 +14,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getPolymorphismOperations(t *testing.T) complexgroup.PolymorphismOperations {
-	client, err := complexgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create complex client: %v", err)
-	}
-	return client.PolymorphismOperations()
-}
-
 // GetComplicated - Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
 func TestPolymorphismGetComplicated(t *testing.T) {
-	client := getPolymorphismOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PolymorphismOperations()
 	result, err := client.GetComplicated(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -90,7 +82,7 @@ func TestPolymorphismGetComplicated(t *testing.T) {
 
 // GetComposedWithDiscriminator - Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
 func TestPolymorphismGetComposedWithDiscriminator(t *testing.T) {
-	client := getPolymorphismOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PolymorphismOperations()
 	result, err := client.GetComposedWithDiscriminator(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -153,7 +145,7 @@ func TestPolymorphismGetComposedWithDiscriminator(t *testing.T) {
 
 // GetComposedWithoutDiscriminator - Get complex object composing a polymorphic scalar property and array property with polymorphic element type, without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
 func TestPolymorphismGetComposedWithoutDiscriminator(t *testing.T) {
-	client := getPolymorphismOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PolymorphismOperations()
 	result, err := client.GetComposedWithoutDiscriminator(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -198,7 +190,7 @@ func TestPolymorphismGetComposedWithoutDiscriminator(t *testing.T) {
 
 // GetDotSyntax - Get complex types that are polymorphic, JSON key contains a dot
 func TestPolymorphismGetDotSyntax(t *testing.T) {
-	client := getPolymorphismOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PolymorphismOperations()
 	result, err := client.GetDotSyntax(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -215,7 +207,7 @@ func TestPolymorphismGetDotSyntax(t *testing.T) {
 
 // GetValid - Get complex types that are polymorphic
 func TestPolymorphismGetValid(t *testing.T) {
-	client := getPolymorphismOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PolymorphismOperations()
 	result, err := client.GetValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -281,7 +273,7 @@ func TestPolymorphismPutComplicated(t *testing.T) {
 
 // PutMissingDiscriminator - Put complex types that are polymorphic, omitting the discriminator
 func TestPolymorphismPutMissingDiscriminator(t *testing.T) {
-	client := getPolymorphismOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PolymorphismOperations()
 	goblinBday := time.Date(2015, time.August, 8, 0, 0, 0, 0, time.UTC)
 	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
 	sharkBday := time.Date(2012, time.January, 5, 1, 0, 0, 0, time.UTC)
@@ -334,7 +326,7 @@ func TestPolymorphismPutMissingDiscriminator(t *testing.T) {
 
 // PutValid - Put complex types that are polymorphic
 func TestPolymorphismPutValid(t *testing.T) {
-	client := getPolymorphismOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PolymorphismOperations()
 	goblinBday := time.Date(2015, time.August, 8, 0, 0, 0, 0, time.UTC)
 	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
 	sharkBday := time.Date(2012, time.January, 5, 1, 0, 0, 0, time.UTC)

--- a/test/autorest/complexgroup/primitive_test.go
+++ b/test/autorest/complexgroup/primitive_test.go
@@ -14,16 +14,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getPrimitiveOperations(t *testing.T) complexgroup.PrimitiveOperations {
-	client, err := complexgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create complex client: %v", err)
-	}
-	return client.PrimitiveOperations()
-}
-
 func TestPrimitiveGetInt(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	result, err := client.GetInt(context.Background())
 	if err != nil {
 		t.Fatalf("GetInt: %v", err)
@@ -32,7 +24,7 @@ func TestPrimitiveGetInt(t *testing.T) {
 }
 
 func TestPrimitivePutInt(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	a, b := int32(-1), int32(2)
 	result, err := client.PutInt(context.Background(), complexgroup.IntWrapper{Field1: &a, Field2: &b})
 	if err != nil {
@@ -42,7 +34,7 @@ func TestPrimitivePutInt(t *testing.T) {
 }
 
 func TestPrimitiveGetLong(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	result, err := client.GetLong(context.Background())
 	if err != nil {
 		t.Fatalf("GetLong: %v", err)
@@ -54,7 +46,7 @@ func TestPrimitiveGetLong(t *testing.T) {
 }
 
 func TestPrimitivePutLong(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	a, b := int64(1099511627775), int64(-999511627788)
 	result, err := client.PutLong(context.Background(), complexgroup.LongWrapper{Field1: &a, Field2: &b})
 	if err != nil {
@@ -64,7 +56,7 @@ func TestPrimitivePutLong(t *testing.T) {
 }
 
 func TestPrimitiveGetFloat(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	result, err := client.GetFloat(context.Background())
 	if err != nil {
 		t.Fatalf("GetFloat: %v", err)
@@ -76,7 +68,7 @@ func TestPrimitiveGetFloat(t *testing.T) {
 }
 
 func TestPrimitivePutFloat(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	a, b := float32(1.05), float32(-0.003)
 	result, err := client.PutFloat(context.Background(), complexgroup.FloatWrapper{Field1: &a, Field2: &b})
 	if err != nil {
@@ -86,7 +78,7 @@ func TestPrimitivePutFloat(t *testing.T) {
 }
 
 func TestPrimitiveGetDouble(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	result, err := client.GetDouble(context.Background())
 	if err != nil {
 		t.Fatalf("GetDouble: %v", err)
@@ -98,7 +90,7 @@ func TestPrimitiveGetDouble(t *testing.T) {
 }
 
 func TestPrimitivePutDouble(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	a, b := float64(3e-100), float64(-0.000000000000000000000000000000000000000000000000000000005)
 	result, err := client.PutDouble(context.Background(), complexgroup.DoubleWrapper{Field1: &a, Field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose: &b})
 	if err != nil {
@@ -108,7 +100,7 @@ func TestPrimitivePutDouble(t *testing.T) {
 }
 
 func TestPrimitiveGetBool(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	result, err := client.GetBool(context.Background())
 	if err != nil {
 		t.Fatalf("GetBool: %v", err)
@@ -120,7 +112,7 @@ func TestPrimitiveGetBool(t *testing.T) {
 }
 
 func TestPrimitiveGetByte(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	result, err := client.GetByte(context.Background())
 	if err != nil {
 		t.Fatalf("GetByte: %v", err)
@@ -129,7 +121,7 @@ func TestPrimitiveGetByte(t *testing.T) {
 }
 
 func TestPrimitivePutBool(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	a, b := true, false
 	result, err := client.PutBool(context.Background(), complexgroup.BooleanWrapper{FieldTrue: &a, FieldFalse: &b})
 	if err != nil {
@@ -139,7 +131,7 @@ func TestPrimitivePutBool(t *testing.T) {
 }
 
 func TestPrimitivePutByte(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	val := []byte{255, 254, 253, 252, 0, 250, 249, 248, 247, 246}
 	result, err := client.PutByte(context.Background(), complexgroup.ByteWrapper{Field: &val})
 	if err != nil {
@@ -149,7 +141,7 @@ func TestPrimitivePutByte(t *testing.T) {
 }
 
 func TestPrimitiveGetString(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	result, err := client.GetString(context.Background())
 	if err != nil {
 		t.Fatalf("GetString: %v", err)
@@ -161,7 +153,7 @@ func TestPrimitiveGetString(t *testing.T) {
 }
 
 func TestPrimitivePutString(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	var c *string
 	a, b, c := "goodrequest", "", nil
 	result, err := client.PutString(context.Background(), complexgroup.StringWrapper{Field: &a, Empty: &b, Null: c})
@@ -172,7 +164,7 @@ func TestPrimitivePutString(t *testing.T) {
 }
 
 // func TestPrimitiveGetDate(t *testing.T) {
-// 	client := getPrimitiveOperations(t)
+// 	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 // 	result, err := client.GetDate(context.Background())
 // 	if err != nil {
 // 		t.Fatalf("GetDate: %v", err)
@@ -193,7 +185,7 @@ func TestPrimitivePutString(t *testing.T) {
 // }
 
 // func TestPrimitivePutDate(t *testing.T) {
-// 	client := getPrimitiveOperations(t)
+// 	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 // 	a, err := time.Parse("2006-01-02", "0001-01-01")
 // 	if err != nil {
 // 		t.Fatalf("Unable to parse date string: %v", err)
@@ -213,7 +205,7 @@ func TestPrimitivePutString(t *testing.T) {
 // }
 
 func TestPrimitiveGetDuration(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	result, err := client.GetDuration(context.Background())
 	if err != nil {
 		t.Fatalf("GetDuration: %v", err)
@@ -224,7 +216,7 @@ func TestPrimitiveGetDuration(t *testing.T) {
 }
 
 func TestPrimitivePutDuration(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	result, err := client.PutDuration(context.Background(), complexgroup.DurationWrapper{Field: to.StringPtr("P123DT22H14M12.011S")})
 	if err != nil {
 		t.Fatalf("PutDuration: %v", err)
@@ -233,7 +225,7 @@ func TestPrimitivePutDuration(t *testing.T) {
 }
 
 func TestPrimitiveGetDateTime(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	result, err := client.GetDateTime(context.Background())
 	if err != nil {
 		t.Fatalf("GetDateTime: %v", err)
@@ -247,7 +239,7 @@ func TestPrimitiveGetDateTime(t *testing.T) {
 }
 
 func TestPrimitiveGetDateTimeRFC1123(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	result, err := client.GetDateTimeRFC1123(context.Background())
 	if err != nil {
 		t.Fatalf("GetDateTimeRFC1123: %v", err)
@@ -261,7 +253,7 @@ func TestPrimitiveGetDateTimeRFC1123(t *testing.T) {
 }
 
 func TestPrimitivePutDateTime(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	f, _ := time.Parse(time.RFC3339, "0001-01-01T00:00:00Z")
 	n, _ := time.Parse(time.RFC3339, "2015-05-18T18:38:00Z")
 	result, err := client.PutDateTime(context.Background(), complexgroup.DatetimeWrapper{
@@ -275,7 +267,7 @@ func TestPrimitivePutDateTime(t *testing.T) {
 }
 
 func TestPrimitivePutDateTimeRFC1123(t *testing.T) {
-	client := getPrimitiveOperations(t)
+	client := complexgroup.NewDefaultClient(nil).PrimitiveOperations()
 	f, _ := time.Parse(time.RFC1123, "Mon, 01 Jan 0001 00:00:00 GMT")
 	n, _ := time.Parse(time.RFC1123, "Mon, 18 May 2015 11:38:00 GMT")
 	result, err := client.PutDateTimeRFC1123(context.Background(), complexgroup.Datetimerfc1123Wrapper{

--- a/test/autorest/complexgroup/readonlyproperty_test.go
+++ b/test/autorest/complexgroup/readonlyproperty_test.go
@@ -13,16 +13,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getReadonlypropertyOperations(t *testing.T) complexgroup.ReadonlypropertyOperations {
-	client, err := complexgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create complex client: %v", err)
-	}
-	return client.ReadonlypropertyOperations()
-}
-
 func TestReadonlypropertyGetValid(t *testing.T) {
-	client := getReadonlypropertyOperations(t)
+	client := complexgroup.NewDefaultClient(nil).ReadonlypropertyOperations()
 	result, err := client.GetValid(context.Background())
 	if err != nil {
 		t.Fatalf("GetValid: %v", err)
@@ -31,7 +23,7 @@ func TestReadonlypropertyGetValid(t *testing.T) {
 }
 
 func TestReadonlypropertyPutValid(t *testing.T) {
-	client := getReadonlypropertyOperations(t)
+	client := complexgroup.NewDefaultClient(nil).ReadonlypropertyOperations()
 	id, size := "1234", int32(2)
 	result, err := client.PutValid(context.Background(), complexgroup.ReadonlyObj{ID: &id, Size: &size})
 	if err != nil {

--- a/test/autorest/complexmodelgroup/complexmodelgroup_test.go
+++ b/test/autorest/complexmodelgroup/complexmodelgroup_test.go
@@ -9,16 +9,8 @@ import (
 	"testing"
 )
 
-func getOperations(t *testing.T) complexmodelgroup.ComplexModelClientOperations {
-	client, err := complexmodelgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create complex client: %v", err)
-	}
-	return client.ComplexModelClientOperations()
-}
-
 func TestCreate(t *testing.T) {
-	client := getOperations(t)
+	client := complexmodelgroup.NewDefaultClient(nil).ComplexModelClientOperations()
 	_, err := client.Create(context.Background(), "sub", "rg", complexmodelgroup.CatalogDictionaryOfArray{})
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -26,7 +18,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
-	client := getOperations(t)
+	client := complexmodelgroup.NewDefaultClient(nil).ComplexModelClientOperations()
 	_, err := client.List(context.Background(), "")
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -34,7 +26,7 @@ func TestList(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	client := getOperations(t)
+	client := complexmodelgroup.NewDefaultClient(nil).ComplexModelClientOperations()
 	_, err := client.Update(context.Background(), "", "", complexmodelgroup.CatalogArrayOfDictionary{})
 	if err == nil {
 		t.Fatal("unexpected nil error")

--- a/test/autorest/covreport/main.go
+++ b/test/autorest/covreport/main.go
@@ -13,18 +13,12 @@ import (
 
 // generate autorest test server coverage report
 func main() {
-	vanillaClient, err := reportgroup.NewDefaultClient(nil)
-	if err != nil {
-		panic(err)
-	}
+	vanillaClient := reportgroup.NewDefaultClient(nil)
 	vanillaReport, err := vanillaClient.AutoRestReportServiceOperations().GetReport(context.Background(), nil)
 	if err != nil {
 		panic(err)
 	}
-	azureClient, err := azurereportgroup.NewDefaultClient(nil)
-	if err != nil {
-		panic(err)
-	}
+	azureClient := azurereportgroup.NewDefaultClient(nil)
 	azureReport, err := azureClient.AutoRestReportServiceForAzureOperations().GetReport(context.Background(), nil)
 	if err != nil {
 		panic(err)

--- a/test/autorest/custombaseurlgroup/custombaseurlgroup_test.go
+++ b/test/autorest/custombaseurlgroup/custombaseurlgroup_test.go
@@ -13,16 +13,13 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getCustomBaseURLClient(t *testing.T) custombaseurlgroup.PathsOperations {
-	client, err := custombaseurlgroup.NewClient(to.StringPtr(":3000"), nil)
-	if err != nil {
-		t.Fatalf("failed to create custom base URL client: %v", err)
-	}
+func getCustomBaseURLClient() custombaseurlgroup.PathsOperations {
+	client := custombaseurlgroup.NewClient(to.StringPtr(":3000"), nil)
 	return client.PathsOperations()
 }
 
 func TestGetEmpty(t *testing.T) {
-	client := getCustomBaseURLClient(t)
+	client := getCustomBaseURLClient()
 	result, err := client.GetEmpty(context.Background(), "localhost")
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)

--- a/test/autorest/datetimegroup/datetimegroup_test.go
+++ b/test/autorest/datetimegroup/datetimegroup_test.go
@@ -12,16 +12,8 @@ import (
 	"time"
 )
 
-func getDatetimeOperations(t *testing.T) datetimegroup.DatetimeOperations {
-	client, err := datetimegroup.NewClient("http://localhost:3000", nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.DatetimeOperations()
-}
-
 func TestGetInvalid(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	_, err := client.GetInvalid(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -29,7 +21,7 @@ func TestGetInvalid(t *testing.T) {
 }
 
 func TestGetLocalNegativeOffsetLowercaseMaxDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	result, err := client.GetLocalNegativeOffsetLowercaseMaxDateTime(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -42,7 +34,7 @@ func TestGetLocalNegativeOffsetLowercaseMaxDateTime(t *testing.T) {
 }
 
 func TestGetLocalNegativeOffsetMinDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	result, err := client.GetLocalNegativeOffsetMinDateTime(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -55,7 +47,7 @@ func TestGetLocalNegativeOffsetMinDateTime(t *testing.T) {
 }
 
 func TestGetLocalNegativeOffsetUppercaseMaxDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	result, err := client.GetLocalNegativeOffsetUppercaseMaxDateTime(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -68,7 +60,7 @@ func TestGetLocalNegativeOffsetUppercaseMaxDateTime(t *testing.T) {
 }
 
 func TestGetLocalPositiveOffsetLowercaseMaxDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	result, err := client.GetLocalPositiveOffsetLowercaseMaxDateTime(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -81,7 +73,7 @@ func TestGetLocalPositiveOffsetLowercaseMaxDateTime(t *testing.T) {
 }
 
 func TestGetLocalPositiveOffsetMinDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	result, err := client.GetLocalPositiveOffsetMinDateTime(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -94,7 +86,7 @@ func TestGetLocalPositiveOffsetMinDateTime(t *testing.T) {
 }
 
 func TestGetLocalNoOffsetMinDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	result, err := client.GetLocalNoOffsetMinDateTime(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -107,7 +99,7 @@ func TestGetLocalNoOffsetMinDateTime(t *testing.T) {
 }
 
 func TestGetLocalPositiveOffsetUppercaseMaxDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	result, err := client.GetLocalPositiveOffsetUppercaseMaxDateTime(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -120,7 +112,7 @@ func TestGetLocalPositiveOffsetUppercaseMaxDateTime(t *testing.T) {
 }
 
 func TestGetNull(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	result, err := client.GetNull(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -131,7 +123,7 @@ func TestGetNull(t *testing.T) {
 
 func TestGetOverflow(t *testing.T) {
 	t.Skip("API doesn't actually overflow")
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	_, err := client.GetOverflow(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -139,7 +131,7 @@ func TestGetOverflow(t *testing.T) {
 }
 
 func TestGetUnderflow(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	_, err := client.GetUnderflow(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -147,7 +139,7 @@ func TestGetUnderflow(t *testing.T) {
 }
 
 func TestGetUTCLowercaseMaxDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	result, err := client.GetUTCLowercaseMaxDateTime(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -160,7 +152,7 @@ func TestGetUTCLowercaseMaxDateTime(t *testing.T) {
 }
 
 func TestGetUTCMinDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	result, err := client.GetUTCMinDateTime(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -173,7 +165,7 @@ func TestGetUTCMinDateTime(t *testing.T) {
 }
 
 func TestGetUTCUppercaseMaxDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	result, err := client.GetUTCUppercaseMaxDateTime(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -186,7 +178,7 @@ func TestGetUTCUppercaseMaxDateTime(t *testing.T) {
 }
 
 func TestGetUTCUppercaseMaxDateTime7Digits(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	result, err := client.GetUTCUppercaseMaxDateTime7Digits(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -199,7 +191,7 @@ func TestGetUTCUppercaseMaxDateTime7Digits(t *testing.T) {
 }
 
 func TestPutLocalNegativeOffsetMaxDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	body, err := time.Parse(time.RFC3339, "9999-12-31T23:59:59.999-14:00")
 	if err != nil {
 		t.Fatal(err)
@@ -212,7 +204,7 @@ func TestPutLocalNegativeOffsetMaxDateTime(t *testing.T) {
 }
 
 func TestPutLocalNegativeOffsetMinDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	body, err := time.Parse(time.RFC3339, "0001-01-01T00:00:00-14:00")
 	if err != nil {
 		t.Fatal(err)
@@ -225,7 +217,7 @@ func TestPutLocalNegativeOffsetMinDateTime(t *testing.T) {
 }
 
 func TestPutLocalPositiveOffsetMaxDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	body, err := time.Parse(time.RFC3339, "9999-12-31T23:59:59.999+14:00")
 	if err != nil {
 		t.Fatal(err)
@@ -238,7 +230,7 @@ func TestPutLocalPositiveOffsetMaxDateTime(t *testing.T) {
 }
 
 func TestPutLocalPositiveOffsetMinDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	body, err := time.Parse(time.RFC3339, "0001-01-01T00:00:00+14:00")
 	if err != nil {
 		t.Fatal(err)
@@ -251,7 +243,7 @@ func TestPutLocalPositiveOffsetMinDateTime(t *testing.T) {
 }
 
 func TestPutUTCMaxDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	body, err := time.Parse(time.RFC3339, "9999-12-31T23:59:59.999Z")
 	if err != nil {
 		t.Fatal(err)
@@ -264,7 +256,7 @@ func TestPutUTCMaxDateTime(t *testing.T) {
 }
 
 func TestPutUTCMaxDateTime7Digits(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	body, err := time.Parse(time.RFC3339, "9999-12-31T23:59:59.9999999Z")
 	if err != nil {
 		t.Fatal(err)
@@ -277,7 +269,7 @@ func TestPutUTCMaxDateTime7Digits(t *testing.T) {
 }
 
 func TestPutUTCMinDateTime(t *testing.T) {
-	client := getDatetimeOperations(t)
+	client := datetimegroup.NewDefaultClient(nil).DatetimeOperations()
 	body, err := time.Parse(time.RFC3339, "0001-01-01T00:00:00Z")
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/datetimerfc1123group/datetimerfc1123group_test.go
+++ b/test/autorest/datetimerfc1123group/datetimerfc1123group_test.go
@@ -12,16 +12,8 @@ import (
 	"time"
 )
 
-func getDatetimerfc1123Operations(t *testing.T) datetimerfc1123group.Datetimerfc1123Operations {
-	client, err := datetimerfc1123group.NewClient("http://localhost:3000", nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.Datetimerfc1123Operations()
-}
-
 func TestGetInvalid(t *testing.T) {
-	client := getDatetimerfc1123Operations(t)
+	client := datetimerfc1123group.NewDefaultClient(nil).Datetimerfc1123Operations()
 	_, err := client.GetInvalid(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -29,7 +21,7 @@ func TestGetInvalid(t *testing.T) {
 }
 
 func TestGetNull(t *testing.T) {
-	client := getDatetimerfc1123Operations(t)
+	client := datetimerfc1123group.NewDefaultClient(nil).Datetimerfc1123Operations()
 	result, err := client.GetNull(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -39,7 +31,7 @@ func TestGetNull(t *testing.T) {
 }
 
 func TestGetOverflow(t *testing.T) {
-	client := getDatetimerfc1123Operations(t)
+	client := datetimerfc1123group.NewDefaultClient(nil).Datetimerfc1123Operations()
 	_, err := client.GetOverflow(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -48,7 +40,7 @@ func TestGetOverflow(t *testing.T) {
 
 // GetUTCLowercaseMaxDateTime - Get max datetime value fri, 31 dec 9999 23:59:59 gmt
 func TestGetUTCLowercaseMaxDateTime(t *testing.T) {
-	client := getDatetimerfc1123Operations(t)
+	client := datetimerfc1123group.NewDefaultClient(nil).Datetimerfc1123Operations()
 	result, err := client.GetUTCLowercaseMaxDateTime(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -62,7 +54,7 @@ func TestGetUTCLowercaseMaxDateTime(t *testing.T) {
 
 // GetUTCMinDateTime - Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT
 func TestGetUTCMinDateTime(t *testing.T) {
-	client := getDatetimerfc1123Operations(t)
+	client := datetimerfc1123group.NewDefaultClient(nil).Datetimerfc1123Operations()
 	result, err := client.GetUTCMinDateTime(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -76,7 +68,7 @@ func TestGetUTCMinDateTime(t *testing.T) {
 
 // GetUTCUppercaseMaxDateTime - Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT
 func TestGetUTCUppercaseMaxDateTime(t *testing.T) {
-	client := getDatetimerfc1123Operations(t)
+	client := datetimerfc1123group.NewDefaultClient(nil).Datetimerfc1123Operations()
 	result, err := client.GetUTCUppercaseMaxDateTime(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -89,7 +81,7 @@ func TestGetUTCUppercaseMaxDateTime(t *testing.T) {
 }
 
 func TestGetUnderflow(t *testing.T) {
-	client := getDatetimerfc1123Operations(t)
+	client := datetimerfc1123group.NewDefaultClient(nil).Datetimerfc1123Operations()
 	_, err := client.GetUnderflow(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -98,7 +90,7 @@ func TestGetUnderflow(t *testing.T) {
 
 // PutUTCMaxDateTime - Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT
 func TestPutUTCMaxDateTime(t *testing.T) {
-	client := getDatetimerfc1123Operations(t)
+	client := datetimerfc1123group.NewDefaultClient(nil).Datetimerfc1123Operations()
 	body, err := time.Parse(time.RFC1123, "Fri, 31 Dec 9999 23:59:59 GMT")
 	if err != nil {
 		t.Fatal(err)
@@ -112,7 +104,7 @@ func TestPutUTCMaxDateTime(t *testing.T) {
 
 // PutUTCMinDateTime - Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT
 func TestPutUTCMinDateTime(t *testing.T) {
-	client := getDatetimerfc1123Operations(t)
+	client := datetimerfc1123group.NewDefaultClient(nil).Datetimerfc1123Operations()
 	body, err := time.Parse(time.RFC1123, "Mon, 01 Jan 0001 00:00:00 GMT")
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/dictionarygroup/dictionarygroup_test.go
+++ b/test/autorest/dictionarygroup/dictionarygroup_test.go
@@ -14,17 +14,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getClient(t *testing.T) dictionarygroup.DictionaryOperations {
-	client, err := dictionarygroup.NewClient("http://localhost:3000", nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.DictionaryOperations()
-}
-
 // GetArrayEmpty - Get an empty dictionary {}
 func TestGetArrayEmpty(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetArrayEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +28,7 @@ func TestGetArrayEmpty(t *testing.T) {
 
 // GetArrayItemEmpty - Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}
 func TestGetArrayItemEmpty(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetArrayItemEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -50,7 +42,7 @@ func TestGetArrayItemEmpty(t *testing.T) {
 
 // GetArrayItemNull - Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}
 func TestGetArrayItemNull(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetArrayItemNull(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -65,7 +57,7 @@ func TestGetArrayItemNull(t *testing.T) {
 
 // GetArrayNull - Get a null array
 func TestGetArrayNull(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetArrayNull(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -77,7 +69,7 @@ func TestGetArrayNull(t *testing.T) {
 
 // GetArrayValid - Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
 func TestGetArrayValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetArrayValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -97,7 +89,7 @@ func TestGetBase64URL(t *testing.T) {
 // GetBooleanInvalidNull - Get boolean dictionary value {"0": true, "1": null, "2": false }
 func TestGetBooleanInvalidNull(t *testing.T) {
 	t.Skip("no x-nullable, should fail")
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetBooleanInvalidNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -109,7 +101,7 @@ func TestGetBooleanInvalidNull(t *testing.T) {
 
 // GetBooleanInvalidString - Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'
 func TestGetBooleanInvalidString(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetBooleanInvalidString(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -121,7 +113,7 @@ func TestGetBooleanInvalidString(t *testing.T) {
 
 // GetBooleanTfft - Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }
 func TestGetBooleanTfft(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetBooleanTfft(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -137,7 +129,7 @@ func TestGetBooleanTfft(t *testing.T) {
 // GetByteInvalidNull - Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded
 func TestGetByteInvalidNull(t *testing.T) {
 	t.Skip("no x-nullable, should fail")
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetByteInvalidNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -149,7 +141,7 @@ func TestGetByteInvalidNull(t *testing.T) {
 
 // GetByteValid - Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64
 func TestGetByteValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetByteValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -163,7 +155,7 @@ func TestGetByteValid(t *testing.T) {
 
 // GetComplexEmpty - Get empty dictionary of complex type {}
 func TestGetComplexEmpty(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetComplexEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -173,7 +165,7 @@ func TestGetComplexEmpty(t *testing.T) {
 
 // GetComplexItemEmpty - Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}
 func TestGetComplexItemEmpty(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetComplexItemEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -189,7 +181,7 @@ func TestGetComplexItemEmpty(t *testing.T) {
 /*
 test is invalid, expects nil value but missing x-nullable
 func TestGetComplexItemNull(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetComplexItemNull(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -203,7 +195,7 @@ func TestGetComplexItemNull(t *testing.T) {
 
 // GetComplexNull - Get dictionary of complex type null value
 func TestGetComplexNull(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetComplexNull(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -215,7 +207,7 @@ func TestGetComplexNull(t *testing.T) {
 
 // GetComplexValid - Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
 func TestGetComplexValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetComplexValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -239,7 +231,7 @@ func TestGetDateInvalidNull(t *testing.T) {
 
 // GetDateTimeInvalidChars - Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}
 func TestGetDateTimeInvalidChars(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetDateTimeInvalidChars(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -251,7 +243,7 @@ func TestGetDateTimeInvalidChars(t *testing.T) {
 
 // GetDateTimeInvalidNull - Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}
 func TestGetDateTimeInvalidNull(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetDateTimeInvalidNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -263,7 +255,7 @@ func TestGetDateTimeInvalidNull(t *testing.T) {
 
 // GetDateTimeRFC1123Valid - Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
 func TestGetDateTimeRFC1123Valid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetDateTimeRFC1123Valid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -280,7 +272,7 @@ func TestGetDateTimeRFC1123Valid(t *testing.T) {
 
 // GetDateTimeValid - Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
 func TestGetDateTimeValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetDateTimeValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -302,7 +294,7 @@ func TestGetDateValid(t *testing.T) {
 
 // GetDictionaryEmpty - Get an dictionaries of dictionaries of type <string, string> with value {}
 func TestGetDictionaryEmpty(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetDictionaryEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -313,7 +305,7 @@ func TestGetDictionaryEmpty(t *testing.T) {
 // GetDictionaryItemEmpty - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
 func TestGetDictionaryItemEmpty(t *testing.T) {
 	t.Skip("needs codegen fix")
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetDictionaryItemEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -339,7 +331,7 @@ func TestGetDictionaryValid(t *testing.T) {
 // GetDoubleInvalidNull - Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
 func TestGetDoubleInvalidNull(t *testing.T) {
 	t.Skip("should fail as mising x-nullable")
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetDoubleInvalidNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -351,7 +343,7 @@ func TestGetDoubleInvalidNull(t *testing.T) {
 
 // GetDoubleInvalidString - Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
 func TestGetDoubleInvalidString(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetDoubleInvalidString(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -363,7 +355,7 @@ func TestGetDoubleInvalidString(t *testing.T) {
 
 // GetDoubleValid - Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 func TestGetDoubleValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetDoubleValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -377,7 +369,7 @@ func TestGetDoubleValid(t *testing.T) {
 
 // GetDurationValid - Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
 func TestGetDurationValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetDurationValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -390,7 +382,7 @@ func TestGetDurationValid(t *testing.T) {
 
 // GetEmpty - Get empty dictionary value {}
 func TestGetEmpty(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -402,7 +394,7 @@ func TestGetEmpty(t *testing.T) {
 
 // GetEmptyStringKey - Get Dictionary with key as empty string
 func TestGetEmptyStringKey(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetEmptyStringKey(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -413,7 +405,7 @@ func TestGetEmptyStringKey(t *testing.T) {
 // GetFloatInvalidNull - Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
 func TestGetFloatInvalidNull(t *testing.T) {
 	t.Skip("should fail, nil but no x-nullable")
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetFloatInvalidNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -425,7 +417,7 @@ func TestGetFloatInvalidNull(t *testing.T) {
 
 // GetFloatInvalidString - Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
 func TestGetFloatInvalidString(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetFloatInvalidString(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -437,7 +429,7 @@ func TestGetFloatInvalidString(t *testing.T) {
 
 // GetFloatValid - Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 func TestGetFloatValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetFloatValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -452,7 +444,7 @@ func TestGetFloatValid(t *testing.T) {
 // GetIntInvalidNull - Get integer dictionary value {"0": 1, "1": null, "2": 0}
 func TestGetIntInvalidNull(t *testing.T) {
 	t.Skip("should fail, nil but no x-nullable")
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetIntInvalidNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -464,7 +456,7 @@ func TestGetIntInvalidNull(t *testing.T) {
 
 // GetIntInvalidString - Get integer dictionary value {"0": 1, "1": "integer", "2": 0}
 func TestGetIntInvalidString(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetIntInvalidString(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -476,7 +468,7 @@ func TestGetIntInvalidString(t *testing.T) {
 
 // GetIntegerValid - Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
 func TestGetIntegerValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetIntegerValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -491,7 +483,7 @@ func TestGetIntegerValid(t *testing.T) {
 
 // GetInvalid - Get invalid Dictionary value
 func TestGetInvalid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetInvalid(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -504,7 +496,7 @@ func TestGetInvalid(t *testing.T) {
 // GetLongInvalidNull - Get long dictionary value {"0": 1, "1": null, "2": 0}
 func TestGetLongInvalidNull(t *testing.T) {
 	t.Skip("should fail, nil but no x-nullable")
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetLongInvalidNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -516,7 +508,7 @@ func TestGetLongInvalidNull(t *testing.T) {
 
 // GetLongInvalidString - Get long dictionary value {"0": 1, "1": "integer", "2": 0}
 func TestGetLongInvalidString(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetLongInvalidString(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -528,7 +520,7 @@ func TestGetLongInvalidString(t *testing.T) {
 
 // GetLongValid - Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
 func TestGetLongValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetLongValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -543,7 +535,7 @@ func TestGetLongValid(t *testing.T) {
 
 // GetNull - Get null dictionary value
 func TestGetNull(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetNull(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -555,7 +547,7 @@ func TestGetNull(t *testing.T) {
 
 // GetNullKey - Get Dictionary with null key
 func TestGetNullKey(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetNullKey(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -568,7 +560,7 @@ func TestGetNullKey(t *testing.T) {
 // GetNullValue - Get Dictionary with null value
 func TestGetNullValue(t *testing.T) {
 	t.Skip("should fail, nil but no x-nullable")
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetNullValue(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -580,7 +572,7 @@ func TestGetNullValue(t *testing.T) {
 
 // GetStringValid - Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
 func TestGetStringValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetStringValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -594,7 +586,7 @@ func TestGetStringValid(t *testing.T) {
 
 // GetStringWithInvalid - Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}
 func TestGetStringWithInvalid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetStringWithInvalid(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -607,7 +599,7 @@ func TestGetStringWithInvalid(t *testing.T) {
 // GetStringWithNull - Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}
 func TestGetStringWithNull(t *testing.T) {
 	t.Skip("should fail, nil but no x-nullable")
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.GetStringWithNull(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -619,7 +611,7 @@ func TestGetStringWithNull(t *testing.T) {
 
 // PutArrayValid - Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
 func TestPutArrayValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.PutArrayValid(context.Background(), map[string][]string{
 		"0": []string{"1", "2", "3"},
 		"1": []string{"4", "5", "6"},
@@ -633,7 +625,7 @@ func TestPutArrayValid(t *testing.T) {
 
 // PutBooleanTfft - Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }
 func TestPutBooleanTfft(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.PutBooleanTfft(context.Background(), map[string]bool{
 		"0": true,
 		"1": false,
@@ -648,7 +640,7 @@ func TestPutBooleanTfft(t *testing.T) {
 
 // PutByteValid - Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64
 func TestPutByteValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.PutByteValid(context.Background(), map[string][]byte{
 		"0": {255, 255, 255, 250},
 		"1": {1, 2, 3},
@@ -662,7 +654,7 @@ func TestPutByteValid(t *testing.T) {
 
 // PutComplexValid - Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
 func TestPutComplexValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.PutComplexValid(context.Background(), map[string]dictionarygroup.Widget{
 		"0": dictionarygroup.Widget{Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		"1": dictionarygroup.Widget{Integer: to.Int32Ptr(3), String: to.StringPtr("4")},
@@ -676,7 +668,7 @@ func TestPutComplexValid(t *testing.T) {
 
 // PutDateTimeRFC1123Valid - Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
 func TestPutDateTimeRFC1123Valid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	dt1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
 	dt2, _ := time.Parse(time.RFC1123, "Wed, 02 Jan 1980 00:11:35 GMT")
 	dt3, _ := time.Parse(time.RFC1123, "Wed, 12 Oct 1492 10:15:01 GMT")
@@ -693,7 +685,7 @@ func TestPutDateTimeRFC1123Valid(t *testing.T) {
 
 // PutDateTimeValid - Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
 func TestPutDateTimeValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	dt1, _ := time.Parse(time.RFC3339, "2000-12-01T00:00:01Z")
 	dt2, _ := time.Parse(time.RFC3339, "1980-01-01T23:11:35Z")
 	dt3, _ := time.Parse(time.RFC3339, "1492-10-12T18:15:01Z")
@@ -720,7 +712,7 @@ func TestPutDictionaryValid(t *testing.T) {
 
 // PutDoubleValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 func TestPutDoubleValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.PutDoubleValid(context.Background(), map[string]float64{
 		"0": 0,
 		"1": -0.01,
@@ -734,7 +726,7 @@ func TestPutDoubleValid(t *testing.T) {
 
 // PutDurationValid - Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
 func TestPutDurationValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.PutDurationValid(context.Background(), map[string]string{
 		"0": "P123DT22H14M12.011S",
 		"1": "P5DT1H",
@@ -747,7 +739,7 @@ func TestPutDurationValid(t *testing.T) {
 
 // PutEmpty - Set dictionary value empty {}
 func TestPutEmpty(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.PutEmpty(context.Background(), map[string]string{})
 	if err != nil {
 		t.Fatal(err)
@@ -757,7 +749,7 @@ func TestPutEmpty(t *testing.T) {
 
 // PutFloatValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 func TestPutFloatValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.PutFloatValid(context.Background(), map[string]float32{
 		"0": 0,
 		"1": -0.01,
@@ -771,7 +763,7 @@ func TestPutFloatValid(t *testing.T) {
 
 // PutIntegerValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
 func TestPutIntegerValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.PutIntegerValid(context.Background(), map[string]int32{
 		"0": 1,
 		"1": -1,
@@ -786,7 +778,7 @@ func TestPutIntegerValid(t *testing.T) {
 
 // PutLongValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
 func TestPutLongValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.PutLongValid(context.Background(), map[string]int64{
 		"0": 1,
 		"1": -1,
@@ -801,7 +793,7 @@ func TestPutLongValid(t *testing.T) {
 
 // PutStringValid - Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
 func TestPutStringValid(t *testing.T) {
-	client := getClient(t)
+	client := dictionarygroup.NewDefaultClient(nil).DictionaryOperations()
 	resp, err := client.PutStringValid(context.Background(), map[string]string{
 		"0": "foo1",
 		"1": "foo2",

--- a/test/autorest/durationgroup/durationgroup_test.go
+++ b/test/autorest/durationgroup/durationgroup_test.go
@@ -13,17 +13,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getDurationOperations(t *testing.T) durationgroup.DurationOperations {
-	client, err := durationgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.DurationOperations()
-}
-
 func TestGetInvalid(t *testing.T) {
 	t.Skip("this does not apply to us meanwhile we do not parse durations")
-	client := getDurationOperations(t)
+	client := durationgroup.NewDefaultClient(nil).DurationOperations()
 	_, err := client.GetInvalid(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -31,7 +23,7 @@ func TestGetInvalid(t *testing.T) {
 }
 
 func TestGetNull(t *testing.T) {
-	client := getDurationOperations(t)
+	client := durationgroup.NewDefaultClient(nil).DurationOperations()
 	result, err := client.GetNull(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -41,7 +33,7 @@ func TestGetNull(t *testing.T) {
 }
 
 func TestGetPositiveDuration(t *testing.T) {
-	client := getDurationOperations(t)
+	client := durationgroup.NewDefaultClient(nil).DurationOperations()
 	result, err := client.GetPositiveDuration(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -50,7 +42,7 @@ func TestGetPositiveDuration(t *testing.T) {
 }
 
 func TestPutPositiveDuration(t *testing.T) {
-	client := getDurationOperations(t)
+	client := durationgroup.NewDefaultClient(nil).DurationOperations()
 	result, err := client.PutPositiveDuration(context.Background(), "P123DT22H14M12.011S")
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/errorsgroup/errorsgroup_test.go
+++ b/test/autorest/errorsgroup/errorsgroup_test.go
@@ -14,19 +14,16 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getClient(t *testing.T) errorsgroup.PetOperations {
+func getClient() errorsgroup.PetOperations {
 	options := errorsgroup.DefaultClientOptions()
 	options.Retry.MaxRetryDelay = 20 * time.Millisecond
-	client, err := errorsgroup.NewClient("http://localhost:3000", &options)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
+	client := errorsgroup.NewClient("http://localhost:3000", &options)
 	return client.PetOperations()
 }
 
 // DoSomething - Asks pet to do something
 func TestDoSomethingSuccess(t *testing.T) {
-	client := getClient(t)
+	client := getClient()
 	result, err := client.DoSomething(context.Background(), "stay")
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +33,7 @@ func TestDoSomethingSuccess(t *testing.T) {
 }
 
 func TestDoSomethingError1(t *testing.T) {
-	client := getClient(t)
+	client := getClient()
 	result, err := client.DoSomething(context.Background(), "jump")
 	sadErr, ok := err.(*errorsgroup.PetSadError)
 	if !ok {
@@ -55,7 +52,7 @@ func TestDoSomethingError1(t *testing.T) {
 }
 
 func TestDoSomethingError2(t *testing.T) {
-	client := getClient(t)
+	client := getClient()
 	result, err := client.DoSomething(context.Background(), "fetch")
 	hungrErr, ok := err.(*errorsgroup.PetHungryOrThirstyError)
 	if !ok {
@@ -77,7 +74,7 @@ func TestDoSomethingError2(t *testing.T) {
 }
 
 func TestDoSomethingError3(t *testing.T) {
-	client := getClient(t)
+	client := getClient()
 	result, err := client.DoSomething(context.Background(), "unknown")
 	actErr, ok := err.(*errorsgroup.PetActionError)
 	if !ok {
@@ -91,7 +88,7 @@ func TestDoSomethingError3(t *testing.T) {
 
 // GetPetByID - Gets pets by id.
 func TestGetPetByIDSuccess1(t *testing.T) {
-	client := getClient(t)
+	client := getClient()
 	result, err := client.GetPetByID(context.Background(), "tommy")
 	if err != nil {
 		t.Fatal(err)
@@ -105,7 +102,7 @@ func TestGetPetByIDSuccess1(t *testing.T) {
 }
 
 func TestGetPetByIDSuccess2(t *testing.T) {
-	client := getClient(t)
+	client := getClient()
 	result, err := client.GetPetByID(context.Background(), "django")
 	if err != nil {
 		t.Fatal(err)
@@ -114,7 +111,7 @@ func TestGetPetByIDSuccess2(t *testing.T) {
 }
 
 func TestGetPetByIDError1(t *testing.T) {
-	client := getClient(t)
+	client := getClient()
 	result, err := client.GetPetByID(context.Background(), "coyoteUgly")
 	anfe, ok := err.(*errorsgroup.AnimalNotFound)
 	if !ok {
@@ -136,7 +133,7 @@ func TestGetPetByIDError1(t *testing.T) {
 }
 
 func TestGetPetByIDError2(t *testing.T) {
-	client := getClient(t)
+	client := getClient()
 	result, err := client.GetPetByID(context.Background(), "weirdAlYankovic")
 	lnfe, ok := err.(*errorsgroup.LinkNotFound)
 	if !ok {
@@ -158,7 +155,7 @@ func TestGetPetByIDError2(t *testing.T) {
 }
 
 func TestGetPetByIDError3(t *testing.T) {
-	client := getClient(t)
+	client := getClient()
 	result, err := client.GetPetByID(context.Background(), "ringo")
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -173,7 +170,7 @@ func TestGetPetByIDError3(t *testing.T) {
 }
 
 func TestGetPetByIDError4(t *testing.T) {
-	client := getClient(t)
+	client := getClient()
 	result, err := client.GetPetByID(context.Background(), "alien123")
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -188,7 +185,7 @@ func TestGetPetByIDError4(t *testing.T) {
 }
 
 func TestGetPetByIDError5(t *testing.T) {
-	client := getClient(t)
+	client := getClient()
 	result, err := client.GetPetByID(context.Background(), "unknown")
 	// default generic error (no schema)
 	helpers.DeepEqualOrFatal(t, err.Error(), "That's all folks!!")

--- a/test/autorest/extenumsgroup/extenumsgroup_test.go
+++ b/test/autorest/extenumsgroup/extenumsgroup_test.go
@@ -12,16 +12,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getPetOperations(t *testing.T) extenumsgroup.PetOperations {
-	client, err := extenumsgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create enum client: %v", err)
-	}
-	return client.PetOperations()
-}
-
 func TestAddPet(t *testing.T) {
-	client := getPetOperations(t)
+	client := extenumsgroup.NewDefaultClient(nil).PetOperations()
 	result, err := client.AddPet(context.Background(), &extenumsgroup.PetAddPetOptions{
 		PetParam: &extenumsgroup.Pet{
 			Name: to.StringPtr("Retriever"),
@@ -36,7 +28,7 @@ func TestAddPet(t *testing.T) {
 }
 
 func TestGetByPetIDExpected(t *testing.T) {
-	client := getPetOperations(t)
+	client := extenumsgroup.NewDefaultClient(nil).PetOperations()
 	result, err := client.GetByPetID(context.Background(), "tommy")
 	if err != nil {
 		t.Fatal(err)
@@ -49,7 +41,7 @@ func TestGetByPetIDExpected(t *testing.T) {
 }
 
 func TestGetByPetIDUnexpected(t *testing.T) {
-	client := getPetOperations(t)
+	client := extenumsgroup.NewDefaultClient(nil).PetOperations()
 	result, err := client.GetByPetID(context.Background(), "casper")
 	if err != nil {
 		t.Fatal(err)
@@ -62,7 +54,7 @@ func TestGetByPetIDUnexpected(t *testing.T) {
 }
 
 func TestGetByPetIDAllowed(t *testing.T) {
-	client := getPetOperations(t)
+	client := extenumsgroup.NewDefaultClient(nil).PetOperations()
 	result, err := client.GetByPetID(context.Background(), "scooby")
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/filegroup/filegroup_test.go
+++ b/test/autorest/filegroup/filegroup_test.go
@@ -12,16 +12,8 @@ import (
 	"testing"
 )
 
-func getFileGroupClient(t *testing.T) filegroup.FilesOperations {
-	client, err := filegroup.NewClient("http://localhost:3000", nil)
-	if err != nil {
-		t.Fatalf("failed to create more custom base URL client: %v", err)
-	}
-	return client.FilesOperations()
-}
-
 func TestGetEmptyFile(t *testing.T) {
-	client := getFileGroupClient(t)
+	client := filegroup.NewDefaultClient(nil).FilesOperations()
 	result, err := client.GetEmptyFile(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -37,7 +29,7 @@ func TestGetEmptyFile(t *testing.T) {
 }
 
 func TestGetFile(t *testing.T) {
-	client := getFileGroupClient(t)
+	client := filegroup.NewDefaultClient(nil).FilesOperations()
 	result, err := client.GetFile(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -58,7 +50,7 @@ func TestGetFile(t *testing.T) {
 
 func TestGetFileLarge(t *testing.T) {
 	t.Skip("test is unreliable, can fail when running on a machine with low memory")
-	client := getFileGroupClient(t)
+	client := filegroup.NewDefaultClient(nil).FilesOperations()
 	result, err := client.GetFileLarge(context.Background())
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/generated/additionalpropsgroup/client.go
+++ b/test/autorest/generated/additionalpropsgroup/client.go
@@ -8,7 +8,6 @@ package additionalpropsgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-additionalpropsgroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // PetsOperations returns the PetsOperations associated with this client.

--- a/test/autorest/generated/additionalpropsgroup/pets.go
+++ b/test/autorest/generated/additionalpropsgroup/pets.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // PetsOperations contains the methods for the Pets group.
@@ -52,8 +52,12 @@ func (client *petsOperations) CreateApInProperties(ctx context.Context, createPa
 
 // createApInPropertiesCreateRequest creates the CreateApInProperties request.
 func (client *petsOperations) createApInPropertiesCreateRequest(createParameters PetApInProperties) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/additionalProperties/in/properties"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +102,12 @@ func (client *petsOperations) CreateApInPropertiesWithApstring(ctx context.Conte
 
 // createApInPropertiesWithApstringCreateRequest creates the CreateApInPropertiesWithApstring request.
 func (client *petsOperations) createApInPropertiesWithApstringCreateRequest(createParameters PetApInPropertiesWithApstring) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/additionalProperties/in/properties/with/additionalProperties/string"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -144,8 +152,12 @@ func (client *petsOperations) CreateApObject(ctx context.Context, createParamete
 
 // createApObjectCreateRequest creates the CreateApObject request.
 func (client *petsOperations) createApObjectCreateRequest(createParameters PetApObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/additionalProperties/type/object"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -190,8 +202,12 @@ func (client *petsOperations) CreateApString(ctx context.Context, createParamete
 
 // createApStringCreateRequest creates the CreateApString request.
 func (client *petsOperations) createApStringCreateRequest(createParameters PetApString) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/additionalProperties/type/string"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -236,8 +252,12 @@ func (client *petsOperations) CreateApTrue(ctx context.Context, createParameters
 
 // createApTrueCreateRequest creates the CreateApTrue request.
 func (client *petsOperations) createApTrueCreateRequest(createParameters PetApTrue) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/additionalProperties/true"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -282,8 +302,12 @@ func (client *petsOperations) CreateCatApTrue(ctx context.Context, createParamet
 
 // createCatApTrueCreateRequest creates the CreateCatApTrue request.
 func (client *petsOperations) createCatApTrueCreateRequest(createParameters CatApTrue) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/additionalProperties/true-subclass"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/additionalpropsgroup/pets.go
+++ b/test/autorest/generated/additionalpropsgroup/pets.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // PetsOperations contains the methods for the Pets group.
@@ -57,7 +58,7 @@ func (client *petsOperations) createApInPropertiesCreateRequest(createParameters
 		return nil, err
 	}
 	urlPath := "/additionalProperties/in/properties"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,7 @@ func (client *petsOperations) createApInPropertiesWithApstringCreateRequest(crea
 		return nil, err
 	}
 	urlPath := "/additionalProperties/in/properties/with/additionalProperties/string"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +158,7 @@ func (client *petsOperations) createApObjectCreateRequest(createParameters PetAp
 		return nil, err
 	}
 	urlPath := "/additionalProperties/type/object"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +208,7 @@ func (client *petsOperations) createApStringCreateRequest(createParameters PetAp
 		return nil, err
 	}
 	urlPath := "/additionalProperties/type/string"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +258,7 @@ func (client *petsOperations) createApTrueCreateRequest(createParameters PetApTr
 		return nil, err
 	}
 	urlPath := "/additionalProperties/true"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +308,7 @@ func (client *petsOperations) createCatApTrueCreateRequest(createParameters CatA
 		return nil, err
 	}
 	urlPath := "/additionalProperties/true-subclass"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/arraygroup/array.go
+++ b/test/autorest/generated/arraygroup/array.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 )
 
@@ -184,7 +185,7 @@ func (client *arrayOperations) getArrayEmptyCreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/array/array/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +235,7 @@ func (client *arrayOperations) getArrayItemEmptyCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/array/array/itemempty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +285,7 @@ func (client *arrayOperations) getArrayItemNullCreateRequest() (*azcore.Request,
 		return nil, err
 	}
 	urlPath := "/array/array/itemnull"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +335,7 @@ func (client *arrayOperations) getArrayNullCreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/array/array/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -384,7 +385,7 @@ func (client *arrayOperations) getArrayValidCreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/array/array/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -434,7 +435,7 @@ func (client *arrayOperations) getBase64UrlCreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/array/prim/base64url/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -484,7 +485,7 @@ func (client *arrayOperations) getBooleanInvalidNullCreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/array/prim/boolean/true.null.false"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -534,7 +535,7 @@ func (client *arrayOperations) getBooleanInvalidStringCreateRequest() (*azcore.R
 		return nil, err
 	}
 	urlPath := "/array/prim/boolean/true.boolean.false"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -584,7 +585,7 @@ func (client *arrayOperations) getBooleanTfftCreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/array/prim/boolean/tfft"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -634,7 +635,7 @@ func (client *arrayOperations) getByteInvalidNullCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/array/prim/byte/invalidnull"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -684,7 +685,7 @@ func (client *arrayOperations) getByteValidCreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/array/prim/byte/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -734,7 +735,7 @@ func (client *arrayOperations) getComplexEmptyCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/array/complex/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -784,7 +785,7 @@ func (client *arrayOperations) getComplexItemEmptyCreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/array/complex/itemempty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -834,7 +835,7 @@ func (client *arrayOperations) getComplexItemNullCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/array/complex/itemnull"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -884,7 +885,7 @@ func (client *arrayOperations) getComplexNullCreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/array/complex/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -934,7 +935,7 @@ func (client *arrayOperations) getComplexValidCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/array/complex/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -984,7 +985,7 @@ func (client *arrayOperations) getDateInvalidCharsCreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/array/prim/date/invalidchars"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1034,7 +1035,7 @@ func (client *arrayOperations) getDateInvalidNullCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/array/prim/date/invalidnull"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1084,7 +1085,7 @@ func (client *arrayOperations) getDateTimeInvalidCharsCreateRequest() (*azcore.R
 		return nil, err
 	}
 	urlPath := "/array/prim/date-time/invalidchars"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1141,7 +1142,7 @@ func (client *arrayOperations) getDateTimeInvalidNullCreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/array/prim/date-time/invalidnull"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1198,7 +1199,7 @@ func (client *arrayOperations) getDateTimeRfc1123ValidCreateRequest() (*azcore.R
 		return nil, err
 	}
 	urlPath := "/array/prim/date-time-rfc1123/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1255,7 +1256,7 @@ func (client *arrayOperations) getDateTimeValidCreateRequest() (*azcore.Request,
 		return nil, err
 	}
 	urlPath := "/array/prim/date-time/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1312,7 +1313,7 @@ func (client *arrayOperations) getDateValidCreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/array/prim/date/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1362,7 +1363,7 @@ func (client *arrayOperations) getDictionaryEmptyCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/array/dictionary/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1412,7 +1413,7 @@ func (client *arrayOperations) getDictionaryItemEmptyCreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/array/dictionary/itemempty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1462,7 +1463,7 @@ func (client *arrayOperations) getDictionaryItemNullCreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/array/dictionary/itemnull"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1512,7 +1513,7 @@ func (client *arrayOperations) getDictionaryNullCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/array/dictionary/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1562,7 +1563,7 @@ func (client *arrayOperations) getDictionaryValidCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/array/dictionary/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1612,7 +1613,7 @@ func (client *arrayOperations) getDoubleInvalidNullCreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/array/prim/double/0.0-null-1.2e20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1662,7 +1663,7 @@ func (client *arrayOperations) getDoubleInvalidStringCreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/array/prim/double/1.number.0"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1712,7 +1713,7 @@ func (client *arrayOperations) getDoubleValidCreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/array/prim/double/0--0.01-1.2e20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1762,7 +1763,7 @@ func (client *arrayOperations) getDurationValidCreateRequest() (*azcore.Request,
 		return nil, err
 	}
 	urlPath := "/array/prim/duration/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1812,7 +1813,7 @@ func (client *arrayOperations) getEmptyCreateRequest() (*azcore.Request, error) 
 		return nil, err
 	}
 	urlPath := "/array/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1862,7 +1863,7 @@ func (client *arrayOperations) getEnumValidCreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/array/prim/enum/foo1.foo2.foo3"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1912,7 +1913,7 @@ func (client *arrayOperations) getFloatInvalidNullCreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/array/prim/float/0.0-null-1.2e20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1962,7 +1963,7 @@ func (client *arrayOperations) getFloatInvalidStringCreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/array/prim/float/1.number.0"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2012,7 +2013,7 @@ func (client *arrayOperations) getFloatValidCreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/array/prim/float/0--0.01-1.2e20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2062,7 +2063,7 @@ func (client *arrayOperations) getIntInvalidNullCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/array/prim/integer/1.null.zero"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2112,7 +2113,7 @@ func (client *arrayOperations) getIntInvalidStringCreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/array/prim/integer/1.integer.0"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2162,7 +2163,7 @@ func (client *arrayOperations) getIntegerValidCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/array/prim/integer/1.-1.3.300"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2212,7 +2213,7 @@ func (client *arrayOperations) getInvalidCreateRequest() (*azcore.Request, error
 		return nil, err
 	}
 	urlPath := "/array/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2262,7 +2263,7 @@ func (client *arrayOperations) getLongInvalidNullCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/array/prim/long/1.null.zero"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2312,7 +2313,7 @@ func (client *arrayOperations) getLongInvalidStringCreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/array/prim/long/1.integer.0"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2362,7 +2363,7 @@ func (client *arrayOperations) getLongValidCreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/array/prim/long/1.-1.3.300"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2412,7 +2413,7 @@ func (client *arrayOperations) getNullCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/array/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2462,7 +2463,7 @@ func (client *arrayOperations) getStringEnumValidCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/array/prim/string-enum/foo1.foo2.foo3"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2512,7 +2513,7 @@ func (client *arrayOperations) getStringValidCreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/array/prim/string/foo1.foo2.foo3"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2562,7 +2563,7 @@ func (client *arrayOperations) getStringWithInvalidCreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/array/prim/string/foo.123.foo2"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2612,7 +2613,7 @@ func (client *arrayOperations) getStringWithNullCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/array/prim/string/foo.null.foo2"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2662,7 +2663,7 @@ func (client *arrayOperations) getUuidInvalidCharsCreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/array/prim/uuid/invalidchars"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2712,7 +2713,7 @@ func (client *arrayOperations) getUuidValidCreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/array/prim/uuid/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2762,7 +2763,7 @@ func (client *arrayOperations) putArrayValidCreateRequest(arrayBody [][]string) 
 		return nil, err
 	}
 	urlPath := "/array/array/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2811,7 +2812,7 @@ func (client *arrayOperations) putBooleanTfftCreateRequest(arrayBody []bool) (*a
 		return nil, err
 	}
 	urlPath := "/array/prim/boolean/tfft"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2860,7 +2861,7 @@ func (client *arrayOperations) putByteValidCreateRequest(arrayBody [][]byte) (*a
 		return nil, err
 	}
 	urlPath := "/array/prim/byte/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2909,7 +2910,7 @@ func (client *arrayOperations) putComplexValidCreateRequest(arrayBody []Product)
 		return nil, err
 	}
 	urlPath := "/array/complex/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2958,7 +2959,7 @@ func (client *arrayOperations) putDateTimeRfc1123ValidCreateRequest(arrayBody []
 		return nil, err
 	}
 	urlPath := "/array/prim/date-time-rfc1123/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3011,7 +3012,7 @@ func (client *arrayOperations) putDateTimeValidCreateRequest(arrayBody []time.Ti
 		return nil, err
 	}
 	urlPath := "/array/prim/date-time/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3060,7 +3061,7 @@ func (client *arrayOperations) putDateValidCreateRequest(arrayBody []time.Time) 
 		return nil, err
 	}
 	urlPath := "/array/prim/date/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3109,7 +3110,7 @@ func (client *arrayOperations) putDictionaryValidCreateRequest(arrayBody []map[s
 		return nil, err
 	}
 	urlPath := "/array/dictionary/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3158,7 +3159,7 @@ func (client *arrayOperations) putDoubleValidCreateRequest(arrayBody []float64) 
 		return nil, err
 	}
 	urlPath := "/array/prim/double/0--0.01-1.2e20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3207,7 +3208,7 @@ func (client *arrayOperations) putDurationValidCreateRequest(arrayBody []string)
 		return nil, err
 	}
 	urlPath := "/array/prim/duration/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3256,7 +3257,7 @@ func (client *arrayOperations) putEmptyCreateRequest(arrayBody []string) (*azcor
 		return nil, err
 	}
 	urlPath := "/array/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3305,7 +3306,7 @@ func (client *arrayOperations) putEnumValidCreateRequest(arrayBody []FooEnum) (*
 		return nil, err
 	}
 	urlPath := "/array/prim/enum/foo1.foo2.foo3"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3354,7 +3355,7 @@ func (client *arrayOperations) putFloatValidCreateRequest(arrayBody []float32) (
 		return nil, err
 	}
 	urlPath := "/array/prim/float/0--0.01-1.2e20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3403,7 +3404,7 @@ func (client *arrayOperations) putIntegerValidCreateRequest(arrayBody []int32) (
 		return nil, err
 	}
 	urlPath := "/array/prim/integer/1.-1.3.300"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3452,7 +3453,7 @@ func (client *arrayOperations) putLongValidCreateRequest(arrayBody []int64) (*az
 		return nil, err
 	}
 	urlPath := "/array/prim/long/1.-1.3.300"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3501,7 +3502,7 @@ func (client *arrayOperations) putStringEnumValidCreateRequest(arrayBody []Enum1
 		return nil, err
 	}
 	urlPath := "/array/prim/string-enum/foo1.foo2.foo3"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3550,7 +3551,7 @@ func (client *arrayOperations) putStringValidCreateRequest(arrayBody []string) (
 		return nil, err
 	}
 	urlPath := "/array/prim/string/foo1.foo2.foo3"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3599,7 +3600,7 @@ func (client *arrayOperations) putUuidValidCreateRequest(arrayBody []string) (*a
 		return nil, err
 	}
 	urlPath := "/array/prim/uuid/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/arraygroup/array.go
+++ b/test/autorest/generated/arraygroup/array.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 	"time"
 )
 
@@ -179,8 +179,12 @@ func (client *arrayOperations) GetArrayEmpty(ctx context.Context) (*StringArrayA
 
 // getArrayEmptyCreateRequest creates the GetArrayEmpty request.
 func (client *arrayOperations) getArrayEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/array/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -225,8 +229,12 @@ func (client *arrayOperations) GetArrayItemEmpty(ctx context.Context) (*StringAr
 
 // getArrayItemEmptyCreateRequest creates the GetArrayItemEmpty request.
 func (client *arrayOperations) getArrayItemEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/array/itemempty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -271,8 +279,12 @@ func (client *arrayOperations) GetArrayItemNull(ctx context.Context) (*StringArr
 
 // getArrayItemNullCreateRequest creates the GetArrayItemNull request.
 func (client *arrayOperations) getArrayItemNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/array/itemnull"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -317,8 +329,12 @@ func (client *arrayOperations) GetArrayNull(ctx context.Context) (*StringArrayAr
 
 // getArrayNullCreateRequest creates the GetArrayNull request.
 func (client *arrayOperations) getArrayNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/array/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -363,8 +379,12 @@ func (client *arrayOperations) GetArrayValid(ctx context.Context) (*StringArrayA
 
 // getArrayValidCreateRequest creates the GetArrayValid request.
 func (client *arrayOperations) getArrayValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/array/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -409,8 +429,12 @@ func (client *arrayOperations) GetBase64URL(ctx context.Context) (*ByteArrayArra
 
 // getBase64UrlCreateRequest creates the GetBase64URL request.
 func (client *arrayOperations) getBase64UrlCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/base64url/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -455,8 +479,12 @@ func (client *arrayOperations) GetBooleanInvalidNull(ctx context.Context) (*Bool
 
 // getBooleanInvalidNullCreateRequest creates the GetBooleanInvalidNull request.
 func (client *arrayOperations) getBooleanInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/boolean/true.null.false"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -501,8 +529,12 @@ func (client *arrayOperations) GetBooleanInvalidString(ctx context.Context) (*Bo
 
 // getBooleanInvalidStringCreateRequest creates the GetBooleanInvalidString request.
 func (client *arrayOperations) getBooleanInvalidStringCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/boolean/true.boolean.false"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -547,8 +579,12 @@ func (client *arrayOperations) GetBooleanTfft(ctx context.Context) (*BoolArrayRe
 
 // getBooleanTfftCreateRequest creates the GetBooleanTfft request.
 func (client *arrayOperations) getBooleanTfftCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/boolean/tfft"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -593,8 +629,12 @@ func (client *arrayOperations) GetByteInvalidNull(ctx context.Context) (*ByteArr
 
 // getByteInvalidNullCreateRequest creates the GetByteInvalidNull request.
 func (client *arrayOperations) getByteInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/byte/invalidnull"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -639,8 +679,12 @@ func (client *arrayOperations) GetByteValid(ctx context.Context) (*ByteArrayArra
 
 // getByteValidCreateRequest creates the GetByteValid request.
 func (client *arrayOperations) getByteValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/byte/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -685,8 +729,12 @@ func (client *arrayOperations) GetComplexEmpty(ctx context.Context) (*ProductArr
 
 // getComplexEmptyCreateRequest creates the GetComplexEmpty request.
 func (client *arrayOperations) getComplexEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/complex/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -731,8 +779,12 @@ func (client *arrayOperations) GetComplexItemEmpty(ctx context.Context) (*Produc
 
 // getComplexItemEmptyCreateRequest creates the GetComplexItemEmpty request.
 func (client *arrayOperations) getComplexItemEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/complex/itemempty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -777,8 +829,12 @@ func (client *arrayOperations) GetComplexItemNull(ctx context.Context) (*Product
 
 // getComplexItemNullCreateRequest creates the GetComplexItemNull request.
 func (client *arrayOperations) getComplexItemNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/complex/itemnull"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -823,8 +879,12 @@ func (client *arrayOperations) GetComplexNull(ctx context.Context) (*ProductArra
 
 // getComplexNullCreateRequest creates the GetComplexNull request.
 func (client *arrayOperations) getComplexNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/complex/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -869,8 +929,12 @@ func (client *arrayOperations) GetComplexValid(ctx context.Context) (*ProductArr
 
 // getComplexValidCreateRequest creates the GetComplexValid request.
 func (client *arrayOperations) getComplexValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/complex/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -915,8 +979,12 @@ func (client *arrayOperations) GetDateInvalidChars(ctx context.Context) (*TimeAr
 
 // getDateInvalidCharsCreateRequest creates the GetDateInvalidChars request.
 func (client *arrayOperations) getDateInvalidCharsCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/date/invalidchars"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -961,8 +1029,12 @@ func (client *arrayOperations) GetDateInvalidNull(ctx context.Context) (*TimeArr
 
 // getDateInvalidNullCreateRequest creates the GetDateInvalidNull request.
 func (client *arrayOperations) getDateInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/date/invalidnull"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1007,8 +1079,12 @@ func (client *arrayOperations) GetDateTimeInvalidChars(ctx context.Context) (*Ti
 
 // getDateTimeInvalidCharsCreateRequest creates the GetDateTimeInvalidChars request.
 func (client *arrayOperations) getDateTimeInvalidCharsCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/date-time/invalidchars"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1060,8 +1136,12 @@ func (client *arrayOperations) GetDateTimeInvalidNull(ctx context.Context) (*Tim
 
 // getDateTimeInvalidNullCreateRequest creates the GetDateTimeInvalidNull request.
 func (client *arrayOperations) getDateTimeInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/date-time/invalidnull"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1113,8 +1193,12 @@ func (client *arrayOperations) GetDateTimeRFC1123Valid(ctx context.Context) (*Ti
 
 // getDateTimeRfc1123ValidCreateRequest creates the GetDateTimeRFC1123Valid request.
 func (client *arrayOperations) getDateTimeRfc1123ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/date-time-rfc1123/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1166,8 +1250,12 @@ func (client *arrayOperations) GetDateTimeValid(ctx context.Context) (*TimeArray
 
 // getDateTimeValidCreateRequest creates the GetDateTimeValid request.
 func (client *arrayOperations) getDateTimeValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/date-time/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1219,8 +1307,12 @@ func (client *arrayOperations) GetDateValid(ctx context.Context) (*TimeArrayResp
 
 // getDateValidCreateRequest creates the GetDateValid request.
 func (client *arrayOperations) getDateValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/date/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1265,8 +1357,12 @@ func (client *arrayOperations) GetDictionaryEmpty(ctx context.Context) (*MapOfSt
 
 // getDictionaryEmptyCreateRequest creates the GetDictionaryEmpty request.
 func (client *arrayOperations) getDictionaryEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/dictionary/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1311,8 +1407,12 @@ func (client *arrayOperations) GetDictionaryItemEmpty(ctx context.Context) (*Map
 
 // getDictionaryItemEmptyCreateRequest creates the GetDictionaryItemEmpty request.
 func (client *arrayOperations) getDictionaryItemEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/dictionary/itemempty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1357,8 +1457,12 @@ func (client *arrayOperations) GetDictionaryItemNull(ctx context.Context) (*MapO
 
 // getDictionaryItemNullCreateRequest creates the GetDictionaryItemNull request.
 func (client *arrayOperations) getDictionaryItemNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/dictionary/itemnull"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1403,8 +1507,12 @@ func (client *arrayOperations) GetDictionaryNull(ctx context.Context) (*MapOfStr
 
 // getDictionaryNullCreateRequest creates the GetDictionaryNull request.
 func (client *arrayOperations) getDictionaryNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/dictionary/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1449,8 +1557,12 @@ func (client *arrayOperations) GetDictionaryValid(ctx context.Context) (*MapOfSt
 
 // getDictionaryValidCreateRequest creates the GetDictionaryValid request.
 func (client *arrayOperations) getDictionaryValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/dictionary/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1495,8 +1607,12 @@ func (client *arrayOperations) GetDoubleInvalidNull(ctx context.Context) (*Float
 
 // getDoubleInvalidNullCreateRequest creates the GetDoubleInvalidNull request.
 func (client *arrayOperations) getDoubleInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/double/0.0-null-1.2e20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1541,8 +1657,12 @@ func (client *arrayOperations) GetDoubleInvalidString(ctx context.Context) (*Flo
 
 // getDoubleInvalidStringCreateRequest creates the GetDoubleInvalidString request.
 func (client *arrayOperations) getDoubleInvalidStringCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/double/1.number.0"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1587,8 +1707,12 @@ func (client *arrayOperations) GetDoubleValid(ctx context.Context) (*Float64Arra
 
 // getDoubleValidCreateRequest creates the GetDoubleValid request.
 func (client *arrayOperations) getDoubleValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/double/0--0.01-1.2e20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1633,8 +1757,12 @@ func (client *arrayOperations) GetDurationValid(ctx context.Context) (*StringArr
 
 // getDurationValidCreateRequest creates the GetDurationValid request.
 func (client *arrayOperations) getDurationValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/duration/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1679,8 +1807,12 @@ func (client *arrayOperations) GetEmpty(ctx context.Context) (*Int32ArrayRespons
 
 // getEmptyCreateRequest creates the GetEmpty request.
 func (client *arrayOperations) getEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1725,8 +1857,12 @@ func (client *arrayOperations) GetEnumValid(ctx context.Context) (*FooEnumArrayR
 
 // getEnumValidCreateRequest creates the GetEnumValid request.
 func (client *arrayOperations) getEnumValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/enum/foo1.foo2.foo3"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1771,8 +1907,12 @@ func (client *arrayOperations) GetFloatInvalidNull(ctx context.Context) (*Float3
 
 // getFloatInvalidNullCreateRequest creates the GetFloatInvalidNull request.
 func (client *arrayOperations) getFloatInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/float/0.0-null-1.2e20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1817,8 +1957,12 @@ func (client *arrayOperations) GetFloatInvalidString(ctx context.Context) (*Floa
 
 // getFloatInvalidStringCreateRequest creates the GetFloatInvalidString request.
 func (client *arrayOperations) getFloatInvalidStringCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/float/1.number.0"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1863,8 +2007,12 @@ func (client *arrayOperations) GetFloatValid(ctx context.Context) (*Float32Array
 
 // getFloatValidCreateRequest creates the GetFloatValid request.
 func (client *arrayOperations) getFloatValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/float/0--0.01-1.2e20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1909,8 +2057,12 @@ func (client *arrayOperations) GetIntInvalidNull(ctx context.Context) (*Int32Arr
 
 // getIntInvalidNullCreateRequest creates the GetIntInvalidNull request.
 func (client *arrayOperations) getIntInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/integer/1.null.zero"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1955,8 +2107,12 @@ func (client *arrayOperations) GetIntInvalidString(ctx context.Context) (*Int32A
 
 // getIntInvalidStringCreateRequest creates the GetIntInvalidString request.
 func (client *arrayOperations) getIntInvalidStringCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/integer/1.integer.0"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2001,8 +2157,12 @@ func (client *arrayOperations) GetIntegerValid(ctx context.Context) (*Int32Array
 
 // getIntegerValidCreateRequest creates the GetIntegerValid request.
 func (client *arrayOperations) getIntegerValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/integer/1.-1.3.300"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2047,8 +2207,12 @@ func (client *arrayOperations) GetInvalid(ctx context.Context) (*Int32ArrayRespo
 
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *arrayOperations) getInvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2093,8 +2257,12 @@ func (client *arrayOperations) GetLongInvalidNull(ctx context.Context) (*Int64Ar
 
 // getLongInvalidNullCreateRequest creates the GetLongInvalidNull request.
 func (client *arrayOperations) getLongInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/long/1.null.zero"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2139,8 +2307,12 @@ func (client *arrayOperations) GetLongInvalidString(ctx context.Context) (*Int64
 
 // getLongInvalidStringCreateRequest creates the GetLongInvalidString request.
 func (client *arrayOperations) getLongInvalidStringCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/long/1.integer.0"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2185,8 +2357,12 @@ func (client *arrayOperations) GetLongValid(ctx context.Context) (*Int64ArrayRes
 
 // getLongValidCreateRequest creates the GetLongValid request.
 func (client *arrayOperations) getLongValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/long/1.-1.3.300"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2231,8 +2407,12 @@ func (client *arrayOperations) GetNull(ctx context.Context) (*Int32ArrayResponse
 
 // getNullCreateRequest creates the GetNull request.
 func (client *arrayOperations) getNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2277,8 +2457,12 @@ func (client *arrayOperations) GetStringEnumValid(ctx context.Context) (*Enum0Ar
 
 // getStringEnumValidCreateRequest creates the GetStringEnumValid request.
 func (client *arrayOperations) getStringEnumValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/string-enum/foo1.foo2.foo3"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2323,8 +2507,12 @@ func (client *arrayOperations) GetStringValid(ctx context.Context) (*StringArray
 
 // getStringValidCreateRequest creates the GetStringValid request.
 func (client *arrayOperations) getStringValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/string/foo1.foo2.foo3"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2369,8 +2557,12 @@ func (client *arrayOperations) GetStringWithInvalid(ctx context.Context) (*Strin
 
 // getStringWithInvalidCreateRequest creates the GetStringWithInvalid request.
 func (client *arrayOperations) getStringWithInvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/string/foo.123.foo2"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2415,8 +2607,12 @@ func (client *arrayOperations) GetStringWithNull(ctx context.Context) (*StringAr
 
 // getStringWithNullCreateRequest creates the GetStringWithNull request.
 func (client *arrayOperations) getStringWithNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/string/foo.null.foo2"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2461,8 +2657,12 @@ func (client *arrayOperations) GetUUIDInvalidChars(ctx context.Context) (*String
 
 // getUuidInvalidCharsCreateRequest creates the GetUUIDInvalidChars request.
 func (client *arrayOperations) getUuidInvalidCharsCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/uuid/invalidchars"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2507,8 +2707,12 @@ func (client *arrayOperations) GetUUIDValid(ctx context.Context) (*StringArrayRe
 
 // getUuidValidCreateRequest creates the GetUUIDValid request.
 func (client *arrayOperations) getUuidValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/uuid/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2553,8 +2757,12 @@ func (client *arrayOperations) PutArrayValid(ctx context.Context, arrayBody [][]
 
 // putArrayValidCreateRequest creates the PutArrayValid request.
 func (client *arrayOperations) putArrayValidCreateRequest(arrayBody [][]string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/array/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2598,8 +2806,12 @@ func (client *arrayOperations) PutBooleanTfft(ctx context.Context, arrayBody []b
 
 // putBooleanTfftCreateRequest creates the PutBooleanTfft request.
 func (client *arrayOperations) putBooleanTfftCreateRequest(arrayBody []bool) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/boolean/tfft"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2643,8 +2855,12 @@ func (client *arrayOperations) PutByteValid(ctx context.Context, arrayBody [][]b
 
 // putByteValidCreateRequest creates the PutByteValid request.
 func (client *arrayOperations) putByteValidCreateRequest(arrayBody [][]byte) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/byte/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2688,8 +2904,12 @@ func (client *arrayOperations) PutComplexValid(ctx context.Context, arrayBody []
 
 // putComplexValidCreateRequest creates the PutComplexValid request.
 func (client *arrayOperations) putComplexValidCreateRequest(arrayBody []Product) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/complex/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2733,8 +2953,12 @@ func (client *arrayOperations) PutDateTimeRFC1123Valid(ctx context.Context, arra
 
 // putDateTimeRfc1123ValidCreateRequest creates the PutDateTimeRFC1123Valid request.
 func (client *arrayOperations) putDateTimeRfc1123ValidCreateRequest(arrayBody []time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/date-time-rfc1123/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2782,8 +3006,12 @@ func (client *arrayOperations) PutDateTimeValid(ctx context.Context, arrayBody [
 
 // putDateTimeValidCreateRequest creates the PutDateTimeValid request.
 func (client *arrayOperations) putDateTimeValidCreateRequest(arrayBody []time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/date-time/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2827,8 +3055,12 @@ func (client *arrayOperations) PutDateValid(ctx context.Context, arrayBody []tim
 
 // putDateValidCreateRequest creates the PutDateValid request.
 func (client *arrayOperations) putDateValidCreateRequest(arrayBody []time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/date/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2872,8 +3104,12 @@ func (client *arrayOperations) PutDictionaryValid(ctx context.Context, arrayBody
 
 // putDictionaryValidCreateRequest creates the PutDictionaryValid request.
 func (client *arrayOperations) putDictionaryValidCreateRequest(arrayBody []map[string]string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/dictionary/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2917,8 +3153,12 @@ func (client *arrayOperations) PutDoubleValid(ctx context.Context, arrayBody []f
 
 // putDoubleValidCreateRequest creates the PutDoubleValid request.
 func (client *arrayOperations) putDoubleValidCreateRequest(arrayBody []float64) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/double/0--0.01-1.2e20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2962,8 +3202,12 @@ func (client *arrayOperations) PutDurationValid(ctx context.Context, arrayBody [
 
 // putDurationValidCreateRequest creates the PutDurationValid request.
 func (client *arrayOperations) putDurationValidCreateRequest(arrayBody []string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/duration/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -3007,8 +3251,12 @@ func (client *arrayOperations) PutEmpty(ctx context.Context, arrayBody []string)
 
 // putEmptyCreateRequest creates the PutEmpty request.
 func (client *arrayOperations) putEmptyCreateRequest(arrayBody []string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -3052,8 +3300,12 @@ func (client *arrayOperations) PutEnumValid(ctx context.Context, arrayBody []Foo
 
 // putEnumValidCreateRequest creates the PutEnumValid request.
 func (client *arrayOperations) putEnumValidCreateRequest(arrayBody []FooEnum) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/enum/foo1.foo2.foo3"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -3097,8 +3349,12 @@ func (client *arrayOperations) PutFloatValid(ctx context.Context, arrayBody []fl
 
 // putFloatValidCreateRequest creates the PutFloatValid request.
 func (client *arrayOperations) putFloatValidCreateRequest(arrayBody []float32) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/float/0--0.01-1.2e20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -3142,8 +3398,12 @@ func (client *arrayOperations) PutIntegerValid(ctx context.Context, arrayBody []
 
 // putIntegerValidCreateRequest creates the PutIntegerValid request.
 func (client *arrayOperations) putIntegerValidCreateRequest(arrayBody []int32) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/integer/1.-1.3.300"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -3187,8 +3447,12 @@ func (client *arrayOperations) PutLongValid(ctx context.Context, arrayBody []int
 
 // putLongValidCreateRequest creates the PutLongValid request.
 func (client *arrayOperations) putLongValidCreateRequest(arrayBody []int64) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/long/1.-1.3.300"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -3232,8 +3496,12 @@ func (client *arrayOperations) PutStringEnumValid(ctx context.Context, arrayBody
 
 // putStringEnumValidCreateRequest creates the PutStringEnumValid request.
 func (client *arrayOperations) putStringEnumValidCreateRequest(arrayBody []Enum1) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/string-enum/foo1.foo2.foo3"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -3277,8 +3545,12 @@ func (client *arrayOperations) PutStringValid(ctx context.Context, arrayBody []s
 
 // putStringValidCreateRequest creates the PutStringValid request.
 func (client *arrayOperations) putStringValidCreateRequest(arrayBody []string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/string/foo1.foo2.foo3"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -3322,8 +3594,12 @@ func (client *arrayOperations) PutUUIDValid(ctx context.Context, arrayBody []str
 
 // putUuidValidCreateRequest creates the PutUUIDValid request.
 func (client *arrayOperations) putUuidValidCreateRequest(arrayBody []string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/array/prim/uuid/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/arraygroup/client.go
+++ b/test/autorest/generated/arraygroup/client.go
@@ -8,7 +8,6 @@ package arraygroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-arraygroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest Swagger BAT
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // ArrayOperations returns the ArrayOperations associated with this client.

--- a/test/autorest/generated/azurereportgroup/autorestreportserviceforazure.go
+++ b/test/autorest/generated/azurereportgroup/autorestreportserviceforazure.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // AutoRestReportServiceForAzureOperations contains the methods for the AutoRestReportServiceForAzure group.
@@ -47,7 +48,7 @@ func (client *autoRestReportServiceForAzureOperations) getReportCreateRequest(au
 		return nil, err
 	}
 	urlPath := "/report/azure"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurereportgroup/autorestreportserviceforazure.go
+++ b/test/autorest/generated/azurereportgroup/autorestreportserviceforazure.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // AutoRestReportServiceForAzureOperations contains the methods for the AutoRestReportServiceForAzure group.
@@ -42,8 +42,12 @@ func (client *autoRestReportServiceForAzureOperations) GetReport(ctx context.Con
 
 // getReportCreateRequest creates the GetReport request.
 func (client *autoRestReportServiceForAzureOperations) getReportCreateRequest(autoRestReportServiceForAzureGetReportOptions *AutoRestReportServiceForAzureGetReportOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/report/azure"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurereportgroup/client.go
+++ b/test/autorest/generated/azurereportgroup/client.go
@@ -8,7 +8,6 @@ package azurereportgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-azurereportgroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // AutoRestReportServiceForAzureOperations returns the AutoRestReportServiceForAzureOperations associated with this client.

--- a/test/autorest/generated/azurespecialsgroup/apiversiondefault.go
+++ b/test/autorest/generated/azurespecialsgroup/apiversiondefault.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // APIVersionDefaultOperations contains the methods for the APIVersionDefault group.
@@ -53,7 +54,7 @@ func (client *apiVersionDefaultOperations) getMethodGlobalNotProvidedValidCreate
 		return nil, err
 	}
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ func (client *apiVersionDefaultOperations) getMethodGlobalValidCreateRequest() (
 		return nil, err
 	}
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +158,7 @@ func (client *apiVersionDefaultOperations) getPathGlobalValidCreateRequest() (*a
 		return nil, err
 	}
 	urlPath := "/azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +210,7 @@ func (client *apiVersionDefaultOperations) getSwaggerGlobalValidCreateRequest() 
 		return nil, err
 	}
 	urlPath := "/azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/apiversiondefault.go
+++ b/test/autorest/generated/azurespecialsgroup/apiversiondefault.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // APIVersionDefaultOperations contains the methods for the APIVersionDefault group.
@@ -48,8 +48,12 @@ func (client *apiVersionDefaultOperations) GetMethodGlobalNotProvidedValid(ctx c
 
 // getMethodGlobalNotProvidedValidCreateRequest creates the GetMethodGlobalNotProvidedValid request.
 func (client *apiVersionDefaultOperations) getMethodGlobalNotProvidedValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +100,12 @@ func (client *apiVersionDefaultOperations) GetMethodGlobalValid(ctx context.Cont
 
 // getMethodGlobalValidCreateRequest creates the GetMethodGlobalValid request.
 func (client *apiVersionDefaultOperations) getMethodGlobalValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -144,8 +152,12 @@ func (client *apiVersionDefaultOperations) GetPathGlobalValid(ctx context.Contex
 
 // getPathGlobalValidCreateRequest creates the GetPathGlobalValid request.
 func (client *apiVersionDefaultOperations) getPathGlobalValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -192,8 +204,12 @@ func (client *apiVersionDefaultOperations) GetSwaggerGlobalValid(ctx context.Con
 
 // getSwaggerGlobalValidCreateRequest creates the GetSwaggerGlobalValid request.
 func (client *apiVersionDefaultOperations) getSwaggerGlobalValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/apiversionlocal.go
+++ b/test/autorest/generated/azurespecialsgroup/apiversionlocal.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // APIVersionLocalOperations contains the methods for the APIVersionLocal group.
@@ -53,7 +54,7 @@ func (client *apiVersionLocalOperations) getMethodLocalNullCreateRequest(apiVers
 		return nil, err
 	}
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/local/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,7 @@ func (client *apiVersionLocalOperations) getMethodLocalValidCreateRequest() (*az
 		return nil, err
 	}
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/local/2.0"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +160,7 @@ func (client *apiVersionLocalOperations) getPathLocalValidCreateRequest() (*azco
 		return nil, err
 	}
 	urlPath := "/azurespecials/apiVersion/path/string/none/query/local/2.0"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +212,7 @@ func (client *apiVersionLocalOperations) getSwaggerLocalValidCreateRequest() (*a
 		return nil, err
 	}
 	urlPath := "/azurespecials/apiVersion/swagger/string/none/query/local/2.0"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/apiversionlocal.go
+++ b/test/autorest/generated/azurespecialsgroup/apiversionlocal.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // APIVersionLocalOperations contains the methods for the APIVersionLocal group.
@@ -48,8 +48,12 @@ func (client *apiVersionLocalOperations) GetMethodLocalNull(ctx context.Context,
 
 // getMethodLocalNullCreateRequest creates the GetMethodLocalNull request.
 func (client *apiVersionLocalOperations) getMethodLocalNullCreateRequest(apiVersionLocalGetMethodLocalNullOptions *APIVersionLocalGetMethodLocalNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/local/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +102,12 @@ func (client *apiVersionLocalOperations) GetMethodLocalValid(ctx context.Context
 
 // getMethodLocalValidCreateRequest creates the GetMethodLocalValid request.
 func (client *apiVersionLocalOperations) getMethodLocalValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/local/2.0"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -146,8 +154,12 @@ func (client *apiVersionLocalOperations) GetPathLocalValid(ctx context.Context) 
 
 // getPathLocalValidCreateRequest creates the GetPathLocalValid request.
 func (client *apiVersionLocalOperations) getPathLocalValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/apiVersion/path/string/none/query/local/2.0"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -194,8 +206,12 @@ func (client *apiVersionLocalOperations) GetSwaggerLocalValid(ctx context.Contex
 
 // getSwaggerLocalValidCreateRequest creates the GetSwaggerLocalValid request.
 func (client *apiVersionLocalOperations) getSwaggerLocalValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/apiVersion/swagger/string/none/query/local/2.0"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/client.go
+++ b/test/autorest/generated/azurespecialsgroup/client.go
@@ -8,7 +8,6 @@ package azurespecialsgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-azurespecialsgroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // XMSClientRequestIDOperations returns the XMSClientRequestIDOperations associated with this client.

--- a/test/autorest/generated/azurespecialsgroup/header.go
+++ b/test/autorest/generated/azurespecialsgroup/header.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // HeaderOperations contains the methods for the Header group.
@@ -51,7 +52,7 @@ func (client *headerOperations) customNamedRequestIdCreateRequest(fooClientReque
 		return nil, err
 	}
 	urlPath := "/azurespecials/customNamedRequestId"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ func (client *headerOperations) customNamedRequestIdHeadCreateRequest(fooClientR
 		return nil, err
 	}
 	urlPath := "/azurespecials/customNamedRequestIdHead"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +160,7 @@ func (client *headerOperations) customNamedRequestIdParamGroupingCreateRequest(h
 		return nil, err
 	}
 	urlPath := "/azurespecials/customNamedRequestIdParamGrouping"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/header.go
+++ b/test/autorest/generated/azurespecialsgroup/header.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // HeaderOperations contains the methods for the Header group.
@@ -46,8 +46,12 @@ func (client *headerOperations) CustomNamedRequestID(ctx context.Context, fooCli
 
 // customNamedRequestIdCreateRequest creates the CustomNamedRequestID request.
 func (client *headerOperations) customNamedRequestIdCreateRequest(fooClientRequestId string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/customNamedRequestId"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +100,12 @@ func (client *headerOperations) CustomNamedRequestIDHead(ctx context.Context, fo
 
 // customNamedRequestIdHeadCreateRequest creates the CustomNamedRequestIDHead request.
 func (client *headerOperations) customNamedRequestIdHeadCreateRequest(fooClientRequestId string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/customNamedRequestIdHead"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -146,8 +154,12 @@ func (client *headerOperations) CustomNamedRequestIDParamGrouping(ctx context.Co
 
 // customNamedRequestIdParamGroupingCreateRequest creates the CustomNamedRequestIDParamGrouping request.
 func (client *headerOperations) customNamedRequestIdParamGroupingCreateRequest(headerCustomNamedRequestIdParamGroupingParameters HeaderCustomNamedRequestIDParamGroupingParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/customNamedRequestIdParamGrouping"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/odata.go
+++ b/test/autorest/generated/azurespecialsgroup/odata.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 	"strconv"
 )
 
@@ -43,8 +43,12 @@ func (client *odataOperations) GetWithFilter(ctx context.Context, odataGetWithFi
 
 // getWithFilterCreateRequest creates the GetWithFilter request.
 func (client *odataOperations) getWithFilterCreateRequest(odataGetWithFilterOptions *OdataGetWithFilterOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/odata/filter"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/odata.go
+++ b/test/autorest/generated/azurespecialsgroup/odata.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 )
 
@@ -48,7 +49,7 @@ func (client *odataOperations) getWithFilterCreateRequest(odataGetWithFilterOpti
 		return nil, err
 	}
 	urlPath := "/azurespecials/odata/filter"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/skipurlencoding.go
+++ b/test/autorest/generated/azurespecialsgroup/skipurlencoding.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -61,7 +62,7 @@ func (client *skipUrlEncodingOperations) getMethodPathValidCreateRequest(unencod
 	}
 	urlPath := "/azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}"
 	urlPath = strings.ReplaceAll(urlPath, "{unencodedPathParam}", unencodedPathParam)
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (client *skipUrlEncodingOperations) getMethodQueryNullCreateRequest(skipUrl
 		return nil, err
 	}
 	urlPath := "/azurespecials/skipUrlEncoding/method/query/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +165,7 @@ func (client *skipUrlEncodingOperations) getMethodQueryValidCreateRequest(q1 str
 		return nil, err
 	}
 	urlPath := "/azurespecials/skipUrlEncoding/method/query/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +217,7 @@ func (client *skipUrlEncodingOperations) getPathQueryValidCreateRequest(q1 strin
 		return nil, err
 	}
 	urlPath := "/azurespecials/skipUrlEncoding/path/query/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +270,7 @@ func (client *skipUrlEncodingOperations) getPathValidCreateRequest(unencodedPath
 	}
 	urlPath := "/azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}"
 	urlPath = strings.ReplaceAll(urlPath, "{unencodedPathParam}", unencodedPathParam)
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -319,7 +320,7 @@ func (client *skipUrlEncodingOperations) getSwaggerPathValidCreateRequest() (*az
 	}
 	urlPath := "/azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}"
 	urlPath = strings.ReplaceAll(urlPath, "{unencodedPathParam}", "path1/path2/path3")
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -368,7 +369,7 @@ func (client *skipUrlEncodingOperations) getSwaggerQueryValidCreateRequest() (*a
 		return nil, err
 	}
 	urlPath := "/azurespecials/skipUrlEncoding/swagger/query/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/skipurlencoding.go
+++ b/test/autorest/generated/azurespecialsgroup/skipurlencoding.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 	"strings"
 )
 
@@ -55,9 +55,13 @@ func (client *skipUrlEncodingOperations) GetMethodPathValid(ctx context.Context,
 
 // getMethodPathValidCreateRequest creates the GetMethodPathValid request.
 func (client *skipUrlEncodingOperations) getMethodPathValidCreateRequest(unencodedPathParam string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}"
 	urlPath = strings.ReplaceAll(urlPath, "{unencodedPathParam}", unencodedPathParam)
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -101,8 +105,12 @@ func (client *skipUrlEncodingOperations) GetMethodQueryNull(ctx context.Context,
 
 // getMethodQueryNullCreateRequest creates the GetMethodQueryNull request.
 func (client *skipUrlEncodingOperations) getMethodQueryNullCreateRequest(skipUrlEncodingGetMethodQueryNullOptions *SkipURLEncodingGetMethodQueryNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/skipUrlEncoding/method/query/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -151,8 +159,12 @@ func (client *skipUrlEncodingOperations) GetMethodQueryValid(ctx context.Context
 
 // getMethodQueryValidCreateRequest creates the GetMethodQueryValid request.
 func (client *skipUrlEncodingOperations) getMethodQueryValidCreateRequest(q1 string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/skipUrlEncoding/method/query/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -199,8 +211,12 @@ func (client *skipUrlEncodingOperations) GetPathQueryValid(ctx context.Context, 
 
 // getPathQueryValidCreateRequest creates the GetPathQueryValid request.
 func (client *skipUrlEncodingOperations) getPathQueryValidCreateRequest(q1 string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/skipUrlEncoding/path/query/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -247,9 +263,13 @@ func (client *skipUrlEncodingOperations) GetPathValid(ctx context.Context, unenc
 
 // getPathValidCreateRequest creates the GetPathValid request.
 func (client *skipUrlEncodingOperations) getPathValidCreateRequest(unencodedPathParam string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}"
 	urlPath = strings.ReplaceAll(urlPath, "{unencodedPathParam}", unencodedPathParam)
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -293,9 +313,13 @@ func (client *skipUrlEncodingOperations) GetSwaggerPathValid(ctx context.Context
 
 // getSwaggerPathValidCreateRequest creates the GetSwaggerPathValid request.
 func (client *skipUrlEncodingOperations) getSwaggerPathValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}"
 	urlPath = strings.ReplaceAll(urlPath, "{unencodedPathParam}", "path1/path2/path3")
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -339,8 +363,12 @@ func (client *skipUrlEncodingOperations) GetSwaggerQueryValid(ctx context.Contex
 
 // getSwaggerQueryValidCreateRequest creates the GetSwaggerQueryValid request.
 func (client *skipUrlEncodingOperations) getSwaggerQueryValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/skipUrlEncoding/swagger/query/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/subscriptionincredentials.go
+++ b/test/autorest/generated/azurespecialsgroup/subscriptionincredentials.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -53,9 +52,13 @@ func (client *subscriptionInCredentialsOperations) PostMethodGlobalNotProvidedVa
 
 // postMethodGlobalNotProvidedValidCreateRequest creates the PostMethodGlobalNotProvidedValid request.
 func (client *subscriptionInCredentialsOperations) postMethodGlobalNotProvidedValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -102,9 +105,13 @@ func (client *subscriptionInCredentialsOperations) PostMethodGlobalNull(ctx cont
 
 // postMethodGlobalNullCreateRequest creates the PostMethodGlobalNull request.
 func (client *subscriptionInCredentialsOperations) postMethodGlobalNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -148,9 +155,13 @@ func (client *subscriptionInCredentialsOperations) PostMethodGlobalValid(ctx con
 
 // postMethodGlobalValidCreateRequest creates the PostMethodGlobalValid request.
 func (client *subscriptionInCredentialsOperations) postMethodGlobalValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -194,9 +205,13 @@ func (client *subscriptionInCredentialsOperations) PostPathGlobalValid(ctx conte
 
 // postPathGlobalValidCreateRequest creates the PostPathGlobalValid request.
 func (client *subscriptionInCredentialsOperations) postPathGlobalValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -240,9 +255,13 @@ func (client *subscriptionInCredentialsOperations) PostSwaggerGlobalValid(ctx co
 
 // postSwaggerGlobalValidCreateRequest creates the PostSwaggerGlobalValid request.
 func (client *subscriptionInCredentialsOperations) postSwaggerGlobalValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/subscriptionincredentials.go
+++ b/test/autorest/generated/azurespecialsgroup/subscriptionincredentials.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -58,7 +59,7 @@ func (client *subscriptionInCredentialsOperations) postMethodGlobalNotProvidedVa
 	}
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +112,7 @@ func (client *subscriptionInCredentialsOperations) postMethodGlobalNullCreateReq
 	}
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *subscriptionInCredentialsOperations) postMethodGlobalValidCreateRe
 	}
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +212,7 @@ func (client *subscriptionInCredentialsOperations) postPathGlobalValidCreateRequ
 	}
 	urlPath := "/azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +262,7 @@ func (client *subscriptionInCredentialsOperations) postSwaggerGlobalValidCreateR
 	}
 	urlPath := "/azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/subscriptioninmethod.go
+++ b/test/autorest/generated/azurespecialsgroup/subscriptioninmethod.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -50,9 +49,13 @@ func (client *subscriptionInMethodOperations) PostMethodLocalNull(ctx context.Co
 
 // postMethodLocalNullCreateRequest creates the PostMethodLocalNull request.
 func (client *subscriptionInMethodOperations) postMethodLocalNullCreateRequest(subscriptionId string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -96,9 +99,13 @@ func (client *subscriptionInMethodOperations) PostMethodLocalValid(ctx context.C
 
 // postMethodLocalValidCreateRequest creates the PostMethodLocalValid request.
 func (client *subscriptionInMethodOperations) postMethodLocalValidCreateRequest(subscriptionId string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -142,9 +149,13 @@ func (client *subscriptionInMethodOperations) PostPathLocalValid(ctx context.Con
 
 // postPathLocalValidCreateRequest creates the PostPathLocalValid request.
 func (client *subscriptionInMethodOperations) postPathLocalValidCreateRequest(subscriptionId string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -188,9 +199,13 @@ func (client *subscriptionInMethodOperations) PostSwaggerLocalValid(ctx context.
 
 // postSwaggerLocalValidCreateRequest creates the PostSwaggerLocalValid request.
 func (client *subscriptionInMethodOperations) postSwaggerLocalValidCreateRequest(subscriptionId string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/subscriptioninmethod.go
+++ b/test/autorest/generated/azurespecialsgroup/subscriptioninmethod.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -55,7 +56,7 @@ func (client *subscriptionInMethodOperations) postMethodLocalNullCreateRequest(s
 	}
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ func (client *subscriptionInMethodOperations) postMethodLocalValidCreateRequest(
 	}
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +156,7 @@ func (client *subscriptionInMethodOperations) postPathLocalValidCreateRequest(su
 	}
 	urlPath := "/azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +206,7 @@ func (client *subscriptionInMethodOperations) postSwaggerLocalValidCreateRequest
 	}
 	urlPath := "/azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/xmsclientrequestid.go
+++ b/test/autorest/generated/azurespecialsgroup/xmsclientrequestid.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // XMSClientRequestIDOperations contains the methods for the XMSClientRequestID group.
@@ -52,7 +53,7 @@ func (client *xmsClientRequestIdoperations) getCreateRequest() (*azcore.Request,
 		return nil, err
 	}
 	urlPath := "/azurespecials/overwrite/x-ms-client-request-id/method/"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +105,7 @@ func (client *xmsClientRequestIdoperations) paramGetCreateRequest(xMSClientReque
 		return nil, err
 	}
 	urlPath := "/azurespecials/overwrite/x-ms-client-request-id/via-param/method/"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/azurespecialsgroup/xmsclientrequestid.go
+++ b/test/autorest/generated/azurespecialsgroup/xmsclientrequestid.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"io/ioutil"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // XMSClientRequestIDOperations contains the methods for the XMSClientRequestID group.
@@ -47,8 +47,12 @@ func (client *xmsClientRequestIdoperations) Get(ctx context.Context) (*http.Resp
 
 // getCreateRequest creates the Get request.
 func (client *xmsClientRequestIdoperations) getCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/overwrite/x-ms-client-request-id/method/"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +99,12 @@ func (client *xmsClientRequestIdoperations) ParamGet(ctx context.Context, xMSCli
 
 // paramGetCreateRequest creates the ParamGet request.
 func (client *xmsClientRequestIdoperations) paramGetCreateRequest(xMSClientRequestId string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/azurespecials/overwrite/x-ms-client-request-id/via-param/method/"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/booleangroup/bool.go
+++ b/test/autorest/generated/booleangroup/bool.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // BoolOperations contains the methods for the Bool group.
@@ -52,8 +52,12 @@ func (client *boolOperations) GetFalse(ctx context.Context) (*BoolResponse, erro
 
 // getFalseCreateRequest creates the GetFalse request.
 func (client *boolOperations) getFalseCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/bool/false"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +102,12 @@ func (client *boolOperations) GetInvalid(ctx context.Context) (*BoolResponse, er
 
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *boolOperations) getInvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/bool/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -144,8 +152,12 @@ func (client *boolOperations) GetNull(ctx context.Context) (*BoolResponse, error
 
 // getNullCreateRequest creates the GetNull request.
 func (client *boolOperations) getNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/bool/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -190,8 +202,12 @@ func (client *boolOperations) GetTrue(ctx context.Context) (*BoolResponse, error
 
 // getTrueCreateRequest creates the GetTrue request.
 func (client *boolOperations) getTrueCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/bool/true"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -236,8 +252,12 @@ func (client *boolOperations) PutFalse(ctx context.Context) (*http.Response, err
 
 // putFalseCreateRequest creates the PutFalse request.
 func (client *boolOperations) putFalseCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/bool/false"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -281,8 +301,12 @@ func (client *boolOperations) PutTrue(ctx context.Context) (*http.Response, erro
 
 // putTrueCreateRequest creates the PutTrue request.
 func (client *boolOperations) putTrueCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/bool/true"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/booleangroup/bool.go
+++ b/test/autorest/generated/booleangroup/bool.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // BoolOperations contains the methods for the Bool group.
@@ -57,7 +58,7 @@ func (client *boolOperations) getFalseCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/bool/false"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,7 @@ func (client *boolOperations) getInvalidCreateRequest() (*azcore.Request, error)
 		return nil, err
 	}
 	urlPath := "/bool/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +158,7 @@ func (client *boolOperations) getNullCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/bool/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +208,7 @@ func (client *boolOperations) getTrueCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/bool/true"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +258,7 @@ func (client *boolOperations) putFalseCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/bool/false"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +307,7 @@ func (client *boolOperations) putTrueCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/bool/true"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/booleangroup/client.go
+++ b/test/autorest/generated/booleangroup/client.go
@@ -8,7 +8,6 @@ package booleangroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-booleangroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // BoolOperations returns the BoolOperations associated with this client.

--- a/test/autorest/generated/bytegroup/byte.go
+++ b/test/autorest/generated/bytegroup/byte.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // ByteOperations contains the methods for the Byte group.
@@ -55,7 +56,7 @@ func (client *byteOperations) getEmptyCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/byte/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ func (client *byteOperations) getInvalidCreateRequest() (*azcore.Request, error)
 		return nil, err
 	}
 	urlPath := "/byte/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +156,7 @@ func (client *byteOperations) getNonAsciiCreateRequest() (*azcore.Request, error
 		return nil, err
 	}
 	urlPath := "/byte/nonAscii"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +206,7 @@ func (client *byteOperations) getNullCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/byte/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +256,7 @@ func (client *byteOperations) putNonAsciiCreateRequest(byteBody []byte) (*azcore
 		return nil, err
 	}
 	urlPath := "/byte/nonAscii"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/bytegroup/byte.go
+++ b/test/autorest/generated/bytegroup/byte.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // ByteOperations contains the methods for the Byte group.
@@ -50,8 +50,12 @@ func (client *byteOperations) GetEmpty(ctx context.Context) (*ByteArrayResponse,
 
 // getEmptyCreateRequest creates the GetEmpty request.
 func (client *byteOperations) getEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/byte/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +100,12 @@ func (client *byteOperations) GetInvalid(ctx context.Context) (*ByteArrayRespons
 
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *byteOperations) getInvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/byte/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -142,8 +150,12 @@ func (client *byteOperations) GetNonASCII(ctx context.Context) (*ByteArrayRespon
 
 // getNonAsciiCreateRequest creates the GetNonASCII request.
 func (client *byteOperations) getNonAsciiCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/byte/nonAscii"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -188,8 +200,12 @@ func (client *byteOperations) GetNull(ctx context.Context) (*ByteArrayResponse, 
 
 // getNullCreateRequest creates the GetNull request.
 func (client *byteOperations) getNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/byte/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -234,8 +250,12 @@ func (client *byteOperations) PutNonASCII(ctx context.Context, byteBody []byte) 
 
 // putNonAsciiCreateRequest creates the PutNonASCII request.
 func (client *byteOperations) putNonAsciiCreateRequest(byteBody []byte) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/byte/nonAscii"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/bytegroup/client.go
+++ b/test/autorest/generated/bytegroup/client.go
@@ -8,7 +8,6 @@ package bytegroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-bytegroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest Swagger BAT
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // ByteOperations returns the ByteOperations associated with this client.

--- a/test/autorest/generated/complexgroup/array.go
+++ b/test/autorest/generated/complexgroup/array.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // ArrayOperations contains the methods for the Array group.
@@ -55,7 +56,7 @@ func (client *arrayOperations) getEmptyCreateRequest() (*azcore.Request, error) 
 		return nil, err
 	}
 	urlPath := "/complex/array/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ func (client *arrayOperations) getNotProvidedCreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/complex/array/notprovided"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +156,7 @@ func (client *arrayOperations) getValidCreateRequest() (*azcore.Request, error) 
 		return nil, err
 	}
 	urlPath := "/complex/array/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +206,7 @@ func (client *arrayOperations) putEmptyCreateRequest(complexBody ArrayWrapper) (
 		return nil, err
 	}
 	urlPath := "/complex/array/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +255,7 @@ func (client *arrayOperations) putValidCreateRequest(complexBody ArrayWrapper) (
 		return nil, err
 	}
 	urlPath := "/complex/array/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/array.go
+++ b/test/autorest/generated/complexgroup/array.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // ArrayOperations contains the methods for the Array group.
@@ -50,8 +50,12 @@ func (client *arrayOperations) GetEmpty(ctx context.Context) (*ArrayWrapperRespo
 
 // getEmptyCreateRequest creates the GetEmpty request.
 func (client *arrayOperations) getEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/array/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +100,12 @@ func (client *arrayOperations) GetNotProvided(ctx context.Context) (*ArrayWrappe
 
 // getNotProvidedCreateRequest creates the GetNotProvided request.
 func (client *arrayOperations) getNotProvidedCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/array/notprovided"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -142,8 +150,12 @@ func (client *arrayOperations) GetValid(ctx context.Context) (*ArrayWrapperRespo
 
 // getValidCreateRequest creates the GetValid request.
 func (client *arrayOperations) getValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/array/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -188,8 +200,12 @@ func (client *arrayOperations) PutEmpty(ctx context.Context, complexBody ArrayWr
 
 // putEmptyCreateRequest creates the PutEmpty request.
 func (client *arrayOperations) putEmptyCreateRequest(complexBody ArrayWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/array/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -233,8 +249,12 @@ func (client *arrayOperations) PutValid(ctx context.Context, complexBody ArrayWr
 
 // putValidCreateRequest creates the PutValid request.
 func (client *arrayOperations) putValidCreateRequest(complexBody ArrayWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/array/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/basic.go
+++ b/test/autorest/generated/complexgroup/basic.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // BasicOperations contains the methods for the Basic group.
@@ -52,8 +52,12 @@ func (client *basicOperations) GetEmpty(ctx context.Context) (*BasicResponse, er
 
 // getEmptyCreateRequest creates the GetEmpty request.
 func (client *basicOperations) getEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/basic/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +102,12 @@ func (client *basicOperations) GetInvalid(ctx context.Context) (*BasicResponse, 
 
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *basicOperations) getInvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/basic/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -144,8 +152,12 @@ func (client *basicOperations) GetNotProvided(ctx context.Context) (*BasicRespon
 
 // getNotProvidedCreateRequest creates the GetNotProvided request.
 func (client *basicOperations) getNotProvidedCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/basic/notprovided"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -190,8 +202,12 @@ func (client *basicOperations) GetNull(ctx context.Context) (*BasicResponse, err
 
 // getNullCreateRequest creates the GetNull request.
 func (client *basicOperations) getNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/basic/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -236,8 +252,12 @@ func (client *basicOperations) GetValid(ctx context.Context) (*BasicResponse, er
 
 // getValidCreateRequest creates the GetValid request.
 func (client *basicOperations) getValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/basic/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -282,8 +302,12 @@ func (client *basicOperations) PutValid(ctx context.Context, complexBody Basic) 
 
 // putValidCreateRequest creates the PutValid request.
 func (client *basicOperations) putValidCreateRequest(complexBody Basic) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/basic/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/basic.go
+++ b/test/autorest/generated/complexgroup/basic.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // BasicOperations contains the methods for the Basic group.
@@ -57,7 +58,7 @@ func (client *basicOperations) getEmptyCreateRequest() (*azcore.Request, error) 
 		return nil, err
 	}
 	urlPath := "/complex/basic/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,7 @@ func (client *basicOperations) getInvalidCreateRequest() (*azcore.Request, error
 		return nil, err
 	}
 	urlPath := "/complex/basic/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +158,7 @@ func (client *basicOperations) getNotProvidedCreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/complex/basic/notprovided"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +208,7 @@ func (client *basicOperations) getNullCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/complex/basic/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +258,7 @@ func (client *basicOperations) getValidCreateRequest() (*azcore.Request, error) 
 		return nil, err
 	}
 	urlPath := "/complex/basic/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +308,7 @@ func (client *basicOperations) putValidCreateRequest(complexBody Basic) (*azcore
 		return nil, err
 	}
 	urlPath := "/complex/basic/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/client.go
+++ b/test/autorest/generated/complexgroup/client.go
@@ -8,7 +8,6 @@ package complexgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-complexgroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // BasicOperations returns the BasicOperations associated with this client.

--- a/test/autorest/generated/complexgroup/dictionary.go
+++ b/test/autorest/generated/complexgroup/dictionary.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // DictionaryOperations contains the methods for the Dictionary group.
@@ -52,8 +52,12 @@ func (client *dictionaryOperations) GetEmpty(ctx context.Context) (*DictionaryWr
 
 // getEmptyCreateRequest creates the GetEmpty request.
 func (client *dictionaryOperations) getEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/dictionary/typed/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +102,12 @@ func (client *dictionaryOperations) GetNotProvided(ctx context.Context) (*Dictio
 
 // getNotProvidedCreateRequest creates the GetNotProvided request.
 func (client *dictionaryOperations) getNotProvidedCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/dictionary/typed/notprovided"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -144,8 +152,12 @@ func (client *dictionaryOperations) GetNull(ctx context.Context) (*DictionaryWra
 
 // getNullCreateRequest creates the GetNull request.
 func (client *dictionaryOperations) getNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/dictionary/typed/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -190,8 +202,12 @@ func (client *dictionaryOperations) GetValid(ctx context.Context) (*DictionaryWr
 
 // getValidCreateRequest creates the GetValid request.
 func (client *dictionaryOperations) getValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/dictionary/typed/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -236,8 +252,12 @@ func (client *dictionaryOperations) PutEmpty(ctx context.Context, complexBody Di
 
 // putEmptyCreateRequest creates the PutEmpty request.
 func (client *dictionaryOperations) putEmptyCreateRequest(complexBody DictionaryWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/dictionary/typed/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -281,8 +301,12 @@ func (client *dictionaryOperations) PutValid(ctx context.Context, complexBody Di
 
 // putValidCreateRequest creates the PutValid request.
 func (client *dictionaryOperations) putValidCreateRequest(complexBody DictionaryWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/dictionary/typed/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/dictionary.go
+++ b/test/autorest/generated/complexgroup/dictionary.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // DictionaryOperations contains the methods for the Dictionary group.
@@ -57,7 +58,7 @@ func (client *dictionaryOperations) getEmptyCreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/complex/dictionary/typed/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,7 @@ func (client *dictionaryOperations) getNotProvidedCreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/complex/dictionary/typed/notprovided"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +158,7 @@ func (client *dictionaryOperations) getNullCreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/complex/dictionary/typed/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +208,7 @@ func (client *dictionaryOperations) getValidCreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/complex/dictionary/typed/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +258,7 @@ func (client *dictionaryOperations) putEmptyCreateRequest(complexBody Dictionary
 		return nil, err
 	}
 	urlPath := "/complex/dictionary/typed/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +307,7 @@ func (client *dictionaryOperations) putValidCreateRequest(complexBody Dictionary
 		return nil, err
 	}
 	urlPath := "/complex/dictionary/typed/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/flattencomplex.go
+++ b/test/autorest/generated/complexgroup/flattencomplex.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // FlattencomplexOperations contains the methods for the Flattencomplex group.
@@ -48,7 +49,7 @@ func (client *flattencomplexOperations) getValidCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/complex/flatten/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/flattencomplex.go
+++ b/test/autorest/generated/complexgroup/flattencomplex.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"io/ioutil"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // FlattencomplexOperations contains the methods for the Flattencomplex group.
@@ -43,8 +43,12 @@ func (client *flattencomplexOperations) GetValid(ctx context.Context) (*MyBaseTy
 
 // getValidCreateRequest creates the GetValid request.
 func (client *flattencomplexOperations) getValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/flatten/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/inheritance.go
+++ b/test/autorest/generated/complexgroup/inheritance.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // InheritanceOperations contains the methods for the Inheritance group.
@@ -49,7 +50,7 @@ func (client *inheritanceOperations) getValidCreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/complex/inheritance/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +100,7 @@ func (client *inheritanceOperations) putValidCreateRequest(complexBody Siamese) 
 		return nil, err
 	}
 	urlPath := "/complex/inheritance/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/inheritance.go
+++ b/test/autorest/generated/complexgroup/inheritance.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // InheritanceOperations contains the methods for the Inheritance group.
@@ -44,8 +44,12 @@ func (client *inheritanceOperations) GetValid(ctx context.Context) (*SiameseResp
 
 // getValidCreateRequest creates the GetValid request.
 func (client *inheritanceOperations) getValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/inheritance/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +94,12 @@ func (client *inheritanceOperations) PutValid(ctx context.Context, complexBody S
 
 // putValidCreateRequest creates the PutValid request.
 func (client *inheritanceOperations) putValidCreateRequest(complexBody Siamese) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/inheritance/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/polymorphicrecursive.go
+++ b/test/autorest/generated/complexgroup/polymorphicrecursive.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // PolymorphicrecursiveOperations contains the methods for the Polymorphicrecursive group.
@@ -44,8 +44,12 @@ func (client *polymorphicrecursiveOperations) GetValid(ctx context.Context) (*Fi
 
 // getValidCreateRequest creates the GetValid request.
 func (client *polymorphicrecursiveOperations) getValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/polymorphicrecursive/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +94,12 @@ func (client *polymorphicrecursiveOperations) PutValid(ctx context.Context, comp
 
 // putValidCreateRequest creates the PutValid request.
 func (client *polymorphicrecursiveOperations) putValidCreateRequest(complexBody FishClassification) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/polymorphicrecursive/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/polymorphicrecursive.go
+++ b/test/autorest/generated/complexgroup/polymorphicrecursive.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // PolymorphicrecursiveOperations contains the methods for the Polymorphicrecursive group.
@@ -49,7 +50,7 @@ func (client *polymorphicrecursiveOperations) getValidCreateRequest() (*azcore.R
 		return nil, err
 	}
 	urlPath := "/complex/polymorphicrecursive/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +100,7 @@ func (client *polymorphicrecursiveOperations) putValidCreateRequest(complexBody 
 		return nil, err
 	}
 	urlPath := "/complex/polymorphicrecursive/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/polymorphism.go
+++ b/test/autorest/generated/complexgroup/polymorphism.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // PolymorphismOperations contains the methods for the Polymorphism group.
@@ -58,8 +58,12 @@ func (client *polymorphismOperations) GetComplicated(ctx context.Context) (*Salm
 
 // getComplicatedCreateRequest creates the GetComplicated request.
 func (client *polymorphismOperations) getComplicatedCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/polymorphism/complicated"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -104,8 +108,12 @@ func (client *polymorphismOperations) GetComposedWithDiscriminator(ctx context.C
 
 // getComposedWithDiscriminatorCreateRequest creates the GetComposedWithDiscriminator request.
 func (client *polymorphismOperations) getComposedWithDiscriminatorCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/polymorphism/composedWithDiscriminator"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -150,8 +158,12 @@ func (client *polymorphismOperations) GetComposedWithoutDiscriminator(ctx contex
 
 // getComposedWithoutDiscriminatorCreateRequest creates the GetComposedWithoutDiscriminator request.
 func (client *polymorphismOperations) getComposedWithoutDiscriminatorCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/polymorphism/composedWithoutDiscriminator"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -196,8 +208,12 @@ func (client *polymorphismOperations) GetDotSyntax(ctx context.Context) (*DotFis
 
 // getDotSyntaxCreateRequest creates the GetDotSyntax request.
 func (client *polymorphismOperations) getDotSyntaxCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/polymorphism/dotsyntax"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -242,8 +258,12 @@ func (client *polymorphismOperations) GetValid(ctx context.Context) (*FishRespon
 
 // getValidCreateRequest creates the GetValid request.
 func (client *polymorphismOperations) getValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/polymorphism/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -288,8 +308,12 @@ func (client *polymorphismOperations) PutComplicated(ctx context.Context, comple
 
 // putComplicatedCreateRequest creates the PutComplicated request.
 func (client *polymorphismOperations) putComplicatedCreateRequest(complexBody SalmonClassification) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/polymorphism/complicated"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -333,8 +357,12 @@ func (client *polymorphismOperations) PutMissingDiscriminator(ctx context.Contex
 
 // putMissingDiscriminatorCreateRequest creates the PutMissingDiscriminator request.
 func (client *polymorphismOperations) putMissingDiscriminatorCreateRequest(complexBody SalmonClassification) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/polymorphism/missingdiscriminator"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -379,8 +407,12 @@ func (client *polymorphismOperations) PutValid(ctx context.Context, complexBody 
 
 // putValidCreateRequest creates the PutValid request.
 func (client *polymorphismOperations) putValidCreateRequest(complexBody FishClassification) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/polymorphism/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -424,8 +456,12 @@ func (client *polymorphismOperations) PutValidMissingRequired(ctx context.Contex
 
 // putValidMissingRequiredCreateRequest creates the PutValidMissingRequired request.
 func (client *polymorphismOperations) putValidMissingRequiredCreateRequest(complexBody FishClassification) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/polymorphism/missingrequired/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/polymorphism.go
+++ b/test/autorest/generated/complexgroup/polymorphism.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // PolymorphismOperations contains the methods for the Polymorphism group.
@@ -63,7 +64,7 @@ func (client *polymorphismOperations) getComplicatedCreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/complex/polymorphism/complicated"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +114,7 @@ func (client *polymorphismOperations) getComposedWithDiscriminatorCreateRequest(
 		return nil, err
 	}
 	urlPath := "/complex/polymorphism/composedWithDiscriminator"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *polymorphismOperations) getComposedWithoutDiscriminatorCreateReque
 		return nil, err
 	}
 	urlPath := "/complex/polymorphism/composedWithoutDiscriminator"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +214,7 @@ func (client *polymorphismOperations) getDotSyntaxCreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/complex/polymorphism/dotsyntax"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +264,7 @@ func (client *polymorphismOperations) getValidCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/complex/polymorphism/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -313,7 +314,7 @@ func (client *polymorphismOperations) putComplicatedCreateRequest(complexBody Sa
 		return nil, err
 	}
 	urlPath := "/complex/polymorphism/complicated"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -362,7 +363,7 @@ func (client *polymorphismOperations) putMissingDiscriminatorCreateRequest(compl
 		return nil, err
 	}
 	urlPath := "/complex/polymorphism/missingdiscriminator"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -412,7 +413,7 @@ func (client *polymorphismOperations) putValidCreateRequest(complexBody FishClas
 		return nil, err
 	}
 	urlPath := "/complex/polymorphism/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -461,7 +462,7 @@ func (client *polymorphismOperations) putValidMissingRequiredCreateRequest(compl
 		return nil, err
 	}
 	urlPath := "/complex/polymorphism/missingrequired/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/primitive.go
+++ b/test/autorest/generated/complexgroup/primitive.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // PrimitiveOperations contains the methods for the Primitive group.
@@ -89,7 +90,7 @@ func (client *primitiveOperations) getBoolCreateRequest() (*azcore.Request, erro
 		return nil, err
 	}
 	urlPath := "/complex/primitive/bool"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +140,7 @@ func (client *primitiveOperations) getByteCreateRequest() (*azcore.Request, erro
 		return nil, err
 	}
 	urlPath := "/complex/primitive/byte"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +190,7 @@ func (client *primitiveOperations) getDateCreateRequest() (*azcore.Request, erro
 		return nil, err
 	}
 	urlPath := "/complex/primitive/date"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +240,7 @@ func (client *primitiveOperations) getDateTimeCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/complex/primitive/datetime"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +290,7 @@ func (client *primitiveOperations) getDateTimeRfc1123CreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/complex/primitive/datetimerfc1123"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +340,7 @@ func (client *primitiveOperations) getDoubleCreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/complex/primitive/double"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +390,7 @@ func (client *primitiveOperations) getDurationCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/complex/primitive/duration"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -439,7 +440,7 @@ func (client *primitiveOperations) getFloatCreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/complex/primitive/float"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -489,7 +490,7 @@ func (client *primitiveOperations) getIntCreateRequest() (*azcore.Request, error
 		return nil, err
 	}
 	urlPath := "/complex/primitive/integer"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -539,7 +540,7 @@ func (client *primitiveOperations) getLongCreateRequest() (*azcore.Request, erro
 		return nil, err
 	}
 	urlPath := "/complex/primitive/long"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -589,7 +590,7 @@ func (client *primitiveOperations) getStringCreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/complex/primitive/string"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -639,7 +640,7 @@ func (client *primitiveOperations) putBoolCreateRequest(complexBody BooleanWrapp
 		return nil, err
 	}
 	urlPath := "/complex/primitive/bool"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -688,7 +689,7 @@ func (client *primitiveOperations) putByteCreateRequest(complexBody ByteWrapper)
 		return nil, err
 	}
 	urlPath := "/complex/primitive/byte"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -737,7 +738,7 @@ func (client *primitiveOperations) putDateCreateRequest(complexBody DateWrapper)
 		return nil, err
 	}
 	urlPath := "/complex/primitive/date"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -786,7 +787,7 @@ func (client *primitiveOperations) putDateTimeCreateRequest(complexBody Datetime
 		return nil, err
 	}
 	urlPath := "/complex/primitive/datetime"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -835,7 +836,7 @@ func (client *primitiveOperations) putDateTimeRfc1123CreateRequest(complexBody D
 		return nil, err
 	}
 	urlPath := "/complex/primitive/datetimerfc1123"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -884,7 +885,7 @@ func (client *primitiveOperations) putDoubleCreateRequest(complexBody DoubleWrap
 		return nil, err
 	}
 	urlPath := "/complex/primitive/double"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -933,7 +934,7 @@ func (client *primitiveOperations) putDurationCreateRequest(complexBody Duration
 		return nil, err
 	}
 	urlPath := "/complex/primitive/duration"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -982,7 +983,7 @@ func (client *primitiveOperations) putFloatCreateRequest(complexBody FloatWrappe
 		return nil, err
 	}
 	urlPath := "/complex/primitive/float"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1031,7 +1032,7 @@ func (client *primitiveOperations) putIntCreateRequest(complexBody IntWrapper) (
 		return nil, err
 	}
 	urlPath := "/complex/primitive/integer"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1080,7 +1081,7 @@ func (client *primitiveOperations) putLongCreateRequest(complexBody LongWrapper)
 		return nil, err
 	}
 	urlPath := "/complex/primitive/long"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1129,7 +1130,7 @@ func (client *primitiveOperations) putStringCreateRequest(complexBody StringWrap
 		return nil, err
 	}
 	urlPath := "/complex/primitive/string"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/primitive.go
+++ b/test/autorest/generated/complexgroup/primitive.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // PrimitiveOperations contains the methods for the Primitive group.
@@ -84,8 +84,12 @@ func (client *primitiveOperations) GetBool(ctx context.Context) (*BooleanWrapper
 
 // getBoolCreateRequest creates the GetBool request.
 func (client *primitiveOperations) getBoolCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/bool"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -130,8 +134,12 @@ func (client *primitiveOperations) GetByte(ctx context.Context) (*ByteWrapperRes
 
 // getByteCreateRequest creates the GetByte request.
 func (client *primitiveOperations) getByteCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/byte"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -176,8 +184,12 @@ func (client *primitiveOperations) GetDate(ctx context.Context) (*DateWrapperRes
 
 // getDateCreateRequest creates the GetDate request.
 func (client *primitiveOperations) getDateCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/date"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -222,8 +234,12 @@ func (client *primitiveOperations) GetDateTime(ctx context.Context) (*DatetimeWr
 
 // getDateTimeCreateRequest creates the GetDateTime request.
 func (client *primitiveOperations) getDateTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/datetime"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -268,8 +284,12 @@ func (client *primitiveOperations) GetDateTimeRFC1123(ctx context.Context) (*Dat
 
 // getDateTimeRfc1123CreateRequest creates the GetDateTimeRFC1123 request.
 func (client *primitiveOperations) getDateTimeRfc1123CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/datetimerfc1123"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -314,8 +334,12 @@ func (client *primitiveOperations) GetDouble(ctx context.Context) (*DoubleWrappe
 
 // getDoubleCreateRequest creates the GetDouble request.
 func (client *primitiveOperations) getDoubleCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/double"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -360,8 +384,12 @@ func (client *primitiveOperations) GetDuration(ctx context.Context) (*DurationWr
 
 // getDurationCreateRequest creates the GetDuration request.
 func (client *primitiveOperations) getDurationCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/duration"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -406,8 +434,12 @@ func (client *primitiveOperations) GetFloat(ctx context.Context) (*FloatWrapperR
 
 // getFloatCreateRequest creates the GetFloat request.
 func (client *primitiveOperations) getFloatCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/float"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -452,8 +484,12 @@ func (client *primitiveOperations) GetInt(ctx context.Context) (*IntWrapperRespo
 
 // getIntCreateRequest creates the GetInt request.
 func (client *primitiveOperations) getIntCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/integer"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -498,8 +534,12 @@ func (client *primitiveOperations) GetLong(ctx context.Context) (*LongWrapperRes
 
 // getLongCreateRequest creates the GetLong request.
 func (client *primitiveOperations) getLongCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/long"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -544,8 +584,12 @@ func (client *primitiveOperations) GetString(ctx context.Context) (*StringWrappe
 
 // getStringCreateRequest creates the GetString request.
 func (client *primitiveOperations) getStringCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/string"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -590,8 +634,12 @@ func (client *primitiveOperations) PutBool(ctx context.Context, complexBody Bool
 
 // putBoolCreateRequest creates the PutBool request.
 func (client *primitiveOperations) putBoolCreateRequest(complexBody BooleanWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/bool"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -635,8 +683,12 @@ func (client *primitiveOperations) PutByte(ctx context.Context, complexBody Byte
 
 // putByteCreateRequest creates the PutByte request.
 func (client *primitiveOperations) putByteCreateRequest(complexBody ByteWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/byte"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -680,8 +732,12 @@ func (client *primitiveOperations) PutDate(ctx context.Context, complexBody Date
 
 // putDateCreateRequest creates the PutDate request.
 func (client *primitiveOperations) putDateCreateRequest(complexBody DateWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/date"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -725,8 +781,12 @@ func (client *primitiveOperations) PutDateTime(ctx context.Context, complexBody 
 
 // putDateTimeCreateRequest creates the PutDateTime request.
 func (client *primitiveOperations) putDateTimeCreateRequest(complexBody DatetimeWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/datetime"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -770,8 +830,12 @@ func (client *primitiveOperations) PutDateTimeRFC1123(ctx context.Context, compl
 
 // putDateTimeRfc1123CreateRequest creates the PutDateTimeRFC1123 request.
 func (client *primitiveOperations) putDateTimeRfc1123CreateRequest(complexBody Datetimerfc1123Wrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/datetimerfc1123"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -815,8 +879,12 @@ func (client *primitiveOperations) PutDouble(ctx context.Context, complexBody Do
 
 // putDoubleCreateRequest creates the PutDouble request.
 func (client *primitiveOperations) putDoubleCreateRequest(complexBody DoubleWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/double"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -860,8 +928,12 @@ func (client *primitiveOperations) PutDuration(ctx context.Context, complexBody 
 
 // putDurationCreateRequest creates the PutDuration request.
 func (client *primitiveOperations) putDurationCreateRequest(complexBody DurationWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/duration"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -905,8 +977,12 @@ func (client *primitiveOperations) PutFloat(ctx context.Context, complexBody Flo
 
 // putFloatCreateRequest creates the PutFloat request.
 func (client *primitiveOperations) putFloatCreateRequest(complexBody FloatWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/float"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -950,8 +1026,12 @@ func (client *primitiveOperations) PutInt(ctx context.Context, complexBody IntWr
 
 // putIntCreateRequest creates the PutInt request.
 func (client *primitiveOperations) putIntCreateRequest(complexBody IntWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/integer"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -995,8 +1075,12 @@ func (client *primitiveOperations) PutLong(ctx context.Context, complexBody Long
 
 // putLongCreateRequest creates the PutLong request.
 func (client *primitiveOperations) putLongCreateRequest(complexBody LongWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/long"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1040,8 +1124,12 @@ func (client *primitiveOperations) PutString(ctx context.Context, complexBody St
 
 // putStringCreateRequest creates the PutString request.
 func (client *primitiveOperations) putStringCreateRequest(complexBody StringWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/primitive/string"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/readonlyproperty.go
+++ b/test/autorest/generated/complexgroup/readonlyproperty.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // ReadonlypropertyOperations contains the methods for the Readonlyproperty group.
@@ -44,8 +44,12 @@ func (client *readonlypropertyOperations) GetValid(ctx context.Context) (*Readon
 
 // getValidCreateRequest creates the GetValid request.
 func (client *readonlypropertyOperations) getValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/readonlyproperty/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +94,12 @@ func (client *readonlypropertyOperations) PutValid(ctx context.Context, complexB
 
 // putValidCreateRequest creates the PutValid request.
 func (client *readonlypropertyOperations) putValidCreateRequest(complexBody ReadonlyObj) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/complex/readonlyproperty/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexgroup/readonlyproperty.go
+++ b/test/autorest/generated/complexgroup/readonlyproperty.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // ReadonlypropertyOperations contains the methods for the Readonlyproperty group.
@@ -49,7 +50,7 @@ func (client *readonlypropertyOperations) getValidCreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/complex/readonlyproperty/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +100,7 @@ func (client *readonlypropertyOperations) putValidCreateRequest(complexBody Read
 		return nil, err
 	}
 	urlPath := "/complex/readonlyproperty/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexmodelgroup/client.go
+++ b/test/autorest/generated/complexmodelgroup/client.go
@@ -8,7 +8,6 @@ package complexmodelgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-complexmodelgroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Some cool documentation.
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // ComplexModelClientOperations returns the ComplexModelClientOperations associated with this client.

--- a/test/autorest/generated/complexmodelgroup/complexmodelclient.go
+++ b/test/autorest/generated/complexmodelgroup/complexmodelclient.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -54,7 +55,7 @@ func (client *complexModelClientOperations) createCreateRequest(subscriptionId s
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +110,7 @@ func (client *complexModelClientOperations) listCreateRequest(resourceGroupName 
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape("123456"))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +165,7 @@ func (client *complexModelClientOperations) updateCreateRequest(subscriptionId s
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/complexmodelgroup/complexmodelclient.go
+++ b/test/autorest/generated/complexmodelgroup/complexmodelclient.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -48,10 +47,14 @@ func (client *complexModelClientOperations) Create(ctx context.Context, subscrip
 
 // createCreateRequest creates the Create request.
 func (client *complexModelClientOperations) createCreateRequest(subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -99,10 +102,14 @@ func (client *complexModelClientOperations) List(ctx context.Context, resourceGr
 
 // listCreateRequest creates the List request.
 func (client *complexModelClientOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape("123456"))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -150,10 +157,14 @@ func (client *complexModelClientOperations) Update(ctx context.Context, subscrip
 
 // updateCreateRequest creates the Update request.
 func (client *complexModelClientOperations) updateCreateRequest(subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/custombaseurlgroup/client.go
+++ b/test/autorest/generated/custombaseurlgroup/client.go
@@ -49,7 +49,7 @@ type Client struct {
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(host *string, options *ClientOptions) (*Client, error) {
+func NewClient(host *string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -63,7 +63,7 @@ func NewClient(host *string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(host *string, p azcore.Pipeline) (*Client, error) {
+func NewClientWithPipeline(host *string, p azcore.Pipeline) *Client {
 	client := &Client{
 		p:    p,
 		host: "host",
@@ -71,7 +71,7 @@ func NewClientWithPipeline(host *string, p azcore.Pipeline) (*Client, error) {
 	if host != nil {
 		client.host = *host
 	}
-	return client, nil
+	return client
 }
 
 // PathsOperations returns the PathsOperations associated with this client.

--- a/test/autorest/generated/custombaseurlgroup/paths.go
+++ b/test/autorest/generated/custombaseurlgroup/paths.go
@@ -46,8 +46,12 @@ func (client *pathsOperations) getEmptyCreateRequest(accountName string) (*azcor
 	host := "http://{accountName}{host}"
 	host = strings.ReplaceAll(host, "{host}", client.host)
 	host = strings.ReplaceAll(host, "{accountName}", accountName)
+	u, err := url.Parse(host)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/customuri"
-	u, err := url.Parse(host + urlPath)
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/custombaseurlgroup/paths.go
+++ b/test/autorest/generated/custombaseurlgroup/paths.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -51,7 +52,7 @@ func (client *pathsOperations) getEmptyCreateRequest(accountName string) (*azcor
 		return nil, err
 	}
 	urlPath := "/customuri"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/datetimegroup/client.go
+++ b/test/autorest/generated/datetimegroup/client.go
@@ -8,7 +8,6 @@ package datetimegroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-datetimegroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // DatetimeOperations returns the DatetimeOperations associated with this client.

--- a/test/autorest/generated/datetimegroup/datetime.go
+++ b/test/autorest/generated/datetimegroup/datetime.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 	"time"
 )
 
@@ -85,8 +85,12 @@ func (client *datetimeOperations) GetInvalid(ctx context.Context) (*TimeResponse
 
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *datetimeOperations) getInvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -132,8 +136,12 @@ func (client *datetimeOperations) GetLocalNegativeOffsetLowercaseMaxDateTime(ctx
 
 // getLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest creates the GetLocalNegativeOffsetLowercaseMaxDateTime request.
 func (client *datetimeOperations) getLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/max/localnegativeoffset/lowercase"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -179,8 +187,12 @@ func (client *datetimeOperations) GetLocalNegativeOffsetMinDateTime(ctx context.
 
 // getLocalNegativeOffsetMinDateTimeCreateRequest creates the GetLocalNegativeOffsetMinDateTime request.
 func (client *datetimeOperations) getLocalNegativeOffsetMinDateTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/min/localnegativeoffset"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -226,8 +238,12 @@ func (client *datetimeOperations) GetLocalNegativeOffsetUppercaseMaxDateTime(ctx
 
 // getLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest creates the GetLocalNegativeOffsetUppercaseMaxDateTime request.
 func (client *datetimeOperations) getLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/max/localnegativeoffset/uppercase"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -273,8 +289,12 @@ func (client *datetimeOperations) GetLocalNoOffsetMinDateTime(ctx context.Contex
 
 // getLocalNoOffsetMinDateTimeCreateRequest creates the GetLocalNoOffsetMinDateTime request.
 func (client *datetimeOperations) getLocalNoOffsetMinDateTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/min/localnooffset"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -320,8 +340,12 @@ func (client *datetimeOperations) GetLocalPositiveOffsetLowercaseMaxDateTime(ctx
 
 // getLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest creates the GetLocalPositiveOffsetLowercaseMaxDateTime request.
 func (client *datetimeOperations) getLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/max/localpositiveoffset/lowercase"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -367,8 +391,12 @@ func (client *datetimeOperations) GetLocalPositiveOffsetMinDateTime(ctx context.
 
 // getLocalPositiveOffsetMinDateTimeCreateRequest creates the GetLocalPositiveOffsetMinDateTime request.
 func (client *datetimeOperations) getLocalPositiveOffsetMinDateTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/min/localpositiveoffset"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -414,8 +442,12 @@ func (client *datetimeOperations) GetLocalPositiveOffsetUppercaseMaxDateTime(ctx
 
 // getLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest creates the GetLocalPositiveOffsetUppercaseMaxDateTime request.
 func (client *datetimeOperations) getLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/max/localpositiveoffset/uppercase"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -461,8 +493,12 @@ func (client *datetimeOperations) GetNull(ctx context.Context) (*TimeResponse, e
 
 // getNullCreateRequest creates the GetNull request.
 func (client *datetimeOperations) getNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -508,8 +544,12 @@ func (client *datetimeOperations) GetOverflow(ctx context.Context) (*TimeRespons
 
 // getOverflowCreateRequest creates the GetOverflow request.
 func (client *datetimeOperations) getOverflowCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/overflow"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -555,8 +595,12 @@ func (client *datetimeOperations) GetUTCLowercaseMaxDateTime(ctx context.Context
 
 // getUtcLowercaseMaxDateTimeCreateRequest creates the GetUTCLowercaseMaxDateTime request.
 func (client *datetimeOperations) getUtcLowercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/max/utc/lowercase"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -602,8 +646,12 @@ func (client *datetimeOperations) GetUTCMinDateTime(ctx context.Context) (*TimeR
 
 // getUtcMinDateTimeCreateRequest creates the GetUTCMinDateTime request.
 func (client *datetimeOperations) getUtcMinDateTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/min/utc"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -649,8 +697,12 @@ func (client *datetimeOperations) GetUTCUppercaseMaxDateTime(ctx context.Context
 
 // getUtcUppercaseMaxDateTimeCreateRequest creates the GetUTCUppercaseMaxDateTime request.
 func (client *datetimeOperations) getUtcUppercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/max/utc/uppercase"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -696,8 +748,12 @@ func (client *datetimeOperations) GetUTCUppercaseMaxDateTime7Digits(ctx context.
 
 // getUtcUppercaseMaxDateTime7DigitsCreateRequest creates the GetUTCUppercaseMaxDateTime7Digits request.
 func (client *datetimeOperations) getUtcUppercaseMaxDateTime7DigitsCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/max/utc7ms/uppercase"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -743,8 +799,12 @@ func (client *datetimeOperations) GetUnderflow(ctx context.Context) (*TimeRespon
 
 // getUnderflowCreateRequest creates the GetUnderflow request.
 func (client *datetimeOperations) getUnderflowCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/underflow"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -790,8 +850,12 @@ func (client *datetimeOperations) PutLocalNegativeOffsetMaxDateTime(ctx context.
 
 // putLocalNegativeOffsetMaxDateTimeCreateRequest creates the PutLocalNegativeOffsetMaxDateTime request.
 func (client *datetimeOperations) putLocalNegativeOffsetMaxDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/max/localnegativeoffset"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -835,8 +899,12 @@ func (client *datetimeOperations) PutLocalNegativeOffsetMinDateTime(ctx context.
 
 // putLocalNegativeOffsetMinDateTimeCreateRequest creates the PutLocalNegativeOffsetMinDateTime request.
 func (client *datetimeOperations) putLocalNegativeOffsetMinDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/min/localnegativeoffset"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -880,8 +948,12 @@ func (client *datetimeOperations) PutLocalPositiveOffsetMaxDateTime(ctx context.
 
 // putLocalPositiveOffsetMaxDateTimeCreateRequest creates the PutLocalPositiveOffsetMaxDateTime request.
 func (client *datetimeOperations) putLocalPositiveOffsetMaxDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/max/localpositiveoffset"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -925,8 +997,12 @@ func (client *datetimeOperations) PutLocalPositiveOffsetMinDateTime(ctx context.
 
 // putLocalPositiveOffsetMinDateTimeCreateRequest creates the PutLocalPositiveOffsetMinDateTime request.
 func (client *datetimeOperations) putLocalPositiveOffsetMinDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/min/localpositiveoffset"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -970,8 +1046,12 @@ func (client *datetimeOperations) PutUTCMaxDateTime(ctx context.Context, datetim
 
 // putUtcMaxDateTimeCreateRequest creates the PutUTCMaxDateTime request.
 func (client *datetimeOperations) putUtcMaxDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/max/utc"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1015,8 +1095,12 @@ func (client *datetimeOperations) PutUTCMaxDateTime7Digits(ctx context.Context, 
 
 // putUtcMaxDateTime7DigitsCreateRequest creates the PutUTCMaxDateTime7Digits request.
 func (client *datetimeOperations) putUtcMaxDateTime7DigitsCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/max/utc7ms"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1060,8 +1144,12 @@ func (client *datetimeOperations) PutUTCMinDateTime(ctx context.Context, datetim
 
 // putUtcMinDateTimeCreateRequest creates the PutUTCMinDateTime request.
 func (client *datetimeOperations) putUtcMinDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetime/min/utc"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/datetimegroup/datetime.go
+++ b/test/autorest/generated/datetimegroup/datetime.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 )
 
@@ -90,7 +91,7 @@ func (client *datetimeOperations) getInvalidCreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/datetime/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +142,7 @@ func (client *datetimeOperations) getLocalNegativeOffsetLowercaseMaxDateTimeCrea
 		return nil, err
 	}
 	urlPath := "/datetime/max/localnegativeoffset/lowercase"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +193,7 @@ func (client *datetimeOperations) getLocalNegativeOffsetMinDateTimeCreateRequest
 		return nil, err
 	}
 	urlPath := "/datetime/min/localnegativeoffset"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +244,7 @@ func (client *datetimeOperations) getLocalNegativeOffsetUppercaseMaxDateTimeCrea
 		return nil, err
 	}
 	urlPath := "/datetime/max/localnegativeoffset/uppercase"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +295,7 @@ func (client *datetimeOperations) getLocalNoOffsetMinDateTimeCreateRequest() (*a
 		return nil, err
 	}
 	urlPath := "/datetime/min/localnooffset"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +346,7 @@ func (client *datetimeOperations) getLocalPositiveOffsetLowercaseMaxDateTimeCrea
 		return nil, err
 	}
 	urlPath := "/datetime/max/localpositiveoffset/lowercase"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -396,7 +397,7 @@ func (client *datetimeOperations) getLocalPositiveOffsetMinDateTimeCreateRequest
 		return nil, err
 	}
 	urlPath := "/datetime/min/localpositiveoffset"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +448,7 @@ func (client *datetimeOperations) getLocalPositiveOffsetUppercaseMaxDateTimeCrea
 		return nil, err
 	}
 	urlPath := "/datetime/max/localpositiveoffset/uppercase"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -498,7 +499,7 @@ func (client *datetimeOperations) getNullCreateRequest() (*azcore.Request, error
 		return nil, err
 	}
 	urlPath := "/datetime/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -549,7 +550,7 @@ func (client *datetimeOperations) getOverflowCreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/datetime/overflow"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -600,7 +601,7 @@ func (client *datetimeOperations) getUtcLowercaseMaxDateTimeCreateRequest() (*az
 		return nil, err
 	}
 	urlPath := "/datetime/max/utc/lowercase"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -651,7 +652,7 @@ func (client *datetimeOperations) getUtcMinDateTimeCreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/datetime/min/utc"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -702,7 +703,7 @@ func (client *datetimeOperations) getUtcUppercaseMaxDateTimeCreateRequest() (*az
 		return nil, err
 	}
 	urlPath := "/datetime/max/utc/uppercase"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -753,7 +754,7 @@ func (client *datetimeOperations) getUtcUppercaseMaxDateTime7DigitsCreateRequest
 		return nil, err
 	}
 	urlPath := "/datetime/max/utc7ms/uppercase"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -804,7 +805,7 @@ func (client *datetimeOperations) getUnderflowCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/datetime/underflow"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -855,7 +856,7 @@ func (client *datetimeOperations) putLocalNegativeOffsetMaxDateTimeCreateRequest
 		return nil, err
 	}
 	urlPath := "/datetime/max/localnegativeoffset"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -904,7 +905,7 @@ func (client *datetimeOperations) putLocalNegativeOffsetMinDateTimeCreateRequest
 		return nil, err
 	}
 	urlPath := "/datetime/min/localnegativeoffset"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -953,7 +954,7 @@ func (client *datetimeOperations) putLocalPositiveOffsetMaxDateTimeCreateRequest
 		return nil, err
 	}
 	urlPath := "/datetime/max/localpositiveoffset"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1002,7 +1003,7 @@ func (client *datetimeOperations) putLocalPositiveOffsetMinDateTimeCreateRequest
 		return nil, err
 	}
 	urlPath := "/datetime/min/localpositiveoffset"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1051,7 +1052,7 @@ func (client *datetimeOperations) putUtcMaxDateTimeCreateRequest(datetimeBody ti
 		return nil, err
 	}
 	urlPath := "/datetime/max/utc"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1100,7 +1101,7 @@ func (client *datetimeOperations) putUtcMaxDateTime7DigitsCreateRequest(datetime
 		return nil, err
 	}
 	urlPath := "/datetime/max/utc7ms"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1149,7 +1150,7 @@ func (client *datetimeOperations) putUtcMinDateTimeCreateRequest(datetimeBody ti
 		return nil, err
 	}
 	urlPath := "/datetime/min/utc"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/datetimerfc1123group/client.go
+++ b/test/autorest/generated/datetimerfc1123group/client.go
@@ -8,7 +8,6 @@ package datetimerfc1123group
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-datetimerfc1123group/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // Datetimerfc1123Operations returns the Datetimerfc1123Operations associated with this client.

--- a/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
+++ b/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 )
 
@@ -64,7 +65,7 @@ func (client *datetimerfc1123Operations) getInvalidCreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/datetimerfc1123/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +116,7 @@ func (client *datetimerfc1123Operations) getNullCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/datetimerfc1123/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +167,7 @@ func (client *datetimerfc1123Operations) getOverflowCreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/datetimerfc1123/overflow"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +218,7 @@ func (client *datetimerfc1123Operations) getUtcLowercaseMaxDateTimeCreateRequest
 		return nil, err
 	}
 	urlPath := "/datetimerfc1123/max/lowercase"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +269,7 @@ func (client *datetimerfc1123Operations) getUtcMinDateTimeCreateRequest() (*azco
 		return nil, err
 	}
 	urlPath := "/datetimerfc1123/min"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -319,7 +320,7 @@ func (client *datetimerfc1123Operations) getUtcUppercaseMaxDateTimeCreateRequest
 		return nil, err
 	}
 	urlPath := "/datetimerfc1123/max/uppercase"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +371,7 @@ func (client *datetimerfc1123Operations) getUnderflowCreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/datetimerfc1123/underflow"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -421,7 +422,7 @@ func (client *datetimerfc1123Operations) putUtcMaxDateTimeCreateRequest(datetime
 		return nil, err
 	}
 	urlPath := "/datetimerfc1123/max"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +472,7 @@ func (client *datetimerfc1123Operations) putUtcMinDateTimeCreateRequest(datetime
 		return nil, err
 	}
 	urlPath := "/datetimerfc1123/min"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
+++ b/test/autorest/generated/datetimerfc1123group/datetimerfc1123.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 	"time"
 )
 
@@ -59,8 +59,12 @@ func (client *datetimerfc1123Operations) GetInvalid(ctx context.Context) (*TimeR
 
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *datetimerfc1123Operations) getInvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetimerfc1123/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -106,8 +110,12 @@ func (client *datetimerfc1123Operations) GetNull(ctx context.Context) (*TimeResp
 
 // getNullCreateRequest creates the GetNull request.
 func (client *datetimerfc1123Operations) getNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetimerfc1123/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -153,8 +161,12 @@ func (client *datetimerfc1123Operations) GetOverflow(ctx context.Context) (*Time
 
 // getOverflowCreateRequest creates the GetOverflow request.
 func (client *datetimerfc1123Operations) getOverflowCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetimerfc1123/overflow"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -200,8 +212,12 @@ func (client *datetimerfc1123Operations) GetUTCLowercaseMaxDateTime(ctx context.
 
 // getUtcLowercaseMaxDateTimeCreateRequest creates the GetUTCLowercaseMaxDateTime request.
 func (client *datetimerfc1123Operations) getUtcLowercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetimerfc1123/max/lowercase"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -247,8 +263,12 @@ func (client *datetimerfc1123Operations) GetUTCMinDateTime(ctx context.Context) 
 
 // getUtcMinDateTimeCreateRequest creates the GetUTCMinDateTime request.
 func (client *datetimerfc1123Operations) getUtcMinDateTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetimerfc1123/min"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -294,8 +314,12 @@ func (client *datetimerfc1123Operations) GetUTCUppercaseMaxDateTime(ctx context.
 
 // getUtcUppercaseMaxDateTimeCreateRequest creates the GetUTCUppercaseMaxDateTime request.
 func (client *datetimerfc1123Operations) getUtcUppercaseMaxDateTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetimerfc1123/max/uppercase"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -341,8 +365,12 @@ func (client *datetimerfc1123Operations) GetUnderflow(ctx context.Context) (*Tim
 
 // getUnderflowCreateRequest creates the GetUnderflow request.
 func (client *datetimerfc1123Operations) getUnderflowCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetimerfc1123/underflow"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -388,8 +416,12 @@ func (client *datetimerfc1123Operations) PutUTCMaxDateTime(ctx context.Context, 
 
 // putUtcMaxDateTimeCreateRequest creates the PutUTCMaxDateTime request.
 func (client *datetimerfc1123Operations) putUtcMaxDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetimerfc1123/max"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -434,8 +466,12 @@ func (client *datetimerfc1123Operations) PutUTCMinDateTime(ctx context.Context, 
 
 // putUtcMinDateTimeCreateRequest creates the PutUTCMinDateTime request.
 func (client *datetimerfc1123Operations) putUtcMinDateTimeCreateRequest(datetimeBody time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/datetimerfc1123/min"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/dictionarygroup/client.go
+++ b/test/autorest/generated/dictionarygroup/client.go
@@ -8,7 +8,6 @@ package dictionarygroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-dictionarygroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest Swagger BAT
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // DictionaryOperations returns the DictionaryOperations associated with this client.

--- a/test/autorest/generated/dictionarygroup/dictionary.go
+++ b/test/autorest/generated/dictionarygroup/dictionary.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 	"time"
 )
 
@@ -171,8 +171,12 @@ func (client *dictionaryOperations) GetArrayEmpty(ctx context.Context) (*MapOfSt
 
 // getArrayEmptyCreateRequest creates the GetArrayEmpty request.
 func (client *dictionaryOperations) getArrayEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/array/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -217,8 +221,12 @@ func (client *dictionaryOperations) GetArrayItemEmpty(ctx context.Context) (*Map
 
 // getArrayItemEmptyCreateRequest creates the GetArrayItemEmpty request.
 func (client *dictionaryOperations) getArrayItemEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/array/itemempty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -263,8 +271,12 @@ func (client *dictionaryOperations) GetArrayItemNull(ctx context.Context) (*MapO
 
 // getArrayItemNullCreateRequest creates the GetArrayItemNull request.
 func (client *dictionaryOperations) getArrayItemNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/array/itemnull"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -309,8 +321,12 @@ func (client *dictionaryOperations) GetArrayNull(ctx context.Context) (*MapOfStr
 
 // getArrayNullCreateRequest creates the GetArrayNull request.
 func (client *dictionaryOperations) getArrayNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/array/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -355,8 +371,12 @@ func (client *dictionaryOperations) GetArrayValid(ctx context.Context) (*MapOfSt
 
 // getArrayValidCreateRequest creates the GetArrayValid request.
 func (client *dictionaryOperations) getArrayValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/array/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -401,8 +421,12 @@ func (client *dictionaryOperations) GetBase64URL(ctx context.Context) (*MapOfByt
 
 // getBase64UrlCreateRequest creates the GetBase64URL request.
 func (client *dictionaryOperations) getBase64UrlCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/base64url/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -447,8 +471,12 @@ func (client *dictionaryOperations) GetBooleanInvalidNull(ctx context.Context) (
 
 // getBooleanInvalidNullCreateRequest creates the GetBooleanInvalidNull request.
 func (client *dictionaryOperations) getBooleanInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/boolean/true.null.false"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -493,8 +521,12 @@ func (client *dictionaryOperations) GetBooleanInvalidString(ctx context.Context)
 
 // getBooleanInvalidStringCreateRequest creates the GetBooleanInvalidString request.
 func (client *dictionaryOperations) getBooleanInvalidStringCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/boolean/true.boolean.false"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -539,8 +571,12 @@ func (client *dictionaryOperations) GetBooleanTfft(ctx context.Context) (*MapOfB
 
 // getBooleanTfftCreateRequest creates the GetBooleanTfft request.
 func (client *dictionaryOperations) getBooleanTfftCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/boolean/tfft"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -585,8 +621,12 @@ func (client *dictionaryOperations) GetByteInvalidNull(ctx context.Context) (*Ma
 
 // getByteInvalidNullCreateRequest creates the GetByteInvalidNull request.
 func (client *dictionaryOperations) getByteInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/byte/invalidnull"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -631,8 +671,12 @@ func (client *dictionaryOperations) GetByteValid(ctx context.Context) (*MapOfByt
 
 // getByteValidCreateRequest creates the GetByteValid request.
 func (client *dictionaryOperations) getByteValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/byte/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -677,8 +721,12 @@ func (client *dictionaryOperations) GetComplexEmpty(ctx context.Context) (*MapOf
 
 // getComplexEmptyCreateRequest creates the GetComplexEmpty request.
 func (client *dictionaryOperations) getComplexEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/complex/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -723,8 +771,12 @@ func (client *dictionaryOperations) GetComplexItemEmpty(ctx context.Context) (*M
 
 // getComplexItemEmptyCreateRequest creates the GetComplexItemEmpty request.
 func (client *dictionaryOperations) getComplexItemEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/complex/itemempty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -769,8 +821,12 @@ func (client *dictionaryOperations) GetComplexItemNull(ctx context.Context) (*Ma
 
 // getComplexItemNullCreateRequest creates the GetComplexItemNull request.
 func (client *dictionaryOperations) getComplexItemNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/complex/itemnull"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -815,8 +871,12 @@ func (client *dictionaryOperations) GetComplexNull(ctx context.Context) (*MapOfW
 
 // getComplexNullCreateRequest creates the GetComplexNull request.
 func (client *dictionaryOperations) getComplexNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/complex/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -861,8 +921,12 @@ func (client *dictionaryOperations) GetComplexValid(ctx context.Context) (*MapOf
 
 // getComplexValidCreateRequest creates the GetComplexValid request.
 func (client *dictionaryOperations) getComplexValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/complex/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -907,8 +971,12 @@ func (client *dictionaryOperations) GetDateInvalidChars(ctx context.Context) (*M
 
 // getDateInvalidCharsCreateRequest creates the GetDateInvalidChars request.
 func (client *dictionaryOperations) getDateInvalidCharsCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/date/invalidchars"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -953,8 +1021,12 @@ func (client *dictionaryOperations) GetDateInvalidNull(ctx context.Context) (*Ma
 
 // getDateInvalidNullCreateRequest creates the GetDateInvalidNull request.
 func (client *dictionaryOperations) getDateInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/date/invalidnull"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -999,8 +1071,12 @@ func (client *dictionaryOperations) GetDateTimeInvalidChars(ctx context.Context)
 
 // getDateTimeInvalidCharsCreateRequest creates the GetDateTimeInvalidChars request.
 func (client *dictionaryOperations) getDateTimeInvalidCharsCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/date-time/invalidchars"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1052,8 +1128,12 @@ func (client *dictionaryOperations) GetDateTimeInvalidNull(ctx context.Context) 
 
 // getDateTimeInvalidNullCreateRequest creates the GetDateTimeInvalidNull request.
 func (client *dictionaryOperations) getDateTimeInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/date-time/invalidnull"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1105,8 +1185,12 @@ func (client *dictionaryOperations) GetDateTimeRFC1123Valid(ctx context.Context)
 
 // getDateTimeRfc1123ValidCreateRequest creates the GetDateTimeRFC1123Valid request.
 func (client *dictionaryOperations) getDateTimeRfc1123ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/date-time-rfc1123/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1158,8 +1242,12 @@ func (client *dictionaryOperations) GetDateTimeValid(ctx context.Context) (*MapO
 
 // getDateTimeValidCreateRequest creates the GetDateTimeValid request.
 func (client *dictionaryOperations) getDateTimeValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/date-time/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1211,8 +1299,12 @@ func (client *dictionaryOperations) GetDateValid(ctx context.Context) (*MapOfTim
 
 // getDateValidCreateRequest creates the GetDateValid request.
 func (client *dictionaryOperations) getDateValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/date/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1257,8 +1349,12 @@ func (client *dictionaryOperations) GetDictionaryEmpty(ctx context.Context) (*Ma
 
 // getDictionaryEmptyCreateRequest creates the GetDictionaryEmpty request.
 func (client *dictionaryOperations) getDictionaryEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/dictionary/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1303,8 +1399,12 @@ func (client *dictionaryOperations) GetDictionaryItemEmpty(ctx context.Context) 
 
 // getDictionaryItemEmptyCreateRequest creates the GetDictionaryItemEmpty request.
 func (client *dictionaryOperations) getDictionaryItemEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/dictionary/itemempty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1349,8 +1449,12 @@ func (client *dictionaryOperations) GetDictionaryItemNull(ctx context.Context) (
 
 // getDictionaryItemNullCreateRequest creates the GetDictionaryItemNull request.
 func (client *dictionaryOperations) getDictionaryItemNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/dictionary/itemnull"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1395,8 +1499,12 @@ func (client *dictionaryOperations) GetDictionaryNull(ctx context.Context) (*Map
 
 // getDictionaryNullCreateRequest creates the GetDictionaryNull request.
 func (client *dictionaryOperations) getDictionaryNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/dictionary/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1441,8 +1549,12 @@ func (client *dictionaryOperations) GetDictionaryValid(ctx context.Context) (*Ma
 
 // getDictionaryValidCreateRequest creates the GetDictionaryValid request.
 func (client *dictionaryOperations) getDictionaryValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/dictionary/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1487,8 +1599,12 @@ func (client *dictionaryOperations) GetDoubleInvalidNull(ctx context.Context) (*
 
 // getDoubleInvalidNullCreateRequest creates the GetDoubleInvalidNull request.
 func (client *dictionaryOperations) getDoubleInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/double/0.0-null-1.2e20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1533,8 +1649,12 @@ func (client *dictionaryOperations) GetDoubleInvalidString(ctx context.Context) 
 
 // getDoubleInvalidStringCreateRequest creates the GetDoubleInvalidString request.
 func (client *dictionaryOperations) getDoubleInvalidStringCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/double/1.number.0"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1579,8 +1699,12 @@ func (client *dictionaryOperations) GetDoubleValid(ctx context.Context) (*MapOfF
 
 // getDoubleValidCreateRequest creates the GetDoubleValid request.
 func (client *dictionaryOperations) getDoubleValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/double/0--0.01-1.2e20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1625,8 +1749,12 @@ func (client *dictionaryOperations) GetDurationValid(ctx context.Context) (*MapO
 
 // getDurationValidCreateRequest creates the GetDurationValid request.
 func (client *dictionaryOperations) getDurationValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/duration/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1671,8 +1799,12 @@ func (client *dictionaryOperations) GetEmpty(ctx context.Context) (*MapOfInt32Re
 
 // getEmptyCreateRequest creates the GetEmpty request.
 func (client *dictionaryOperations) getEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1717,8 +1849,12 @@ func (client *dictionaryOperations) GetEmptyStringKey(ctx context.Context) (*Map
 
 // getEmptyStringKeyCreateRequest creates the GetEmptyStringKey request.
 func (client *dictionaryOperations) getEmptyStringKeyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/keyemptystring"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1763,8 +1899,12 @@ func (client *dictionaryOperations) GetFloatInvalidNull(ctx context.Context) (*M
 
 // getFloatInvalidNullCreateRequest creates the GetFloatInvalidNull request.
 func (client *dictionaryOperations) getFloatInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/float/0.0-null-1.2e20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1809,8 +1949,12 @@ func (client *dictionaryOperations) GetFloatInvalidString(ctx context.Context) (
 
 // getFloatInvalidStringCreateRequest creates the GetFloatInvalidString request.
 func (client *dictionaryOperations) getFloatInvalidStringCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/float/1.number.0"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1855,8 +1999,12 @@ func (client *dictionaryOperations) GetFloatValid(ctx context.Context) (*MapOfFl
 
 // getFloatValidCreateRequest creates the GetFloatValid request.
 func (client *dictionaryOperations) getFloatValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/float/0--0.01-1.2e20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1901,8 +2049,12 @@ func (client *dictionaryOperations) GetIntInvalidNull(ctx context.Context) (*Map
 
 // getIntInvalidNullCreateRequest creates the GetIntInvalidNull request.
 func (client *dictionaryOperations) getIntInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/integer/1.null.zero"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1947,8 +2099,12 @@ func (client *dictionaryOperations) GetIntInvalidString(ctx context.Context) (*M
 
 // getIntInvalidStringCreateRequest creates the GetIntInvalidString request.
 func (client *dictionaryOperations) getIntInvalidStringCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/integer/1.integer.0"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1993,8 +2149,12 @@ func (client *dictionaryOperations) GetIntegerValid(ctx context.Context) (*MapOf
 
 // getIntegerValidCreateRequest creates the GetIntegerValid request.
 func (client *dictionaryOperations) getIntegerValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/integer/1.-1.3.300"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2039,8 +2199,12 @@ func (client *dictionaryOperations) GetInvalid(ctx context.Context) (*MapOfStrin
 
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *dictionaryOperations) getInvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2085,8 +2249,12 @@ func (client *dictionaryOperations) GetLongInvalidNull(ctx context.Context) (*Ma
 
 // getLongInvalidNullCreateRequest creates the GetLongInvalidNull request.
 func (client *dictionaryOperations) getLongInvalidNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/long/1.null.zero"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2131,8 +2299,12 @@ func (client *dictionaryOperations) GetLongInvalidString(ctx context.Context) (*
 
 // getLongInvalidStringCreateRequest creates the GetLongInvalidString request.
 func (client *dictionaryOperations) getLongInvalidStringCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/long/1.integer.0"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2177,8 +2349,12 @@ func (client *dictionaryOperations) GetLongValid(ctx context.Context) (*MapOfInt
 
 // getLongValidCreateRequest creates the GetLongValid request.
 func (client *dictionaryOperations) getLongValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/long/1.-1.3.300"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2223,8 +2399,12 @@ func (client *dictionaryOperations) GetNull(ctx context.Context) (*MapOfInt32Res
 
 // getNullCreateRequest creates the GetNull request.
 func (client *dictionaryOperations) getNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2269,8 +2449,12 @@ func (client *dictionaryOperations) GetNullKey(ctx context.Context) (*MapOfStrin
 
 // getNullKeyCreateRequest creates the GetNullKey request.
 func (client *dictionaryOperations) getNullKeyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/nullkey"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2315,8 +2499,12 @@ func (client *dictionaryOperations) GetNullValue(ctx context.Context) (*MapOfStr
 
 // getNullValueCreateRequest creates the GetNullValue request.
 func (client *dictionaryOperations) getNullValueCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/nullvalue"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2361,8 +2549,12 @@ func (client *dictionaryOperations) GetStringValid(ctx context.Context) (*MapOfS
 
 // getStringValidCreateRequest creates the GetStringValid request.
 func (client *dictionaryOperations) getStringValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/string/foo1.foo2.foo3"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2407,8 +2599,12 @@ func (client *dictionaryOperations) GetStringWithInvalid(ctx context.Context) (*
 
 // getStringWithInvalidCreateRequest creates the GetStringWithInvalid request.
 func (client *dictionaryOperations) getStringWithInvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/string/foo.123.foo2"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2453,8 +2649,12 @@ func (client *dictionaryOperations) GetStringWithNull(ctx context.Context) (*Map
 
 // getStringWithNullCreateRequest creates the GetStringWithNull request.
 func (client *dictionaryOperations) getStringWithNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/string/foo.null.foo2"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2499,8 +2699,12 @@ func (client *dictionaryOperations) PutArrayValid(ctx context.Context, arrayBody
 
 // putArrayValidCreateRequest creates the PutArrayValid request.
 func (client *dictionaryOperations) putArrayValidCreateRequest(arrayBody map[string][]string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/array/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2544,8 +2748,12 @@ func (client *dictionaryOperations) PutBooleanTfft(ctx context.Context, arrayBod
 
 // putBooleanTfftCreateRequest creates the PutBooleanTfft request.
 func (client *dictionaryOperations) putBooleanTfftCreateRequest(arrayBody map[string]bool) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/boolean/tfft"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2589,8 +2797,12 @@ func (client *dictionaryOperations) PutByteValid(ctx context.Context, arrayBody 
 
 // putByteValidCreateRequest creates the PutByteValid request.
 func (client *dictionaryOperations) putByteValidCreateRequest(arrayBody map[string][]byte) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/byte/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2634,8 +2846,12 @@ func (client *dictionaryOperations) PutComplexValid(ctx context.Context, arrayBo
 
 // putComplexValidCreateRequest creates the PutComplexValid request.
 func (client *dictionaryOperations) putComplexValidCreateRequest(arrayBody map[string]Widget) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/complex/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2679,8 +2895,12 @@ func (client *dictionaryOperations) PutDateTimeRFC1123Valid(ctx context.Context,
 
 // putDateTimeRfc1123ValidCreateRequest creates the PutDateTimeRFC1123Valid request.
 func (client *dictionaryOperations) putDateTimeRfc1123ValidCreateRequest(arrayBody map[string]time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/date-time-rfc1123/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2728,8 +2948,12 @@ func (client *dictionaryOperations) PutDateTimeValid(ctx context.Context, arrayB
 
 // putDateTimeValidCreateRequest creates the PutDateTimeValid request.
 func (client *dictionaryOperations) putDateTimeValidCreateRequest(arrayBody map[string]time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/date-time/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2777,8 +3001,12 @@ func (client *dictionaryOperations) PutDateValid(ctx context.Context, arrayBody 
 
 // putDateValidCreateRequest creates the PutDateValid request.
 func (client *dictionaryOperations) putDateValidCreateRequest(arrayBody map[string]time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/date/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2822,8 +3050,12 @@ func (client *dictionaryOperations) PutDictionaryValid(ctx context.Context, arra
 
 // putDictionaryValidCreateRequest creates the PutDictionaryValid request.
 func (client *dictionaryOperations) putDictionaryValidCreateRequest(arrayBody map[string]interface{}) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/dictionary/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2867,8 +3099,12 @@ func (client *dictionaryOperations) PutDoubleValid(ctx context.Context, arrayBod
 
 // putDoubleValidCreateRequest creates the PutDoubleValid request.
 func (client *dictionaryOperations) putDoubleValidCreateRequest(arrayBody map[string]float64) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/double/0--0.01-1.2e20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2912,8 +3148,12 @@ func (client *dictionaryOperations) PutDurationValid(ctx context.Context, arrayB
 
 // putDurationValidCreateRequest creates the PutDurationValid request.
 func (client *dictionaryOperations) putDurationValidCreateRequest(arrayBody map[string]string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/duration/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2957,8 +3197,12 @@ func (client *dictionaryOperations) PutEmpty(ctx context.Context, arrayBody map[
 
 // putEmptyCreateRequest creates the PutEmpty request.
 func (client *dictionaryOperations) putEmptyCreateRequest(arrayBody map[string]string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -3002,8 +3246,12 @@ func (client *dictionaryOperations) PutFloatValid(ctx context.Context, arrayBody
 
 // putFloatValidCreateRequest creates the PutFloatValid request.
 func (client *dictionaryOperations) putFloatValidCreateRequest(arrayBody map[string]float32) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/float/0--0.01-1.2e20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -3047,8 +3295,12 @@ func (client *dictionaryOperations) PutIntegerValid(ctx context.Context, arrayBo
 
 // putIntegerValidCreateRequest creates the PutIntegerValid request.
 func (client *dictionaryOperations) putIntegerValidCreateRequest(arrayBody map[string]int32) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/integer/1.-1.3.300"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -3092,8 +3344,12 @@ func (client *dictionaryOperations) PutLongValid(ctx context.Context, arrayBody 
 
 // putLongValidCreateRequest creates the PutLongValid request.
 func (client *dictionaryOperations) putLongValidCreateRequest(arrayBody map[string]int64) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/long/1.-1.3.300"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -3137,8 +3393,12 @@ func (client *dictionaryOperations) PutStringValid(ctx context.Context, arrayBod
 
 // putStringValidCreateRequest creates the PutStringValid request.
 func (client *dictionaryOperations) putStringValidCreateRequest(arrayBody map[string]string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/dictionary/prim/string/foo1.foo2.foo3"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/dictionarygroup/dictionary.go
+++ b/test/autorest/generated/dictionarygroup/dictionary.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 )
 
@@ -176,7 +177,7 @@ func (client *dictionaryOperations) getArrayEmptyCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/dictionary/array/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *dictionaryOperations) getArrayItemEmptyCreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/dictionary/array/itemempty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +277,7 @@ func (client *dictionaryOperations) getArrayItemNullCreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/dictionary/array/itemnull"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +327,7 @@ func (client *dictionaryOperations) getArrayNullCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/dictionary/array/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +377,7 @@ func (client *dictionaryOperations) getArrayValidCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/dictionary/array/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -426,7 +427,7 @@ func (client *dictionaryOperations) getBase64UrlCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/base64url/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -476,7 +477,7 @@ func (client *dictionaryOperations) getBooleanInvalidNullCreateRequest() (*azcor
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/boolean/true.null.false"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -526,7 +527,7 @@ func (client *dictionaryOperations) getBooleanInvalidStringCreateRequest() (*azc
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/boolean/true.boolean.false"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -576,7 +577,7 @@ func (client *dictionaryOperations) getBooleanTfftCreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/boolean/tfft"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -626,7 +627,7 @@ func (client *dictionaryOperations) getByteInvalidNullCreateRequest() (*azcore.R
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/byte/invalidnull"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -676,7 +677,7 @@ func (client *dictionaryOperations) getByteValidCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/byte/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -726,7 +727,7 @@ func (client *dictionaryOperations) getComplexEmptyCreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/dictionary/complex/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -776,7 +777,7 @@ func (client *dictionaryOperations) getComplexItemEmptyCreateRequest() (*azcore.
 		return nil, err
 	}
 	urlPath := "/dictionary/complex/itemempty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -826,7 +827,7 @@ func (client *dictionaryOperations) getComplexItemNullCreateRequest() (*azcore.R
 		return nil, err
 	}
 	urlPath := "/dictionary/complex/itemnull"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -876,7 +877,7 @@ func (client *dictionaryOperations) getComplexNullCreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/dictionary/complex/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -926,7 +927,7 @@ func (client *dictionaryOperations) getComplexValidCreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/dictionary/complex/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -976,7 +977,7 @@ func (client *dictionaryOperations) getDateInvalidCharsCreateRequest() (*azcore.
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/date/invalidchars"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1026,7 +1027,7 @@ func (client *dictionaryOperations) getDateInvalidNullCreateRequest() (*azcore.R
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/date/invalidnull"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1076,7 +1077,7 @@ func (client *dictionaryOperations) getDateTimeInvalidCharsCreateRequest() (*azc
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/date-time/invalidchars"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1133,7 +1134,7 @@ func (client *dictionaryOperations) getDateTimeInvalidNullCreateRequest() (*azco
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/date-time/invalidnull"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1190,7 +1191,7 @@ func (client *dictionaryOperations) getDateTimeRfc1123ValidCreateRequest() (*azc
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/date-time-rfc1123/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1247,7 +1248,7 @@ func (client *dictionaryOperations) getDateTimeValidCreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/date-time/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1304,7 +1305,7 @@ func (client *dictionaryOperations) getDateValidCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/date/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1354,7 +1355,7 @@ func (client *dictionaryOperations) getDictionaryEmptyCreateRequest() (*azcore.R
 		return nil, err
 	}
 	urlPath := "/dictionary/dictionary/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1404,7 +1405,7 @@ func (client *dictionaryOperations) getDictionaryItemEmptyCreateRequest() (*azco
 		return nil, err
 	}
 	urlPath := "/dictionary/dictionary/itemempty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1454,7 +1455,7 @@ func (client *dictionaryOperations) getDictionaryItemNullCreateRequest() (*azcor
 		return nil, err
 	}
 	urlPath := "/dictionary/dictionary/itemnull"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1504,7 +1505,7 @@ func (client *dictionaryOperations) getDictionaryNullCreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/dictionary/dictionary/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1554,7 +1555,7 @@ func (client *dictionaryOperations) getDictionaryValidCreateRequest() (*azcore.R
 		return nil, err
 	}
 	urlPath := "/dictionary/dictionary/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1604,7 +1605,7 @@ func (client *dictionaryOperations) getDoubleInvalidNullCreateRequest() (*azcore
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/double/0.0-null-1.2e20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1654,7 +1655,7 @@ func (client *dictionaryOperations) getDoubleInvalidStringCreateRequest() (*azco
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/double/1.number.0"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1704,7 +1705,7 @@ func (client *dictionaryOperations) getDoubleValidCreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/double/0--0.01-1.2e20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1754,7 +1755,7 @@ func (client *dictionaryOperations) getDurationValidCreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/duration/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1804,7 +1805,7 @@ func (client *dictionaryOperations) getEmptyCreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/dictionary/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1854,7 +1855,7 @@ func (client *dictionaryOperations) getEmptyStringKeyCreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/dictionary/keyemptystring"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1904,7 +1905,7 @@ func (client *dictionaryOperations) getFloatInvalidNullCreateRequest() (*azcore.
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/float/0.0-null-1.2e20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1954,7 +1955,7 @@ func (client *dictionaryOperations) getFloatInvalidStringCreateRequest() (*azcor
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/float/1.number.0"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2004,7 +2005,7 @@ func (client *dictionaryOperations) getFloatValidCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/float/0--0.01-1.2e20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2054,7 +2055,7 @@ func (client *dictionaryOperations) getIntInvalidNullCreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/integer/1.null.zero"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2104,7 +2105,7 @@ func (client *dictionaryOperations) getIntInvalidStringCreateRequest() (*azcore.
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/integer/1.integer.0"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2154,7 +2155,7 @@ func (client *dictionaryOperations) getIntegerValidCreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/integer/1.-1.3.300"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2204,7 +2205,7 @@ func (client *dictionaryOperations) getInvalidCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/dictionary/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2254,7 +2255,7 @@ func (client *dictionaryOperations) getLongInvalidNullCreateRequest() (*azcore.R
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/long/1.null.zero"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2304,7 +2305,7 @@ func (client *dictionaryOperations) getLongInvalidStringCreateRequest() (*azcore
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/long/1.integer.0"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2354,7 +2355,7 @@ func (client *dictionaryOperations) getLongValidCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/long/1.-1.3.300"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2404,7 +2405,7 @@ func (client *dictionaryOperations) getNullCreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/dictionary/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2454,7 +2455,7 @@ func (client *dictionaryOperations) getNullKeyCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/dictionary/nullkey"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2504,7 +2505,7 @@ func (client *dictionaryOperations) getNullValueCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/dictionary/nullvalue"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2554,7 +2555,7 @@ func (client *dictionaryOperations) getStringValidCreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/string/foo1.foo2.foo3"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2604,7 +2605,7 @@ func (client *dictionaryOperations) getStringWithInvalidCreateRequest() (*azcore
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/string/foo.123.foo2"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2654,7 +2655,7 @@ func (client *dictionaryOperations) getStringWithNullCreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/string/foo.null.foo2"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2704,7 +2705,7 @@ func (client *dictionaryOperations) putArrayValidCreateRequest(arrayBody map[str
 		return nil, err
 	}
 	urlPath := "/dictionary/array/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2753,7 +2754,7 @@ func (client *dictionaryOperations) putBooleanTfftCreateRequest(arrayBody map[st
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/boolean/tfft"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2802,7 +2803,7 @@ func (client *dictionaryOperations) putByteValidCreateRequest(arrayBody map[stri
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/byte/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2851,7 +2852,7 @@ func (client *dictionaryOperations) putComplexValidCreateRequest(arrayBody map[s
 		return nil, err
 	}
 	urlPath := "/dictionary/complex/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2900,7 +2901,7 @@ func (client *dictionaryOperations) putDateTimeRfc1123ValidCreateRequest(arrayBo
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/date-time-rfc1123/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2953,7 +2954,7 @@ func (client *dictionaryOperations) putDateTimeValidCreateRequest(arrayBody map[
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/date-time/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3006,7 +3007,7 @@ func (client *dictionaryOperations) putDateValidCreateRequest(arrayBody map[stri
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/date/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3055,7 +3056,7 @@ func (client *dictionaryOperations) putDictionaryValidCreateRequest(arrayBody ma
 		return nil, err
 	}
 	urlPath := "/dictionary/dictionary/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3104,7 +3105,7 @@ func (client *dictionaryOperations) putDoubleValidCreateRequest(arrayBody map[st
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/double/0--0.01-1.2e20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3153,7 +3154,7 @@ func (client *dictionaryOperations) putDurationValidCreateRequest(arrayBody map[
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/duration/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3202,7 +3203,7 @@ func (client *dictionaryOperations) putEmptyCreateRequest(arrayBody map[string]s
 		return nil, err
 	}
 	urlPath := "/dictionary/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3251,7 +3252,7 @@ func (client *dictionaryOperations) putFloatValidCreateRequest(arrayBody map[str
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/float/0--0.01-1.2e20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3300,7 +3301,7 @@ func (client *dictionaryOperations) putIntegerValidCreateRequest(arrayBody map[s
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/integer/1.-1.3.300"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3349,7 +3350,7 @@ func (client *dictionaryOperations) putLongValidCreateRequest(arrayBody map[stri
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/long/1.-1.3.300"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3398,7 +3399,7 @@ func (client *dictionaryOperations) putStringValidCreateRequest(arrayBody map[st
 		return nil, err
 	}
 	urlPath := "/dictionary/prim/string/foo1.foo2.foo3"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/durationgroup/client.go
+++ b/test/autorest/generated/durationgroup/client.go
@@ -8,7 +8,6 @@ package durationgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-durationgroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // DurationOperations returns the DurationOperations associated with this client.

--- a/test/autorest/generated/durationgroup/duration.go
+++ b/test/autorest/generated/durationgroup/duration.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // DurationOperations contains the methods for the Duration group.
@@ -53,7 +54,7 @@ func (client *durationOperations) getInvalidCreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/duration/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +104,7 @@ func (client *durationOperations) getNullCreateRequest() (*azcore.Request, error
 		return nil, err
 	}
 	urlPath := "/duration/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +154,7 @@ func (client *durationOperations) getPositiveDurationCreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/duration/positiveduration"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +204,7 @@ func (client *durationOperations) putPositiveDurationCreateRequest(durationBody 
 		return nil, err
 	}
 	urlPath := "/duration/positiveduration"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/durationgroup/duration.go
+++ b/test/autorest/generated/durationgroup/duration.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // DurationOperations contains the methods for the Duration group.
@@ -48,8 +48,12 @@ func (client *durationOperations) GetInvalid(ctx context.Context) (*StringRespon
 
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *durationOperations) getInvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/duration/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -94,8 +98,12 @@ func (client *durationOperations) GetNull(ctx context.Context) (*StringResponse,
 
 // getNullCreateRequest creates the GetNull request.
 func (client *durationOperations) getNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/duration/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -140,8 +148,12 @@ func (client *durationOperations) GetPositiveDuration(ctx context.Context) (*Str
 
 // getPositiveDurationCreateRequest creates the GetPositiveDuration request.
 func (client *durationOperations) getPositiveDurationCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/duration/positiveduration"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -186,8 +198,12 @@ func (client *durationOperations) PutPositiveDuration(ctx context.Context, durat
 
 // putPositiveDurationCreateRequest creates the PutPositiveDuration request.
 func (client *durationOperations) putPositiveDurationCreateRequest(durationBody string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/duration/positiveduration"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/errorsgroup/client.go
+++ b/test/autorest/generated/errorsgroup/client.go
@@ -8,7 +8,6 @@ package errorsgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-errorsgroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - XMS Error Response Extensions
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // PetOperations returns the PetOperations associated with this client.

--- a/test/autorest/generated/errorsgroup/pet.go
+++ b/test/autorest/generated/errorsgroup/pet.go
@@ -13,7 +13,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -49,9 +48,13 @@ func (client *petOperations) DoSomething(ctx context.Context, whatAction string)
 
 // doSomethingCreateRequest creates the DoSomething request.
 func (client *petOperations) doSomethingCreateRequest(whatAction string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/errorStatusCodes/Pets/doSomething/{whatAction}"
 	urlPath = strings.ReplaceAll(urlPath, "{whatAction}", url.PathEscape(whatAction))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -105,9 +108,13 @@ func (client *petOperations) GetPetByID(ctx context.Context, petId string) (*Pet
 
 // getPetByIdCreateRequest creates the GetPetByID request.
 func (client *petOperations) getPetByIdCreateRequest(petId string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/errorStatusCodes/Pets/{petId}/GetPet"
 	urlPath = strings.ReplaceAll(urlPath, "{petId}", url.PathEscape(petId))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/errorsgroup/pet.go
+++ b/test/autorest/generated/errorsgroup/pet.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -54,7 +55,7 @@ func (client *petOperations) doSomethingCreateRequest(whatAction string) (*azcor
 	}
 	urlPath := "/errorStatusCodes/Pets/doSomething/{whatAction}"
 	urlPath = strings.ReplaceAll(urlPath, "{whatAction}", url.PathEscape(whatAction))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +115,7 @@ func (client *petOperations) getPetByIdCreateRequest(petId string) (*azcore.Requ
 	}
 	urlPath := "/errorStatusCodes/Pets/{petId}/GetPet"
 	urlPath = strings.ReplaceAll(urlPath, "{petId}", url.PathEscape(petId))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/extenumsgroup/client.go
+++ b/test/autorest/generated/extenumsgroup/client.go
@@ -8,7 +8,6 @@ package extenumsgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-extenumsgroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - PetStore
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // PetOperations returns the PetOperations associated with this client.

--- a/test/autorest/generated/extenumsgroup/pet.go
+++ b/test/autorest/generated/extenumsgroup/pet.go
@@ -13,7 +13,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -49,8 +48,12 @@ func (client *petOperations) AddPet(ctx context.Context, petAddPetOptions *PetAd
 
 // addPetCreateRequest creates the AddPet request.
 func (client *petOperations) addPetCreateRequest(petAddPetOptions *PetAddPetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/extensibleenums/pet/addPet"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -101,9 +104,13 @@ func (client *petOperations) GetByPetID(ctx context.Context, petId string) (*Pet
 
 // getByPetIdCreateRequest creates the GetByPetID request.
 func (client *petOperations) getByPetIdCreateRequest(petId string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/extensibleenums/pet/{petId}"
 	urlPath = strings.ReplaceAll(urlPath, "{petId}", url.PathEscape(petId))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/extenumsgroup/pet.go
+++ b/test/autorest/generated/extenumsgroup/pet.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -53,7 +54,7 @@ func (client *petOperations) addPetCreateRequest(petAddPetOptions *PetAddPetOpti
 		return nil, err
 	}
 	urlPath := "/extensibleenums/pet/addPet"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (client *petOperations) getByPetIdCreateRequest(petId string) (*azcore.Requ
 	}
 	urlPath := "/extensibleenums/pet/{petId}"
 	urlPath = strings.ReplaceAll(urlPath, "{petId}", url.PathEscape(petId))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/filegroup/client.go
+++ b/test/autorest/generated/filegroup/client.go
@@ -8,7 +8,6 @@ package filegroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-filegroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest Swagger BAT
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // FilesOperations returns the FilesOperations associated with this client.

--- a/test/autorest/generated/filegroup/files.go
+++ b/test/autorest/generated/filegroup/files.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // FilesOperations contains the methods for the Files group.
@@ -46,8 +46,12 @@ func (client *filesOperations) GetEmptyFile(ctx context.Context) (*http.Response
 
 // getEmptyFileCreateRequest creates the GetEmptyFile request.
 func (client *filesOperations) getEmptyFileCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/files/stream/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -92,8 +96,12 @@ func (client *filesOperations) GetFile(ctx context.Context) (*http.Response, err
 
 // getFileCreateRequest creates the GetFile request.
 func (client *filesOperations) getFileCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/files/stream/nonempty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -138,8 +146,12 @@ func (client *filesOperations) GetFileLarge(ctx context.Context) (*http.Response
 
 // getFileLargeCreateRequest creates the GetFileLarge request.
 func (client *filesOperations) getFileLargeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/files/stream/verylarge"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/filegroup/files.go
+++ b/test/autorest/generated/filegroup/files.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // FilesOperations contains the methods for the Files group.
@@ -51,7 +52,7 @@ func (client *filesOperations) getEmptyFileCreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/files/stream/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +102,7 @@ func (client *filesOperations) getFileCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/files/stream/nonempty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +152,7 @@ func (client *filesOperations) getFileLargeCreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/files/stream/verylarge"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/headergroup/client.go
+++ b/test/autorest/generated/headergroup/client.go
@@ -8,7 +8,6 @@ package headergroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-headergroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // HeaderOperations returns the HeaderOperations associated with this client.

--- a/test/autorest/generated/headergroup/header.go
+++ b/test/autorest/generated/headergroup/header.go
@@ -10,7 +10,7 @@ import (
 	"encoding/base64"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 	"strconv"
 	"time"
 )
@@ -101,8 +101,12 @@ func (client *headerOperations) CustomRequestID(ctx context.Context) (*http.Resp
 
 // customRequestIdCreateRequest creates the CustomRequestID request.
 func (client *headerOperations) customRequestIdCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -146,8 +150,12 @@ func (client *headerOperations) ParamBool(ctx context.Context, scenario string, 
 
 // paramBoolCreateRequest creates the ParamBool request.
 func (client *headerOperations) paramBoolCreateRequest(scenario string, value bool) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/param/prim/bool"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -193,8 +201,12 @@ func (client *headerOperations) ParamByte(ctx context.Context, scenario string, 
 
 // paramByteCreateRequest creates the ParamByte request.
 func (client *headerOperations) paramByteCreateRequest(scenario string, value []byte) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/param/prim/byte"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -240,8 +252,12 @@ func (client *headerOperations) ParamDate(ctx context.Context, scenario string, 
 
 // paramDateCreateRequest creates the ParamDate request.
 func (client *headerOperations) paramDateCreateRequest(scenario string, value time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/param/prim/date"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -287,8 +303,12 @@ func (client *headerOperations) ParamDatetime(ctx context.Context, scenario stri
 
 // paramDatetimeCreateRequest creates the ParamDatetime request.
 func (client *headerOperations) paramDatetimeCreateRequest(scenario string, value time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/param/prim/datetime"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -334,8 +354,12 @@ func (client *headerOperations) ParamDatetimeRFC1123(ctx context.Context, scenar
 
 // paramDatetimeRfc1123CreateRequest creates the ParamDatetimeRFC1123 request.
 func (client *headerOperations) paramDatetimeRfc1123CreateRequest(scenario string, headerParamDatetimeRfc1123Options *HeaderParamDatetimeRFC1123Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/param/prim/datetimerfc1123"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -383,8 +407,12 @@ func (client *headerOperations) ParamDouble(ctx context.Context, scenario string
 
 // paramDoubleCreateRequest creates the ParamDouble request.
 func (client *headerOperations) paramDoubleCreateRequest(scenario string, value float64) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/param/prim/double"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -430,8 +458,12 @@ func (client *headerOperations) ParamDuration(ctx context.Context, scenario stri
 
 // paramDurationCreateRequest creates the ParamDuration request.
 func (client *headerOperations) paramDurationCreateRequest(scenario string, value string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/param/prim/duration"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -477,8 +509,12 @@ func (client *headerOperations) ParamEnum(ctx context.Context, scenario string, 
 
 // paramEnumCreateRequest creates the ParamEnum request.
 func (client *headerOperations) paramEnumCreateRequest(scenario string, headerParamEnumOptions *HeaderParamEnumOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/param/prim/enum"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -526,8 +562,12 @@ func (client *headerOperations) ParamExistingKey(ctx context.Context, userAgent 
 
 // paramExistingKeyCreateRequest creates the ParamExistingKey request.
 func (client *headerOperations) paramExistingKeyCreateRequest(userAgent string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/param/existingkey"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -572,8 +612,12 @@ func (client *headerOperations) ParamFloat(ctx context.Context, scenario string,
 
 // paramFloatCreateRequest creates the ParamFloat request.
 func (client *headerOperations) paramFloatCreateRequest(scenario string, value float32) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/param/prim/float"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -619,8 +663,12 @@ func (client *headerOperations) ParamInteger(ctx context.Context, scenario strin
 
 // paramIntegerCreateRequest creates the ParamInteger request.
 func (client *headerOperations) paramIntegerCreateRequest(scenario string, value int32) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/param/prim/integer"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -666,8 +714,12 @@ func (client *headerOperations) ParamLong(ctx context.Context, scenario string, 
 
 // paramLongCreateRequest creates the ParamLong request.
 func (client *headerOperations) paramLongCreateRequest(scenario string, value int64) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/param/prim/long"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -713,8 +765,12 @@ func (client *headerOperations) ParamProtectedKey(ctx context.Context, contentTy
 
 // paramProtectedKeyCreateRequest creates the ParamProtectedKey request.
 func (client *headerOperations) paramProtectedKeyCreateRequest(contentType string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/param/protectedkey"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -759,8 +815,12 @@ func (client *headerOperations) ParamString(ctx context.Context, scenario string
 
 // paramStringCreateRequest creates the ParamString request.
 func (client *headerOperations) paramStringCreateRequest(scenario string, headerParamStringOptions *HeaderParamStringOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/param/prim/string"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -808,8 +868,12 @@ func (client *headerOperations) ResponseBool(ctx context.Context, scenario strin
 
 // responseBoolCreateRequest creates the ResponseBool request.
 func (client *headerOperations) responseBoolCreateRequest(scenario string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/response/prim/bool"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -862,8 +926,12 @@ func (client *headerOperations) ResponseByte(ctx context.Context, scenario strin
 
 // responseByteCreateRequest creates the ResponseByte request.
 func (client *headerOperations) responseByteCreateRequest(scenario string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/response/prim/byte"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -916,8 +984,12 @@ func (client *headerOperations) ResponseDate(ctx context.Context, scenario strin
 
 // responseDateCreateRequest creates the ResponseDate request.
 func (client *headerOperations) responseDateCreateRequest(scenario string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/response/prim/date"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -970,8 +1042,12 @@ func (client *headerOperations) ResponseDatetime(ctx context.Context, scenario s
 
 // responseDatetimeCreateRequest creates the ResponseDatetime request.
 func (client *headerOperations) responseDatetimeCreateRequest(scenario string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/response/prim/datetime"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1024,8 +1100,12 @@ func (client *headerOperations) ResponseDatetimeRFC1123(ctx context.Context, sce
 
 // responseDatetimeRfc1123CreateRequest creates the ResponseDatetimeRFC1123 request.
 func (client *headerOperations) responseDatetimeRfc1123CreateRequest(scenario string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/response/prim/datetimerfc1123"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1078,8 +1158,12 @@ func (client *headerOperations) ResponseDouble(ctx context.Context, scenario str
 
 // responseDoubleCreateRequest creates the ResponseDouble request.
 func (client *headerOperations) responseDoubleCreateRequest(scenario string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/response/prim/double"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1132,8 +1216,12 @@ func (client *headerOperations) ResponseDuration(ctx context.Context, scenario s
 
 // responseDurationCreateRequest creates the ResponseDuration request.
 func (client *headerOperations) responseDurationCreateRequest(scenario string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/response/prim/duration"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1182,8 +1270,12 @@ func (client *headerOperations) ResponseEnum(ctx context.Context, scenario strin
 
 // responseEnumCreateRequest creates the ResponseEnum request.
 func (client *headerOperations) responseEnumCreateRequest(scenario string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/response/prim/enum"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1232,8 +1324,12 @@ func (client *headerOperations) ResponseExistingKey(ctx context.Context) (*Heade
 
 // responseExistingKeyCreateRequest creates the ResponseExistingKey request.
 func (client *headerOperations) responseExistingKeyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/response/existingkey"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1281,8 +1377,12 @@ func (client *headerOperations) ResponseFloat(ctx context.Context, scenario stri
 
 // responseFloatCreateRequest creates the ResponseFloat request.
 func (client *headerOperations) responseFloatCreateRequest(scenario string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/response/prim/float"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1336,8 +1436,12 @@ func (client *headerOperations) ResponseInteger(ctx context.Context, scenario st
 
 // responseIntegerCreateRequest creates the ResponseInteger request.
 func (client *headerOperations) responseIntegerCreateRequest(scenario string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/response/prim/integer"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1391,8 +1495,12 @@ func (client *headerOperations) ResponseLong(ctx context.Context, scenario strin
 
 // responseLongCreateRequest creates the ResponseLong request.
 func (client *headerOperations) responseLongCreateRequest(scenario string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/response/prim/long"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1445,8 +1553,12 @@ func (client *headerOperations) ResponseProtectedKey(ctx context.Context) (*Head
 
 // responseProtectedKeyCreateRequest creates the ResponseProtectedKey request.
 func (client *headerOperations) responseProtectedKeyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/response/protectedkey"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1494,8 +1606,12 @@ func (client *headerOperations) ResponseString(ctx context.Context, scenario str
 
 // responseStringCreateRequest creates the ResponseString request.
 func (client *headerOperations) responseStringCreateRequest(scenario string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/header/response/prim/string"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/headergroup/header.go
+++ b/test/autorest/generated/headergroup/header.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"time"
 )
@@ -106,7 +107,7 @@ func (client *headerOperations) customRequestIdCreateRequest() (*azcore.Request,
 		return nil, err
 	}
 	urlPath := "/header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +156,7 @@ func (client *headerOperations) paramBoolCreateRequest(scenario string, value bo
 		return nil, err
 	}
 	urlPath := "/header/param/prim/bool"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +207,7 @@ func (client *headerOperations) paramByteCreateRequest(scenario string, value []
 		return nil, err
 	}
 	urlPath := "/header/param/prim/byte"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +258,7 @@ func (client *headerOperations) paramDateCreateRequest(scenario string, value ti
 		return nil, err
 	}
 	urlPath := "/header/param/prim/date"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +309,7 @@ func (client *headerOperations) paramDatetimeCreateRequest(scenario string, valu
 		return nil, err
 	}
 	urlPath := "/header/param/prim/datetime"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +360,7 @@ func (client *headerOperations) paramDatetimeRfc1123CreateRequest(scenario strin
 		return nil, err
 	}
 	urlPath := "/header/param/prim/datetimerfc1123"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -412,7 +413,7 @@ func (client *headerOperations) paramDoubleCreateRequest(scenario string, value 
 		return nil, err
 	}
 	urlPath := "/header/param/prim/double"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -463,7 +464,7 @@ func (client *headerOperations) paramDurationCreateRequest(scenario string, valu
 		return nil, err
 	}
 	urlPath := "/header/param/prim/duration"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +515,7 @@ func (client *headerOperations) paramEnumCreateRequest(scenario string, headerPa
 		return nil, err
 	}
 	urlPath := "/header/param/prim/enum"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -567,7 +568,7 @@ func (client *headerOperations) paramExistingKeyCreateRequest(userAgent string) 
 		return nil, err
 	}
 	urlPath := "/header/param/existingkey"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -617,7 +618,7 @@ func (client *headerOperations) paramFloatCreateRequest(scenario string, value f
 		return nil, err
 	}
 	urlPath := "/header/param/prim/float"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -668,7 +669,7 @@ func (client *headerOperations) paramIntegerCreateRequest(scenario string, value
 		return nil, err
 	}
 	urlPath := "/header/param/prim/integer"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -719,7 +720,7 @@ func (client *headerOperations) paramLongCreateRequest(scenario string, value in
 		return nil, err
 	}
 	urlPath := "/header/param/prim/long"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -770,7 +771,7 @@ func (client *headerOperations) paramProtectedKeyCreateRequest(contentType strin
 		return nil, err
 	}
 	urlPath := "/header/param/protectedkey"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -820,7 +821,7 @@ func (client *headerOperations) paramStringCreateRequest(scenario string, header
 		return nil, err
 	}
 	urlPath := "/header/param/prim/string"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -873,7 +874,7 @@ func (client *headerOperations) responseBoolCreateRequest(scenario string) (*azc
 		return nil, err
 	}
 	urlPath := "/header/response/prim/bool"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -931,7 +932,7 @@ func (client *headerOperations) responseByteCreateRequest(scenario string) (*azc
 		return nil, err
 	}
 	urlPath := "/header/response/prim/byte"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -989,7 +990,7 @@ func (client *headerOperations) responseDateCreateRequest(scenario string) (*azc
 		return nil, err
 	}
 	urlPath := "/header/response/prim/date"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1047,7 +1048,7 @@ func (client *headerOperations) responseDatetimeCreateRequest(scenario string) (
 		return nil, err
 	}
 	urlPath := "/header/response/prim/datetime"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1105,7 +1106,7 @@ func (client *headerOperations) responseDatetimeRfc1123CreateRequest(scenario st
 		return nil, err
 	}
 	urlPath := "/header/response/prim/datetimerfc1123"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1163,7 +1164,7 @@ func (client *headerOperations) responseDoubleCreateRequest(scenario string) (*a
 		return nil, err
 	}
 	urlPath := "/header/response/prim/double"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1221,7 +1222,7 @@ func (client *headerOperations) responseDurationCreateRequest(scenario string) (
 		return nil, err
 	}
 	urlPath := "/header/response/prim/duration"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1275,7 +1276,7 @@ func (client *headerOperations) responseEnumCreateRequest(scenario string) (*azc
 		return nil, err
 	}
 	urlPath := "/header/response/prim/enum"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1329,7 +1330,7 @@ func (client *headerOperations) responseExistingKeyCreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/header/response/existingkey"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1382,7 +1383,7 @@ func (client *headerOperations) responseFloatCreateRequest(scenario string) (*az
 		return nil, err
 	}
 	urlPath := "/header/response/prim/float"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1441,7 +1442,7 @@ func (client *headerOperations) responseIntegerCreateRequest(scenario string) (*
 		return nil, err
 	}
 	urlPath := "/header/response/prim/integer"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1500,7 +1501,7 @@ func (client *headerOperations) responseLongCreateRequest(scenario string) (*azc
 		return nil, err
 	}
 	urlPath := "/header/response/prim/long"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1558,7 +1559,7 @@ func (client *headerOperations) responseProtectedKeyCreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/header/response/protectedkey"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1611,7 +1612,7 @@ func (client *headerOperations) responseStringCreateRequest(scenario string) (*a
 		return nil, err
 	}
 	urlPath := "/header/response/prim/string"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/client.go
+++ b/test/autorest/generated/httpinfrastructuregroup/client.go
@@ -8,7 +8,6 @@ package httpinfrastructuregroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-httpinfrastructuregroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // HTTPFailureOperations returns the HTTPFailureOperations associated with this client.

--- a/test/autorest/generated/httpinfrastructuregroup/httpclientfailure.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpclientfailure.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // HTTPClientFailureOperations contains the methods for the HTTPClientFailure group.
@@ -92,8 +92,12 @@ func (client *httpClientFailureOperations) Delete400(ctx context.Context) (*http
 
 // delete400CreateRequest creates the Delete400 request.
 func (client *httpClientFailureOperations) delete400CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -134,8 +138,12 @@ func (client *httpClientFailureOperations) Delete407(ctx context.Context) (*http
 
 // delete407CreateRequest creates the Delete407 request.
 func (client *httpClientFailureOperations) delete407CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/407"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -176,8 +184,12 @@ func (client *httpClientFailureOperations) Delete417(ctx context.Context) (*http
 
 // delete417CreateRequest creates the Delete417 request.
 func (client *httpClientFailureOperations) delete417CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/417"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -218,8 +230,12 @@ func (client *httpClientFailureOperations) Get400(ctx context.Context) (*http.Re
 
 // get400CreateRequest creates the Get400 request.
 func (client *httpClientFailureOperations) get400CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -260,8 +276,12 @@ func (client *httpClientFailureOperations) Get402(ctx context.Context) (*http.Re
 
 // get402CreateRequest creates the Get402 request.
 func (client *httpClientFailureOperations) get402CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/402"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -302,8 +322,12 @@ func (client *httpClientFailureOperations) Get403(ctx context.Context) (*http.Re
 
 // get403CreateRequest creates the Get403 request.
 func (client *httpClientFailureOperations) get403CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/403"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -344,8 +368,12 @@ func (client *httpClientFailureOperations) Get411(ctx context.Context) (*http.Re
 
 // get411CreateRequest creates the Get411 request.
 func (client *httpClientFailureOperations) get411CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/411"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -386,8 +414,12 @@ func (client *httpClientFailureOperations) Get412(ctx context.Context) (*http.Re
 
 // get412CreateRequest creates the Get412 request.
 func (client *httpClientFailureOperations) get412CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/412"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -428,8 +460,12 @@ func (client *httpClientFailureOperations) Get416(ctx context.Context) (*http.Re
 
 // get416CreateRequest creates the Get416 request.
 func (client *httpClientFailureOperations) get416CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/416"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -470,8 +506,12 @@ func (client *httpClientFailureOperations) Head400(ctx context.Context) (*http.R
 
 // head400CreateRequest creates the Head400 request.
 func (client *httpClientFailureOperations) head400CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -512,8 +552,12 @@ func (client *httpClientFailureOperations) Head401(ctx context.Context) (*http.R
 
 // head401CreateRequest creates the Head401 request.
 func (client *httpClientFailureOperations) head401CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/401"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -554,8 +598,12 @@ func (client *httpClientFailureOperations) Head410(ctx context.Context) (*http.R
 
 // head410CreateRequest creates the Head410 request.
 func (client *httpClientFailureOperations) head410CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/410"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -596,8 +644,12 @@ func (client *httpClientFailureOperations) Head429(ctx context.Context) (*http.R
 
 // head429CreateRequest creates the Head429 request.
 func (client *httpClientFailureOperations) head429CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/429"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -638,8 +690,12 @@ func (client *httpClientFailureOperations) Options400(ctx context.Context) (*htt
 
 // options400CreateRequest creates the Options400 request.
 func (client *httpClientFailureOperations) options400CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -680,8 +736,12 @@ func (client *httpClientFailureOperations) Options403(ctx context.Context) (*htt
 
 // options403CreateRequest creates the Options403 request.
 func (client *httpClientFailureOperations) options403CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/403"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -722,8 +782,12 @@ func (client *httpClientFailureOperations) Options412(ctx context.Context) (*htt
 
 // options412CreateRequest creates the Options412 request.
 func (client *httpClientFailureOperations) options412CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/412"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -764,8 +828,12 @@ func (client *httpClientFailureOperations) Patch400(ctx context.Context) (*http.
 
 // patch400CreateRequest creates the Patch400 request.
 func (client *httpClientFailureOperations) patch400CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -806,8 +874,12 @@ func (client *httpClientFailureOperations) Patch405(ctx context.Context) (*http.
 
 // patch405CreateRequest creates the Patch405 request.
 func (client *httpClientFailureOperations) patch405CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/405"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -848,8 +920,12 @@ func (client *httpClientFailureOperations) Patch414(ctx context.Context) (*http.
 
 // patch414CreateRequest creates the Patch414 request.
 func (client *httpClientFailureOperations) patch414CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/414"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -890,8 +966,12 @@ func (client *httpClientFailureOperations) Post400(ctx context.Context) (*http.R
 
 // post400CreateRequest creates the Post400 request.
 func (client *httpClientFailureOperations) post400CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -932,8 +1012,12 @@ func (client *httpClientFailureOperations) Post406(ctx context.Context) (*http.R
 
 // post406CreateRequest creates the Post406 request.
 func (client *httpClientFailureOperations) post406CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/406"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -974,8 +1058,12 @@ func (client *httpClientFailureOperations) Post415(ctx context.Context) (*http.R
 
 // post415CreateRequest creates the Post415 request.
 func (client *httpClientFailureOperations) post415CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/415"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1016,8 +1104,12 @@ func (client *httpClientFailureOperations) Put400(ctx context.Context) (*http.Re
 
 // put400CreateRequest creates the Put400 request.
 func (client *httpClientFailureOperations) put400CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1058,8 +1150,12 @@ func (client *httpClientFailureOperations) Put404(ctx context.Context) (*http.Re
 
 // put404CreateRequest creates the Put404 request.
 func (client *httpClientFailureOperations) put404CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/404"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1100,8 +1196,12 @@ func (client *httpClientFailureOperations) Put409(ctx context.Context) (*http.Re
 
 // put409CreateRequest creates the Put409 request.
 func (client *httpClientFailureOperations) put409CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/409"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1142,8 +1242,12 @@ func (client *httpClientFailureOperations) Put413(ctx context.Context) (*http.Re
 
 // put413CreateRequest creates the Put413 request.
 func (client *httpClientFailureOperations) put413CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/client/413"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpclientfailure.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpclientfailure.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // HTTPClientFailureOperations contains the methods for the HTTPClientFailure group.
@@ -97,7 +98,7 @@ func (client *httpClientFailureOperations) delete400CreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/http/failure/client/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +144,7 @@ func (client *httpClientFailureOperations) delete407CreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/http/failure/client/407"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +190,7 @@ func (client *httpClientFailureOperations) delete417CreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/http/failure/client/417"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +236,7 @@ func (client *httpClientFailureOperations) get400CreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/http/failure/client/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +282,7 @@ func (client *httpClientFailureOperations) get402CreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/http/failure/client/402"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +328,7 @@ func (client *httpClientFailureOperations) get403CreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/http/failure/client/403"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +374,7 @@ func (client *httpClientFailureOperations) get411CreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/http/failure/client/411"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +420,7 @@ func (client *httpClientFailureOperations) get412CreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/http/failure/client/412"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +466,7 @@ func (client *httpClientFailureOperations) get416CreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/http/failure/client/416"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -511,7 +512,7 @@ func (client *httpClientFailureOperations) head400CreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/http/failure/client/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -557,7 +558,7 @@ func (client *httpClientFailureOperations) head401CreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/http/failure/client/401"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -603,7 +604,7 @@ func (client *httpClientFailureOperations) head410CreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/http/failure/client/410"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -649,7 +650,7 @@ func (client *httpClientFailureOperations) head429CreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/http/failure/client/429"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -695,7 +696,7 @@ func (client *httpClientFailureOperations) options400CreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/http/failure/client/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -741,7 +742,7 @@ func (client *httpClientFailureOperations) options403CreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/http/failure/client/403"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -787,7 +788,7 @@ func (client *httpClientFailureOperations) options412CreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/http/failure/client/412"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -833,7 +834,7 @@ func (client *httpClientFailureOperations) patch400CreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/http/failure/client/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -879,7 +880,7 @@ func (client *httpClientFailureOperations) patch405CreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/http/failure/client/405"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -925,7 +926,7 @@ func (client *httpClientFailureOperations) patch414CreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/http/failure/client/414"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -971,7 +972,7 @@ func (client *httpClientFailureOperations) post400CreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/http/failure/client/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1017,7 +1018,7 @@ func (client *httpClientFailureOperations) post406CreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/http/failure/client/406"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1063,7 +1064,7 @@ func (client *httpClientFailureOperations) post415CreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/http/failure/client/415"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1109,7 +1110,7 @@ func (client *httpClientFailureOperations) put400CreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/http/failure/client/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1155,7 +1156,7 @@ func (client *httpClientFailureOperations) put404CreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/http/failure/client/404"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1201,7 +1202,7 @@ func (client *httpClientFailureOperations) put409CreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/http/failure/client/409"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1247,7 +1248,7 @@ func (client *httpClientFailureOperations) put413CreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/http/failure/client/413"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpfailure.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpfailure.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // HTTPFailureOperations contains the methods for the HTTPFailure group.
@@ -54,7 +55,7 @@ func (client *httpFailureOperations) getEmptyErrorCreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/http/failure/emptybody/error"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +105,7 @@ func (client *httpFailureOperations) getNoModelEmptyCreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/http/failure/nomodel/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +158,7 @@ func (client *httpFailureOperations) getNoModelErrorCreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/http/failure/nomodel/error"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpfailure.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpfailure.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"io/ioutil"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // HTTPFailureOperations contains the methods for the HTTPFailure group.
@@ -49,8 +49,12 @@ func (client *httpFailureOperations) GetEmptyError(ctx context.Context) (*BoolRe
 
 // getEmptyErrorCreateRequest creates the GetEmptyError request.
 func (client *httpFailureOperations) getEmptyErrorCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/emptybody/error"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +99,12 @@ func (client *httpFailureOperations) GetNoModelEmpty(ctx context.Context) (*Bool
 
 // getNoModelEmptyCreateRequest creates the GetNoModelEmpty request.
 func (client *httpFailureOperations) getNoModelEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/nomodel/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -144,8 +152,12 @@ func (client *httpFailureOperations) GetNoModelError(ctx context.Context) (*Bool
 
 // getNoModelErrorCreateRequest creates the GetNoModelError request.
 func (client *httpFailureOperations) getNoModelErrorCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/nomodel/error"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpredirects.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpredirects.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // HTTPRedirectsOperations contains the methods for the HTTPRedirects group.
@@ -73,8 +73,12 @@ func (client *httpRedirectsOperations) Delete307(ctx context.Context) (*http.Res
 
 // delete307CreateRequest creates the Delete307 request.
 func (client *httpRedirectsOperations) delete307CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/307"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -119,8 +123,12 @@ func (client *httpRedirectsOperations) Get300(ctx context.Context) (interface{},
 
 // get300CreateRequest creates the Get300 request.
 func (client *httpRedirectsOperations) get300CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/300"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -176,8 +184,12 @@ func (client *httpRedirectsOperations) Get301(ctx context.Context) (*http.Respon
 
 // get301CreateRequest creates the Get301 request.
 func (client *httpRedirectsOperations) get301CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/301"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -221,8 +233,12 @@ func (client *httpRedirectsOperations) Get302(ctx context.Context) (*http.Respon
 
 // get302CreateRequest creates the Get302 request.
 func (client *httpRedirectsOperations) get302CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/302"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -266,8 +282,12 @@ func (client *httpRedirectsOperations) Get307(ctx context.Context) (*http.Respon
 
 // get307CreateRequest creates the Get307 request.
 func (client *httpRedirectsOperations) get307CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/307"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -311,8 +331,12 @@ func (client *httpRedirectsOperations) Head300(ctx context.Context) (*HTTPRedire
 
 // head300CreateRequest creates the Head300 request.
 func (client *httpRedirectsOperations) head300CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/300"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -360,8 +384,12 @@ func (client *httpRedirectsOperations) Head301(ctx context.Context) (*http.Respo
 
 // head301CreateRequest creates the Head301 request.
 func (client *httpRedirectsOperations) head301CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/301"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -405,8 +433,12 @@ func (client *httpRedirectsOperations) Head302(ctx context.Context) (*http.Respo
 
 // head302CreateRequest creates the Head302 request.
 func (client *httpRedirectsOperations) head302CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/302"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -450,8 +482,12 @@ func (client *httpRedirectsOperations) Head307(ctx context.Context) (*http.Respo
 
 // head307CreateRequest creates the Head307 request.
 func (client *httpRedirectsOperations) head307CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/307"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -495,8 +531,12 @@ func (client *httpRedirectsOperations) Options307(ctx context.Context) (*http.Re
 
 // options307CreateRequest creates the Options307 request.
 func (client *httpRedirectsOperations) options307CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/307"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -540,8 +580,12 @@ func (client *httpRedirectsOperations) Patch302(ctx context.Context) (*HTTPRedir
 
 // patch302CreateRequest creates the Patch302 request.
 func (client *httpRedirectsOperations) patch302CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/302"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -589,8 +633,12 @@ func (client *httpRedirectsOperations) Patch307(ctx context.Context) (*http.Resp
 
 // patch307CreateRequest creates the Patch307 request.
 func (client *httpRedirectsOperations) patch307CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/307"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -634,8 +682,12 @@ func (client *httpRedirectsOperations) Post303(ctx context.Context) (*HTTPRedire
 
 // post303CreateRequest creates the Post303 request.
 func (client *httpRedirectsOperations) post303CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/303"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -683,8 +735,12 @@ func (client *httpRedirectsOperations) Post307(ctx context.Context) (*http.Respo
 
 // post307CreateRequest creates the Post307 request.
 func (client *httpRedirectsOperations) post307CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/307"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -728,8 +784,12 @@ func (client *httpRedirectsOperations) Put301(ctx context.Context) (*HTTPRedirec
 
 // put301CreateRequest creates the Put301 request.
 func (client *httpRedirectsOperations) put301CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/301"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -777,8 +837,12 @@ func (client *httpRedirectsOperations) Put307(ctx context.Context) (*http.Respon
 
 // put307CreateRequest creates the Put307 request.
 func (client *httpRedirectsOperations) put307CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/redirect/307"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpredirects.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpredirects.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // HTTPRedirectsOperations contains the methods for the HTTPRedirects group.
@@ -78,7 +79,7 @@ func (client *httpRedirectsOperations) delete307CreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/http/redirect/307"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +129,7 @@ func (client *httpRedirectsOperations) get300CreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/http/redirect/300"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +190,7 @@ func (client *httpRedirectsOperations) get301CreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/http/redirect/301"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +239,7 @@ func (client *httpRedirectsOperations) get302CreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/http/redirect/302"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +288,7 @@ func (client *httpRedirectsOperations) get307CreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/http/redirect/307"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +337,7 @@ func (client *httpRedirectsOperations) head300CreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/http/redirect/300"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +390,7 @@ func (client *httpRedirectsOperations) head301CreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/http/redirect/301"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -438,7 +439,7 @@ func (client *httpRedirectsOperations) head302CreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/http/redirect/302"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -487,7 +488,7 @@ func (client *httpRedirectsOperations) head307CreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/http/redirect/307"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -536,7 +537,7 @@ func (client *httpRedirectsOperations) options307CreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/http/redirect/307"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -585,7 +586,7 @@ func (client *httpRedirectsOperations) patch302CreateRequest() (*azcore.Request,
 		return nil, err
 	}
 	urlPath := "/http/redirect/302"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -638,7 +639,7 @@ func (client *httpRedirectsOperations) patch307CreateRequest() (*azcore.Request,
 		return nil, err
 	}
 	urlPath := "/http/redirect/307"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -687,7 +688,7 @@ func (client *httpRedirectsOperations) post303CreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/http/redirect/303"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -740,7 +741,7 @@ func (client *httpRedirectsOperations) post307CreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/http/redirect/307"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -789,7 +790,7 @@ func (client *httpRedirectsOperations) put301CreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/http/redirect/301"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -842,7 +843,7 @@ func (client *httpRedirectsOperations) put307CreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/http/redirect/307"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpretry.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpretry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // HTTPRetryOperations contains the methods for the HTTPRetry group.
@@ -63,7 +64,7 @@ func (client *httpRetryOperations) delete503CreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/http/retry/503"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +113,7 @@ func (client *httpRetryOperations) get502CreateRequest() (*azcore.Request, error
 		return nil, err
 	}
 	urlPath := "/http/retry/502"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (client *httpRetryOperations) head408CreateRequest() (*azcore.Request, erro
 		return nil, err
 	}
 	urlPath := "/http/retry/408"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +211,7 @@ func (client *httpRetryOperations) options502CreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/http/retry/502"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +261,7 @@ func (client *httpRetryOperations) patch500CreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/http/retry/500"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +310,7 @@ func (client *httpRetryOperations) patch504CreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/http/retry/504"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +359,7 @@ func (client *httpRetryOperations) post503CreateRequest() (*azcore.Request, erro
 		return nil, err
 	}
 	urlPath := "/http/retry/503"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +408,7 @@ func (client *httpRetryOperations) put500CreateRequest() (*azcore.Request, error
 		return nil, err
 	}
 	urlPath := "/http/retry/500"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +457,7 @@ func (client *httpRetryOperations) put504CreateRequest() (*azcore.Request, error
 		return nil, err
 	}
 	urlPath := "/http/retry/504"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpretry.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpretry.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // HTTPRetryOperations contains the methods for the HTTPRetry group.
@@ -58,8 +58,12 @@ func (client *httpRetryOperations) Delete503(ctx context.Context) (*http.Respons
 
 // delete503CreateRequest creates the Delete503 request.
 func (client *httpRetryOperations) delete503CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/retry/503"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -103,8 +107,12 @@ func (client *httpRetryOperations) Get502(ctx context.Context) (*http.Response, 
 
 // get502CreateRequest creates the Get502 request.
 func (client *httpRetryOperations) get502CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/retry/502"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -148,8 +156,12 @@ func (client *httpRetryOperations) Head408(ctx context.Context) (*http.Response,
 
 // head408CreateRequest creates the Head408 request.
 func (client *httpRetryOperations) head408CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/retry/408"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -193,8 +205,12 @@ func (client *httpRetryOperations) Options502(ctx context.Context) (*BoolRespons
 
 // options502CreateRequest creates the Options502 request.
 func (client *httpRetryOperations) options502CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/retry/502"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -239,8 +255,12 @@ func (client *httpRetryOperations) Patch500(ctx context.Context) (*http.Response
 
 // patch500CreateRequest creates the Patch500 request.
 func (client *httpRetryOperations) patch500CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/retry/500"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -284,8 +304,12 @@ func (client *httpRetryOperations) Patch504(ctx context.Context) (*http.Response
 
 // patch504CreateRequest creates the Patch504 request.
 func (client *httpRetryOperations) patch504CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/retry/504"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -329,8 +353,12 @@ func (client *httpRetryOperations) Post503(ctx context.Context) (*http.Response,
 
 // post503CreateRequest creates the Post503 request.
 func (client *httpRetryOperations) post503CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/retry/503"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -374,8 +402,12 @@ func (client *httpRetryOperations) Put500(ctx context.Context) (*http.Response, 
 
 // put500CreateRequest creates the Put500 request.
 func (client *httpRetryOperations) put500CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/retry/500"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -419,8 +451,12 @@ func (client *httpRetryOperations) Put504(ctx context.Context) (*http.Response, 
 
 // put504CreateRequest creates the Put504 request.
 func (client *httpRetryOperations) put504CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/retry/504"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpserverfailure.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpserverfailure.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // HTTPServerFailureOperations contains the methods for the HTTPServerFailure group.
@@ -48,8 +48,12 @@ func (client *httpServerFailureOperations) Delete505(ctx context.Context) (*http
 
 // delete505CreateRequest creates the Delete505 request.
 func (client *httpServerFailureOperations) delete505CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/server/505"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +94,12 @@ func (client *httpServerFailureOperations) Get501(ctx context.Context) (*http.Re
 
 // get501CreateRequest creates the Get501 request.
 func (client *httpServerFailureOperations) get501CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/server/501"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -132,8 +140,12 @@ func (client *httpServerFailureOperations) Head501(ctx context.Context) (*http.R
 
 // head501CreateRequest creates the Head501 request.
 func (client *httpServerFailureOperations) head501CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/server/501"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -174,8 +186,12 @@ func (client *httpServerFailureOperations) Post505(ctx context.Context) (*http.R
 
 // post505CreateRequest creates the Post505 request.
 func (client *httpServerFailureOperations) post505CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/failure/server/505"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpserverfailure.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpserverfailure.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // HTTPServerFailureOperations contains the methods for the HTTPServerFailure group.
@@ -53,7 +54,7 @@ func (client *httpServerFailureOperations) delete505CreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/http/failure/server/505"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +100,7 @@ func (client *httpServerFailureOperations) get501CreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/http/failure/server/501"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +146,7 @@ func (client *httpServerFailureOperations) head501CreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/http/failure/server/501"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +192,7 @@ func (client *httpServerFailureOperations) post505CreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/http/failure/server/505"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpsuccess.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpsuccess.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // HTTPSuccessOperations contains the methods for the HTTPSuccess group.
@@ -78,8 +78,12 @@ func (client *httpSuccessOperations) Delete200(ctx context.Context) (*http.Respo
 
 // delete200CreateRequest creates the Delete200 request.
 func (client *httpSuccessOperations) delete200CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -123,8 +127,12 @@ func (client *httpSuccessOperations) Delete202(ctx context.Context) (*http.Respo
 
 // delete202CreateRequest creates the Delete202 request.
 func (client *httpSuccessOperations) delete202CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/202"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -168,8 +176,12 @@ func (client *httpSuccessOperations) Delete204(ctx context.Context) (*http.Respo
 
 // delete204CreateRequest creates the Delete204 request.
 func (client *httpSuccessOperations) delete204CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/204"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -213,8 +225,12 @@ func (client *httpSuccessOperations) Get200(ctx context.Context) (*BoolResponse,
 
 // get200CreateRequest creates the Get200 request.
 func (client *httpSuccessOperations) get200CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -259,8 +275,12 @@ func (client *httpSuccessOperations) Head200(ctx context.Context) (*http.Respons
 
 // head200CreateRequest creates the Head200 request.
 func (client *httpSuccessOperations) head200CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -304,8 +324,12 @@ func (client *httpSuccessOperations) Head204(ctx context.Context) (*http.Respons
 
 // head204CreateRequest creates the Head204 request.
 func (client *httpSuccessOperations) head204CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/204"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -349,8 +373,12 @@ func (client *httpSuccessOperations) Head404(ctx context.Context) (*http.Respons
 
 // head404CreateRequest creates the Head404 request.
 func (client *httpSuccessOperations) head404CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/404"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -394,8 +422,12 @@ func (client *httpSuccessOperations) Options200(ctx context.Context) (*BoolRespo
 
 // options200CreateRequest creates the Options200 request.
 func (client *httpSuccessOperations) options200CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -440,8 +472,12 @@ func (client *httpSuccessOperations) Patch200(ctx context.Context) (*http.Respon
 
 // patch200CreateRequest creates the Patch200 request.
 func (client *httpSuccessOperations) patch200CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -485,8 +521,12 @@ func (client *httpSuccessOperations) Patch202(ctx context.Context) (*http.Respon
 
 // patch202CreateRequest creates the Patch202 request.
 func (client *httpSuccessOperations) patch202CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/202"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -530,8 +570,12 @@ func (client *httpSuccessOperations) Patch204(ctx context.Context) (*http.Respon
 
 // patch204CreateRequest creates the Patch204 request.
 func (client *httpSuccessOperations) patch204CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/204"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -575,8 +619,12 @@ func (client *httpSuccessOperations) Post200(ctx context.Context) (*http.Respons
 
 // post200CreateRequest creates the Post200 request.
 func (client *httpSuccessOperations) post200CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -620,8 +668,12 @@ func (client *httpSuccessOperations) Post201(ctx context.Context) (*http.Respons
 
 // post201CreateRequest creates the Post201 request.
 func (client *httpSuccessOperations) post201CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/201"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -665,8 +717,12 @@ func (client *httpSuccessOperations) Post202(ctx context.Context) (*http.Respons
 
 // post202CreateRequest creates the Post202 request.
 func (client *httpSuccessOperations) post202CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/202"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -710,8 +766,12 @@ func (client *httpSuccessOperations) Post204(ctx context.Context) (*http.Respons
 
 // post204CreateRequest creates the Post204 request.
 func (client *httpSuccessOperations) post204CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/204"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -755,8 +815,12 @@ func (client *httpSuccessOperations) Put200(ctx context.Context) (*http.Response
 
 // put200CreateRequest creates the Put200 request.
 func (client *httpSuccessOperations) put200CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -800,8 +864,12 @@ func (client *httpSuccessOperations) Put201(ctx context.Context) (*http.Response
 
 // put201CreateRequest creates the Put201 request.
 func (client *httpSuccessOperations) put201CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/201"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -845,8 +913,12 @@ func (client *httpSuccessOperations) Put202(ctx context.Context) (*http.Response
 
 // put202CreateRequest creates the Put202 request.
 func (client *httpSuccessOperations) put202CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/202"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -890,8 +962,12 @@ func (client *httpSuccessOperations) Put204(ctx context.Context) (*http.Response
 
 // put204CreateRequest creates the Put204 request.
 func (client *httpSuccessOperations) put204CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/success/204"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/httpsuccess.go
+++ b/test/autorest/generated/httpinfrastructuregroup/httpsuccess.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // HTTPSuccessOperations contains the methods for the HTTPSuccess group.
@@ -83,7 +84,7 @@ func (client *httpSuccessOperations) delete200CreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/http/success/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +133,7 @@ func (client *httpSuccessOperations) delete202CreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/http/success/202"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +182,7 @@ func (client *httpSuccessOperations) delete204CreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/http/success/204"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +231,7 @@ func (client *httpSuccessOperations) get200CreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/http/success/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +281,7 @@ func (client *httpSuccessOperations) head200CreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/http/success/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +330,7 @@ func (client *httpSuccessOperations) head204CreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/http/success/204"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +379,7 @@ func (client *httpSuccessOperations) head404CreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/http/success/404"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -427,7 +428,7 @@ func (client *httpSuccessOperations) options200CreateRequest() (*azcore.Request,
 		return nil, err
 	}
 	urlPath := "/http/success/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -477,7 +478,7 @@ func (client *httpSuccessOperations) patch200CreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/http/success/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -526,7 +527,7 @@ func (client *httpSuccessOperations) patch202CreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/http/success/202"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -575,7 +576,7 @@ func (client *httpSuccessOperations) patch204CreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/http/success/204"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -624,7 +625,7 @@ func (client *httpSuccessOperations) post200CreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/http/success/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -673,7 +674,7 @@ func (client *httpSuccessOperations) post201CreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/http/success/201"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -722,7 +723,7 @@ func (client *httpSuccessOperations) post202CreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/http/success/202"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -771,7 +772,7 @@ func (client *httpSuccessOperations) post204CreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/http/success/204"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -820,7 +821,7 @@ func (client *httpSuccessOperations) put200CreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/http/success/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -869,7 +870,7 @@ func (client *httpSuccessOperations) put201CreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/http/success/201"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -918,7 +919,7 @@ func (client *httpSuccessOperations) put202CreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/http/success/202"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -967,7 +968,7 @@ func (client *httpSuccessOperations) put204CreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/http/success/204"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/multipleresponses.go
+++ b/test/autorest/generated/httpinfrastructuregroup/multipleresponses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"io/ioutil"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // MultipleResponsesOperations contains the methods for the MultipleResponses group.
@@ -119,8 +119,12 @@ func (client *multipleResponsesOperations) Get200Model201ModelDefaultError200Val
 
 // get200Model201ModelDefaultError200ValidCreateRequest creates the Get200Model201ModelDefaultError200Valid request.
 func (client *multipleResponsesOperations) get200Model201ModelDefaultError200ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/201/B/default/Error/response/200/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -171,8 +175,12 @@ func (client *multipleResponsesOperations) Get200Model201ModelDefaultError201Val
 
 // get200Model201ModelDefaultError201ValidCreateRequest creates the Get200Model201ModelDefaultError201Valid request.
 func (client *multipleResponsesOperations) get200Model201ModelDefaultError201ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/201/B/default/Error/response/201/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -223,8 +231,12 @@ func (client *multipleResponsesOperations) Get200Model201ModelDefaultError400Val
 
 // get200Model201ModelDefaultError400ValidCreateRequest creates the Get200Model201ModelDefaultError400Valid request.
 func (client *multipleResponsesOperations) get200Model201ModelDefaultError400ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/201/B/default/Error/response/400/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -274,8 +286,12 @@ func (client *multipleResponsesOperations) Get200Model204NoModelDefaultError200V
 
 // get200Model204NoModelDefaultError200ValidCreateRequest creates the Get200Model204NoModelDefaultError200Valid request.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError200ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/200/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -320,8 +336,12 @@ func (client *multipleResponsesOperations) Get200Model204NoModelDefaultError201I
 
 // get200Model204NoModelDefaultError201InvalidCreateRequest creates the Get200Model204NoModelDefaultError201Invalid request.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError201InvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/201/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -366,8 +386,12 @@ func (client *multipleResponsesOperations) Get200Model204NoModelDefaultError202N
 
 // get200Model204NoModelDefaultError202NoneCreateRequest creates the Get200Model204NoModelDefaultError202None request.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError202NoneCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/202/none"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -412,8 +436,12 @@ func (client *multipleResponsesOperations) Get200Model204NoModelDefaultError204V
 
 // get200Model204NoModelDefaultError204ValidCreateRequest creates the Get200Model204NoModelDefaultError204Valid request.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError204ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/204/none"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -458,8 +486,12 @@ func (client *multipleResponsesOperations) Get200Model204NoModelDefaultError400V
 
 // get200Model204NoModelDefaultError400ValidCreateRequest creates the Get200Model204NoModelDefaultError400Valid request.
 func (client *multipleResponsesOperations) get200Model204NoModelDefaultError400ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/400/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -504,8 +536,12 @@ func (client *multipleResponsesOperations) Get200ModelA200Invalid(ctx context.Co
 
 // get200ModelA200InvalidCreateRequest creates the Get200ModelA200Invalid request.
 func (client *multipleResponsesOperations) get200ModelA200InvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/response/200/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -553,8 +589,12 @@ func (client *multipleResponsesOperations) Get200ModelA200None(ctx context.Conte
 
 // get200ModelA200NoneCreateRequest creates the Get200ModelA200None request.
 func (client *multipleResponsesOperations) get200ModelA200NoneCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/response/200/none"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -602,8 +642,12 @@ func (client *multipleResponsesOperations) Get200ModelA200Valid(ctx context.Cont
 
 // get200ModelA200ValidCreateRequest creates the Get200ModelA200Valid request.
 func (client *multipleResponsesOperations) get200ModelA200ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/response/200/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -652,8 +696,12 @@ func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefault
 
 // get200ModelA201ModelC404ModelDDefaultError200ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError200Valid request.
 func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError200ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/200/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -707,8 +755,12 @@ func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefault
 
 // get200ModelA201ModelC404ModelDDefaultError201ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError201Valid request.
 func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError201ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/201/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -762,8 +814,12 @@ func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefault
 
 // get200ModelA201ModelC404ModelDDefaultError400ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError400Valid request.
 func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError400ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/400/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -817,8 +873,12 @@ func (client *multipleResponsesOperations) Get200ModelA201ModelC404ModelDDefault
 
 // get200ModelA201ModelC404ModelDDefaultError404ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError404Valid request.
 func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefaultError404ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/404/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -871,8 +931,12 @@ func (client *multipleResponsesOperations) Get200ModelA202Valid(ctx context.Cont
 
 // get200ModelA202ValidCreateRequest creates the Get200ModelA202Valid request.
 func (client *multipleResponsesOperations) get200ModelA202ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/response/202/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -920,8 +984,12 @@ func (client *multipleResponsesOperations) Get200ModelA400Invalid(ctx context.Co
 
 // get200ModelA400InvalidCreateRequest creates the Get200ModelA400Invalid request.
 func (client *multipleResponsesOperations) get200ModelA400InvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/response/400/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -969,8 +1037,12 @@ func (client *multipleResponsesOperations) Get200ModelA400None(ctx context.Conte
 
 // get200ModelA400NoneCreateRequest creates the Get200ModelA400None request.
 func (client *multipleResponsesOperations) get200ModelA400NoneCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/response/400/none"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1018,8 +1090,12 @@ func (client *multipleResponsesOperations) Get200ModelA400Valid(ctx context.Cont
 
 // get200ModelA400ValidCreateRequest creates the Get200ModelA400Valid request.
 func (client *multipleResponsesOperations) get200ModelA400ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/200/A/response/400/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1067,8 +1143,12 @@ func (client *multipleResponsesOperations) Get202None204NoneDefaultError202None(
 
 // get202None204NoneDefaultError202NoneCreateRequest creates the Get202None204NoneDefaultError202None request.
 func (client *multipleResponsesOperations) get202None204NoneDefaultError202NoneCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/202/none/204/none/default/Error/response/202/none"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1112,8 +1192,12 @@ func (client *multipleResponsesOperations) Get202None204NoneDefaultError204None(
 
 // get202None204NoneDefaultError204NoneCreateRequest creates the Get202None204NoneDefaultError204None request.
 func (client *multipleResponsesOperations) get202None204NoneDefaultError204NoneCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/202/none/204/none/default/Error/response/204/none"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1157,8 +1241,12 @@ func (client *multipleResponsesOperations) Get202None204NoneDefaultError400Valid
 
 // get202None204NoneDefaultError400ValidCreateRequest creates the Get202None204NoneDefaultError400Valid request.
 func (client *multipleResponsesOperations) get202None204NoneDefaultError400ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/202/none/204/none/default/Error/response/400/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1202,8 +1290,12 @@ func (client *multipleResponsesOperations) Get202None204NoneDefaultNone202Invali
 
 // get202None204NoneDefaultNone202InvalidCreateRequest creates the Get202None204NoneDefaultNone202Invalid request.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone202InvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/202/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1250,8 +1342,12 @@ func (client *multipleResponsesOperations) Get202None204NoneDefaultNone204None(c
 
 // get202None204NoneDefaultNone204NoneCreateRequest creates the Get202None204NoneDefaultNone204None request.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone204NoneCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/204/none"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1298,8 +1394,12 @@ func (client *multipleResponsesOperations) Get202None204NoneDefaultNone400Invali
 
 // get202None204NoneDefaultNone400InvalidCreateRequest creates the Get202None204NoneDefaultNone400Invalid request.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone400InvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/400/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1346,8 +1446,12 @@ func (client *multipleResponsesOperations) Get202None204NoneDefaultNone400None(c
 
 // get202None204NoneDefaultNone400NoneCreateRequest creates the Get202None204NoneDefaultNone400None request.
 func (client *multipleResponsesOperations) get202None204NoneDefaultNone400NoneCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/400/none"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1394,8 +1498,12 @@ func (client *multipleResponsesOperations) GetDefaultModelA200None(ctx context.C
 
 // getDefaultModelA200NoneCreateRequest creates the GetDefaultModelA200None request.
 func (client *multipleResponsesOperations) getDefaultModelA200NoneCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/default/A/response/200/none"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1443,8 +1551,12 @@ func (client *multipleResponsesOperations) GetDefaultModelA200Valid(ctx context.
 
 // getDefaultModelA200ValidCreateRequest creates the GetDefaultModelA200Valid request.
 func (client *multipleResponsesOperations) getDefaultModelA200ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/default/A/response/200/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1492,8 +1604,12 @@ func (client *multipleResponsesOperations) GetDefaultModelA400None(ctx context.C
 
 // getDefaultModelA400NoneCreateRequest creates the GetDefaultModelA400None request.
 func (client *multipleResponsesOperations) getDefaultModelA400NoneCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/default/A/response/400/none"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1537,8 +1653,12 @@ func (client *multipleResponsesOperations) GetDefaultModelA400Valid(ctx context.
 
 // getDefaultModelA400ValidCreateRequest creates the GetDefaultModelA400Valid request.
 func (client *multipleResponsesOperations) getDefaultModelA400ValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/default/A/response/400/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1582,8 +1702,12 @@ func (client *multipleResponsesOperations) GetDefaultNone200Invalid(ctx context.
 
 // getDefaultNone200InvalidCreateRequest creates the GetDefaultNone200Invalid request.
 func (client *multipleResponsesOperations) getDefaultNone200InvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/default/none/response/200/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1630,8 +1754,12 @@ func (client *multipleResponsesOperations) GetDefaultNone200None(ctx context.Con
 
 // getDefaultNone200NoneCreateRequest creates the GetDefaultNone200None request.
 func (client *multipleResponsesOperations) getDefaultNone200NoneCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/default/none/response/200/none"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1678,8 +1806,12 @@ func (client *multipleResponsesOperations) GetDefaultNone400Invalid(ctx context.
 
 // getDefaultNone400InvalidCreateRequest creates the GetDefaultNone400Invalid request.
 func (client *multipleResponsesOperations) getDefaultNone400InvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/default/none/response/400/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1726,8 +1858,12 @@ func (client *multipleResponsesOperations) GetDefaultNone400None(ctx context.Con
 
 // getDefaultNone400NoneCreateRequest creates the GetDefaultNone400None request.
 func (client *multipleResponsesOperations) getDefaultNone400NoneCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/http/payloads/default/none/response/400/none"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/httpinfrastructuregroup/multipleresponses.go
+++ b/test/autorest/generated/httpinfrastructuregroup/multipleresponses.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // MultipleResponsesOperations contains the methods for the MultipleResponses group.
@@ -124,7 +125,7 @@ func (client *multipleResponsesOperations) get200Model201ModelDefaultError200Val
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/201/B/default/Error/response/200/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +181,7 @@ func (client *multipleResponsesOperations) get200Model201ModelDefaultError201Val
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/201/B/default/Error/response/201/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +237,7 @@ func (client *multipleResponsesOperations) get200Model201ModelDefaultError400Val
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/201/B/default/Error/response/400/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +292,7 @@ func (client *multipleResponsesOperations) get200Model204NoModelDefaultError200V
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/200/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +342,7 @@ func (client *multipleResponsesOperations) get200Model204NoModelDefaultError201I
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/201/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +392,7 @@ func (client *multipleResponsesOperations) get200Model204NoModelDefaultError202N
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/202/none"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -441,7 +442,7 @@ func (client *multipleResponsesOperations) get200Model204NoModelDefaultError204V
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/204/none"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -491,7 +492,7 @@ func (client *multipleResponsesOperations) get200Model204NoModelDefaultError400V
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/400/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -541,7 +542,7 @@ func (client *multipleResponsesOperations) get200ModelA200InvalidCreateRequest()
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/response/200/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -594,7 +595,7 @@ func (client *multipleResponsesOperations) get200ModelA200NoneCreateRequest() (*
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/response/200/none"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -647,7 +648,7 @@ func (client *multipleResponsesOperations) get200ModelA200ValidCreateRequest() (
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/response/200/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -701,7 +702,7 @@ func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefault
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/200/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -760,7 +761,7 @@ func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefault
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/201/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -819,7 +820,7 @@ func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefault
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/400/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -878,7 +879,7 @@ func (client *multipleResponsesOperations) get200ModelA201ModelC404ModelDDefault
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/404/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -936,7 +937,7 @@ func (client *multipleResponsesOperations) get200ModelA202ValidCreateRequest() (
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/response/202/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -989,7 +990,7 @@ func (client *multipleResponsesOperations) get200ModelA400InvalidCreateRequest()
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/response/400/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1042,7 +1043,7 @@ func (client *multipleResponsesOperations) get200ModelA400NoneCreateRequest() (*
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/response/400/none"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1095,7 +1096,7 @@ func (client *multipleResponsesOperations) get200ModelA400ValidCreateRequest() (
 		return nil, err
 	}
 	urlPath := "/http/payloads/200/A/response/400/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1148,7 +1149,7 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultError202NoneC
 		return nil, err
 	}
 	urlPath := "/http/payloads/202/none/204/none/default/Error/response/202/none"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1197,7 +1198,7 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultError204NoneC
 		return nil, err
 	}
 	urlPath := "/http/payloads/202/none/204/none/default/Error/response/204/none"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1246,7 +1247,7 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultError400Valid
 		return nil, err
 	}
 	urlPath := "/http/payloads/202/none/204/none/default/Error/response/400/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1295,7 +1296,7 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultNone202Invali
 		return nil, err
 	}
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/202/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1347,7 +1348,7 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultNone204NoneCr
 		return nil, err
 	}
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/204/none"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1399,7 +1400,7 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultNone400Invali
 		return nil, err
 	}
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/400/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1451,7 +1452,7 @@ func (client *multipleResponsesOperations) get202None204NoneDefaultNone400NoneCr
 		return nil, err
 	}
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/400/none"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1503,7 +1504,7 @@ func (client *multipleResponsesOperations) getDefaultModelA200NoneCreateRequest(
 		return nil, err
 	}
 	urlPath := "/http/payloads/default/A/response/200/none"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1556,7 +1557,7 @@ func (client *multipleResponsesOperations) getDefaultModelA200ValidCreateRequest
 		return nil, err
 	}
 	urlPath := "/http/payloads/default/A/response/200/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1609,7 +1610,7 @@ func (client *multipleResponsesOperations) getDefaultModelA400NoneCreateRequest(
 		return nil, err
 	}
 	urlPath := "/http/payloads/default/A/response/400/none"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1658,7 +1659,7 @@ func (client *multipleResponsesOperations) getDefaultModelA400ValidCreateRequest
 		return nil, err
 	}
 	urlPath := "/http/payloads/default/A/response/400/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1707,7 +1708,7 @@ func (client *multipleResponsesOperations) getDefaultNone200InvalidCreateRequest
 		return nil, err
 	}
 	urlPath := "/http/payloads/default/none/response/200/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1759,7 +1760,7 @@ func (client *multipleResponsesOperations) getDefaultNone200NoneCreateRequest() 
 		return nil, err
 	}
 	urlPath := "/http/payloads/default/none/response/200/none"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1811,7 +1812,7 @@ func (client *multipleResponsesOperations) getDefaultNone400InvalidCreateRequest
 		return nil, err
 	}
 	urlPath := "/http/payloads/default/none/response/400/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1863,7 +1864,7 @@ func (client *multipleResponsesOperations) getDefaultNone400NoneCreateRequest() 
 		return nil, err
 	}
 	urlPath := "/http/payloads/default/none/response/400/none"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/integergroup/client.go
+++ b/test/autorest/generated/integergroup/client.go
@@ -8,7 +8,6 @@ package integergroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-integergroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // IntOperations returns the IntOperations associated with this client.

--- a/test/autorest/generated/integergroup/int.go
+++ b/test/autorest/generated/integergroup/int.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 )
 
@@ -74,7 +75,7 @@ func (client *intOperations) getInvalidCreateRequest() (*azcore.Request, error) 
 		return nil, err
 	}
 	urlPath := "/int/invalid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +125,7 @@ func (client *intOperations) getInvalidUnixTimeCreateRequest() (*azcore.Request,
 		return nil, err
 	}
 	urlPath := "/int/invalidunixtime"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +176,7 @@ func (client *intOperations) getNullCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/int/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +226,7 @@ func (client *intOperations) getNullUnixTimeCreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/int/nullunixtime"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +277,7 @@ func (client *intOperations) getOverflowInt32CreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/int/overflowint32"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +327,7 @@ func (client *intOperations) getOverflowInt64CreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/int/overflowint64"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +377,7 @@ func (client *intOperations) getUnderflowInt32CreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/int/underflowint32"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -426,7 +427,7 @@ func (client *intOperations) getUnderflowInt64CreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/int/underflowint64"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -476,7 +477,7 @@ func (client *intOperations) getUnixTimeCreateRequest() (*azcore.Request, error)
 		return nil, err
 	}
 	urlPath := "/int/unixtime"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -527,7 +528,7 @@ func (client *intOperations) putMax32CreateRequest(intBody int32) (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/int/max/32"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -576,7 +577,7 @@ func (client *intOperations) putMax64CreateRequest(intBody int64) (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/int/max/64"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -625,7 +626,7 @@ func (client *intOperations) putMin32CreateRequest(intBody int32) (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/int/min/32"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -674,7 +675,7 @@ func (client *intOperations) putMin64CreateRequest(intBody int64) (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/int/min/64"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -723,7 +724,7 @@ func (client *intOperations) putUnixTimeDateCreateRequest(intBody time.Time) (*a
 		return nil, err
 	}
 	urlPath := "/int/unixtime"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/integergroup/int.go
+++ b/test/autorest/generated/integergroup/int.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 	"time"
 )
 
@@ -69,8 +69,12 @@ func (client *intOperations) GetInvalid(ctx context.Context) (*Int32Response, er
 
 // getInvalidCreateRequest creates the GetInvalid request.
 func (client *intOperations) getInvalidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/int/invalid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -115,8 +119,12 @@ func (client *intOperations) GetInvalidUnixTime(ctx context.Context) (*TimeRespo
 
 // getInvalidUnixTimeCreateRequest creates the GetInvalidUnixTime request.
 func (client *intOperations) getInvalidUnixTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/int/invalidunixtime"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -162,8 +170,12 @@ func (client *intOperations) GetNull(ctx context.Context) (*Int32Response, error
 
 // getNullCreateRequest creates the GetNull request.
 func (client *intOperations) getNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/int/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -208,8 +220,12 @@ func (client *intOperations) GetNullUnixTime(ctx context.Context) (*TimeResponse
 
 // getNullUnixTimeCreateRequest creates the GetNullUnixTime request.
 func (client *intOperations) getNullUnixTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/int/nullunixtime"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -255,8 +271,12 @@ func (client *intOperations) GetOverflowInt32(ctx context.Context) (*Int32Respon
 
 // getOverflowInt32CreateRequest creates the GetOverflowInt32 request.
 func (client *intOperations) getOverflowInt32CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/int/overflowint32"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -301,8 +321,12 @@ func (client *intOperations) GetOverflowInt64(ctx context.Context) (*Int64Respon
 
 // getOverflowInt64CreateRequest creates the GetOverflowInt64 request.
 func (client *intOperations) getOverflowInt64CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/int/overflowint64"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -347,8 +371,12 @@ func (client *intOperations) GetUnderflowInt32(ctx context.Context) (*Int32Respo
 
 // getUnderflowInt32CreateRequest creates the GetUnderflowInt32 request.
 func (client *intOperations) getUnderflowInt32CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/int/underflowint32"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -393,8 +421,12 @@ func (client *intOperations) GetUnderflowInt64(ctx context.Context) (*Int64Respo
 
 // getUnderflowInt64CreateRequest creates the GetUnderflowInt64 request.
 func (client *intOperations) getUnderflowInt64CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/int/underflowint64"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -439,8 +471,12 @@ func (client *intOperations) GetUnixTime(ctx context.Context) (*TimeResponse, er
 
 // getUnixTimeCreateRequest creates the GetUnixTime request.
 func (client *intOperations) getUnixTimeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/int/unixtime"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -486,8 +522,12 @@ func (client *intOperations) PutMax32(ctx context.Context, intBody int32) (*http
 
 // putMax32CreateRequest creates the PutMax32 request.
 func (client *intOperations) putMax32CreateRequest(intBody int32) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/int/max/32"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -531,8 +571,12 @@ func (client *intOperations) PutMax64(ctx context.Context, intBody int64) (*http
 
 // putMax64CreateRequest creates the PutMax64 request.
 func (client *intOperations) putMax64CreateRequest(intBody int64) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/int/max/64"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -576,8 +620,12 @@ func (client *intOperations) PutMin32(ctx context.Context, intBody int32) (*http
 
 // putMin32CreateRequest creates the PutMin32 request.
 func (client *intOperations) putMin32CreateRequest(intBody int32) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/int/min/32"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -621,8 +669,12 @@ func (client *intOperations) PutMin64(ctx context.Context, intBody int64) (*http
 
 // putMin64CreateRequest creates the PutMin64 request.
 func (client *intOperations) putMin64CreateRequest(intBody int64) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/int/min/64"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -666,8 +718,12 @@ func (client *intOperations) PutUnixTimeDate(ctx context.Context, intBody time.T
 
 // putUnixTimeDateCreateRequest creates the PutUnixTimeDate request.
 func (client *intOperations) putUnixTimeDateCreateRequest(intBody time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/int/unixtime"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/client.go
+++ b/test/autorest/generated/lrogroup/client.go
@@ -8,7 +8,6 @@ package lrogroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-lrogroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Long-running Operation for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // LrOSOperations returns the LrOSOperations associated with this client.

--- a/test/autorest/generated/lrogroup/lroretrys.go
+++ b/test/autorest/generated/lrogroup/lroretrys.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 	"time"
 )
 
@@ -94,8 +94,12 @@ func (client *lroRetrysOperations) ResumeDelete202Retry200(token string) (HTTPPo
 
 // delete202Retry200CreateRequest creates the Delete202Retry200 request.
 func (client *lroRetrysOperations) delete202Retry200CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/retryerror/delete/202/retry/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -163,8 +167,12 @@ func (client *lroRetrysOperations) ResumeDeleteAsyncRelativeRetrySucceeded(token
 
 // deleteAsyncRelativeRetrySucceededCreateRequest creates the DeleteAsyncRelativeRetrySucceeded request.
 func (client *lroRetrysOperations) deleteAsyncRelativeRetrySucceededCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/retryerror/deleteasync/retry/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -232,8 +240,12 @@ func (client *lroRetrysOperations) ResumeDeleteProvisioning202Accepted200Succeed
 
 // deleteProvisioning202Accepted200SucceededCreateRequest creates the DeleteProvisioning202Accepted200Succeeded request.
 func (client *lroRetrysOperations) deleteProvisioning202Accepted200SucceededCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/retryerror/delete/provisioning/202/accepted/200/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -301,8 +313,12 @@ func (client *lroRetrysOperations) ResumePost202Retry200(token string) (HTTPPoll
 
 // post202Retry200CreateRequest creates the Post202Retry200 request.
 func (client *lroRetrysOperations) post202Retry200CreateRequest(lroRetrysPost202Retry200Options *LroRetrysPost202Retry200Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/retryerror/post/202/retry/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -373,8 +389,12 @@ func (client *lroRetrysOperations) ResumePostAsyncRelativeRetrySucceeded(token s
 
 // postAsyncRelativeRetrySucceededCreateRequest creates the PostAsyncRelativeRetrySucceeded request.
 func (client *lroRetrysOperations) postAsyncRelativeRetrySucceededCreateRequest(lroRetrysPostAsyncRelativeRetrySucceededOptions *LroRetrysPostAsyncRelativeRetrySucceededOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/retryerror/postasync/retry/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -445,8 +465,12 @@ func (client *lroRetrysOperations) ResumePut201CreatingSucceeded200(token string
 
 // put201CreatingSucceeded200CreateRequest creates the Put201CreatingSucceeded200 request.
 func (client *lroRetrysOperations) put201CreatingSucceeded200CreateRequest(lroRetrysPut201CreatingSucceeded200Options *LroRetrysPut201CreatingSucceeded200Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/retryerror/put/201/creating/succeeded/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -517,8 +541,12 @@ func (client *lroRetrysOperations) ResumePutAsyncRelativeRetrySucceeded(token st
 
 // putAsyncRelativeRetrySucceededCreateRequest creates the PutAsyncRelativeRetrySucceeded request.
 func (client *lroRetrysOperations) putAsyncRelativeRetrySucceededCreateRequest(lroRetrysPutAsyncRelativeRetrySucceededOptions *LroRetrysPutAsyncRelativeRetrySucceededOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/retryerror/putasync/retry/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lroretrys.go
+++ b/test/autorest/generated/lrogroup/lroretrys.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 )
 
@@ -99,7 +100,7 @@ func (client *lroRetrysOperations) delete202Retry200CreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/lro/retryerror/delete/202/retry/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *lroRetrysOperations) deleteAsyncRelativeRetrySucceededCreateReques
 		return nil, err
 	}
 	urlPath := "/lro/retryerror/deleteasync/retry/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +246,7 @@ func (client *lroRetrysOperations) deleteProvisioning202Accepted200SucceededCrea
 		return nil, err
 	}
 	urlPath := "/lro/retryerror/delete/provisioning/202/accepted/200/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +319,7 @@ func (client *lroRetrysOperations) post202Retry200CreateRequest(lroRetrysPost202
 		return nil, err
 	}
 	urlPath := "/lro/retryerror/post/202/retry/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -394,7 +395,7 @@ func (client *lroRetrysOperations) postAsyncRelativeRetrySucceededCreateRequest(
 		return nil, err
 	}
 	urlPath := "/lro/retryerror/postasync/retry/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -470,7 +471,7 @@ func (client *lroRetrysOperations) put201CreatingSucceeded200CreateRequest(lroRe
 		return nil, err
 	}
 	urlPath := "/lro/retryerror/put/201/creating/succeeded/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -546,7 +547,7 @@ func (client *lroRetrysOperations) putAsyncRelativeRetrySucceededCreateRequest(l
 		return nil, err
 	}
 	urlPath := "/lro/retryerror/putasync/retry/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lros.go
+++ b/test/autorest/generated/lrogroup/lros.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 	"time"
 )
 
@@ -230,8 +230,12 @@ func (client *lrOSOperations) ResumeDelete202NoRetry204(token string) (ProductPo
 
 // delete202NoRetry204CreateRequest creates the Delete202NoRetry204 request.
 func (client *lrOSOperations) delete202NoRetry204CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/delete/202/noretry/204"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -299,8 +303,12 @@ func (client *lrOSOperations) ResumeDelete202Retry200(token string) (ProductPoll
 
 // delete202Retry200CreateRequest creates the Delete202Retry200 request.
 func (client *lrOSOperations) delete202Retry200CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/delete/202/retry/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -368,8 +376,12 @@ func (client *lrOSOperations) ResumeDelete204Succeeded(token string) (HTTPPoller
 
 // delete204SucceededCreateRequest creates the Delete204Succeeded request.
 func (client *lrOSOperations) delete204SucceededCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/delete/204/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -437,8 +449,12 @@ func (client *lrOSOperations) ResumeDeleteAsyncNoHeaderInRetry(token string) (HT
 
 // deleteAsyncNoHeaderInRetryCreateRequest creates the DeleteAsyncNoHeaderInRetry request.
 func (client *lrOSOperations) deleteAsyncNoHeaderInRetryCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/deleteasync/noheader/202/204"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -506,8 +522,12 @@ func (client *lrOSOperations) ResumeDeleteAsyncNoRetrySucceeded(token string) (H
 
 // deleteAsyncNoRetrySucceededCreateRequest creates the DeleteAsyncNoRetrySucceeded request.
 func (client *lrOSOperations) deleteAsyncNoRetrySucceededCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/deleteasync/noretry/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -575,8 +595,12 @@ func (client *lrOSOperations) ResumeDeleteAsyncRetryFailed(token string) (HTTPPo
 
 // deleteAsyncRetryFailedCreateRequest creates the DeleteAsyncRetryFailed request.
 func (client *lrOSOperations) deleteAsyncRetryFailedCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/deleteasync/retry/failed"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -644,8 +668,12 @@ func (client *lrOSOperations) ResumeDeleteAsyncRetrySucceeded(token string) (HTT
 
 // deleteAsyncRetrySucceededCreateRequest creates the DeleteAsyncRetrySucceeded request.
 func (client *lrOSOperations) deleteAsyncRetrySucceededCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/deleteasync/retry/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -713,8 +741,12 @@ func (client *lrOSOperations) ResumeDeleteAsyncRetrycanceled(token string) (HTTP
 
 // deleteAsyncRetrycanceledCreateRequest creates the DeleteAsyncRetrycanceled request.
 func (client *lrOSOperations) deleteAsyncRetrycanceledCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/deleteasync/retry/canceled"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -782,8 +814,12 @@ func (client *lrOSOperations) ResumeDeleteNoHeaderInRetry(token string) (HTTPPol
 
 // deleteNoHeaderInRetryCreateRequest creates the DeleteNoHeaderInRetry request.
 func (client *lrOSOperations) deleteNoHeaderInRetryCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/delete/noheader"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -851,8 +887,12 @@ func (client *lrOSOperations) ResumeDeleteProvisioning202Accepted200Succeeded(to
 
 // deleteProvisioning202Accepted200SucceededCreateRequest creates the DeleteProvisioning202Accepted200Succeeded request.
 func (client *lrOSOperations) deleteProvisioning202Accepted200SucceededCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/delete/provisioning/202/accepted/200/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -920,8 +960,12 @@ func (client *lrOSOperations) ResumeDeleteProvisioning202DeletingFailed200(token
 
 // deleteProvisioning202DeletingFailed200CreateRequest creates the DeleteProvisioning202DeletingFailed200 request.
 func (client *lrOSOperations) deleteProvisioning202DeletingFailed200CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/delete/provisioning/202/deleting/200/failed"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -989,8 +1033,12 @@ func (client *lrOSOperations) ResumeDeleteProvisioning202Deletingcanceled200(tok
 
 // deleteProvisioning202Deletingcanceled200CreateRequest creates the DeleteProvisioning202Deletingcanceled200 request.
 func (client *lrOSOperations) deleteProvisioning202Deletingcanceled200CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/delete/provisioning/202/deleting/200/canceled"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1058,8 +1106,12 @@ func (client *lrOSOperations) ResumePost200WithPayload(token string) (SkuPoller,
 
 // post200WithPayloadCreateRequest creates the Post200WithPayload request.
 func (client *lrOSOperations) post200WithPayloadCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/post/payload/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1127,8 +1179,12 @@ func (client *lrOSOperations) ResumePost202List(token string) (ProductArrayPolle
 
 // post202ListCreateRequest creates the Post202List request.
 func (client *lrOSOperations) post202ListCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/list"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1196,8 +1252,12 @@ func (client *lrOSOperations) ResumePost202NoRetry204(token string) (ProductPoll
 
 // post202NoRetry204CreateRequest creates the Post202NoRetry204 request.
 func (client *lrOSOperations) post202NoRetry204CreateRequest(lrOSPost202NoRetry204Options *LrOSPost202NoRetry204Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/post/202/noretry/204"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1268,8 +1328,12 @@ func (client *lrOSOperations) ResumePost202Retry200(token string) (HTTPPoller, e
 
 // post202Retry200CreateRequest creates the Post202Retry200 request.
 func (client *lrOSOperations) post202Retry200CreateRequest(lrOSPost202Retry200Options *LrOSPost202Retry200Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/post/202/retry/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1340,8 +1404,12 @@ func (client *lrOSOperations) ResumePostAsyncNoRetrySucceeded(token string) (Pro
 
 // postAsyncNoRetrySucceededCreateRequest creates the PostAsyncNoRetrySucceeded request.
 func (client *lrOSOperations) postAsyncNoRetrySucceededCreateRequest(lrOSPostAsyncNoRetrySucceededOptions *LrOSPostAsyncNoRetrySucceededOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/postasync/noretry/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1412,8 +1480,12 @@ func (client *lrOSOperations) ResumePostAsyncRetryFailed(token string) (HTTPPoll
 
 // postAsyncRetryFailedCreateRequest creates the PostAsyncRetryFailed request.
 func (client *lrOSOperations) postAsyncRetryFailedCreateRequest(lrOSPostAsyncRetryFailedOptions *LrOSPostAsyncRetryFailedOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/postasync/retry/failed"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1484,8 +1556,12 @@ func (client *lrOSOperations) ResumePostAsyncRetrySucceeded(token string) (Produ
 
 // postAsyncRetrySucceededCreateRequest creates the PostAsyncRetrySucceeded request.
 func (client *lrOSOperations) postAsyncRetrySucceededCreateRequest(lrOSPostAsyncRetrySucceededOptions *LrOSPostAsyncRetrySucceededOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/postasync/retry/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1556,8 +1632,12 @@ func (client *lrOSOperations) ResumePostAsyncRetrycanceled(token string) (HTTPPo
 
 // postAsyncRetrycanceledCreateRequest creates the PostAsyncRetrycanceled request.
 func (client *lrOSOperations) postAsyncRetrycanceledCreateRequest(lrOSPostAsyncRetrycanceledOptions *LrOSPostAsyncRetrycanceledOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/postasync/retry/canceled"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1628,8 +1708,12 @@ func (client *lrOSOperations) ResumePostDoubleHeadersFinalAzureHeaderGet(token s
 
 // postDoubleHeadersFinalAzureHeaderGetCreateRequest creates the PostDoubleHeadersFinalAzureHeaderGet request.
 func (client *lrOSOperations) postDoubleHeadersFinalAzureHeaderGetCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/LROPostDoubleHeadersFinalAzureHeaderGet"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1697,8 +1781,12 @@ func (client *lrOSOperations) ResumePostDoubleHeadersFinalAzureHeaderGetDefault(
 
 // postDoubleHeadersFinalAzureHeaderGetDefaultCreateRequest creates the PostDoubleHeadersFinalAzureHeaderGetDefault request.
 func (client *lrOSOperations) postDoubleHeadersFinalAzureHeaderGetDefaultCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/LROPostDoubleHeadersFinalAzureHeaderGetDefault"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1766,8 +1854,12 @@ func (client *lrOSOperations) ResumePostDoubleHeadersFinalLocationGet(token stri
 
 // postDoubleHeadersFinalLocationGetCreateRequest creates the PostDoubleHeadersFinalLocationGet request.
 func (client *lrOSOperations) postDoubleHeadersFinalLocationGetCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/LROPostDoubleHeadersFinalLocationGet"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1835,8 +1927,12 @@ func (client *lrOSOperations) ResumePut200Acceptedcanceled200(token string) (Pro
 
 // put200Acceptedcanceled200CreateRequest creates the Put200Acceptedcanceled200 request.
 func (client *lrOSOperations) put200Acceptedcanceled200CreateRequest(lrOSPut200Acceptedcanceled200Options *LrOSPut200Acceptedcanceled200Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/put/200/accepted/canceled/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1907,8 +2003,12 @@ func (client *lrOSOperations) ResumePut200Succeeded(token string) (ProductPoller
 
 // put200SucceededCreateRequest creates the Put200Succeeded request.
 func (client *lrOSOperations) put200SucceededCreateRequest(lrOSPut200SucceededOptions *LrOSPut200SucceededOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/put/200/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1979,8 +2079,12 @@ func (client *lrOSOperations) ResumePut200SucceededNoState(token string) (Produc
 
 // put200SucceededNoStateCreateRequest creates the Put200SucceededNoState request.
 func (client *lrOSOperations) put200SucceededNoStateCreateRequest(lrOSPut200SucceededNoStateOptions *LrOSPut200SucceededNoStateOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/put/200/succeeded/nostate"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2051,8 +2155,12 @@ func (client *lrOSOperations) ResumePut200UpdatingSucceeded204(token string) (Pr
 
 // put200UpdatingSucceeded204CreateRequest creates the Put200UpdatingSucceeded204 request.
 func (client *lrOSOperations) put200UpdatingSucceeded204CreateRequest(lrOSPut200UpdatingSucceeded204Options *LrOSPut200UpdatingSucceeded204Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/put/200/updating/succeeded/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2123,8 +2231,12 @@ func (client *lrOSOperations) ResumePut201CreatingFailed200(token string) (Produ
 
 // put201CreatingFailed200CreateRequest creates the Put201CreatingFailed200 request.
 func (client *lrOSOperations) put201CreatingFailed200CreateRequest(lrOSPut201CreatingFailed200Options *LrOSPut201CreatingFailed200Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/put/201/created/failed/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2195,8 +2307,12 @@ func (client *lrOSOperations) ResumePut201CreatingSucceeded200(token string) (Pr
 
 // put201CreatingSucceeded200CreateRequest creates the Put201CreatingSucceeded200 request.
 func (client *lrOSOperations) put201CreatingSucceeded200CreateRequest(lrOSPut201CreatingSucceeded200Options *LrOSPut201CreatingSucceeded200Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/put/201/creating/succeeded/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2267,8 +2383,12 @@ func (client *lrOSOperations) ResumePut201Succeeded(token string) (ProductPoller
 
 // put201SucceededCreateRequest creates the Put201Succeeded request.
 func (client *lrOSOperations) put201SucceededCreateRequest(lrOSPut201SucceededOptions *LrOSPut201SucceededOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/put/201/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2339,8 +2459,12 @@ func (client *lrOSOperations) ResumePut202Retry200(token string) (ProductPoller,
 
 // put202Retry200CreateRequest creates the Put202Retry200 request.
 func (client *lrOSOperations) put202Retry200CreateRequest(lrOSPut202Retry200Options *LrOSPut202Retry200Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/put/202/retry/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2411,8 +2535,12 @@ func (client *lrOSOperations) ResumePutAsyncNoHeaderInRetry(token string) (Produ
 
 // putAsyncNoHeaderInRetryCreateRequest creates the PutAsyncNoHeaderInRetry request.
 func (client *lrOSOperations) putAsyncNoHeaderInRetryCreateRequest(lrOSPutAsyncNoHeaderInRetryOptions *LrOSPutAsyncNoHeaderInRetryOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/putasync/noheader/201/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2483,8 +2611,12 @@ func (client *lrOSOperations) ResumePutAsyncNoRetrySucceeded(token string) (Prod
 
 // putAsyncNoRetrySucceededCreateRequest creates the PutAsyncNoRetrySucceeded request.
 func (client *lrOSOperations) putAsyncNoRetrySucceededCreateRequest(lrOSPutAsyncNoRetrySucceededOptions *LrOSPutAsyncNoRetrySucceededOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/putasync/noretry/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2555,8 +2687,12 @@ func (client *lrOSOperations) ResumePutAsyncNoRetrycanceled(token string) (Produ
 
 // putAsyncNoRetrycanceledCreateRequest creates the PutAsyncNoRetrycanceled request.
 func (client *lrOSOperations) putAsyncNoRetrycanceledCreateRequest(lrOSPutAsyncNoRetrycanceledOptions *LrOSPutAsyncNoRetrycanceledOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/putasync/noretry/canceled"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2627,8 +2763,12 @@ func (client *lrOSOperations) ResumePutAsyncNonResource(token string) (SkuPoller
 
 // putAsyncNonResourceCreateRequest creates the PutAsyncNonResource request.
 func (client *lrOSOperations) putAsyncNonResourceCreateRequest(lrOSPutAsyncNonResourceOptions *LrOSPutAsyncNonResourceOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/putnonresourceasync/202/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2699,8 +2839,12 @@ func (client *lrOSOperations) ResumePutAsyncRetryFailed(token string) (ProductPo
 
 // putAsyncRetryFailedCreateRequest creates the PutAsyncRetryFailed request.
 func (client *lrOSOperations) putAsyncRetryFailedCreateRequest(lrOSPutAsyncRetryFailedOptions *LrOSPutAsyncRetryFailedOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/putasync/retry/failed"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2771,8 +2915,12 @@ func (client *lrOSOperations) ResumePutAsyncRetrySucceeded(token string) (Produc
 
 // putAsyncRetrySucceededCreateRequest creates the PutAsyncRetrySucceeded request.
 func (client *lrOSOperations) putAsyncRetrySucceededCreateRequest(lrOSPutAsyncRetrySucceededOptions *LrOSPutAsyncRetrySucceededOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/putasync/retry/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2843,8 +2991,12 @@ func (client *lrOSOperations) ResumePutAsyncSubResource(token string) (SubProduc
 
 // putAsyncSubResourceCreateRequest creates the PutAsyncSubResource request.
 func (client *lrOSOperations) putAsyncSubResourceCreateRequest(lrOSPutAsyncSubResourceOptions *LrOSPutAsyncSubResourceOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/putsubresourceasync/202/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2915,8 +3067,12 @@ func (client *lrOSOperations) ResumePutNoHeaderInRetry(token string) (ProductPol
 
 // putNoHeaderInRetryCreateRequest creates the PutNoHeaderInRetry request.
 func (client *lrOSOperations) putNoHeaderInRetryCreateRequest(lrOSPutNoHeaderInRetryOptions *LrOSPutNoHeaderInRetryOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/put/noheader/202/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -2987,8 +3143,12 @@ func (client *lrOSOperations) ResumePutNonResource(token string) (SkuPoller, err
 
 // putNonResourceCreateRequest creates the PutNonResource request.
 func (client *lrOSOperations) putNonResourceCreateRequest(lrOSPutNonResourceOptions *LrOSPutNonResourceOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/putnonresource/202/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -3059,8 +3219,12 @@ func (client *lrOSOperations) ResumePutSubResource(token string) (SubProductPoll
 
 // putSubResourceCreateRequest creates the PutSubResource request.
 func (client *lrOSOperations) putSubResourceCreateRequest(lrOSPutSubResourceOptions *LrOSPutSubResourceOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/putsubresource/202/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lros.go
+++ b/test/autorest/generated/lrogroup/lros.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 )
 
@@ -235,7 +236,7 @@ func (client *lrOSOperations) delete202NoRetry204CreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/lro/delete/202/noretry/204"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +309,7 @@ func (client *lrOSOperations) delete202Retry200CreateRequest() (*azcore.Request,
 		return nil, err
 	}
 	urlPath := "/lro/delete/202/retry/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +382,7 @@ func (client *lrOSOperations) delete204SucceededCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/lro/delete/204/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +455,7 @@ func (client *lrOSOperations) deleteAsyncNoHeaderInRetryCreateRequest() (*azcore
 		return nil, err
 	}
 	urlPath := "/lro/deleteasync/noheader/202/204"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -527,7 +528,7 @@ func (client *lrOSOperations) deleteAsyncNoRetrySucceededCreateRequest() (*azcor
 		return nil, err
 	}
 	urlPath := "/lro/deleteasync/noretry/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -600,7 +601,7 @@ func (client *lrOSOperations) deleteAsyncRetryFailedCreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/lro/deleteasync/retry/failed"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -673,7 +674,7 @@ func (client *lrOSOperations) deleteAsyncRetrySucceededCreateRequest() (*azcore.
 		return nil, err
 	}
 	urlPath := "/lro/deleteasync/retry/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -746,7 +747,7 @@ func (client *lrOSOperations) deleteAsyncRetrycanceledCreateRequest() (*azcore.R
 		return nil, err
 	}
 	urlPath := "/lro/deleteasync/retry/canceled"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -819,7 +820,7 @@ func (client *lrOSOperations) deleteNoHeaderInRetryCreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/lro/delete/noheader"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -892,7 +893,7 @@ func (client *lrOSOperations) deleteProvisioning202Accepted200SucceededCreateReq
 		return nil, err
 	}
 	urlPath := "/lro/delete/provisioning/202/accepted/200/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -965,7 +966,7 @@ func (client *lrOSOperations) deleteProvisioning202DeletingFailed200CreateReques
 		return nil, err
 	}
 	urlPath := "/lro/delete/provisioning/202/deleting/200/failed"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1038,7 +1039,7 @@ func (client *lrOSOperations) deleteProvisioning202Deletingcanceled200CreateRequ
 		return nil, err
 	}
 	urlPath := "/lro/delete/provisioning/202/deleting/200/canceled"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1111,7 +1112,7 @@ func (client *lrOSOperations) post200WithPayloadCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/lro/post/payload/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1184,7 +1185,7 @@ func (client *lrOSOperations) post202ListCreateRequest() (*azcore.Request, error
 		return nil, err
 	}
 	urlPath := "/lro/list"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1257,7 +1258,7 @@ func (client *lrOSOperations) post202NoRetry204CreateRequest(lrOSPost202NoRetry2
 		return nil, err
 	}
 	urlPath := "/lro/post/202/noretry/204"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1333,7 +1334,7 @@ func (client *lrOSOperations) post202Retry200CreateRequest(lrOSPost202Retry200Op
 		return nil, err
 	}
 	urlPath := "/lro/post/202/retry/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1409,7 +1410,7 @@ func (client *lrOSOperations) postAsyncNoRetrySucceededCreateRequest(lrOSPostAsy
 		return nil, err
 	}
 	urlPath := "/lro/postasync/noretry/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1485,7 +1486,7 @@ func (client *lrOSOperations) postAsyncRetryFailedCreateRequest(lrOSPostAsyncRet
 		return nil, err
 	}
 	urlPath := "/lro/postasync/retry/failed"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1561,7 +1562,7 @@ func (client *lrOSOperations) postAsyncRetrySucceededCreateRequest(lrOSPostAsync
 		return nil, err
 	}
 	urlPath := "/lro/postasync/retry/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1637,7 +1638,7 @@ func (client *lrOSOperations) postAsyncRetrycanceledCreateRequest(lrOSPostAsyncR
 		return nil, err
 	}
 	urlPath := "/lro/postasync/retry/canceled"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1713,7 +1714,7 @@ func (client *lrOSOperations) postDoubleHeadersFinalAzureHeaderGetCreateRequest(
 		return nil, err
 	}
 	urlPath := "/lro/LROPostDoubleHeadersFinalAzureHeaderGet"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1786,7 +1787,7 @@ func (client *lrOSOperations) postDoubleHeadersFinalAzureHeaderGetDefaultCreateR
 		return nil, err
 	}
 	urlPath := "/lro/LROPostDoubleHeadersFinalAzureHeaderGetDefault"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1859,7 +1860,7 @@ func (client *lrOSOperations) postDoubleHeadersFinalLocationGetCreateRequest() (
 		return nil, err
 	}
 	urlPath := "/lro/LROPostDoubleHeadersFinalLocationGet"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1932,7 +1933,7 @@ func (client *lrOSOperations) put200Acceptedcanceled200CreateRequest(lrOSPut200A
 		return nil, err
 	}
 	urlPath := "/lro/put/200/accepted/canceled/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2008,7 +2009,7 @@ func (client *lrOSOperations) put200SucceededCreateRequest(lrOSPut200SucceededOp
 		return nil, err
 	}
 	urlPath := "/lro/put/200/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2084,7 +2085,7 @@ func (client *lrOSOperations) put200SucceededNoStateCreateRequest(lrOSPut200Succ
 		return nil, err
 	}
 	urlPath := "/lro/put/200/succeeded/nostate"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2160,7 +2161,7 @@ func (client *lrOSOperations) put200UpdatingSucceeded204CreateRequest(lrOSPut200
 		return nil, err
 	}
 	urlPath := "/lro/put/200/updating/succeeded/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2236,7 +2237,7 @@ func (client *lrOSOperations) put201CreatingFailed200CreateRequest(lrOSPut201Cre
 		return nil, err
 	}
 	urlPath := "/lro/put/201/created/failed/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2312,7 +2313,7 @@ func (client *lrOSOperations) put201CreatingSucceeded200CreateRequest(lrOSPut201
 		return nil, err
 	}
 	urlPath := "/lro/put/201/creating/succeeded/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2388,7 +2389,7 @@ func (client *lrOSOperations) put201SucceededCreateRequest(lrOSPut201SucceededOp
 		return nil, err
 	}
 	urlPath := "/lro/put/201/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2464,7 +2465,7 @@ func (client *lrOSOperations) put202Retry200CreateRequest(lrOSPut202Retry200Opti
 		return nil, err
 	}
 	urlPath := "/lro/put/202/retry/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2540,7 +2541,7 @@ func (client *lrOSOperations) putAsyncNoHeaderInRetryCreateRequest(lrOSPutAsyncN
 		return nil, err
 	}
 	urlPath := "/lro/putasync/noheader/201/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2616,7 +2617,7 @@ func (client *lrOSOperations) putAsyncNoRetrySucceededCreateRequest(lrOSPutAsync
 		return nil, err
 	}
 	urlPath := "/lro/putasync/noretry/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2692,7 +2693,7 @@ func (client *lrOSOperations) putAsyncNoRetrycanceledCreateRequest(lrOSPutAsyncN
 		return nil, err
 	}
 	urlPath := "/lro/putasync/noretry/canceled"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2768,7 +2769,7 @@ func (client *lrOSOperations) putAsyncNonResourceCreateRequest(lrOSPutAsyncNonRe
 		return nil, err
 	}
 	urlPath := "/lro/putnonresourceasync/202/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2844,7 +2845,7 @@ func (client *lrOSOperations) putAsyncRetryFailedCreateRequest(lrOSPutAsyncRetry
 		return nil, err
 	}
 	urlPath := "/lro/putasync/retry/failed"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2920,7 +2921,7 @@ func (client *lrOSOperations) putAsyncRetrySucceededCreateRequest(lrOSPutAsyncRe
 		return nil, err
 	}
 	urlPath := "/lro/putasync/retry/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2996,7 +2997,7 @@ func (client *lrOSOperations) putAsyncSubResourceCreateRequest(lrOSPutAsyncSubRe
 		return nil, err
 	}
 	urlPath := "/lro/putsubresourceasync/202/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3072,7 +3073,7 @@ func (client *lrOSOperations) putNoHeaderInRetryCreateRequest(lrOSPutNoHeaderInR
 		return nil, err
 	}
 	urlPath := "/lro/put/noheader/202/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3148,7 +3149,7 @@ func (client *lrOSOperations) putNonResourceCreateRequest(lrOSPutNonResourceOpti
 		return nil, err
 	}
 	urlPath := "/lro/putnonresource/202/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -3224,7 +3225,7 @@ func (client *lrOSOperations) putSubResourceCreateRequest(lrOSPutSubResourceOpti
 		return nil, err
 	}
 	urlPath := "/lro/putsubresource/202/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lrosads.go
+++ b/test/autorest/generated/lrogroup/lrosads.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 	"time"
 )
 
@@ -170,8 +170,12 @@ func (client *lrosaDsOperations) ResumeDelete202NonRetry400(token string) (HTTPP
 
 // delete202NonRetry400CreateRequest creates the Delete202NonRetry400 request.
 func (client *lrosaDsOperations) delete202NonRetry400CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/nonretryerror/delete/202/retry/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -239,8 +243,12 @@ func (client *lrosaDsOperations) ResumeDelete202RetryInvalidHeader(token string)
 
 // delete202RetryInvalidHeaderCreateRequest creates the Delete202RetryInvalidHeader request.
 func (client *lrosaDsOperations) delete202RetryInvalidHeaderCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/delete/202/retry/invalidheader"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -308,8 +316,12 @@ func (client *lrosaDsOperations) ResumeDelete204Succeeded(token string) (HTTPPol
 
 // delete204SucceededCreateRequest creates the Delete204Succeeded request.
 func (client *lrosaDsOperations) delete204SucceededCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/delete/204/nolocation"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -377,8 +389,12 @@ func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetry400(token string)
 
 // deleteAsyncRelativeRetry400CreateRequest creates the DeleteAsyncRelativeRetry400 request.
 func (client *lrosaDsOperations) deleteAsyncRelativeRetry400CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/nonretryerror/deleteasync/retry/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -446,8 +462,12 @@ func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetryInvalidHeader(tok
 
 // deleteAsyncRelativeRetryInvalidHeaderCreateRequest creates the DeleteAsyncRelativeRetryInvalidHeader request.
 func (client *lrosaDsOperations) deleteAsyncRelativeRetryInvalidHeaderCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/deleteasync/retry/invalidheader"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -515,8 +535,12 @@ func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetryInvalidJSONPollin
 
 // deleteAsyncRelativeRetryInvalidJsonPollingCreateRequest creates the DeleteAsyncRelativeRetryInvalidJSONPolling request.
 func (client *lrosaDsOperations) deleteAsyncRelativeRetryInvalidJsonPollingCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/deleteasync/retry/invalidjsonpolling"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -584,8 +608,12 @@ func (client *lrosaDsOperations) ResumeDeleteAsyncRelativeRetryNoStatus(token st
 
 // deleteAsyncRelativeRetryNoStatusCreateRequest creates the DeleteAsyncRelativeRetryNoStatus request.
 func (client *lrosaDsOperations) deleteAsyncRelativeRetryNoStatusCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/deleteasync/retry/nostatus"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -653,8 +681,12 @@ func (client *lrosaDsOperations) ResumeDeleteNonRetry400(token string) (HTTPPoll
 
 // deleteNonRetry400CreateRequest creates the DeleteNonRetry400 request.
 func (client *lrosaDsOperations) deleteNonRetry400CreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/nonretryerror/delete/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -722,8 +754,12 @@ func (client *lrosaDsOperations) ResumePost202NoLocation(token string) (HTTPPoll
 
 // post202NoLocationCreateRequest creates the Post202NoLocation request.
 func (client *lrosaDsOperations) post202NoLocationCreateRequest(lrosaDsPost202NoLocationOptions *LrosaDsPost202NoLocationOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/post/202/nolocation"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -794,8 +830,12 @@ func (client *lrosaDsOperations) ResumePost202NonRetry400(token string) (HTTPPol
 
 // post202NonRetry400CreateRequest creates the Post202NonRetry400 request.
 func (client *lrosaDsOperations) post202NonRetry400CreateRequest(lrosaDsPost202NonRetry400Options *LrosaDsPost202NonRetry400Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/nonretryerror/post/202/retry/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -866,8 +906,12 @@ func (client *lrosaDsOperations) ResumePost202RetryInvalidHeader(token string) (
 
 // post202RetryInvalidHeaderCreateRequest creates the Post202RetryInvalidHeader request.
 func (client *lrosaDsOperations) post202RetryInvalidHeaderCreateRequest(lrosaDsPost202RetryInvalidHeaderOptions *LrosaDsPost202RetryInvalidHeaderOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/post/202/retry/invalidheader"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -938,8 +982,12 @@ func (client *lrosaDsOperations) ResumePostAsyncRelativeRetry400(token string) (
 
 // postAsyncRelativeRetry400CreateRequest creates the PostAsyncRelativeRetry400 request.
 func (client *lrosaDsOperations) postAsyncRelativeRetry400CreateRequest(lrosaDsPostAsyncRelativeRetry400Options *LrosaDsPostAsyncRelativeRetry400Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/nonretryerror/postasync/retry/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1010,8 +1058,12 @@ func (client *lrosaDsOperations) ResumePostAsyncRelativeRetryInvalidHeader(token
 
 // postAsyncRelativeRetryInvalidHeaderCreateRequest creates the PostAsyncRelativeRetryInvalidHeader request.
 func (client *lrosaDsOperations) postAsyncRelativeRetryInvalidHeaderCreateRequest(lrosaDsPostAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPostAsyncRelativeRetryInvalidHeaderOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/postasync/retry/invalidheader"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1082,8 +1134,12 @@ func (client *lrosaDsOperations) ResumePostAsyncRelativeRetryInvalidJSONPolling(
 
 // postAsyncRelativeRetryInvalidJsonPollingCreateRequest creates the PostAsyncRelativeRetryInvalidJSONPolling request.
 func (client *lrosaDsOperations) postAsyncRelativeRetryInvalidJsonPollingCreateRequest(lrosaDsPostAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPostAsyncRelativeRetryInvalidJSONPollingOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/postasync/retry/invalidjsonpolling"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1154,8 +1210,12 @@ func (client *lrosaDsOperations) ResumePostAsyncRelativeRetryNoPayload(token str
 
 // postAsyncRelativeRetryNoPayloadCreateRequest creates the PostAsyncRelativeRetryNoPayload request.
 func (client *lrosaDsOperations) postAsyncRelativeRetryNoPayloadCreateRequest(lrosaDsPostAsyncRelativeRetryNoPayloadOptions *LrosaDsPostAsyncRelativeRetryNoPayloadOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/postasync/retry/nopayload"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1226,8 +1286,12 @@ func (client *lrosaDsOperations) ResumePostNonRetry400(token string) (HTTPPoller
 
 // postNonRetry400CreateRequest creates the PostNonRetry400 request.
 func (client *lrosaDsOperations) postNonRetry400CreateRequest(lrosaDsPostNonRetry400Options *LrosaDsPostNonRetry400Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/nonretryerror/post/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1298,8 +1362,12 @@ func (client *lrosaDsOperations) ResumePut200InvalidJSON(token string) (ProductP
 
 // put200InvalidJsonCreateRequest creates the Put200InvalidJSON request.
 func (client *lrosaDsOperations) put200InvalidJsonCreateRequest(lrosaDsPut200InvalidJsonOptions *LrosaDsPut200InvalidJSONOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/put/200/invalidjson"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1370,8 +1438,12 @@ func (client *lrosaDsOperations) ResumePutAsyncRelativeRetry400(token string) (P
 
 // putAsyncRelativeRetry400CreateRequest creates the PutAsyncRelativeRetry400 request.
 func (client *lrosaDsOperations) putAsyncRelativeRetry400CreateRequest(lrosaDsPutAsyncRelativeRetry400Options *LrosaDsPutAsyncRelativeRetry400Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/nonretryerror/putasync/retry/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1442,8 +1514,12 @@ func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryInvalidHeader(token 
 
 // putAsyncRelativeRetryInvalidHeaderCreateRequest creates the PutAsyncRelativeRetryInvalidHeader request.
 func (client *lrosaDsOperations) putAsyncRelativeRetryInvalidHeaderCreateRequest(lrosaDsPutAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPutAsyncRelativeRetryInvalidHeaderOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/putasync/retry/invalidheader"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1514,8 +1590,12 @@ func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryInvalidJSONPolling(t
 
 // putAsyncRelativeRetryInvalidJsonPollingCreateRequest creates the PutAsyncRelativeRetryInvalidJSONPolling request.
 func (client *lrosaDsOperations) putAsyncRelativeRetryInvalidJsonPollingCreateRequest(lrosaDsPutAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPutAsyncRelativeRetryInvalidJSONPollingOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/putasync/retry/invalidjsonpolling"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1586,8 +1666,12 @@ func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryNoStatus(token strin
 
 // putAsyncRelativeRetryNoStatusCreateRequest creates the PutAsyncRelativeRetryNoStatus request.
 func (client *lrosaDsOperations) putAsyncRelativeRetryNoStatusCreateRequest(lrosaDsPutAsyncRelativeRetryNoStatusOptions *LrosaDsPutAsyncRelativeRetryNoStatusOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/putasync/retry/nostatus"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1658,8 +1742,12 @@ func (client *lrosaDsOperations) ResumePutAsyncRelativeRetryNoStatusPayload(toke
 
 // putAsyncRelativeRetryNoStatusPayloadCreateRequest creates the PutAsyncRelativeRetryNoStatusPayload request.
 func (client *lrosaDsOperations) putAsyncRelativeRetryNoStatusPayloadCreateRequest(lrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions *LrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/putasync/retry/nostatuspayload"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1730,8 +1818,12 @@ func (client *lrosaDsOperations) ResumePutError201NoProvisioningStatePayload(tok
 
 // putError201NoProvisioningStatePayloadCreateRequest creates the PutError201NoProvisioningStatePayload request.
 func (client *lrosaDsOperations) putError201NoProvisioningStatePayloadCreateRequest(lrosaDsPutError201NoProvisioningStatePayloadOptions *LrosaDsPutError201NoProvisioningStatePayloadOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/error/put/201/noprovisioningstatepayload"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1802,8 +1894,12 @@ func (client *lrosaDsOperations) ResumePutNonRetry201Creating400(token string) (
 
 // putNonRetry201Creating400CreateRequest creates the PutNonRetry201Creating400 request.
 func (client *lrosaDsOperations) putNonRetry201Creating400CreateRequest(lrosaDsPutNonRetry201Creating400Options *LrosaDsPutNonRetry201Creating400Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/nonretryerror/put/201/creating/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1874,8 +1970,12 @@ func (client *lrosaDsOperations) ResumePutNonRetry201Creating400InvalidJSON(toke
 
 // putNonRetry201Creating400InvalidJsonCreateRequest creates the PutNonRetry201Creating400InvalidJSON request.
 func (client *lrosaDsOperations) putNonRetry201Creating400InvalidJsonCreateRequest(lrosaDsPutNonRetry201Creating400InvalidJsonOptions *LrosaDsPutNonRetry201Creating400InvalidJSONOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/nonretryerror/put/201/creating/400/invalidjson"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1946,8 +2046,12 @@ func (client *lrosaDsOperations) ResumePutNonRetry400(token string) (ProductPoll
 
 // putNonRetry400CreateRequest creates the PutNonRetry400 request.
 func (client *lrosaDsOperations) putNonRetry400CreateRequest(lrosaDsPutNonRetry400Options *LrosaDsPutNonRetry400Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/nonretryerror/put/400"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lrosads.go
+++ b/test/autorest/generated/lrogroup/lrosads.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 )
 
@@ -175,7 +176,7 @@ func (client *lrosaDsOperations) delete202NonRetry400CreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/lro/nonretryerror/delete/202/retry/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +249,7 @@ func (client *lrosaDsOperations) delete202RetryInvalidHeaderCreateRequest() (*az
 		return nil, err
 	}
 	urlPath := "/lro/error/delete/202/retry/invalidheader"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +322,7 @@ func (client *lrosaDsOperations) delete204SucceededCreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/lro/error/delete/204/nolocation"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -394,7 +395,7 @@ func (client *lrosaDsOperations) deleteAsyncRelativeRetry400CreateRequest() (*az
 		return nil, err
 	}
 	urlPath := "/lro/nonretryerror/deleteasync/retry/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -467,7 +468,7 @@ func (client *lrosaDsOperations) deleteAsyncRelativeRetryInvalidHeaderCreateRequ
 		return nil, err
 	}
 	urlPath := "/lro/error/deleteasync/retry/invalidheader"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -540,7 +541,7 @@ func (client *lrosaDsOperations) deleteAsyncRelativeRetryInvalidJsonPollingCreat
 		return nil, err
 	}
 	urlPath := "/lro/error/deleteasync/retry/invalidjsonpolling"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -613,7 +614,7 @@ func (client *lrosaDsOperations) deleteAsyncRelativeRetryNoStatusCreateRequest()
 		return nil, err
 	}
 	urlPath := "/lro/error/deleteasync/retry/nostatus"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -686,7 +687,7 @@ func (client *lrosaDsOperations) deleteNonRetry400CreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/lro/nonretryerror/delete/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -759,7 +760,7 @@ func (client *lrosaDsOperations) post202NoLocationCreateRequest(lrosaDsPost202No
 		return nil, err
 	}
 	urlPath := "/lro/error/post/202/nolocation"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -835,7 +836,7 @@ func (client *lrosaDsOperations) post202NonRetry400CreateRequest(lrosaDsPost202N
 		return nil, err
 	}
 	urlPath := "/lro/nonretryerror/post/202/retry/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -911,7 +912,7 @@ func (client *lrosaDsOperations) post202RetryInvalidHeaderCreateRequest(lrosaDsP
 		return nil, err
 	}
 	urlPath := "/lro/error/post/202/retry/invalidheader"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -987,7 +988,7 @@ func (client *lrosaDsOperations) postAsyncRelativeRetry400CreateRequest(lrosaDsP
 		return nil, err
 	}
 	urlPath := "/lro/nonretryerror/postasync/retry/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1063,7 +1064,7 @@ func (client *lrosaDsOperations) postAsyncRelativeRetryInvalidHeaderCreateReques
 		return nil, err
 	}
 	urlPath := "/lro/error/postasync/retry/invalidheader"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1139,7 +1140,7 @@ func (client *lrosaDsOperations) postAsyncRelativeRetryInvalidJsonPollingCreateR
 		return nil, err
 	}
 	urlPath := "/lro/error/postasync/retry/invalidjsonpolling"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1215,7 +1216,7 @@ func (client *lrosaDsOperations) postAsyncRelativeRetryNoPayloadCreateRequest(lr
 		return nil, err
 	}
 	urlPath := "/lro/error/postasync/retry/nopayload"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1291,7 +1292,7 @@ func (client *lrosaDsOperations) postNonRetry400CreateRequest(lrosaDsPostNonRetr
 		return nil, err
 	}
 	urlPath := "/lro/nonretryerror/post/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1367,7 +1368,7 @@ func (client *lrosaDsOperations) put200InvalidJsonCreateRequest(lrosaDsPut200Inv
 		return nil, err
 	}
 	urlPath := "/lro/error/put/200/invalidjson"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1443,7 +1444,7 @@ func (client *lrosaDsOperations) putAsyncRelativeRetry400CreateRequest(lrosaDsPu
 		return nil, err
 	}
 	urlPath := "/lro/nonretryerror/putasync/retry/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1519,7 +1520,7 @@ func (client *lrosaDsOperations) putAsyncRelativeRetryInvalidHeaderCreateRequest
 		return nil, err
 	}
 	urlPath := "/lro/error/putasync/retry/invalidheader"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1595,7 +1596,7 @@ func (client *lrosaDsOperations) putAsyncRelativeRetryInvalidJsonPollingCreateRe
 		return nil, err
 	}
 	urlPath := "/lro/error/putasync/retry/invalidjsonpolling"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1671,7 +1672,7 @@ func (client *lrosaDsOperations) putAsyncRelativeRetryNoStatusCreateRequest(lros
 		return nil, err
 	}
 	urlPath := "/lro/error/putasync/retry/nostatus"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1747,7 +1748,7 @@ func (client *lrosaDsOperations) putAsyncRelativeRetryNoStatusPayloadCreateReque
 		return nil, err
 	}
 	urlPath := "/lro/error/putasync/retry/nostatuspayload"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1823,7 +1824,7 @@ func (client *lrosaDsOperations) putError201NoProvisioningStatePayloadCreateRequ
 		return nil, err
 	}
 	urlPath := "/lro/error/put/201/noprovisioningstatepayload"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1899,7 +1900,7 @@ func (client *lrosaDsOperations) putNonRetry201Creating400CreateRequest(lrosaDsP
 		return nil, err
 	}
 	urlPath := "/lro/nonretryerror/put/201/creating/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1975,7 +1976,7 @@ func (client *lrosaDsOperations) putNonRetry201Creating400InvalidJsonCreateReque
 		return nil, err
 	}
 	urlPath := "/lro/nonretryerror/put/201/creating/400/invalidjson"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -2051,7 +2052,7 @@ func (client *lrosaDsOperations) putNonRetry400CreateRequest(lrosaDsPutNonRetry4
 		return nil, err
 	}
 	urlPath := "/lro/nonretryerror/put/400"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lroscustomheader.go
+++ b/test/autorest/generated/lrogroup/lroscustomheader.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 )
 
@@ -87,7 +88,7 @@ func (client *lrOSCustomHeaderOperations) post202Retry200CreateRequest(lrOSCusto
 		return nil, err
 	}
 	urlPath := "/lro/customheader/post/202/retry/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *lrOSCustomHeaderOperations) postAsyncRetrySucceededCreateRequest(l
 		return nil, err
 	}
 	urlPath := "/lro/customheader/postasync/retry/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +240,7 @@ func (client *lrOSCustomHeaderOperations) put201CreatingSucceeded200CreateReques
 		return nil, err
 	}
 	urlPath := "/lro/customheader/put/201/creating/succeeded/200"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +316,7 @@ func (client *lrOSCustomHeaderOperations) putAsyncRetrySucceededCreateRequest(lr
 		return nil, err
 	}
 	urlPath := "/lro/customheader/putasync/retry/succeeded"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/lrogroup/lroscustomheader.go
+++ b/test/autorest/generated/lrogroup/lroscustomheader.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 	"time"
 )
 
@@ -82,8 +82,12 @@ func (client *lrOSCustomHeaderOperations) ResumePost202Retry200(token string) (H
 
 // post202Retry200CreateRequest creates the Post202Retry200 request.
 func (client *lrOSCustomHeaderOperations) post202Retry200CreateRequest(lrOSCustomHeaderPost202Retry200Options *LrOSCustomHeaderPost202Retry200Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/customheader/post/202/retry/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -154,8 +158,12 @@ func (client *lrOSCustomHeaderOperations) ResumePostAsyncRetrySucceeded(token st
 
 // postAsyncRetrySucceededCreateRequest creates the PostAsyncRetrySucceeded request.
 func (client *lrOSCustomHeaderOperations) postAsyncRetrySucceededCreateRequest(lrOSCustomHeaderPostAsyncRetrySucceededOptions *LrOSCustomHeaderPostAsyncRetrySucceededOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/customheader/postasync/retry/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -226,8 +234,12 @@ func (client *lrOSCustomHeaderOperations) ResumePut201CreatingSucceeded200(token
 
 // put201CreatingSucceeded200CreateRequest creates the Put201CreatingSucceeded200 request.
 func (client *lrOSCustomHeaderOperations) put201CreatingSucceeded200CreateRequest(lrOSCustomHeaderPut201CreatingSucceeded200Options *LrOSCustomHeaderPut201CreatingSucceeded200Options) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/customheader/put/201/creating/succeeded/200"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -298,8 +310,12 @@ func (client *lrOSCustomHeaderOperations) ResumePutAsyncRetrySucceeded(token str
 
 // putAsyncRetrySucceededCreateRequest creates the PutAsyncRetrySucceeded request.
 func (client *lrOSCustomHeaderOperations) putAsyncRetrySucceededCreateRequest(lrOSCustomHeaderPutAsyncRetrySucceededOptions *LrOSCustomHeaderPutAsyncRetrySucceededOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/lro/customheader/putasync/retry/succeeded"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/migroup/client.go
+++ b/test/autorest/generated/migroup/client.go
@@ -8,7 +8,6 @@ package migroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-migroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Service client for multiinheritance client testing
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // MultipleInheritanceServiceClientOperations returns the MultipleInheritanceServiceClientOperations associated with this client.

--- a/test/autorest/generated/migroup/multipleinheritanceserviceclient.go
+++ b/test/autorest/generated/migroup/multipleinheritanceserviceclient.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // MultipleInheritanceServiceClientOperations contains the methods for the MultipleInheritanceServiceClient group.
@@ -68,7 +69,7 @@ func (client *multipleInheritanceServiceClientOperations) getCatCreateRequest() 
 		return nil, err
 	}
 	urlPath := "/multipleInheritance/cat"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func (client *multipleInheritanceServiceClientOperations) getFelineCreateRequest
 		return nil, err
 	}
 	urlPath := "/multipleInheritance/feline"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +169,7 @@ func (client *multipleInheritanceServiceClientOperations) getHorseCreateRequest(
 		return nil, err
 	}
 	urlPath := "/multipleInheritance/horse"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +219,7 @@ func (client *multipleInheritanceServiceClientOperations) getKittenCreateRequest
 		return nil, err
 	}
 	urlPath := "/multipleInheritance/kitten"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +269,7 @@ func (client *multipleInheritanceServiceClientOperations) getPetCreateRequest() 
 		return nil, err
 	}
 	urlPath := "/multipleInheritance/pet"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +319,7 @@ func (client *multipleInheritanceServiceClientOperations) putCatCreateRequest(ca
 		return nil, err
 	}
 	urlPath := "/multipleInheritance/cat"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -371,7 +372,7 @@ func (client *multipleInheritanceServiceClientOperations) putFelineCreateRequest
 		return nil, err
 	}
 	urlPath := "/multipleInheritance/feline"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -424,7 +425,7 @@ func (client *multipleInheritanceServiceClientOperations) putHorseCreateRequest(
 		return nil, err
 	}
 	urlPath := "/multipleInheritance/horse"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -477,7 +478,7 @@ func (client *multipleInheritanceServiceClientOperations) putKittenCreateRequest
 		return nil, err
 	}
 	urlPath := "/multipleInheritance/kitten"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -530,7 +531,7 @@ func (client *multipleInheritanceServiceClientOperations) putPetCreateRequest(pe
 		return nil, err
 	}
 	urlPath := "/multipleInheritance/pet"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/migroup/multipleinheritanceserviceclient.go
+++ b/test/autorest/generated/migroup/multipleinheritanceserviceclient.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"io/ioutil"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // MultipleInheritanceServiceClientOperations contains the methods for the MultipleInheritanceServiceClient group.
@@ -63,8 +63,12 @@ func (client *multipleInheritanceServiceClientOperations) GetCat(ctx context.Con
 
 // getCatCreateRequest creates the GetCat request.
 func (client *multipleInheritanceServiceClientOperations) getCatCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/multipleInheritance/cat"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -109,8 +113,12 @@ func (client *multipleInheritanceServiceClientOperations) GetFeline(ctx context.
 
 // getFelineCreateRequest creates the GetFeline request.
 func (client *multipleInheritanceServiceClientOperations) getFelineCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/multipleInheritance/feline"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -155,8 +163,12 @@ func (client *multipleInheritanceServiceClientOperations) GetHorse(ctx context.C
 
 // getHorseCreateRequest creates the GetHorse request.
 func (client *multipleInheritanceServiceClientOperations) getHorseCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/multipleInheritance/horse"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -201,8 +213,12 @@ func (client *multipleInheritanceServiceClientOperations) GetKitten(ctx context.
 
 // getKittenCreateRequest creates the GetKitten request.
 func (client *multipleInheritanceServiceClientOperations) getKittenCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/multipleInheritance/kitten"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -247,8 +263,12 @@ func (client *multipleInheritanceServiceClientOperations) GetPet(ctx context.Con
 
 // getPetCreateRequest creates the GetPet request.
 func (client *multipleInheritanceServiceClientOperations) getPetCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/multipleInheritance/pet"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -293,8 +313,12 @@ func (client *multipleInheritanceServiceClientOperations) PutCat(ctx context.Con
 
 // putCatCreateRequest creates the PutCat request.
 func (client *multipleInheritanceServiceClientOperations) putCatCreateRequest(cat Cat) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/multipleInheritance/cat"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -342,8 +366,12 @@ func (client *multipleInheritanceServiceClientOperations) PutFeline(ctx context.
 
 // putFelineCreateRequest creates the PutFeline request.
 func (client *multipleInheritanceServiceClientOperations) putFelineCreateRequest(feline Feline) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/multipleInheritance/feline"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -391,8 +419,12 @@ func (client *multipleInheritanceServiceClientOperations) PutHorse(ctx context.C
 
 // putHorseCreateRequest creates the PutHorse request.
 func (client *multipleInheritanceServiceClientOperations) putHorseCreateRequest(horse Horse) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/multipleInheritance/horse"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -440,8 +472,12 @@ func (client *multipleInheritanceServiceClientOperations) PutKitten(ctx context.
 
 // putKittenCreateRequest creates the PutKitten request.
 func (client *multipleInheritanceServiceClientOperations) putKittenCreateRequest(kitten Kitten) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/multipleInheritance/kitten"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -489,8 +525,12 @@ func (client *multipleInheritanceServiceClientOperations) PutPet(ctx context.Con
 
 // putPetCreateRequest creates the PutPet request.
 func (client *multipleInheritanceServiceClientOperations) putPetCreateRequest(pet Pet) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/multipleInheritance/pet"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/morecustombaseurigroup/client.go
+++ b/test/autorest/generated/morecustombaseurigroup/client.go
@@ -49,7 +49,7 @@ type Client struct {
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(dnsSuffix *string, options *ClientOptions) (*Client, error) {
+func NewClient(dnsSuffix *string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -63,7 +63,7 @@ func NewClient(dnsSuffix *string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(dnsSuffix *string, p azcore.Pipeline) (*Client, error) {
+func NewClientWithPipeline(dnsSuffix *string, p azcore.Pipeline) *Client {
 	client := &Client{
 		p:         p,
 		dnsSuffix: "host",
@@ -71,7 +71,7 @@ func NewClientWithPipeline(dnsSuffix *string, p azcore.Pipeline) (*Client, error
 	if dnsSuffix != nil {
 		client.dnsSuffix = *dnsSuffix
 	}
-	return client, nil
+	return client
 }
 
 // PathsOperations returns the PathsOperations associated with this client.

--- a/test/autorest/generated/morecustombaseurigroup/paths.go
+++ b/test/autorest/generated/morecustombaseurigroup/paths.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -55,7 +56,7 @@ func (client *pathsOperations) getEmptyCreateRequest(vault string, secret string
 	urlPath := "/customuri/{subscriptionId}/{keyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{keyName}", url.PathEscape(keyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/morecustombaseurigroup/paths.go
+++ b/test/autorest/generated/morecustombaseurigroup/paths.go
@@ -48,10 +48,14 @@ func (client *pathsOperations) getEmptyCreateRequest(vault string, secret string
 	host = strings.ReplaceAll(host, "{dnsSuffix}", client.dnsSuffix)
 	host = strings.ReplaceAll(host, "{vault}", vault)
 	host = strings.ReplaceAll(host, "{secret}", secret)
+	u, err := url.Parse(host)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/customuri/{subscriptionId}/{keyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{keyName}", url.PathEscape(keyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := url.Parse(host + urlPath)
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/nonstringenumgroup/client.go
+++ b/test/autorest/generated/nonstringenumgroup/client.go
@@ -8,7 +8,6 @@ package nonstringenumgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-nonstringenumgroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Testing non-string enums.
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // IntOperations returns the IntOperations associated with this client.

--- a/test/autorest/generated/nonstringenumgroup/float.go
+++ b/test/autorest/generated/nonstringenumgroup/float.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // FloatOperations contains the methods for the Float group.
@@ -52,7 +53,7 @@ func (client *floatOperations) getCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/nonStringEnums/float/get"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ func (client *floatOperations) putCreateRequest(floatPutOptions *FloatPutOptions
 		return nil, err
 	}
 	urlPath := "/nonStringEnums/float/put"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/nonstringenumgroup/float.go
+++ b/test/autorest/generated/nonstringenumgroup/float.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"io/ioutil"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // FloatOperations contains the methods for the Float group.
@@ -47,8 +47,12 @@ func (client *floatOperations) Get(ctx context.Context) (*FloatEnumResponse, err
 
 // getCreateRequest creates the Get request.
 func (client *floatOperations) getCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/nonStringEnums/float/get"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +100,12 @@ func (client *floatOperations) Put(ctx context.Context, floatPutOptions *FloatPu
 
 // putCreateRequest creates the Put request.
 func (client *floatOperations) putCreateRequest(floatPutOptions *FloatPutOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/nonStringEnums/float/put"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/nonstringenumgroup/int.go
+++ b/test/autorest/generated/nonstringenumgroup/int.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // IntOperations contains the methods for the Int group.
@@ -52,7 +53,7 @@ func (client *intOperations) getCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/nonStringEnums/int/get"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ func (client *intOperations) putCreateRequest(intPutOptions *IntPutOptions) (*az
 		return nil, err
 	}
 	urlPath := "/nonStringEnums/int/put"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/nonstringenumgroup/int.go
+++ b/test/autorest/generated/nonstringenumgroup/int.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"io/ioutil"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // IntOperations contains the methods for the Int group.
@@ -47,8 +47,12 @@ func (client *intOperations) Get(ctx context.Context) (*IntEnumResponse, error) 
 
 // getCreateRequest creates the Get request.
 func (client *intOperations) getCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/nonStringEnums/int/get"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +100,12 @@ func (client *intOperations) Put(ctx context.Context, intPutOptions *IntPutOptio
 
 // putCreateRequest creates the Put request.
 func (client *intOperations) putCreateRequest(intPutOptions *IntPutOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/nonStringEnums/int/put"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/numbergroup/client.go
+++ b/test/autorest/generated/numbergroup/client.go
@@ -8,7 +8,6 @@ package numbergroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-numbergroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // NumberOperations returns the NumberOperations associated with this client.

--- a/test/autorest/generated/numbergroup/number.go
+++ b/test/autorest/generated/numbergroup/number.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // NumberOperations contains the methods for the Number group.
@@ -88,8 +88,12 @@ func (client *numberOperations) GetBigDecimal(ctx context.Context) (*Float64Resp
 
 // getBigDecimalCreateRequest creates the GetBigDecimal request.
 func (client *numberOperations) getBigDecimalCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/big/decimal/2.5976931e+101"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -134,8 +138,12 @@ func (client *numberOperations) GetBigDecimalNegativeDecimal(ctx context.Context
 
 // getBigDecimalNegativeDecimalCreateRequest creates the GetBigDecimalNegativeDecimal request.
 func (client *numberOperations) getBigDecimalNegativeDecimalCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/big/decimal/-99999999.99"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -180,8 +188,12 @@ func (client *numberOperations) GetBigDecimalPositiveDecimal(ctx context.Context
 
 // getBigDecimalPositiveDecimalCreateRequest creates the GetBigDecimalPositiveDecimal request.
 func (client *numberOperations) getBigDecimalPositiveDecimalCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/big/decimal/99999999.99"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -226,8 +238,12 @@ func (client *numberOperations) GetBigDouble(ctx context.Context) (*Float64Respo
 
 // getBigDoubleCreateRequest creates the GetBigDouble request.
 func (client *numberOperations) getBigDoubleCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/big/double/2.5976931e+101"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -272,8 +288,12 @@ func (client *numberOperations) GetBigDoubleNegativeDecimal(ctx context.Context)
 
 // getBigDoubleNegativeDecimalCreateRequest creates the GetBigDoubleNegativeDecimal request.
 func (client *numberOperations) getBigDoubleNegativeDecimalCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/big/double/-99999999.99"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -318,8 +338,12 @@ func (client *numberOperations) GetBigDoublePositiveDecimal(ctx context.Context)
 
 // getBigDoublePositiveDecimalCreateRequest creates the GetBigDoublePositiveDecimal request.
 func (client *numberOperations) getBigDoublePositiveDecimalCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/big/double/99999999.99"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -364,8 +388,12 @@ func (client *numberOperations) GetBigFloat(ctx context.Context) (*Float32Respon
 
 // getBigFloatCreateRequest creates the GetBigFloat request.
 func (client *numberOperations) getBigFloatCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/big/float/3.402823e+20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -410,8 +438,12 @@ func (client *numberOperations) GetInvalidDecimal(ctx context.Context) (*Float64
 
 // getInvalidDecimalCreateRequest creates the GetInvalidDecimal request.
 func (client *numberOperations) getInvalidDecimalCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/invaliddecimal"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -456,8 +488,12 @@ func (client *numberOperations) GetInvalidDouble(ctx context.Context) (*Float64R
 
 // getInvalidDoubleCreateRequest creates the GetInvalidDouble request.
 func (client *numberOperations) getInvalidDoubleCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/invaliddouble"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -502,8 +538,12 @@ func (client *numberOperations) GetInvalidFloat(ctx context.Context) (*Float32Re
 
 // getInvalidFloatCreateRequest creates the GetInvalidFloat request.
 func (client *numberOperations) getInvalidFloatCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/invalidfloat"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -548,8 +588,12 @@ func (client *numberOperations) GetNull(ctx context.Context) (*Float32Response, 
 
 // getNullCreateRequest creates the GetNull request.
 func (client *numberOperations) getNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -594,8 +638,12 @@ func (client *numberOperations) GetSmallDecimal(ctx context.Context) (*Float64Re
 
 // getSmallDecimalCreateRequest creates the GetSmallDecimal request.
 func (client *numberOperations) getSmallDecimalCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/small/decimal/2.5976931e-101"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -640,8 +688,12 @@ func (client *numberOperations) GetSmallDouble(ctx context.Context) (*Float64Res
 
 // getSmallDoubleCreateRequest creates the GetSmallDouble request.
 func (client *numberOperations) getSmallDoubleCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/small/double/2.5976931e-101"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -686,8 +738,12 @@ func (client *numberOperations) GetSmallFloat(ctx context.Context) (*Float64Resp
 
 // getSmallFloatCreateRequest creates the GetSmallFloat request.
 func (client *numberOperations) getSmallFloatCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/small/float/3.402823e-20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -732,8 +788,12 @@ func (client *numberOperations) PutBigDecimal(ctx context.Context, numberBody fl
 
 // putBigDecimalCreateRequest creates the PutBigDecimal request.
 func (client *numberOperations) putBigDecimalCreateRequest(numberBody float64) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/big/decimal/2.5976931e+101"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -777,8 +837,12 @@ func (client *numberOperations) PutBigDecimalNegativeDecimal(ctx context.Context
 
 // putBigDecimalNegativeDecimalCreateRequest creates the PutBigDecimalNegativeDecimal request.
 func (client *numberOperations) putBigDecimalNegativeDecimalCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/big/decimal/-99999999.99"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -822,8 +886,12 @@ func (client *numberOperations) PutBigDecimalPositiveDecimal(ctx context.Context
 
 // putBigDecimalPositiveDecimalCreateRequest creates the PutBigDecimalPositiveDecimal request.
 func (client *numberOperations) putBigDecimalPositiveDecimalCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/big/decimal/99999999.99"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -867,8 +935,12 @@ func (client *numberOperations) PutBigDouble(ctx context.Context, numberBody flo
 
 // putBigDoubleCreateRequest creates the PutBigDouble request.
 func (client *numberOperations) putBigDoubleCreateRequest(numberBody float64) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/big/double/2.5976931e+101"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -912,8 +984,12 @@ func (client *numberOperations) PutBigDoubleNegativeDecimal(ctx context.Context)
 
 // putBigDoubleNegativeDecimalCreateRequest creates the PutBigDoubleNegativeDecimal request.
 func (client *numberOperations) putBigDoubleNegativeDecimalCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/big/double/-99999999.99"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -957,8 +1033,12 @@ func (client *numberOperations) PutBigDoublePositiveDecimal(ctx context.Context)
 
 // putBigDoublePositiveDecimalCreateRequest creates the PutBigDoublePositiveDecimal request.
 func (client *numberOperations) putBigDoublePositiveDecimalCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/big/double/99999999.99"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1002,8 +1082,12 @@ func (client *numberOperations) PutBigFloat(ctx context.Context, numberBody floa
 
 // putBigFloatCreateRequest creates the PutBigFloat request.
 func (client *numberOperations) putBigFloatCreateRequest(numberBody float32) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/big/float/3.402823e+20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1047,8 +1131,12 @@ func (client *numberOperations) PutSmallDecimal(ctx context.Context, numberBody 
 
 // putSmallDecimalCreateRequest creates the PutSmallDecimal request.
 func (client *numberOperations) putSmallDecimalCreateRequest(numberBody float64) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/small/decimal/2.5976931e-101"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1092,8 +1180,12 @@ func (client *numberOperations) PutSmallDouble(ctx context.Context, numberBody f
 
 // putSmallDoubleCreateRequest creates the PutSmallDouble request.
 func (client *numberOperations) putSmallDoubleCreateRequest(numberBody float64) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/small/double/2.5976931e-101"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1137,8 +1229,12 @@ func (client *numberOperations) PutSmallFloat(ctx context.Context, numberBody fl
 
 // putSmallFloatCreateRequest creates the PutSmallFloat request.
 func (client *numberOperations) putSmallFloatCreateRequest(numberBody float32) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/number/small/float/3.402823e-20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/numbergroup/number.go
+++ b/test/autorest/generated/numbergroup/number.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // NumberOperations contains the methods for the Number group.
@@ -93,7 +94,7 @@ func (client *numberOperations) getBigDecimalCreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/number/big/decimal/2.5976931e+101"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +144,7 @@ func (client *numberOperations) getBigDecimalNegativeDecimalCreateRequest() (*az
 		return nil, err
 	}
 	urlPath := "/number/big/decimal/-99999999.99"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +194,7 @@ func (client *numberOperations) getBigDecimalPositiveDecimalCreateRequest() (*az
 		return nil, err
 	}
 	urlPath := "/number/big/decimal/99999999.99"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +244,7 @@ func (client *numberOperations) getBigDoubleCreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/number/big/double/2.5976931e+101"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +294,7 @@ func (client *numberOperations) getBigDoubleNegativeDecimalCreateRequest() (*azc
 		return nil, err
 	}
 	urlPath := "/number/big/double/-99999999.99"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -343,7 +344,7 @@ func (client *numberOperations) getBigDoublePositiveDecimalCreateRequest() (*azc
 		return nil, err
 	}
 	urlPath := "/number/big/double/99999999.99"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -393,7 +394,7 @@ func (client *numberOperations) getBigFloatCreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/number/big/float/3.402823e+20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -443,7 +444,7 @@ func (client *numberOperations) getInvalidDecimalCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/number/invaliddecimal"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -493,7 +494,7 @@ func (client *numberOperations) getInvalidDoubleCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/number/invaliddouble"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -543,7 +544,7 @@ func (client *numberOperations) getInvalidFloatCreateRequest() (*azcore.Request,
 		return nil, err
 	}
 	urlPath := "/number/invalidfloat"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -593,7 +594,7 @@ func (client *numberOperations) getNullCreateRequest() (*azcore.Request, error) 
 		return nil, err
 	}
 	urlPath := "/number/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -643,7 +644,7 @@ func (client *numberOperations) getSmallDecimalCreateRequest() (*azcore.Request,
 		return nil, err
 	}
 	urlPath := "/number/small/decimal/2.5976931e-101"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -693,7 +694,7 @@ func (client *numberOperations) getSmallDoubleCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/number/small/double/2.5976931e-101"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -743,7 +744,7 @@ func (client *numberOperations) getSmallFloatCreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/number/small/float/3.402823e-20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -793,7 +794,7 @@ func (client *numberOperations) putBigDecimalCreateRequest(numberBody float64) (
 		return nil, err
 	}
 	urlPath := "/number/big/decimal/2.5976931e+101"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -842,7 +843,7 @@ func (client *numberOperations) putBigDecimalNegativeDecimalCreateRequest() (*az
 		return nil, err
 	}
 	urlPath := "/number/big/decimal/-99999999.99"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -891,7 +892,7 @@ func (client *numberOperations) putBigDecimalPositiveDecimalCreateRequest() (*az
 		return nil, err
 	}
 	urlPath := "/number/big/decimal/99999999.99"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -940,7 +941,7 @@ func (client *numberOperations) putBigDoubleCreateRequest(numberBody float64) (*
 		return nil, err
 	}
 	urlPath := "/number/big/double/2.5976931e+101"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -989,7 +990,7 @@ func (client *numberOperations) putBigDoubleNegativeDecimalCreateRequest() (*azc
 		return nil, err
 	}
 	urlPath := "/number/big/double/-99999999.99"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1038,7 +1039,7 @@ func (client *numberOperations) putBigDoublePositiveDecimalCreateRequest() (*azc
 		return nil, err
 	}
 	urlPath := "/number/big/double/99999999.99"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1087,7 +1088,7 @@ func (client *numberOperations) putBigFloatCreateRequest(numberBody float32) (*a
 		return nil, err
 	}
 	urlPath := "/number/big/float/3.402823e+20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1136,7 +1137,7 @@ func (client *numberOperations) putSmallDecimalCreateRequest(numberBody float64)
 		return nil, err
 	}
 	urlPath := "/number/small/decimal/2.5976931e-101"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1185,7 +1186,7 @@ func (client *numberOperations) putSmallDoubleCreateRequest(numberBody float64) 
 		return nil, err
 	}
 	urlPath := "/number/small/double/2.5976931e-101"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1234,7 +1235,7 @@ func (client *numberOperations) putSmallFloatCreateRequest(numberBody float32) (
 		return nil, err
 	}
 	urlPath := "/number/small/float/3.402823e-20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/optionalgroup/client.go
+++ b/test/autorest/generated/optionalgroup/client.go
@@ -8,7 +8,6 @@ package optionalgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-optionalgroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // ImplicitOperations returns the ImplicitOperations associated with this client.

--- a/test/autorest/generated/optionalgroup/explicit.go
+++ b/test/autorest/generated/optionalgroup/explicit.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 )
@@ -91,7 +92,7 @@ func (client *explicitOperations) postOptionalArrayHeaderCreateRequest(explicitP
 		return nil, err
 	}
 	urlPath := "/reqopt/optional/array/header"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +144,7 @@ func (client *explicitOperations) postOptionalArrayParameterCreateRequest(explic
 		return nil, err
 	}
 	urlPath := "/reqopt/optional/array/parameter"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +196,7 @@ func (client *explicitOperations) postOptionalArrayPropertyCreateRequest(explici
 		return nil, err
 	}
 	urlPath := "/reqopt/optional/array/property"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +248,7 @@ func (client *explicitOperations) postOptionalClassParameterCreateRequest(explic
 		return nil, err
 	}
 	urlPath := "/reqopt/optional/class/parameter"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +300,7 @@ func (client *explicitOperations) postOptionalClassPropertyCreateRequest(explici
 		return nil, err
 	}
 	urlPath := "/reqopt/optional/class/property"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +352,7 @@ func (client *explicitOperations) postOptionalIntegerHeaderCreateRequest(explici
 		return nil, err
 	}
 	urlPath := "/reqopt/optional/integer/header"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -403,7 +404,7 @@ func (client *explicitOperations) postOptionalIntegerParameterCreateRequest(expl
 		return nil, err
 	}
 	urlPath := "/reqopt/optional/integer/parameter"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -455,7 +456,7 @@ func (client *explicitOperations) postOptionalIntegerPropertyCreateRequest(expli
 		return nil, err
 	}
 	urlPath := "/reqopt/optional/integer/property"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -507,7 +508,7 @@ func (client *explicitOperations) postOptionalStringHeaderCreateRequest(explicit
 		return nil, err
 	}
 	urlPath := "/reqopt/optional/string/header"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -559,7 +560,7 @@ func (client *explicitOperations) postOptionalStringParameterCreateRequest(expli
 		return nil, err
 	}
 	urlPath := "/reqopt/optional/string/parameter"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -611,7 +612,7 @@ func (client *explicitOperations) postOptionalStringPropertyCreateRequest(explic
 		return nil, err
 	}
 	urlPath := "/reqopt/optional/string/property"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -663,7 +664,7 @@ func (client *explicitOperations) postRequiredArrayHeaderCreateRequest(headerPar
 		return nil, err
 	}
 	urlPath := "/reqopt/requied/array/header"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -713,7 +714,7 @@ func (client *explicitOperations) postRequiredArrayParameterCreateRequest(bodyPa
 		return nil, err
 	}
 	urlPath := "/reqopt/requied/array/parameter"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -762,7 +763,7 @@ func (client *explicitOperations) postRequiredArrayPropertyCreateRequest(bodyPar
 		return nil, err
 	}
 	urlPath := "/reqopt/requied/array/property"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -811,7 +812,7 @@ func (client *explicitOperations) postRequiredClassParameterCreateRequest(bodyPa
 		return nil, err
 	}
 	urlPath := "/reqopt/requied/class/parameter"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -860,7 +861,7 @@ func (client *explicitOperations) postRequiredClassPropertyCreateRequest(bodyPar
 		return nil, err
 	}
 	urlPath := "/reqopt/requied/class/property"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -909,7 +910,7 @@ func (client *explicitOperations) postRequiredIntegerHeaderCreateRequest(headerP
 		return nil, err
 	}
 	urlPath := "/reqopt/requied/integer/header"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -959,7 +960,7 @@ func (client *explicitOperations) postRequiredIntegerParameterCreateRequest(body
 		return nil, err
 	}
 	urlPath := "/reqopt/requied/integer/parameter"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1008,7 +1009,7 @@ func (client *explicitOperations) postRequiredIntegerPropertyCreateRequest(bodyP
 		return nil, err
 	}
 	urlPath := "/reqopt/requied/integer/property"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1057,7 +1058,7 @@ func (client *explicitOperations) postRequiredStringHeaderCreateRequest(headerPa
 		return nil, err
 	}
 	urlPath := "/reqopt/requied/string/header"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1107,7 +1108,7 @@ func (client *explicitOperations) postRequiredStringParameterCreateRequest(bodyP
 		return nil, err
 	}
 	urlPath := "/reqopt/requied/string/parameter"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1156,7 +1157,7 @@ func (client *explicitOperations) postRequiredStringPropertyCreateRequest(bodyPa
 		return nil, err
 	}
 	urlPath := "/reqopt/requied/string/property"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/optionalgroup/explicit.go
+++ b/test/autorest/generated/optionalgroup/explicit.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -86,8 +86,12 @@ func (client *explicitOperations) PostOptionalArrayHeader(ctx context.Context, e
 
 // postOptionalArrayHeaderCreateRequest creates the PostOptionalArrayHeader request.
 func (client *explicitOperations) postOptionalArrayHeaderCreateRequest(explicitPostOptionalArrayHeaderOptions *ExplicitPostOptionalArrayHeaderOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/optional/array/header"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -134,8 +138,12 @@ func (client *explicitOperations) PostOptionalArrayParameter(ctx context.Context
 
 // postOptionalArrayParameterCreateRequest creates the PostOptionalArrayParameter request.
 func (client *explicitOperations) postOptionalArrayParameterCreateRequest(explicitPostOptionalArrayParameterOptions *ExplicitPostOptionalArrayParameterOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/optional/array/parameter"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -182,8 +190,12 @@ func (client *explicitOperations) PostOptionalArrayProperty(ctx context.Context,
 
 // postOptionalArrayPropertyCreateRequest creates the PostOptionalArrayProperty request.
 func (client *explicitOperations) postOptionalArrayPropertyCreateRequest(explicitPostOptionalArrayPropertyOptions *ExplicitPostOptionalArrayPropertyOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/optional/array/property"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -230,8 +242,12 @@ func (client *explicitOperations) PostOptionalClassParameter(ctx context.Context
 
 // postOptionalClassParameterCreateRequest creates the PostOptionalClassParameter request.
 func (client *explicitOperations) postOptionalClassParameterCreateRequest(explicitPostOptionalClassParameterOptions *ExplicitPostOptionalClassParameterOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/optional/class/parameter"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -278,8 +294,12 @@ func (client *explicitOperations) PostOptionalClassProperty(ctx context.Context,
 
 // postOptionalClassPropertyCreateRequest creates the PostOptionalClassProperty request.
 func (client *explicitOperations) postOptionalClassPropertyCreateRequest(explicitPostOptionalClassPropertyOptions *ExplicitPostOptionalClassPropertyOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/optional/class/property"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -326,8 +346,12 @@ func (client *explicitOperations) PostOptionalIntegerHeader(ctx context.Context,
 
 // postOptionalIntegerHeaderCreateRequest creates the PostOptionalIntegerHeader request.
 func (client *explicitOperations) postOptionalIntegerHeaderCreateRequest(explicitPostOptionalIntegerHeaderOptions *ExplicitPostOptionalIntegerHeaderOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/optional/integer/header"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -374,8 +398,12 @@ func (client *explicitOperations) PostOptionalIntegerParameter(ctx context.Conte
 
 // postOptionalIntegerParameterCreateRequest creates the PostOptionalIntegerParameter request.
 func (client *explicitOperations) postOptionalIntegerParameterCreateRequest(explicitPostOptionalIntegerParameterOptions *ExplicitPostOptionalIntegerParameterOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/optional/integer/parameter"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -422,8 +450,12 @@ func (client *explicitOperations) PostOptionalIntegerProperty(ctx context.Contex
 
 // postOptionalIntegerPropertyCreateRequest creates the PostOptionalIntegerProperty request.
 func (client *explicitOperations) postOptionalIntegerPropertyCreateRequest(explicitPostOptionalIntegerPropertyOptions *ExplicitPostOptionalIntegerPropertyOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/optional/integer/property"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -470,8 +502,12 @@ func (client *explicitOperations) PostOptionalStringHeader(ctx context.Context, 
 
 // postOptionalStringHeaderCreateRequest creates the PostOptionalStringHeader request.
 func (client *explicitOperations) postOptionalStringHeaderCreateRequest(explicitPostOptionalStringHeaderOptions *ExplicitPostOptionalStringHeaderOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/optional/string/header"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -518,8 +554,12 @@ func (client *explicitOperations) PostOptionalStringParameter(ctx context.Contex
 
 // postOptionalStringParameterCreateRequest creates the PostOptionalStringParameter request.
 func (client *explicitOperations) postOptionalStringParameterCreateRequest(explicitPostOptionalStringParameterOptions *ExplicitPostOptionalStringParameterOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/optional/string/parameter"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -566,8 +606,12 @@ func (client *explicitOperations) PostOptionalStringProperty(ctx context.Context
 
 // postOptionalStringPropertyCreateRequest creates the PostOptionalStringProperty request.
 func (client *explicitOperations) postOptionalStringPropertyCreateRequest(explicitPostOptionalStringPropertyOptions *ExplicitPostOptionalStringPropertyOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/optional/string/property"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -614,8 +658,12 @@ func (client *explicitOperations) PostRequiredArrayHeader(ctx context.Context, h
 
 // postRequiredArrayHeaderCreateRequest creates the PostRequiredArrayHeader request.
 func (client *explicitOperations) postRequiredArrayHeaderCreateRequest(headerParameter []string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/requied/array/header"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -660,8 +708,12 @@ func (client *explicitOperations) PostRequiredArrayParameter(ctx context.Context
 
 // postRequiredArrayParameterCreateRequest creates the PostRequiredArrayParameter request.
 func (client *explicitOperations) postRequiredArrayParameterCreateRequest(bodyParameter []string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/requied/array/parameter"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -705,8 +757,12 @@ func (client *explicitOperations) PostRequiredArrayProperty(ctx context.Context,
 
 // postRequiredArrayPropertyCreateRequest creates the PostRequiredArrayProperty request.
 func (client *explicitOperations) postRequiredArrayPropertyCreateRequest(bodyParameter ArrayWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/requied/array/property"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -750,8 +806,12 @@ func (client *explicitOperations) PostRequiredClassParameter(ctx context.Context
 
 // postRequiredClassParameterCreateRequest creates the PostRequiredClassParameter request.
 func (client *explicitOperations) postRequiredClassParameterCreateRequest(bodyParameter Product) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/requied/class/parameter"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -795,8 +855,12 @@ func (client *explicitOperations) PostRequiredClassProperty(ctx context.Context,
 
 // postRequiredClassPropertyCreateRequest creates the PostRequiredClassProperty request.
 func (client *explicitOperations) postRequiredClassPropertyCreateRequest(bodyParameter ClassWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/requied/class/property"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -840,8 +904,12 @@ func (client *explicitOperations) PostRequiredIntegerHeader(ctx context.Context,
 
 // postRequiredIntegerHeaderCreateRequest creates the PostRequiredIntegerHeader request.
 func (client *explicitOperations) postRequiredIntegerHeaderCreateRequest(headerParameter int32) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/requied/integer/header"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -886,8 +954,12 @@ func (client *explicitOperations) PostRequiredIntegerParameter(ctx context.Conte
 
 // postRequiredIntegerParameterCreateRequest creates the PostRequiredIntegerParameter request.
 func (client *explicitOperations) postRequiredIntegerParameterCreateRequest(bodyParameter int32) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/requied/integer/parameter"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -931,8 +1003,12 @@ func (client *explicitOperations) PostRequiredIntegerProperty(ctx context.Contex
 
 // postRequiredIntegerPropertyCreateRequest creates the PostRequiredIntegerProperty request.
 func (client *explicitOperations) postRequiredIntegerPropertyCreateRequest(bodyParameter IntWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/requied/integer/property"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -976,8 +1052,12 @@ func (client *explicitOperations) PostRequiredStringHeader(ctx context.Context, 
 
 // postRequiredStringHeaderCreateRequest creates the PostRequiredStringHeader request.
 func (client *explicitOperations) postRequiredStringHeaderCreateRequest(headerParameter string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/requied/string/header"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1022,8 +1102,12 @@ func (client *explicitOperations) PostRequiredStringParameter(ctx context.Contex
 
 // postRequiredStringParameterCreateRequest creates the PostRequiredStringParameter request.
 func (client *explicitOperations) postRequiredStringParameterCreateRequest(bodyParameter string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/requied/string/parameter"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1067,8 +1151,12 @@ func (client *explicitOperations) PostRequiredStringProperty(ctx context.Context
 
 // postRequiredStringPropertyCreateRequest creates the PostRequiredStringProperty request.
 func (client *explicitOperations) postRequiredStringPropertyCreateRequest(bodyParameter StringWrapper) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/requied/string/property"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/optionalgroup/implicit.go
+++ b/test/autorest/generated/optionalgroup/implicit.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 )
@@ -60,8 +59,12 @@ func (client *implicitOperations) GetOptionalGlobalQuery(ctx context.Context) (*
 
 // getOptionalGlobalQueryCreateRequest creates the GetOptionalGlobalQuery request.
 func (client *implicitOperations) getOptionalGlobalQueryCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/global/optional/query"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -110,9 +113,13 @@ func (client *implicitOperations) GetRequiredGlobalPath(ctx context.Context) (*h
 
 // getRequiredGlobalPathCreateRequest creates the GetRequiredGlobalPath request.
 func (client *implicitOperations) getRequiredGlobalPathCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/global/required/path/{required-global-path}"
 	urlPath = strings.ReplaceAll(urlPath, "{required-global-path}", url.PathEscape(client.requiredGlobalPath))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -156,8 +163,12 @@ func (client *implicitOperations) GetRequiredGlobalQuery(ctx context.Context) (*
 
 // getRequiredGlobalQueryCreateRequest creates the GetRequiredGlobalQuery request.
 func (client *implicitOperations) getRequiredGlobalQueryCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/global/required/query"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -204,9 +215,13 @@ func (client *implicitOperations) GetRequiredPath(ctx context.Context, pathParam
 
 // getRequiredPathCreateRequest creates the GetRequiredPath request.
 func (client *implicitOperations) getRequiredPathCreateRequest(pathParameter string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/implicit/required/path/{pathParameter}"
 	urlPath = strings.ReplaceAll(urlPath, "{pathParameter}", url.PathEscape(pathParameter))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -250,8 +265,12 @@ func (client *implicitOperations) PutOptionalBody(ctx context.Context, implicitP
 
 // putOptionalBodyCreateRequest creates the PutOptionalBody request.
 func (client *implicitOperations) putOptionalBodyCreateRequest(implicitPutOptionalBodyOptions *ImplicitPutOptionalBodyOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/implicit/optional/body"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -298,8 +317,12 @@ func (client *implicitOperations) PutOptionalHeader(ctx context.Context, implici
 
 // putOptionalHeaderCreateRequest creates the PutOptionalHeader request.
 func (client *implicitOperations) putOptionalHeaderCreateRequest(implicitPutOptionalHeaderOptions *ImplicitPutOptionalHeaderOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/implicit/optional/header"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -346,8 +369,12 @@ func (client *implicitOperations) PutOptionalQuery(ctx context.Context, implicit
 
 // putOptionalQueryCreateRequest creates the PutOptionalQuery request.
 func (client *implicitOperations) putOptionalQueryCreateRequest(implicitPutOptionalQueryOptions *ImplicitPutOptionalQueryOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/reqopt/implicit/optional/query"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/optionalgroup/implicit.go
+++ b/test/autorest/generated/optionalgroup/implicit.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 )
@@ -64,7 +65,7 @@ func (client *implicitOperations) getOptionalGlobalQueryCreateRequest() (*azcore
 		return nil, err
 	}
 	urlPath := "/reqopt/global/optional/query"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +120,7 @@ func (client *implicitOperations) getRequiredGlobalPathCreateRequest() (*azcore.
 	}
 	urlPath := "/reqopt/global/required/path/{required-global-path}"
 	urlPath = strings.ReplaceAll(urlPath, "{required-global-path}", url.PathEscape(client.requiredGlobalPath))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +169,7 @@ func (client *implicitOperations) getRequiredGlobalQueryCreateRequest() (*azcore
 		return nil, err
 	}
 	urlPath := "/reqopt/global/required/query"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +222,7 @@ func (client *implicitOperations) getRequiredPathCreateRequest(pathParameter str
 	}
 	urlPath := "/reqopt/implicit/required/path/{pathParameter}"
 	urlPath = strings.ReplaceAll(urlPath, "{pathParameter}", url.PathEscape(pathParameter))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +271,7 @@ func (client *implicitOperations) putOptionalBodyCreateRequest(implicitPutOption
 		return nil, err
 	}
 	urlPath := "/reqopt/implicit/optional/body"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +323,7 @@ func (client *implicitOperations) putOptionalHeaderCreateRequest(implicitPutOpti
 		return nil, err
 	}
 	urlPath := "/reqopt/implicit/optional/header"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +375,7 @@ func (client *implicitOperations) putOptionalQueryCreateRequest(implicitPutOptio
 		return nil, err
 	}
 	urlPath := "/reqopt/implicit/optional/query"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/paginggroup/client.go
+++ b/test/autorest/generated/paginggroup/client.go
@@ -8,7 +8,6 @@ package paginggroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-paginggroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Long-running Operation for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // PagingOperations returns the PagingOperations associated with this client.

--- a/test/autorest/generated/paginggroup/paging.go
+++ b/test/autorest/generated/paginggroup/paging.go
@@ -14,6 +14,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -92,7 +93,7 @@ func (client *pagingOperations) getMultiplePagesCreateRequest(pagingGetMultipleP
 		return nil, err
 	}
 	urlPath := "/paging/multiple"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +161,7 @@ func (client *pagingOperations) getMultiplePagesFailureCreateRequest() (*azcore.
 		return nil, err
 	}
 	urlPath := "/paging/multiple/failure"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +220,7 @@ func (client *pagingOperations) getMultiplePagesFailureUriCreateRequest() (*azco
 		return nil, err
 	}
 	urlPath := "/paging/multiple/failureuri"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +273,7 @@ func (client *pagingOperations) getMultiplePagesFragmentNextLinkCreateRequest(ap
 	}
 	urlPath := "/paging/multiple/fragment/{tenant}"
 	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(tenant))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +329,7 @@ func (client *pagingOperations) getMultiplePagesFragmentWithGroupingNextLinkCrea
 	}
 	urlPath := "/paging/multiple/fragmentwithgrouping/{tenant}"
 	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(customParameterGroup.Tenant))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -409,7 +410,7 @@ func (client *pagingOperations) getMultiplePagesLroCreateRequest(pagingGetMultip
 		return nil, err
 	}
 	urlPath := "/paging/multiple/lro"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -485,7 +486,7 @@ func (client *pagingOperations) getMultiplePagesRetryFirstCreateRequest() (*azco
 		return nil, err
 	}
 	urlPath := "/paging/multiple/retryfirst"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -544,7 +545,7 @@ func (client *pagingOperations) getMultiplePagesRetrySecondCreateRequest() (*azc
 		return nil, err
 	}
 	urlPath := "/paging/multiple/retrysecond"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -604,7 +605,7 @@ func (client *pagingOperations) getMultiplePagesWithOffsetCreateRequest(pagingGe
 	}
 	urlPath := "/paging/multiple/withpath/{offset}"
 	urlPath = strings.ReplaceAll(urlPath, "{offset}", url.PathEscape(strconv.FormatInt(int64(pagingGetMultiplePagesWithOffsetOptions.Offset), 10)))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -672,7 +673,7 @@ func (client *pagingOperations) getNoItemNamePagesCreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/paging/noitemname"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -725,7 +726,7 @@ func (client *pagingOperations) getNullNextLinkNamePagesCreateRequest() (*azcore
 		return nil, err
 	}
 	urlPath := "/paging/nullnextlink"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -784,7 +785,7 @@ func (client *pagingOperations) getOdataMultiplePagesCreateRequest(pagingGetOdat
 		return nil, err
 	}
 	urlPath := "/paging/multiple/odata"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -852,7 +853,7 @@ func (client *pagingOperations) getPagingModelWithItemNameWithXmsClientNameCreat
 		return nil, err
 	}
 	urlPath := "/paging/itemNameWithXMSClientName"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -911,7 +912,7 @@ func (client *pagingOperations) getSinglePagesCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/paging/single"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -970,7 +971,7 @@ func (client *pagingOperations) getSinglePagesFailureCreateRequest() (*azcore.Re
 		return nil, err
 	}
 	urlPath := "/paging/single/failure"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1022,7 +1023,7 @@ func (client *pagingOperations) getWithQueryParamsCreateRequest(requiredQueryPar
 		return nil, err
 	}
 	urlPath := "/paging/multiple/getWithQueryParams"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1064,7 +1065,7 @@ func (client *pagingOperations) nextFragmentCreateRequest(apiVersion string, ten
 	urlPath := "/paging/multiple/fragment/{tenant}/{nextLink}"
 	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(tenant))
 	urlPath = strings.ReplaceAll(urlPath, "{nextLink}", nextLink)
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1105,7 +1106,7 @@ func (client *pagingOperations) nextFragmentWithGroupingCreateRequest(nextLink s
 	urlPath := "/paging/multiple/fragmentwithgrouping/{tenant}/{nextLink}"
 	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(customParameterGroup.Tenant))
 	urlPath = strings.ReplaceAll(urlPath, "{nextLink}", nextLink)
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1144,7 +1145,7 @@ func (client *pagingOperations) nextOperationWithQueryParamsCreateRequest() (*az
 		return nil, err
 	}
 	urlPath := "/paging/multiple/nextOperationWithQueryParams"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/paginggroup/paging.go
+++ b/test/autorest/generated/paginggroup/paging.go
@@ -14,7 +14,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -88,8 +87,12 @@ func (client *pagingOperations) GetMultiplePages(pagingGetMultiplePagesOptions *
 
 // getMultiplePagesCreateRequest creates the GetMultiplePages request.
 func (client *pagingOperations) getMultiplePagesCreateRequest(pagingGetMultiplePagesOptions *PagingGetMultiplePagesOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/multiple"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -152,8 +155,12 @@ func (client *pagingOperations) GetMultiplePagesFailure() (ProductResultPager, e
 
 // getMultiplePagesFailureCreateRequest creates the GetMultiplePagesFailure request.
 func (client *pagingOperations) getMultiplePagesFailureCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/multiple/failure"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -207,8 +214,12 @@ func (client *pagingOperations) GetMultiplePagesFailureURI() (ProductResultPager
 
 // getMultiplePagesFailureUriCreateRequest creates the GetMultiplePagesFailureURI request.
 func (client *pagingOperations) getMultiplePagesFailureUriCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/multiple/failureuri"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -255,9 +266,13 @@ func (client *pagingOperations) GetMultiplePagesFragmentNextLink(apiVersion stri
 
 // getMultiplePagesFragmentNextLinkCreateRequest creates the GetMultiplePagesFragmentNextLink request.
 func (client *pagingOperations) getMultiplePagesFragmentNextLinkCreateRequest(apiVersion string, tenant string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/multiple/fragment/{tenant}"
 	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(tenant))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -307,9 +322,13 @@ func (client *pagingOperations) GetMultiplePagesFragmentWithGroupingNextLink(cus
 
 // getMultiplePagesFragmentWithGroupingNextLinkCreateRequest creates the GetMultiplePagesFragmentWithGroupingNextLink request.
 func (client *pagingOperations) getMultiplePagesFragmentWithGroupingNextLinkCreateRequest(customParameterGroup CustomParameterGroup) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/multiple/fragmentwithgrouping/{tenant}"
 	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(customParameterGroup.Tenant))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -385,8 +404,12 @@ func (client *pagingOperations) ResumeGetMultiplePagesLro(token string) (Product
 
 // getMultiplePagesLroCreateRequest creates the GetMultiplePagesLro request.
 func (client *pagingOperations) getMultiplePagesLroCreateRequest(pagingGetMultiplePagesLroOptions *PagingGetMultiplePagesLroOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/multiple/lro"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -457,8 +480,12 @@ func (client *pagingOperations) GetMultiplePagesRetryFirst() (ProductResultPager
 
 // getMultiplePagesRetryFirstCreateRequest creates the GetMultiplePagesRetryFirst request.
 func (client *pagingOperations) getMultiplePagesRetryFirstCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/multiple/retryfirst"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -512,8 +539,12 @@ func (client *pagingOperations) GetMultiplePagesRetrySecond() (ProductResultPage
 
 // getMultiplePagesRetrySecondCreateRequest creates the GetMultiplePagesRetrySecond request.
 func (client *pagingOperations) getMultiplePagesRetrySecondCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/multiple/retrysecond"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -567,9 +598,13 @@ func (client *pagingOperations) GetMultiplePagesWithOffset(pagingGetMultiplePage
 
 // getMultiplePagesWithOffsetCreateRequest creates the GetMultiplePagesWithOffset request.
 func (client *pagingOperations) getMultiplePagesWithOffsetCreateRequest(pagingGetMultiplePagesWithOffsetOptions PagingGetMultiplePagesWithOffsetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/multiple/withpath/{offset}"
 	urlPath = strings.ReplaceAll(urlPath, "{offset}", url.PathEscape(strconv.FormatInt(int64(pagingGetMultiplePagesWithOffsetOptions.Offset), 10)))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -632,8 +667,12 @@ func (client *pagingOperations) GetNoItemNamePages() (ProductResultValuePager, e
 
 // getNoItemNamePagesCreateRequest creates the GetNoItemNamePages request.
 func (client *pagingOperations) getNoItemNamePagesCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/noitemname"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -681,8 +720,12 @@ func (client *pagingOperations) GetNullNextLinkNamePages(ctx context.Context) (*
 
 // getNullNextLinkNamePagesCreateRequest creates the GetNullNextLinkNamePages request.
 func (client *pagingOperations) getNullNextLinkNamePagesCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/nullnextlink"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -736,8 +779,12 @@ func (client *pagingOperations) GetOdataMultiplePages(pagingGetOdataMultiplePage
 
 // getOdataMultiplePagesCreateRequest creates the GetOdataMultiplePages request.
 func (client *pagingOperations) getOdataMultiplePagesCreateRequest(pagingGetOdataMultiplePagesOptions *PagingGetOdataMultiplePagesOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/multiple/odata"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -800,8 +847,12 @@ func (client *pagingOperations) GetPagingModelWithItemNameWithXmsClientName() (P
 
 // getPagingModelWithItemNameWithXmsClientNameCreateRequest creates the GetPagingModelWithItemNameWithXmsClientName request.
 func (client *pagingOperations) getPagingModelWithItemNameWithXmsClientNameCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/itemNameWithXMSClientName"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -855,8 +906,12 @@ func (client *pagingOperations) GetSinglePages() (ProductResultPager, error) {
 
 // getSinglePagesCreateRequest creates the GetSinglePages request.
 func (client *pagingOperations) getSinglePagesCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/single"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -910,8 +965,12 @@ func (client *pagingOperations) GetSinglePagesFailure() (ProductResultPager, err
 
 // getSinglePagesFailureCreateRequest creates the GetSinglePagesFailure request.
 func (client *pagingOperations) getSinglePagesFailureCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/single/failure"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -958,8 +1017,12 @@ func (client *pagingOperations) GetWithQueryParams(requiredQueryParameter int32)
 
 // getWithQueryParamsCreateRequest creates the GetWithQueryParams request.
 func (client *pagingOperations) getWithQueryParamsCreateRequest(requiredQueryParameter int32) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/multiple/getWithQueryParams"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -994,10 +1057,14 @@ func (client *pagingOperations) getWithQueryParamsHandleError(resp *azcore.Respo
 
 // nextFragmentCreateRequest creates the NextFragment request.
 func (client *pagingOperations) nextFragmentCreateRequest(apiVersion string, tenant string, nextLink string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/multiple/fragment/{tenant}/{nextLink}"
 	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(tenant))
 	urlPath = strings.ReplaceAll(urlPath, "{nextLink}", nextLink)
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1031,10 +1098,14 @@ func (client *pagingOperations) nextFragmentHandleError(resp *azcore.Response) e
 
 // nextFragmentWithGroupingCreateRequest creates the NextFragmentWithGrouping request.
 func (client *pagingOperations) nextFragmentWithGroupingCreateRequest(nextLink string, customParameterGroup CustomParameterGroup) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/multiple/fragmentwithgrouping/{tenant}/{nextLink}"
 	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(customParameterGroup.Tenant))
 	urlPath = strings.ReplaceAll(urlPath, "{nextLink}", nextLink)
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1068,8 +1139,12 @@ func (client *pagingOperations) nextFragmentWithGroupingHandleError(resp *azcore
 
 // nextOperationWithQueryParamsCreateRequest creates the NextOperationWithQueryParams request.
 func (client *pagingOperations) nextOperationWithQueryParamsCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paging/multiple/nextOperationWithQueryParams"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/paramgroupinggroup/client.go
+++ b/test/autorest/generated/paramgroupinggroup/client.go
@@ -8,7 +8,6 @@ package paramgroupinggroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-paramgroupinggroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // ParameterGroupingOperations returns the ParameterGroupingOperations associated with this client.

--- a/test/autorest/generated/paramgroupinggroup/parametergrouping.go
+++ b/test/autorest/generated/paramgroupinggroup/parametergrouping.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 )
@@ -51,8 +50,12 @@ func (client *parameterGroupingOperations) PostMultiParamGroups(ctx context.Cont
 
 // postMultiParamGroupsCreateRequest creates the PostMultiParamGroups request.
 func (client *parameterGroupingOperations) postMultiParamGroupsCreateRequest(firstParameterGroup *FirstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup *ParameterGroupingPostMultiParamGroupsSecondParamGroup) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/parameterGrouping/postMultipleParameterGroups"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -110,8 +113,12 @@ func (client *parameterGroupingOperations) PostOptional(ctx context.Context, par
 
 // postOptionalCreateRequest creates the PostOptional request.
 func (client *parameterGroupingOperations) postOptionalCreateRequest(parameterGroupingPostOptionalParameters *ParameterGroupingPostOptionalParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/parameterGrouping/postOptional"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -163,9 +170,13 @@ func (client *parameterGroupingOperations) PostRequired(ctx context.Context, par
 
 // postRequiredCreateRequest creates the PostRequired request.
 func (client *parameterGroupingOperations) postRequiredCreateRequest(parameterGroupingPostRequiredParameters ParameterGroupingPostRequiredParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/parameterGrouping/postRequired/{path}"
 	urlPath = strings.ReplaceAll(urlPath, "{path}", url.PathEscape(parameterGroupingPostRequiredParameters.PathParameter))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -217,8 +228,12 @@ func (client *parameterGroupingOperations) PostSharedParameterGroupObject(ctx co
 
 // postSharedParameterGroupObjectCreateRequest creates the PostSharedParameterGroupObject request.
 func (client *parameterGroupingOperations) postSharedParameterGroupObjectCreateRequest(firstParameterGroup *FirstParameterGroup) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/parameterGrouping/sharedParameterGroupObject"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/paramgroupinggroup/parametergrouping.go
+++ b/test/autorest/generated/paramgroupinggroup/parametergrouping.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 )
@@ -55,7 +56,7 @@ func (client *parameterGroupingOperations) postMultiParamGroupsCreateRequest(fir
 		return nil, err
 	}
 	urlPath := "/parameterGrouping/postMultipleParameterGroups"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func (client *parameterGroupingOperations) postOptionalCreateRequest(parameterGr
 		return nil, err
 	}
 	urlPath := "/parameterGrouping/postOptional"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +177,7 @@ func (client *parameterGroupingOperations) postRequiredCreateRequest(parameterGr
 	}
 	urlPath := "/parameterGrouping/postRequired/{path}"
 	urlPath = strings.ReplaceAll(urlPath, "{path}", url.PathEscape(parameterGroupingPostRequiredParameters.PathParameter))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +234,7 @@ func (client *parameterGroupingOperations) postSharedParameterGroupObjectCreateR
 		return nil, err
 	}
 	urlPath := "/parameterGrouping/sharedParameterGroupObject"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/reportgroup/autorestreportservice.go
+++ b/test/autorest/generated/reportgroup/autorestreportservice.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // AutoRestReportServiceOperations contains the methods for the AutoRestReportService group.
@@ -49,7 +50,7 @@ func (client *autoRestReportServiceOperations) getOptionalReportCreateRequest(au
 		return nil, err
 	}
 	urlPath := "/report/optional"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +105,7 @@ func (client *autoRestReportServiceOperations) getReportCreateRequest(autoRestRe
 		return nil, err
 	}
 	urlPath := "/report"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/reportgroup/autorestreportservice.go
+++ b/test/autorest/generated/reportgroup/autorestreportservice.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // AutoRestReportServiceOperations contains the methods for the AutoRestReportService group.
@@ -44,8 +44,12 @@ func (client *autoRestReportServiceOperations) GetOptionalReport(ctx context.Con
 
 // getOptionalReportCreateRequest creates the GetOptionalReport request.
 func (client *autoRestReportServiceOperations) getOptionalReportCreateRequest(autoRestReportServiceGetOptionalReportOptions *AutoRestReportServiceGetOptionalReportOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/report/optional"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +99,12 @@ func (client *autoRestReportServiceOperations) GetReport(ctx context.Context, au
 
 // getReportCreateRequest creates the GetReport request.
 func (client *autoRestReportServiceOperations) getReportCreateRequest(autoRestReportServiceGetReportOptions *AutoRestReportServiceGetReportOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/report"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/reportgroup/client.go
+++ b/test/autorest/generated/reportgroup/client.go
@@ -8,7 +8,6 @@ package reportgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-reportgroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // AutoRestReportServiceOperations returns the AutoRestReportServiceOperations associated with this client.

--- a/test/autorest/generated/stringgroup/client.go
+++ b/test/autorest/generated/stringgroup/client.go
@@ -8,7 +8,6 @@ package stringgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-stringgroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest Swagger BAT
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // StringOperations returns the StringOperations associated with this client.

--- a/test/autorest/generated/stringgroup/enum.go
+++ b/test/autorest/generated/stringgroup/enum.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // EnumOperations contains the methods for the Enum group.
@@ -57,7 +58,7 @@ func (client *enumOperations) getNotExpandableCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/string/enum/notExpandable"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,7 @@ func (client *enumOperations) getReferencedCreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/string/enum/Referenced"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +158,7 @@ func (client *enumOperations) getReferencedConstantCreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/string/enum/ReferencedConstant"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +208,7 @@ func (client *enumOperations) putNotExpandableCreateRequest(stringBody Colors) (
 		return nil, err
 	}
 	urlPath := "/string/enum/notExpandable"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +257,7 @@ func (client *enumOperations) putReferencedCreateRequest(enumStringBody Colors) 
 		return nil, err
 	}
 	urlPath := "/string/enum/Referenced"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +306,7 @@ func (client *enumOperations) putReferencedConstantCreateRequest(enumStringBody 
 		return nil, err
 	}
 	urlPath := "/string/enum/ReferencedConstant"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/stringgroup/enum.go
+++ b/test/autorest/generated/stringgroup/enum.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // EnumOperations contains the methods for the Enum group.
@@ -52,8 +52,12 @@ func (client *enumOperations) GetNotExpandable(ctx context.Context) (*ColorsResp
 
 // getNotExpandableCreateRequest creates the GetNotExpandable request.
 func (client *enumOperations) getNotExpandableCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/enum/notExpandable"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +102,12 @@ func (client *enumOperations) GetReferenced(ctx context.Context) (*ColorsRespons
 
 // getReferencedCreateRequest creates the GetReferenced request.
 func (client *enumOperations) getReferencedCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/enum/Referenced"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -144,8 +152,12 @@ func (client *enumOperations) GetReferencedConstant(ctx context.Context) (*RefCo
 
 // getReferencedConstantCreateRequest creates the GetReferencedConstant request.
 func (client *enumOperations) getReferencedConstantCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/enum/ReferencedConstant"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -190,8 +202,12 @@ func (client *enumOperations) PutNotExpandable(ctx context.Context, stringBody C
 
 // putNotExpandableCreateRequest creates the PutNotExpandable request.
 func (client *enumOperations) putNotExpandableCreateRequest(stringBody Colors) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/enum/notExpandable"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -235,8 +251,12 @@ func (client *enumOperations) PutReferenced(ctx context.Context, enumStringBody 
 
 // putReferencedCreateRequest creates the PutReferenced request.
 func (client *enumOperations) putReferencedCreateRequest(enumStringBody Colors) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/enum/Referenced"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -280,8 +300,12 @@ func (client *enumOperations) PutReferencedConstant(ctx context.Context, enumStr
 
 // putReferencedConstantCreateRequest creates the PutReferencedConstant request.
 func (client *enumOperations) putReferencedConstantCreateRequest(enumStringBody RefColorConstant) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/enum/ReferencedConstant"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/stringgroup/string.go
+++ b/test/autorest/generated/stringgroup/string.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // StringOperations contains the methods for the String group.
@@ -71,7 +72,7 @@ func (client *stringOperations) getBase64EncodedCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/string/base64Encoding"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +122,7 @@ func (client *stringOperations) getBase64UrlEncodedCreateRequest() (*azcore.Requ
 		return nil, err
 	}
 	urlPath := "/string/base64UrlEncoding"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +172,7 @@ func (client *stringOperations) getEmptyCreateRequest() (*azcore.Request, error)
 		return nil, err
 	}
 	urlPath := "/string/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +222,7 @@ func (client *stringOperations) getMbcsCreateRequest() (*azcore.Request, error) 
 		return nil, err
 	}
 	urlPath := "/string/mbcs"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *stringOperations) getNotProvidedCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/string/notProvided"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +322,7 @@ func (client *stringOperations) getNullCreateRequest() (*azcore.Request, error) 
 		return nil, err
 	}
 	urlPath := "/string/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -371,7 +372,7 @@ func (client *stringOperations) getNullBase64UrlEncodedCreateRequest() (*azcore.
 		return nil, err
 	}
 	urlPath := "/string/nullBase64UrlEncoding"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -421,7 +422,7 @@ func (client *stringOperations) getWhitespaceCreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/string/whitespace"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +472,7 @@ func (client *stringOperations) putBase64UrlEncodedCreateRequest(stringBody []by
 		return nil, err
 	}
 	urlPath := "/string/base64UrlEncoding"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -520,7 +521,7 @@ func (client *stringOperations) putEmptyCreateRequest() (*azcore.Request, error)
 		return nil, err
 	}
 	urlPath := "/string/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -569,7 +570,7 @@ func (client *stringOperations) putMbcsCreateRequest() (*azcore.Request, error) 
 		return nil, err
 	}
 	urlPath := "/string/mbcs"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -618,7 +619,7 @@ func (client *stringOperations) putNullCreateRequest(stringPutNullOptions *Strin
 		return nil, err
 	}
 	urlPath := "/string/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -670,7 +671,7 @@ func (client *stringOperations) putWhitespaceCreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/string/whitespace"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/stringgroup/string.go
+++ b/test/autorest/generated/stringgroup/string.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // StringOperations contains the methods for the String group.
@@ -66,8 +66,12 @@ func (client *stringOperations) GetBase64Encoded(ctx context.Context) (*ByteArra
 
 // getBase64EncodedCreateRequest creates the GetBase64Encoded request.
 func (client *stringOperations) getBase64EncodedCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/base64Encoding"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -112,8 +116,12 @@ func (client *stringOperations) GetBase64URLEncoded(ctx context.Context) (*ByteA
 
 // getBase64UrlEncodedCreateRequest creates the GetBase64URLEncoded request.
 func (client *stringOperations) getBase64UrlEncodedCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/base64UrlEncoding"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,8 +166,12 @@ func (client *stringOperations) GetEmpty(ctx context.Context) (*StringResponse, 
 
 // getEmptyCreateRequest creates the GetEmpty request.
 func (client *stringOperations) getEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -204,8 +216,12 @@ func (client *stringOperations) GetMBCS(ctx context.Context) (*StringResponse, e
 
 // getMbcsCreateRequest creates the GetMBCS request.
 func (client *stringOperations) getMbcsCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/mbcs"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -250,8 +266,12 @@ func (client *stringOperations) GetNotProvided(ctx context.Context) (*StringResp
 
 // getNotProvidedCreateRequest creates the GetNotProvided request.
 func (client *stringOperations) getNotProvidedCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/notProvided"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -296,8 +316,12 @@ func (client *stringOperations) GetNull(ctx context.Context) (*StringResponse, e
 
 // getNullCreateRequest creates the GetNull request.
 func (client *stringOperations) getNullCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -342,8 +366,12 @@ func (client *stringOperations) GetNullBase64URLEncoded(ctx context.Context) (*B
 
 // getNullBase64UrlEncodedCreateRequest creates the GetNullBase64URLEncoded request.
 func (client *stringOperations) getNullBase64UrlEncodedCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/nullBase64UrlEncoding"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -388,8 +416,12 @@ func (client *stringOperations) GetWhitespace(ctx context.Context) (*StringRespo
 
 // getWhitespaceCreateRequest creates the GetWhitespace request.
 func (client *stringOperations) getWhitespaceCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/whitespace"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -434,8 +466,12 @@ func (client *stringOperations) PutBase64URLEncoded(ctx context.Context, stringB
 
 // putBase64UrlEncodedCreateRequest creates the PutBase64URLEncoded request.
 func (client *stringOperations) putBase64UrlEncodedCreateRequest(stringBody []byte) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/base64UrlEncoding"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -479,8 +515,12 @@ func (client *stringOperations) PutEmpty(ctx context.Context) (*http.Response, e
 
 // putEmptyCreateRequest creates the PutEmpty request.
 func (client *stringOperations) putEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -524,8 +564,12 @@ func (client *stringOperations) PutMBCS(ctx context.Context) (*http.Response, er
 
 // putMbcsCreateRequest creates the PutMBCS request.
 func (client *stringOperations) putMbcsCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/mbcs"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -569,8 +613,12 @@ func (client *stringOperations) PutNull(ctx context.Context, stringPutNullOption
 
 // putNullCreateRequest creates the PutNull request.
 func (client *stringOperations) putNullCreateRequest(stringPutNullOptions *StringPutNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -617,8 +665,12 @@ func (client *stringOperations) PutWhitespace(ctx context.Context) (*http.Respon
 
 // putWhitespaceCreateRequest creates the PutWhitespace request.
 func (client *stringOperations) putWhitespaceCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/string/whitespace"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/urlgroup/client.go
+++ b/test/autorest/generated/urlgroup/client.go
@@ -8,7 +8,6 @@ package urlgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-urlgroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // PathsOperations returns the PathsOperations associated with this client.

--- a/test/autorest/generated/urlgroup/pathitems.go
+++ b/test/autorest/generated/urlgroup/pathitems.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -59,7 +60,7 @@ func (client *pathItemsOperations) getAllWithValuesCreateRequest(pathItemStringP
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +123,7 @@ func (client *pathItemsOperations) getGlobalAndLocalQueryNullCreateRequest(pathI
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +186,7 @@ func (client *pathItemsOperations) getGlobalQueryNullCreateRequest(pathItemStrin
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +249,7 @@ func (client *pathItemsOperations) getLocalPathItemQueryNullCreateRequest(pathIt
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/urlgroup/pathitems.go
+++ b/test/autorest/generated/urlgroup/pathitems.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -52,11 +51,15 @@ func (client *pathItemsOperations) GetAllWithValues(ctx context.Context, pathIte
 
 // getAllWithValuesCreateRequest creates the GetAllWithValues request.
 func (client *pathItemsOperations) getAllWithValuesCreateRequest(pathItemStringPath string, localStringPath string, pathItemsGetAllWithValuesOptions *PathItemsGetAllWithValuesOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -111,11 +114,15 @@ func (client *pathItemsOperations) GetGlobalAndLocalQueryNull(ctx context.Contex
 
 // getGlobalAndLocalQueryNullCreateRequest creates the GetGlobalAndLocalQueryNull request.
 func (client *pathItemsOperations) getGlobalAndLocalQueryNullCreateRequest(pathItemStringPath string, localStringPath string, pathItemsGetGlobalAndLocalQueryNullOptions *PathItemsGetGlobalAndLocalQueryNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -170,11 +177,15 @@ func (client *pathItemsOperations) GetGlobalQueryNull(ctx context.Context, pathI
 
 // getGlobalQueryNullCreateRequest creates the GetGlobalQueryNull request.
 func (client *pathItemsOperations) getGlobalQueryNullCreateRequest(pathItemStringPath string, localStringPath string, pathItemsGetGlobalQueryNullOptions *PathItemsGetGlobalQueryNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -229,11 +240,15 @@ func (client *pathItemsOperations) GetLocalPathItemQueryNull(ctx context.Context
 
 // getLocalPathItemQueryNullCreateRequest creates the GetLocalPathItemQueryNull request.
 func (client *pathItemsOperations) getLocalPathItemQueryNullCreateRequest(pathItemStringPath string, localStringPath string, pathItemsGetLocalPathItemQueryNullOptions *PathItemsGetLocalPathItemQueryNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{localStringPath}", url.PathEscape(localStringPath))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/urlgroup/paths.go
+++ b/test/autorest/generated/urlgroup/paths.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -98,9 +97,13 @@ func (client *pathsOperations) ArrayCSVInPath(ctx context.Context, arrayPath []s
 
 // arrayCsvInPathCreateRequest creates the ArrayCSVInPath request.
 func (client *pathsOperations) arrayCsvInPathCreateRequest(arrayPath []string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{arrayPath}", url.PathEscape(strings.Join(arrayPath, ",")))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -144,9 +147,13 @@ func (client *pathsOperations) Base64URL(ctx context.Context, base64UrlPath []by
 
 // base64UrlCreateRequest creates the Base64URL request.
 func (client *pathsOperations) base64UrlCreateRequest(base64UrlPath []byte) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/string/bG9yZW0/{base64UrlPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{base64UrlPath}", url.PathEscape(base64.RawURLEncoding.EncodeToString(base64UrlPath)))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -190,9 +197,13 @@ func (client *pathsOperations) ByteEmpty(ctx context.Context) (*http.Response, e
 
 // byteEmptyCreateRequest creates the ByteEmpty request.
 func (client *pathsOperations) byteEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/byte/empty/{bytePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(""))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -236,9 +247,13 @@ func (client *pathsOperations) ByteMultiByte(ctx context.Context, bytePath []byt
 
 // byteMultiByteCreateRequest creates the ByteMultiByte request.
 func (client *pathsOperations) byteMultiByteCreateRequest(bytePath []byte) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/byte/multibyte/{bytePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(base64.StdEncoding.EncodeToString(bytePath)))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -282,9 +297,13 @@ func (client *pathsOperations) ByteNull(ctx context.Context, bytePath []byte) (*
 
 // byteNullCreateRequest creates the ByteNull request.
 func (client *pathsOperations) byteNullCreateRequest(bytePath []byte) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/byte/null/{bytePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(base64.StdEncoding.EncodeToString(bytePath)))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -328,9 +347,13 @@ func (client *pathsOperations) DateNull(ctx context.Context, datePath time.Time)
 
 // dateNullCreateRequest creates the DateNull request.
 func (client *pathsOperations) dateNullCreateRequest(datePath time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/date/null/{datePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{datePath}", url.PathEscape(datePath.Format("2006-01-02")))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -374,9 +397,13 @@ func (client *pathsOperations) DateTimeNull(ctx context.Context, dateTimePath ti
 
 // dateTimeNullCreateRequest creates the DateTimeNull request.
 func (client *pathsOperations) dateTimeNullCreateRequest(dateTimePath time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/datetime/null/{dateTimePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{dateTimePath}", url.PathEscape(dateTimePath.Format(time.RFC3339Nano)))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -420,9 +447,13 @@ func (client *pathsOperations) DateTimeValid(ctx context.Context) (*http.Respons
 
 // dateTimeValidCreateRequest creates the DateTimeValid request.
 func (client *pathsOperations) dateTimeValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{dateTimePath}", url.PathEscape("2012-01-01T01:01:01Z"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -466,9 +497,13 @@ func (client *pathsOperations) DateValid(ctx context.Context) (*http.Response, e
 
 // dateValidCreateRequest creates the DateValid request.
 func (client *pathsOperations) dateValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/date/2012-01-01/{datePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{datePath}", url.PathEscape("2012-01-01"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -512,9 +547,13 @@ func (client *pathsOperations) DoubleDecimalNegative(ctx context.Context) (*http
 
 // doubleDecimalNegativeCreateRequest creates the DoubleDecimalNegative request.
 func (client *pathsOperations) doubleDecimalNegativeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/double/-9999999.999/{doublePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{doublePath}", url.PathEscape("-9999999.999"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -558,9 +597,13 @@ func (client *pathsOperations) DoubleDecimalPositive(ctx context.Context) (*http
 
 // doubleDecimalPositiveCreateRequest creates the DoubleDecimalPositive request.
 func (client *pathsOperations) doubleDecimalPositiveCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/double/9999999.999/{doublePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{doublePath}", url.PathEscape("9999999.999"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -604,9 +647,13 @@ func (client *pathsOperations) EnumNull(ctx context.Context, enumPath UriColor) 
 
 // enumNullCreateRequest creates the EnumNull request.
 func (client *pathsOperations) enumNullCreateRequest(enumPath UriColor) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/string/null/{enumPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{enumPath}", url.PathEscape(string(enumPath)))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -650,9 +697,13 @@ func (client *pathsOperations) EnumValid(ctx context.Context, enumPath UriColor)
 
 // enumValidCreateRequest creates the EnumValid request.
 func (client *pathsOperations) enumValidCreateRequest(enumPath UriColor) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/enum/green%20color/{enumPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{enumPath}", url.PathEscape(string(enumPath)))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -696,9 +747,13 @@ func (client *pathsOperations) FloatScientificNegative(ctx context.Context) (*ht
 
 // floatScientificNegativeCreateRequest creates the FloatScientificNegative request.
 func (client *pathsOperations) floatScientificNegativeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/float/-1.034E-20/{floatPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{floatPath}", url.PathEscape("-1.034e-20"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -742,9 +797,13 @@ func (client *pathsOperations) FloatScientificPositive(ctx context.Context) (*ht
 
 // floatScientificPositiveCreateRequest creates the FloatScientificPositive request.
 func (client *pathsOperations) floatScientificPositiveCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/float/1.034E+20/{floatPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{floatPath}", url.PathEscape("103400000000000000000"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -788,9 +847,13 @@ func (client *pathsOperations) GetBooleanFalse(ctx context.Context) (*http.Respo
 
 // getBooleanFalseCreateRequest creates the GetBooleanFalse request.
 func (client *pathsOperations) getBooleanFalseCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/bool/false/{boolPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{boolPath}", url.PathEscape("false"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -834,9 +897,13 @@ func (client *pathsOperations) GetBooleanTrue(ctx context.Context) (*http.Respon
 
 // getBooleanTrueCreateRequest creates the GetBooleanTrue request.
 func (client *pathsOperations) getBooleanTrueCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/bool/true/{boolPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{boolPath}", url.PathEscape("true"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -880,9 +947,13 @@ func (client *pathsOperations) GetIntNegativeOneMillion(ctx context.Context) (*h
 
 // getIntNegativeOneMillionCreateRequest creates the GetIntNegativeOneMillion request.
 func (client *pathsOperations) getIntNegativeOneMillionCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/int/-1000000/{intPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{intPath}", url.PathEscape("-1000000"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -926,9 +997,13 @@ func (client *pathsOperations) GetIntOneMillion(ctx context.Context) (*http.Resp
 
 // getIntOneMillionCreateRequest creates the GetIntOneMillion request.
 func (client *pathsOperations) getIntOneMillionCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/int/1000000/{intPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{intPath}", url.PathEscape("1000000"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -972,9 +1047,13 @@ func (client *pathsOperations) GetNegativeTenBillion(ctx context.Context) (*http
 
 // getNegativeTenBillionCreateRequest creates the GetNegativeTenBillion request.
 func (client *pathsOperations) getNegativeTenBillionCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/long/-10000000000/{longPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{longPath}", url.PathEscape("-10000000000"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1018,9 +1097,13 @@ func (client *pathsOperations) GetTenBillion(ctx context.Context) (*http.Respons
 
 // getTenBillionCreateRequest creates the GetTenBillion request.
 func (client *pathsOperations) getTenBillionCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/long/10000000000/{longPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{longPath}", url.PathEscape("10000000000"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1064,9 +1147,13 @@ func (client *pathsOperations) StringEmpty(ctx context.Context) (*http.Response,
 
 // stringEmptyCreateRequest creates the StringEmpty request.
 func (client *pathsOperations) stringEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/string/empty/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape(""))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1110,9 +1197,13 @@ func (client *pathsOperations) StringNull(ctx context.Context, stringPath string
 
 // stringNullCreateRequest creates the StringNull request.
 func (client *pathsOperations) stringNullCreateRequest(stringPath string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/string/null/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape(stringPath))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1156,9 +1247,13 @@ func (client *pathsOperations) StringURLEncoded(ctx context.Context) (*http.Resp
 
 // stringUrlEncodedCreateRequest creates the StringURLEncoded request.
 func (client *pathsOperations) stringUrlEncodedCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape("begin!*'();:@ &=+$,/?#[]end"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1202,9 +1297,13 @@ func (client *pathsOperations) StringURLNonEncoded(ctx context.Context) (*http.R
 
 // stringUrlNonEncodedCreateRequest creates the StringURLNonEncoded request.
 func (client *pathsOperations) stringUrlNonEncodedCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/string/begin!*'();:@&=+$,end/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", "begin!*'();:@&=+$,end")
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1248,9 +1347,13 @@ func (client *pathsOperations) StringUnicode(ctx context.Context) (*http.Respons
 
 // stringUnicodeCreateRequest creates the StringUnicode request.
 func (client *pathsOperations) stringUnicodeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/string/unicode/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape("啊齄丂狛狜隣郎隣兀﨩"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1294,9 +1397,13 @@ func (client *pathsOperations) UnixTimeURL(ctx context.Context, unixTimeUrlPath 
 
 // unixTimeUrlCreateRequest creates the UnixTimeURL request.
 func (client *pathsOperations) unixTimeUrlCreateRequest(unixTimeUrlPath time.Time) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/paths/int/1460505600/{unixTimeUrlPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{unixTimeUrlPath}", url.PathEscape(timeUnix(unixTimeUrlPath).String()))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/urlgroup/paths.go
+++ b/test/autorest/generated/urlgroup/paths.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -103,7 +104,7 @@ func (client *pathsOperations) arrayCsvInPathCreateRequest(arrayPath []string) (
 	}
 	urlPath := "/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{arrayPath}", url.PathEscape(strings.Join(arrayPath, ",")))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +154,7 @@ func (client *pathsOperations) base64UrlCreateRequest(base64UrlPath []byte) (*az
 	}
 	urlPath := "/paths/string/bG9yZW0/{base64UrlPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{base64UrlPath}", url.PathEscape(base64.RawURLEncoding.EncodeToString(base64UrlPath)))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +204,7 @@ func (client *pathsOperations) byteEmptyCreateRequest() (*azcore.Request, error)
 	}
 	urlPath := "/paths/byte/empty/{bytePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(""))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +254,7 @@ func (client *pathsOperations) byteMultiByteCreateRequest(bytePath []byte) (*azc
 	}
 	urlPath := "/paths/byte/multibyte/{bytePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(base64.StdEncoding.EncodeToString(bytePath)))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -303,7 +304,7 @@ func (client *pathsOperations) byteNullCreateRequest(bytePath []byte) (*azcore.R
 	}
 	urlPath := "/paths/byte/null/{bytePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(base64.StdEncoding.EncodeToString(bytePath)))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +354,7 @@ func (client *pathsOperations) dateNullCreateRequest(datePath time.Time) (*azcor
 	}
 	urlPath := "/paths/date/null/{datePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{datePath}", url.PathEscape(datePath.Format("2006-01-02")))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -403,7 +404,7 @@ func (client *pathsOperations) dateTimeNullCreateRequest(dateTimePath time.Time)
 	}
 	urlPath := "/paths/datetime/null/{dateTimePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{dateTimePath}", url.PathEscape(dateTimePath.Format(time.RFC3339Nano)))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -453,7 +454,7 @@ func (client *pathsOperations) dateTimeValidCreateRequest() (*azcore.Request, er
 	}
 	urlPath := "/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{dateTimePath}", url.PathEscape("2012-01-01T01:01:01Z"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -503,7 +504,7 @@ func (client *pathsOperations) dateValidCreateRequest() (*azcore.Request, error)
 	}
 	urlPath := "/paths/date/2012-01-01/{datePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{datePath}", url.PathEscape("2012-01-01"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -553,7 +554,7 @@ func (client *pathsOperations) doubleDecimalNegativeCreateRequest() (*azcore.Req
 	}
 	urlPath := "/paths/double/-9999999.999/{doublePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{doublePath}", url.PathEscape("-9999999.999"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -603,7 +604,7 @@ func (client *pathsOperations) doubleDecimalPositiveCreateRequest() (*azcore.Req
 	}
 	urlPath := "/paths/double/9999999.999/{doublePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{doublePath}", url.PathEscape("9999999.999"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -653,7 +654,7 @@ func (client *pathsOperations) enumNullCreateRequest(enumPath UriColor) (*azcore
 	}
 	urlPath := "/paths/string/null/{enumPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{enumPath}", url.PathEscape(string(enumPath)))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -703,7 +704,7 @@ func (client *pathsOperations) enumValidCreateRequest(enumPath UriColor) (*azcor
 	}
 	urlPath := "/paths/enum/green%20color/{enumPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{enumPath}", url.PathEscape(string(enumPath)))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -753,7 +754,7 @@ func (client *pathsOperations) floatScientificNegativeCreateRequest() (*azcore.R
 	}
 	urlPath := "/paths/float/-1.034E-20/{floatPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{floatPath}", url.PathEscape("-1.034e-20"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -803,7 +804,7 @@ func (client *pathsOperations) floatScientificPositiveCreateRequest() (*azcore.R
 	}
 	urlPath := "/paths/float/1.034E+20/{floatPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{floatPath}", url.PathEscape("103400000000000000000"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -853,7 +854,7 @@ func (client *pathsOperations) getBooleanFalseCreateRequest() (*azcore.Request, 
 	}
 	urlPath := "/paths/bool/false/{boolPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{boolPath}", url.PathEscape("false"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -903,7 +904,7 @@ func (client *pathsOperations) getBooleanTrueCreateRequest() (*azcore.Request, e
 	}
 	urlPath := "/paths/bool/true/{boolPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{boolPath}", url.PathEscape("true"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -953,7 +954,7 @@ func (client *pathsOperations) getIntNegativeOneMillionCreateRequest() (*azcore.
 	}
 	urlPath := "/paths/int/-1000000/{intPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{intPath}", url.PathEscape("-1000000"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1003,7 +1004,7 @@ func (client *pathsOperations) getIntOneMillionCreateRequest() (*azcore.Request,
 	}
 	urlPath := "/paths/int/1000000/{intPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{intPath}", url.PathEscape("1000000"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1053,7 +1054,7 @@ func (client *pathsOperations) getNegativeTenBillionCreateRequest() (*azcore.Req
 	}
 	urlPath := "/paths/long/-10000000000/{longPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{longPath}", url.PathEscape("-10000000000"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1103,7 +1104,7 @@ func (client *pathsOperations) getTenBillionCreateRequest() (*azcore.Request, er
 	}
 	urlPath := "/paths/long/10000000000/{longPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{longPath}", url.PathEscape("10000000000"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1153,7 +1154,7 @@ func (client *pathsOperations) stringEmptyCreateRequest() (*azcore.Request, erro
 	}
 	urlPath := "/paths/string/empty/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape(""))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1203,7 +1204,7 @@ func (client *pathsOperations) stringNullCreateRequest(stringPath string) (*azco
 	}
 	urlPath := "/paths/string/null/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape(stringPath))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1253,7 +1254,7 @@ func (client *pathsOperations) stringUrlEncodedCreateRequest() (*azcore.Request,
 	}
 	urlPath := "/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape("begin!*'();:@ &=+$,/?#[]end"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1303,7 +1304,7 @@ func (client *pathsOperations) stringUrlNonEncodedCreateRequest() (*azcore.Reque
 	}
 	urlPath := "/paths/string/begin!*'();:@&=+$,end/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", "begin!*'();:@&=+$,end")
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1353,7 +1354,7 @@ func (client *pathsOperations) stringUnicodeCreateRequest() (*azcore.Request, er
 	}
 	urlPath := "/paths/string/unicode/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape("啊齄丂狛狜隣郎隣兀﨩"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1403,7 +1404,7 @@ func (client *pathsOperations) unixTimeUrlCreateRequest(unixTimeUrlPath time.Tim
 	}
 	urlPath := "/paths/int/1460505600/{unixTimeUrlPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{unixTimeUrlPath}", url.PathEscape(timeUnix(unixTimeUrlPath).String()))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/urlgroup/queries.go
+++ b/test/autorest/generated/urlgroup/queries.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -119,7 +120,7 @@ func (client *queriesOperations) arrayStringCsvEmptyCreateRequest(queriesArraySt
 		return nil, err
 	}
 	urlPath := "/queries/array/csv/string/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +174,7 @@ func (client *queriesOperations) arrayStringCsvNullCreateRequest(queriesArrayStr
 		return nil, err
 	}
 	urlPath := "/queries/array/csv/string/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *queriesOperations) arrayStringCsvValidCreateRequest(queriesArraySt
 		return nil, err
 	}
 	urlPath := "/queries/array/csv/string/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +282,7 @@ func (client *queriesOperations) arrayStringNoCollectionFormatEmptyCreateRequest
 		return nil, err
 	}
 	urlPath := "/queries/array/none/string/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +336,7 @@ func (client *queriesOperations) arrayStringPipesValidCreateRequest(queriesArray
 		return nil, err
 	}
 	urlPath := "/queries/array/pipes/string/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +390,7 @@ func (client *queriesOperations) arrayStringSsvValidCreateRequest(queriesArraySt
 		return nil, err
 	}
 	urlPath := "/queries/array/ssv/string/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -443,7 +444,7 @@ func (client *queriesOperations) arrayStringTsvValidCreateRequest(queriesArraySt
 		return nil, err
 	}
 	urlPath := "/queries/array/tsv/string/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -497,7 +498,7 @@ func (client *queriesOperations) byteEmptyCreateRequest() (*azcore.Request, erro
 		return nil, err
 	}
 	urlPath := "/queries/byte/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -549,7 +550,7 @@ func (client *queriesOperations) byteMultiByteCreateRequest(queriesByteMultiByte
 		return nil, err
 	}
 	urlPath := "/queries/byte/multibyte"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -603,7 +604,7 @@ func (client *queriesOperations) byteNullCreateRequest(queriesByteNullOptions *Q
 		return nil, err
 	}
 	urlPath := "/queries/byte/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -657,7 +658,7 @@ func (client *queriesOperations) dateNullCreateRequest(queriesDateNullOptions *Q
 		return nil, err
 	}
 	urlPath := "/queries/date/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -711,7 +712,7 @@ func (client *queriesOperations) dateTimeNullCreateRequest(queriesDateTimeNullOp
 		return nil, err
 	}
 	urlPath := "/queries/datetime/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -765,7 +766,7 @@ func (client *queriesOperations) dateTimeValidCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/queries/datetime/2012-01-01T01%3A01%3A01Z"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -817,7 +818,7 @@ func (client *queriesOperations) dateValidCreateRequest() (*azcore.Request, erro
 		return nil, err
 	}
 	urlPath := "/queries/date/2012-01-01"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -869,7 +870,7 @@ func (client *queriesOperations) doubleDecimalNegativeCreateRequest() (*azcore.R
 		return nil, err
 	}
 	urlPath := "/queries/double/-9999999.999"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -921,7 +922,7 @@ func (client *queriesOperations) doubleDecimalPositiveCreateRequest() (*azcore.R
 		return nil, err
 	}
 	urlPath := "/queries/double/9999999.999"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -973,7 +974,7 @@ func (client *queriesOperations) doubleNullCreateRequest(queriesDoubleNullOption
 		return nil, err
 	}
 	urlPath := "/queries/double/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1027,7 +1028,7 @@ func (client *queriesOperations) enumNullCreateRequest(queriesEnumNullOptions *Q
 		return nil, err
 	}
 	urlPath := "/queries/enum/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1081,7 +1082,7 @@ func (client *queriesOperations) enumValidCreateRequest(queriesEnumValidOptions 
 		return nil, err
 	}
 	urlPath := "/queries/enum/green%20color"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1135,7 +1136,7 @@ func (client *queriesOperations) floatNullCreateRequest(queriesFloatNullOptions 
 		return nil, err
 	}
 	urlPath := "/queries/float/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1189,7 +1190,7 @@ func (client *queriesOperations) floatScientificNegativeCreateRequest() (*azcore
 		return nil, err
 	}
 	urlPath := "/queries/float/-1.034E-20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1241,7 +1242,7 @@ func (client *queriesOperations) floatScientificPositiveCreateRequest() (*azcore
 		return nil, err
 	}
 	urlPath := "/queries/float/1.034E+20"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1293,7 +1294,7 @@ func (client *queriesOperations) getBooleanFalseCreateRequest() (*azcore.Request
 		return nil, err
 	}
 	urlPath := "/queries/bool/false"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1345,7 +1346,7 @@ func (client *queriesOperations) getBooleanNullCreateRequest(queriesGetBooleanNu
 		return nil, err
 	}
 	urlPath := "/queries/bool/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1399,7 +1400,7 @@ func (client *queriesOperations) getBooleanTrueCreateRequest() (*azcore.Request,
 		return nil, err
 	}
 	urlPath := "/queries/bool/true"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1451,7 +1452,7 @@ func (client *queriesOperations) getIntNegativeOneMillionCreateRequest() (*azcor
 		return nil, err
 	}
 	urlPath := "/queries/int/-1000000"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1503,7 +1504,7 @@ func (client *queriesOperations) getIntNullCreateRequest(queriesGetIntNullOption
 		return nil, err
 	}
 	urlPath := "/queries/int/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1557,7 +1558,7 @@ func (client *queriesOperations) getIntOneMillionCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/queries/int/1000000"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1609,7 +1610,7 @@ func (client *queriesOperations) getLongNullCreateRequest(queriesGetLongNullOpti
 		return nil, err
 	}
 	urlPath := "/queries/long/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1663,7 +1664,7 @@ func (client *queriesOperations) getNegativeTenBillionCreateRequest() (*azcore.R
 		return nil, err
 	}
 	urlPath := "/queries/long/-10000000000"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1715,7 +1716,7 @@ func (client *queriesOperations) getTenBillionCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/queries/long/10000000000"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1767,7 +1768,7 @@ func (client *queriesOperations) stringEmptyCreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/queries/string/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1819,7 +1820,7 @@ func (client *queriesOperations) stringNullCreateRequest(queriesStringNullOption
 		return nil, err
 	}
 	urlPath := "/queries/string/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1873,7 +1874,7 @@ func (client *queriesOperations) stringUrlEncodedCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1925,7 +1926,7 @@ func (client *queriesOperations) stringUnicodeCreateRequest() (*azcore.Request, 
 		return nil, err
 	}
 	urlPath := "/queries/string/unicode/"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/urlgroup/queries.go
+++ b/test/autorest/generated/urlgroup/queries.go
@@ -10,7 +10,7 @@ import (
 	"encoding/base64"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -114,8 +114,12 @@ func (client *queriesOperations) ArrayStringCSVEmpty(ctx context.Context, querie
 
 // arrayStringCsvEmptyCreateRequest creates the ArrayStringCSVEmpty request.
 func (client *queriesOperations) arrayStringCsvEmptyCreateRequest(queriesArrayStringCsvEmptyOptions *QueriesArrayStringCSVEmptyOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/array/csv/string/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -164,8 +168,12 @@ func (client *queriesOperations) ArrayStringCSVNull(ctx context.Context, queries
 
 // arrayStringCsvNullCreateRequest creates the ArrayStringCSVNull request.
 func (client *queriesOperations) arrayStringCsvNullCreateRequest(queriesArrayStringCsvNullOptions *QueriesArrayStringCSVNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/array/csv/string/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -214,8 +222,12 @@ func (client *queriesOperations) ArrayStringCSVValid(ctx context.Context, querie
 
 // arrayStringCsvValidCreateRequest creates the ArrayStringCSVValid request.
 func (client *queriesOperations) arrayStringCsvValidCreateRequest(queriesArrayStringCsvValidOptions *QueriesArrayStringCSVValidOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/array/csv/string/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -264,8 +276,12 @@ func (client *queriesOperations) ArrayStringNoCollectionFormatEmpty(ctx context.
 
 // arrayStringNoCollectionFormatEmptyCreateRequest creates the ArrayStringNoCollectionFormatEmpty request.
 func (client *queriesOperations) arrayStringNoCollectionFormatEmptyCreateRequest(queriesArrayStringNoCollectionFormatEmptyOptions *QueriesArrayStringNoCollectionFormatEmptyOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/array/none/string/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -314,8 +330,12 @@ func (client *queriesOperations) ArrayStringPipesValid(ctx context.Context, quer
 
 // arrayStringPipesValidCreateRequest creates the ArrayStringPipesValid request.
 func (client *queriesOperations) arrayStringPipesValidCreateRequest(queriesArrayStringPipesValidOptions *QueriesArrayStringPipesValidOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/array/pipes/string/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -364,8 +384,12 @@ func (client *queriesOperations) ArrayStringSsvValid(ctx context.Context, querie
 
 // arrayStringSsvValidCreateRequest creates the ArrayStringSsvValid request.
 func (client *queriesOperations) arrayStringSsvValidCreateRequest(queriesArrayStringSsvValidOptions *QueriesArrayStringSsvValidOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/array/ssv/string/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -414,8 +438,12 @@ func (client *queriesOperations) ArrayStringTsvValid(ctx context.Context, querie
 
 // arrayStringTsvValidCreateRequest creates the ArrayStringTsvValid request.
 func (client *queriesOperations) arrayStringTsvValidCreateRequest(queriesArrayStringTsvValidOptions *QueriesArrayStringTsvValidOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/array/tsv/string/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -464,8 +492,12 @@ func (client *queriesOperations) ByteEmpty(ctx context.Context) (*http.Response,
 
 // byteEmptyCreateRequest creates the ByteEmpty request.
 func (client *queriesOperations) byteEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/byte/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -512,8 +544,12 @@ func (client *queriesOperations) ByteMultiByte(ctx context.Context, queriesByteM
 
 // byteMultiByteCreateRequest creates the ByteMultiByte request.
 func (client *queriesOperations) byteMultiByteCreateRequest(queriesByteMultiByteOptions *QueriesByteMultiByteOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/byte/multibyte"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -562,8 +598,12 @@ func (client *queriesOperations) ByteNull(ctx context.Context, queriesByteNullOp
 
 // byteNullCreateRequest creates the ByteNull request.
 func (client *queriesOperations) byteNullCreateRequest(queriesByteNullOptions *QueriesByteNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/byte/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -612,8 +652,12 @@ func (client *queriesOperations) DateNull(ctx context.Context, queriesDateNullOp
 
 // dateNullCreateRequest creates the DateNull request.
 func (client *queriesOperations) dateNullCreateRequest(queriesDateNullOptions *QueriesDateNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/date/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -662,8 +706,12 @@ func (client *queriesOperations) DateTimeNull(ctx context.Context, queriesDateTi
 
 // dateTimeNullCreateRequest creates the DateTimeNull request.
 func (client *queriesOperations) dateTimeNullCreateRequest(queriesDateTimeNullOptions *QueriesDateTimeNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/datetime/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -712,8 +760,12 @@ func (client *queriesOperations) DateTimeValid(ctx context.Context) (*http.Respo
 
 // dateTimeValidCreateRequest creates the DateTimeValid request.
 func (client *queriesOperations) dateTimeValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/datetime/2012-01-01T01%3A01%3A01Z"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -760,8 +812,12 @@ func (client *queriesOperations) DateValid(ctx context.Context) (*http.Response,
 
 // dateValidCreateRequest creates the DateValid request.
 func (client *queriesOperations) dateValidCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/date/2012-01-01"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -808,8 +864,12 @@ func (client *queriesOperations) DoubleDecimalNegative(ctx context.Context) (*ht
 
 // doubleDecimalNegativeCreateRequest creates the DoubleDecimalNegative request.
 func (client *queriesOperations) doubleDecimalNegativeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/double/-9999999.999"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -856,8 +916,12 @@ func (client *queriesOperations) DoubleDecimalPositive(ctx context.Context) (*ht
 
 // doubleDecimalPositiveCreateRequest creates the DoubleDecimalPositive request.
 func (client *queriesOperations) doubleDecimalPositiveCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/double/9999999.999"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -904,8 +968,12 @@ func (client *queriesOperations) DoubleNull(ctx context.Context, queriesDoubleNu
 
 // doubleNullCreateRequest creates the DoubleNull request.
 func (client *queriesOperations) doubleNullCreateRequest(queriesDoubleNullOptions *QueriesDoubleNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/double/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -954,8 +1022,12 @@ func (client *queriesOperations) EnumNull(ctx context.Context, queriesEnumNullOp
 
 // enumNullCreateRequest creates the EnumNull request.
 func (client *queriesOperations) enumNullCreateRequest(queriesEnumNullOptions *QueriesEnumNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/enum/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1004,8 +1076,12 @@ func (client *queriesOperations) EnumValid(ctx context.Context, queriesEnumValid
 
 // enumValidCreateRequest creates the EnumValid request.
 func (client *queriesOperations) enumValidCreateRequest(queriesEnumValidOptions *QueriesEnumValidOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/enum/green%20color"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1054,8 +1130,12 @@ func (client *queriesOperations) FloatNull(ctx context.Context, queriesFloatNull
 
 // floatNullCreateRequest creates the FloatNull request.
 func (client *queriesOperations) floatNullCreateRequest(queriesFloatNullOptions *QueriesFloatNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/float/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1104,8 +1184,12 @@ func (client *queriesOperations) FloatScientificNegative(ctx context.Context) (*
 
 // floatScientificNegativeCreateRequest creates the FloatScientificNegative request.
 func (client *queriesOperations) floatScientificNegativeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/float/-1.034E-20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1152,8 +1236,12 @@ func (client *queriesOperations) FloatScientificPositive(ctx context.Context) (*
 
 // floatScientificPositiveCreateRequest creates the FloatScientificPositive request.
 func (client *queriesOperations) floatScientificPositiveCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/float/1.034E+20"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1200,8 +1288,12 @@ func (client *queriesOperations) GetBooleanFalse(ctx context.Context) (*http.Res
 
 // getBooleanFalseCreateRequest creates the GetBooleanFalse request.
 func (client *queriesOperations) getBooleanFalseCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/bool/false"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1248,8 +1340,12 @@ func (client *queriesOperations) GetBooleanNull(ctx context.Context, queriesGetB
 
 // getBooleanNullCreateRequest creates the GetBooleanNull request.
 func (client *queriesOperations) getBooleanNullCreateRequest(queriesGetBooleanNullOptions *QueriesGetBooleanNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/bool/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1298,8 +1394,12 @@ func (client *queriesOperations) GetBooleanTrue(ctx context.Context) (*http.Resp
 
 // getBooleanTrueCreateRequest creates the GetBooleanTrue request.
 func (client *queriesOperations) getBooleanTrueCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/bool/true"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1346,8 +1446,12 @@ func (client *queriesOperations) GetIntNegativeOneMillion(ctx context.Context) (
 
 // getIntNegativeOneMillionCreateRequest creates the GetIntNegativeOneMillion request.
 func (client *queriesOperations) getIntNegativeOneMillionCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/int/-1000000"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1394,8 +1498,12 @@ func (client *queriesOperations) GetIntNull(ctx context.Context, queriesGetIntNu
 
 // getIntNullCreateRequest creates the GetIntNull request.
 func (client *queriesOperations) getIntNullCreateRequest(queriesGetIntNullOptions *QueriesGetIntNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/int/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1444,8 +1552,12 @@ func (client *queriesOperations) GetIntOneMillion(ctx context.Context) (*http.Re
 
 // getIntOneMillionCreateRequest creates the GetIntOneMillion request.
 func (client *queriesOperations) getIntOneMillionCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/int/1000000"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1492,8 +1604,12 @@ func (client *queriesOperations) GetLongNull(ctx context.Context, queriesGetLong
 
 // getLongNullCreateRequest creates the GetLongNull request.
 func (client *queriesOperations) getLongNullCreateRequest(queriesGetLongNullOptions *QueriesGetLongNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/long/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1542,8 +1658,12 @@ func (client *queriesOperations) GetNegativeTenBillion(ctx context.Context) (*ht
 
 // getNegativeTenBillionCreateRequest creates the GetNegativeTenBillion request.
 func (client *queriesOperations) getNegativeTenBillionCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/long/-10000000000"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1590,8 +1710,12 @@ func (client *queriesOperations) GetTenBillion(ctx context.Context) (*http.Respo
 
 // getTenBillionCreateRequest creates the GetTenBillion request.
 func (client *queriesOperations) getTenBillionCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/long/10000000000"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1638,8 +1762,12 @@ func (client *queriesOperations) StringEmpty(ctx context.Context) (*http.Respons
 
 // stringEmptyCreateRequest creates the StringEmpty request.
 func (client *queriesOperations) stringEmptyCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/string/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1686,8 +1814,12 @@ func (client *queriesOperations) StringNull(ctx context.Context, queriesStringNu
 
 // stringNullCreateRequest creates the StringNull request.
 func (client *queriesOperations) stringNullCreateRequest(queriesStringNullOptions *QueriesStringNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/string/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1736,8 +1868,12 @@ func (client *queriesOperations) StringURLEncoded(ctx context.Context) (*http.Re
 
 // stringUrlEncodedCreateRequest creates the StringURLEncoded request.
 func (client *queriesOperations) stringUrlEncodedCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1784,8 +1920,12 @@ func (client *queriesOperations) StringUnicode(ctx context.Context) (*http.Respo
 
 // stringUnicodeCreateRequest creates the StringUnicode request.
 func (client *queriesOperations) stringUnicodeCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/string/unicode/"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/urlmultigroup/client.go
+++ b/test/autorest/generated/urlmultigroup/client.go
@@ -8,7 +8,6 @@ package urlmultigroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-urlmultigroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // QueriesOperations returns the QueriesOperations associated with this client.

--- a/test/autorest/generated/urlmultigroup/queries.go
+++ b/test/autorest/generated/urlmultigroup/queries.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // QueriesOperations contains the methods for the Queries group.
@@ -51,7 +52,7 @@ func (client *queriesOperations) arrayStringMultiEmptyCreateRequest(queriesArray
 		return nil, err
 	}
 	urlPath := "/queries/array/multi/string/empty"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,7 @@ func (client *queriesOperations) arrayStringMultiNullCreateRequest(queriesArrayS
 		return nil, err
 	}
 	urlPath := "/queries/array/multi/string/null"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *queriesOperations) arrayStringMultiValidCreateRequest(queriesArray
 		return nil, err
 	}
 	urlPath := "/queries/array/multi/string/valid"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/urlmultigroup/queries.go
+++ b/test/autorest/generated/urlmultigroup/queries.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // QueriesOperations contains the methods for the Queries group.
@@ -46,8 +46,12 @@ func (client *queriesOperations) ArrayStringMultiEmpty(ctx context.Context, quer
 
 // arrayStringMultiEmptyCreateRequest creates the ArrayStringMultiEmpty request.
 func (client *queriesOperations) arrayStringMultiEmptyCreateRequest(queriesArrayStringMultiEmptyOptions *QueriesArrayStringMultiEmptyOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/array/multi/string/empty"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +102,12 @@ func (client *queriesOperations) ArrayStringMultiNull(ctx context.Context, queri
 
 // arrayStringMultiNullCreateRequest creates the ArrayStringMultiNull request.
 func (client *queriesOperations) arrayStringMultiNullCreateRequest(queriesArrayStringMultiNullOptions *QueriesArrayStringMultiNullOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/array/multi/string/null"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -150,8 +158,12 @@ func (client *queriesOperations) ArrayStringMultiValid(ctx context.Context, quer
 
 // arrayStringMultiValidCreateRequest creates the ArrayStringMultiValid request.
 func (client *queriesOperations) arrayStringMultiValidCreateRequest(queriesArrayStringMultiValidOptions *QueriesArrayStringMultiValidOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/queries/array/multi/string/valid"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/validationgroup/autorestvalidationtest.go
+++ b/test/autorest/generated/validationgroup/autorestvalidationtest.go
@@ -13,7 +13,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 )
@@ -52,9 +51,13 @@ func (client *autoRestValidationTestOperations) GetWithConstantInPath(ctx contex
 
 // getWithConstantInPathCreateRequest creates the GetWithConstantInPath request.
 func (client *autoRestValidationTestOperations) getWithConstantInPathCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/validation/constantsInPath/{constantParam}/value"
 	urlPath = strings.ReplaceAll(urlPath, "{constantParam}", url.PathEscape("constant"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -100,9 +103,13 @@ func (client *autoRestValidationTestOperations) PostWithConstantInBody(ctx conte
 
 // postWithConstantInBodyCreateRequest creates the PostWithConstantInBody request.
 func (client *autoRestValidationTestOperations) postWithConstantInBodyCreateRequest(autoRestValidationTestPostWithConstantInBodyOptions *AutoRestValidationTestPostWithConstantInBodyOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/validation/constantsInPath/{constantParam}/value"
 	urlPath = strings.ReplaceAll(urlPath, "{constantParam}", url.PathEscape("constant"))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -153,11 +160,15 @@ func (client *autoRestValidationTestOperations) ValidationOfBody(ctx context.Con
 
 // validationOfBodyCreateRequest creates the ValidationOfBody request.
 func (client *autoRestValidationTestOperations) validationOfBodyCreateRequest(resourceGroupName string, id int32, autoRestValidationTestValidationOfBodyOptions *AutoRestValidationTestValidationOfBodyOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/fakepath/{subscriptionId}/{resourceGroupName}/{id}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{id}", url.PathEscape(strconv.FormatInt(int64(id), 10)))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -208,11 +219,15 @@ func (client *autoRestValidationTestOperations) ValidationOfMethodParameters(ctx
 
 // validationOfMethodParametersCreateRequest creates the ValidationOfMethodParameters request.
 func (client *autoRestValidationTestOperations) validationOfMethodParametersCreateRequest(resourceGroupName string, id int32) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/fakepath/{subscriptionId}/{resourceGroupName}/{id}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{id}", url.PathEscape(strconv.FormatInt(int64(id), 10)))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/validationgroup/autorestvalidationtest.go
+++ b/test/autorest/generated/validationgroup/autorestvalidationtest.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 )
@@ -57,7 +58,7 @@ func (client *autoRestValidationTestOperations) getWithConstantInPathCreateReque
 	}
 	urlPath := "/validation/constantsInPath/{constantParam}/value"
 	urlPath = strings.ReplaceAll(urlPath, "{constantParam}", url.PathEscape("constant"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +110,7 @@ func (client *autoRestValidationTestOperations) postWithConstantInBodyCreateRequ
 	}
 	urlPath := "/validation/constantsInPath/{constantParam}/value"
 	urlPath = strings.ReplaceAll(urlPath, "{constantParam}", url.PathEscape("constant"))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +169,7 @@ func (client *autoRestValidationTestOperations) validationOfBodyCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{id}", url.PathEscape(strconv.FormatInt(int64(id), 10)))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *autoRestValidationTestOperations) validationOfMethodParametersCrea
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{id}", url.PathEscape(strconv.FormatInt(int64(id), 10)))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/validationgroup/client.go
+++ b/test/autorest/generated/validationgroup/client.go
@@ -8,7 +8,6 @@ package validationgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-validationgroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest. No server backend exists for these tests.
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // AutoRestValidationTestOperations returns the AutoRestValidationTestOperations associated with this client.

--- a/test/autorest/generated/xmlgroup/client.go
+++ b/test/autorest/generated/xmlgroup/client.go
@@ -8,7 +8,6 @@ package xmlgroup
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const telemetryInfo = "azsdk-go-xmlgroup/<version>"
@@ -45,7 +44,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Test Infrastructure for AutoRest Swagger BAT
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -53,12 +52,12 @@ type Client struct {
 const DefaultEndpoint = "http://localhost:3000"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(options *ClientOptions) (*Client, error) {
+func NewDefaultClient(options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -72,15 +71,8 @@ func NewClient(endpoint string, options *ClientOptions) (*Client, error) {
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // XMLOperations returns the XMLOperations associated with this client.

--- a/test/autorest/generated/xmlgroup/xml.go
+++ b/test/autorest/generated/xmlgroup/xml.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"io/ioutil"
 	"net/http"
-	"path"
+	"net/url"
 )
 
 // XMLOperations contains the methods for the XML group.
@@ -104,8 +104,12 @@ func (client *xmlOperations) GetACLs(ctx context.Context) (*SignedIDentifierArra
 
 // getAcLsCreateRequest creates the GetACLs request.
 func (client *xmlOperations) getAcLsCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/mycontainer"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -157,8 +161,12 @@ func (client *xmlOperations) GetComplexTypeRefNoMeta(ctx context.Context) (*Root
 
 // getComplexTypeRefNoMetaCreateRequest creates the GetComplexTypeRefNoMeta request.
 func (client *xmlOperations) getComplexTypeRefNoMetaCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/complex-type-ref-no-meta"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -206,8 +214,12 @@ func (client *xmlOperations) GetComplexTypeRefWithMeta(ctx context.Context) (*Ro
 
 // getComplexTypeRefWithMetaCreateRequest creates the GetComplexTypeRefWithMeta request.
 func (client *xmlOperations) getComplexTypeRefWithMetaCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/complex-type-ref-with-meta"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -255,8 +267,12 @@ func (client *xmlOperations) GetEmptyChildElement(ctx context.Context) (*BananaR
 
 // getEmptyChildElementCreateRequest creates the GetEmptyChildElement request.
 func (client *xmlOperations) getEmptyChildElementCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/empty-child-element"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -304,8 +320,12 @@ func (client *xmlOperations) GetEmptyList(ctx context.Context) (*SlideshowRespon
 
 // getEmptyListCreateRequest creates the GetEmptyList request.
 func (client *xmlOperations) getEmptyListCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/empty-list"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -353,8 +373,12 @@ func (client *xmlOperations) GetEmptyRootList(ctx context.Context) (*BananaArray
 
 // getEmptyRootListCreateRequest creates the GetEmptyRootList request.
 func (client *xmlOperations) getEmptyRootListCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/empty-root-list"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -402,8 +426,12 @@ func (client *xmlOperations) GetEmptyWrappedLists(ctx context.Context) (*AppleBa
 
 // getEmptyWrappedListsCreateRequest creates the GetEmptyWrappedLists request.
 func (client *xmlOperations) getEmptyWrappedListsCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/empty-wrapped-lists"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -451,8 +479,12 @@ func (client *xmlOperations) GetHeaders(ctx context.Context) (*XMLGetHeadersResp
 
 // getHeadersCreateRequest creates the GetHeaders request.
 func (client *xmlOperations) getHeadersCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/headers"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -503,8 +535,12 @@ func (client *xmlOperations) GetRootList(ctx context.Context) (*BananaArrayRespo
 
 // getRootListCreateRequest creates the GetRootList request.
 func (client *xmlOperations) getRootListCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/root-list"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -552,8 +588,12 @@ func (client *xmlOperations) GetRootListSingleItem(ctx context.Context) (*Banana
 
 // getRootListSingleItemCreateRequest creates the GetRootListSingleItem request.
 func (client *xmlOperations) getRootListSingleItemCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/root-list-single-item"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -601,8 +641,12 @@ func (client *xmlOperations) GetServiceProperties(ctx context.Context) (*Storage
 
 // getServicePropertiesCreateRequest creates the GetServiceProperties request.
 func (client *xmlOperations) getServicePropertiesCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -654,8 +698,12 @@ func (client *xmlOperations) GetSimple(ctx context.Context) (*SlideshowResponse,
 
 // getSimpleCreateRequest creates the GetSimple request.
 func (client *xmlOperations) getSimpleCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/simple"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -700,8 +748,12 @@ func (client *xmlOperations) GetWrappedLists(ctx context.Context) (*AppleBarrelR
 
 // getWrappedListsCreateRequest creates the GetWrappedLists request.
 func (client *xmlOperations) getWrappedListsCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/wrapped-lists"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -749,8 +801,12 @@ func (client *xmlOperations) GetXMSText(ctx context.Context) (*ObjectWithXMSText
 
 // getXmsTextCreateRequest creates the GetXMSText request.
 func (client *xmlOperations) getXmsTextCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/x-ms-text"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -798,8 +854,12 @@ func (client *xmlOperations) JSONInput(ctx context.Context, properties JSONInput
 
 // jsonInputCreateRequest creates the JSONInput request.
 func (client *xmlOperations) jsonInputCreateRequest(properties JSONInput) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/jsoninput"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -846,8 +906,12 @@ func (client *xmlOperations) JSONOutput(ctx context.Context) (*JSONOutputRespons
 
 // jsonOutputCreateRequest creates the JSONOutput request.
 func (client *xmlOperations) jsonOutputCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/jsonoutput"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -895,8 +959,12 @@ func (client *xmlOperations) ListBlobs(ctx context.Context) (*ListBlobsResponseR
 
 // listBlobsCreateRequest creates the ListBlobs request.
 func (client *xmlOperations) listBlobsCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/mycontainer"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -948,8 +1016,12 @@ func (client *xmlOperations) ListContainers(ctx context.Context) (*ListContainer
 
 // listContainersCreateRequest creates the ListContainers request.
 func (client *xmlOperations) listContainersCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1000,8 +1072,12 @@ func (client *xmlOperations) PutACLs(ctx context.Context, properties []SignedIDe
 
 // putAcLsCreateRequest creates the PutACLs request.
 func (client *xmlOperations) putAcLsCreateRequest(properties []SignedIDentifier) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/mycontainer"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1056,8 +1132,12 @@ func (client *xmlOperations) PutComplexTypeRefNoMeta(ctx context.Context, model 
 
 // putComplexTypeRefNoMetaCreateRequest creates the PutComplexTypeRefNoMeta request.
 func (client *xmlOperations) putComplexTypeRefNoMetaCreateRequest(model RootWithRefAndNoMeta) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/complex-type-ref-no-meta"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1104,8 +1184,12 @@ func (client *xmlOperations) PutComplexTypeRefWithMeta(ctx context.Context, mode
 
 // putComplexTypeRefWithMetaCreateRequest creates the PutComplexTypeRefWithMeta request.
 func (client *xmlOperations) putComplexTypeRefWithMetaCreateRequest(model RootWithRefAndMeta) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/complex-type-ref-with-meta"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1152,8 +1236,12 @@ func (client *xmlOperations) PutEmptyChildElement(ctx context.Context, banana Ba
 
 // putEmptyChildElementCreateRequest creates the PutEmptyChildElement request.
 func (client *xmlOperations) putEmptyChildElementCreateRequest(banana Banana) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/empty-child-element"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1200,8 +1288,12 @@ func (client *xmlOperations) PutEmptyList(ctx context.Context, slideshow Slidesh
 
 // putEmptyListCreateRequest creates the PutEmptyList request.
 func (client *xmlOperations) putEmptyListCreateRequest(slideshow Slideshow) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/empty-list"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1248,8 +1340,12 @@ func (client *xmlOperations) PutEmptyRootList(ctx context.Context, bananas []Ban
 
 // putEmptyRootListCreateRequest creates the PutEmptyRootList request.
 func (client *xmlOperations) putEmptyRootListCreateRequest(bananas []Banana) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/empty-root-list"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1300,8 +1396,12 @@ func (client *xmlOperations) PutEmptyWrappedLists(ctx context.Context, appleBarr
 
 // putEmptyWrappedListsCreateRequest creates the PutEmptyWrappedLists request.
 func (client *xmlOperations) putEmptyWrappedListsCreateRequest(appleBarrel AppleBarrel) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/empty-wrapped-lists"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1348,8 +1448,12 @@ func (client *xmlOperations) PutRootList(ctx context.Context, bananas []Banana) 
 
 // putRootListCreateRequest creates the PutRootList request.
 func (client *xmlOperations) putRootListCreateRequest(bananas []Banana) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/root-list"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1400,8 +1504,12 @@ func (client *xmlOperations) PutRootListSingleItem(ctx context.Context, bananas 
 
 // putRootListSingleItemCreateRequest creates the PutRootListSingleItem request.
 func (client *xmlOperations) putRootListSingleItemCreateRequest(bananas []Banana) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/root-list-single-item"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1452,8 +1560,12 @@ func (client *xmlOperations) PutServiceProperties(ctx context.Context, propertie
 
 // putServicePropertiesCreateRequest creates the PutServiceProperties request.
 func (client *xmlOperations) putServicePropertiesCreateRequest(properties StorageServiceProperties) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1504,8 +1616,12 @@ func (client *xmlOperations) PutSimple(ctx context.Context, slideshow Slideshow)
 
 // putSimpleCreateRequest creates the PutSimple request.
 func (client *xmlOperations) putSimpleCreateRequest(slideshow Slideshow) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/simple"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1549,8 +1665,12 @@ func (client *xmlOperations) PutWrappedLists(ctx context.Context, wrappedLists A
 
 // putWrappedListsCreateRequest creates the PutWrappedLists request.
 func (client *xmlOperations) putWrappedListsCreateRequest(wrappedLists AppleBarrel) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/xml/wrapped-lists"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/generated/xmlgroup/xml.go
+++ b/test/autorest/generated/xmlgroup/xml.go
@@ -14,6 +14,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // XMLOperations contains the methods for the XML group.
@@ -109,7 +110,7 @@ func (client *xmlOperations) getAcLsCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/xml/mycontainer"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +167,7 @@ func (client *xmlOperations) getComplexTypeRefNoMetaCreateRequest() (*azcore.Req
 		return nil, err
 	}
 	urlPath := "/xml/complex-type-ref-no-meta"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +220,7 @@ func (client *xmlOperations) getComplexTypeRefWithMetaCreateRequest() (*azcore.R
 		return nil, err
 	}
 	urlPath := "/xml/complex-type-ref-with-meta"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +273,7 @@ func (client *xmlOperations) getEmptyChildElementCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/xml/empty-child-element"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -325,7 +326,7 @@ func (client *xmlOperations) getEmptyListCreateRequest() (*azcore.Request, error
 		return nil, err
 	}
 	urlPath := "/xml/empty-list"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +379,7 @@ func (client *xmlOperations) getEmptyRootListCreateRequest() (*azcore.Request, e
 		return nil, err
 	}
 	urlPath := "/xml/empty-root-list"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -431,7 +432,7 @@ func (client *xmlOperations) getEmptyWrappedListsCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/xml/empty-wrapped-lists"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -484,7 +485,7 @@ func (client *xmlOperations) getHeadersCreateRequest() (*azcore.Request, error) 
 		return nil, err
 	}
 	urlPath := "/xml/headers"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -540,7 +541,7 @@ func (client *xmlOperations) getRootListCreateRequest() (*azcore.Request, error)
 		return nil, err
 	}
 	urlPath := "/xml/root-list"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -593,7 +594,7 @@ func (client *xmlOperations) getRootListSingleItemCreateRequest() (*azcore.Reque
 		return nil, err
 	}
 	urlPath := "/xml/root-list-single-item"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -646,7 +647,7 @@ func (client *xmlOperations) getServicePropertiesCreateRequest() (*azcore.Reques
 		return nil, err
 	}
 	urlPath := "/xml/"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -703,7 +704,7 @@ func (client *xmlOperations) getSimpleCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/xml/simple"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -753,7 +754,7 @@ func (client *xmlOperations) getWrappedListsCreateRequest() (*azcore.Request, er
 		return nil, err
 	}
 	urlPath := "/xml/wrapped-lists"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -806,7 +807,7 @@ func (client *xmlOperations) getXmsTextCreateRequest() (*azcore.Request, error) 
 		return nil, err
 	}
 	urlPath := "/xml/x-ms-text"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -859,7 +860,7 @@ func (client *xmlOperations) jsonInputCreateRequest(properties JSONInput) (*azco
 		return nil, err
 	}
 	urlPath := "/xml/jsoninput"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -911,7 +912,7 @@ func (client *xmlOperations) jsonOutputCreateRequest() (*azcore.Request, error) 
 		return nil, err
 	}
 	urlPath := "/xml/jsonoutput"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -964,7 +965,7 @@ func (client *xmlOperations) listBlobsCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/xml/mycontainer"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1021,7 +1022,7 @@ func (client *xmlOperations) listContainersCreateRequest() (*azcore.Request, err
 		return nil, err
 	}
 	urlPath := "/xml/"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1077,7 +1078,7 @@ func (client *xmlOperations) putAcLsCreateRequest(properties []SignedIDentifier)
 		return nil, err
 	}
 	urlPath := "/xml/mycontainer"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1137,7 +1138,7 @@ func (client *xmlOperations) putComplexTypeRefNoMetaCreateRequest(model RootWith
 		return nil, err
 	}
 	urlPath := "/xml/complex-type-ref-no-meta"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1189,7 +1190,7 @@ func (client *xmlOperations) putComplexTypeRefWithMetaCreateRequest(model RootWi
 		return nil, err
 	}
 	urlPath := "/xml/complex-type-ref-with-meta"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1241,7 +1242,7 @@ func (client *xmlOperations) putEmptyChildElementCreateRequest(banana Banana) (*
 		return nil, err
 	}
 	urlPath := "/xml/empty-child-element"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1293,7 +1294,7 @@ func (client *xmlOperations) putEmptyListCreateRequest(slideshow Slideshow) (*az
 		return nil, err
 	}
 	urlPath := "/xml/empty-list"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1345,7 +1346,7 @@ func (client *xmlOperations) putEmptyRootListCreateRequest(bananas []Banana) (*a
 		return nil, err
 	}
 	urlPath := "/xml/empty-root-list"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1401,7 +1402,7 @@ func (client *xmlOperations) putEmptyWrappedListsCreateRequest(appleBarrel Apple
 		return nil, err
 	}
 	urlPath := "/xml/empty-wrapped-lists"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1453,7 +1454,7 @@ func (client *xmlOperations) putRootListCreateRequest(bananas []Banana) (*azcore
 		return nil, err
 	}
 	urlPath := "/xml/root-list"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1509,7 +1510,7 @@ func (client *xmlOperations) putRootListSingleItemCreateRequest(bananas []Banana
 		return nil, err
 	}
 	urlPath := "/xml/root-list-single-item"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1565,7 +1566,7 @@ func (client *xmlOperations) putServicePropertiesCreateRequest(properties Storag
 		return nil, err
 	}
 	urlPath := "/xml/"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1621,7 +1622,7 @@ func (client *xmlOperations) putSimpleCreateRequest(slideshow Slideshow) (*azcor
 		return nil, err
 	}
 	urlPath := "/xml/simple"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1670,7 +1671,7 @@ func (client *xmlOperations) putWrappedListsCreateRequest(wrappedLists AppleBarr
 		return nil, err
 	}
 	urlPath := "/xml/wrapped-lists"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/headergroup/headergroup_test.go
+++ b/test/autorest/headergroup/headergroup_test.go
@@ -8,29 +8,14 @@ import (
 	"generatortests/autorest/generated/headergroup"
 	"generatortests/helpers"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getHeaderClient(t *testing.T) headergroup.HeaderOperations {
-	client, err := headergroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create header client: %v", err)
-	}
-	return client.HeaderOperations()
-}
-
-func deepEqualOrFatal(t *testing.T, result interface{}, expected interface{}) {
-	if !reflect.DeepEqual(result, expected) {
-		t.Fatalf("got %+v, want %+v", result, expected)
-	}
-}
-
 // func TestHeaderCustomRequestID(t *testing.T) {
-// 	client := getHeaderClient(t)
+// 	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 // 	result, err := client.CustomRequestID(context.Background())
 // 	if err != nil {
 // 		t.Fatalf("CustomRequestID: %v", err)
@@ -38,11 +23,11 @@ func deepEqualOrFatal(t *testing.T, result interface{}, expected interface{}) {
 // 	expected := &headergroup.HeaderCustomRequestIDResponse{
 // 		StatusCode: http.StatusOK,
 // 	}
-// 	deepEqualOrFatal(t, result, expected)
+// 	helpers.DeepEqualOrFatal(t, result, expected)
 // }
 
 func TestHeaderParamBool(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ParamBool(context.Background(), "true", true)
 	if err != nil {
 		t.Fatalf("ParamBool: %v", err)
@@ -58,7 +43,7 @@ func TestHeaderParamBool(t *testing.T) {
 
 // TODO this required a change in the generated code so that it outputs base64.STDEncoding.EncodeToString()
 func TestHeaderParamByte(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ParamByte(context.Background(), "valid", []byte("啊齄丂狛狜隣郎隣兀﨩"))
 	if err != nil {
 		t.Fatalf("ParamByte: %v", err)
@@ -67,7 +52,7 @@ func TestHeaderParamByte(t *testing.T) {
 }
 
 func TestHeaderParamDate(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	val, err := time.Parse("2006-01-02", "2010-01-01")
 	if err != nil {
 		t.Fatalf("Unable to parse time: %v", err)
@@ -80,7 +65,7 @@ func TestHeaderParamDate(t *testing.T) {
 }
 
 func TestHeaderParamDatetime(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	val, err := time.Parse("2006-01-02T15:04:05Z", "2010-01-01T12:34:56Z")
 	if err != nil {
 		t.Fatalf("Unable to parse time: %v", err)
@@ -93,7 +78,7 @@ func TestHeaderParamDatetime(t *testing.T) {
 }
 
 func TestHeaderParamDatetimeRFC1123(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	val, err := time.Parse(time.RFC1123, "Wed, 01 Jan 2010 12:34:56 GMT")
 	if err != nil {
 		t.Fatalf("Unable to parse time: %v", err)
@@ -106,7 +91,7 @@ func TestHeaderParamDatetimeRFC1123(t *testing.T) {
 }
 
 func TestHeaderParamDouble(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ParamDouble(context.Background(), "positive", 7e120)
 	if err != nil {
 		t.Fatalf("ParamDouble: %v", err)
@@ -121,7 +106,7 @@ func TestHeaderParamDouble(t *testing.T) {
 }
 
 func TestHeaderParamDuration(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ParamDuration(context.Background(), "valid", "P123DT22H14M12.011S")
 	if err != nil {
 		t.Fatalf("ParamDuration: %v", err)
@@ -130,7 +115,7 @@ func TestHeaderParamDuration(t *testing.T) {
 }
 
 func TestHeaderParamEnum(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	val := headergroup.GreyscaleColorsGrey
 	result, err := client.ParamEnum(context.Background(), "valid", &headergroup.HeaderParamEnumOptions{Value: &val})
 	if err != nil {
@@ -146,7 +131,7 @@ func TestHeaderParamEnum(t *testing.T) {
 }
 
 // func TestHeaderParamExistingKey(t *testing.T) {
-// 	client := getHeaderClient(t)
+// 	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 // 	result, err := client.ParamExistingKey(context.Background(), "overwrite")
 // 	if err != nil {
 // 		t.Fatalf("ParamExistingKey: %v", err)
@@ -155,7 +140,7 @@ func TestHeaderParamEnum(t *testing.T) {
 // }
 
 func TestHeaderParamFloat(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ParamFloat(context.Background(), "positive", 0.07)
 	if err != nil {
 		t.Fatalf("ParamFloat: %v", err)
@@ -170,7 +155,7 @@ func TestHeaderParamFloat(t *testing.T) {
 }
 
 func TestHeaderParamInteger(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ParamInteger(context.Background(), "positive", 1)
 	if err != nil {
 		t.Fatalf("ParamInteger: %v", err)
@@ -185,7 +170,7 @@ func TestHeaderParamInteger(t *testing.T) {
 }
 
 func TestHeaderParamLong(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ParamLong(context.Background(), "positive", 105)
 	if err != nil {
 		t.Fatalf("ParamLong: %v", err)
@@ -200,7 +185,7 @@ func TestHeaderParamLong(t *testing.T) {
 }
 
 func TestHeaderParamProtectedKey(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ParamProtectedKey(context.Background(), "text/html")
 	if err != nil {
 		t.Fatalf("ParamProtectedKey: %v", err)
@@ -209,7 +194,7 @@ func TestHeaderParamProtectedKey(t *testing.T) {
 }
 
 func TestHeaderParamString(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	val := "The quick brown fox jumps over the lazy dog"
 	result, err := client.ParamString(context.Background(), "valid", &headergroup.HeaderParamStringOptions{Value: &val})
 	if err != nil {
@@ -233,7 +218,7 @@ func TestHeaderParamString(t *testing.T) {
 
 // TODO check why we dont check for the value returned in all of the tests below this comment
 func TestHeaderResponseBool(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ResponseBool(context.Background(), "true")
 	if err != nil {
 		t.Fatalf("ResponseBool: %v", err)
@@ -254,7 +239,7 @@ func TestHeaderResponseBool(t *testing.T) {
 }
 
 func TestHeaderResponseByte(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ResponseByte(context.Background(), "valid")
 	if err != nil {
 		t.Fatalf("ResponseByte: %v", err)
@@ -265,7 +250,7 @@ func TestHeaderResponseByte(t *testing.T) {
 }
 
 func TestHeaderResponseDate(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ResponseDate(context.Background(), "valid")
 	if err != nil {
 		t.Fatalf("ResponseDate: %v", err)
@@ -297,7 +282,7 @@ func TestHeaderResponseDate(t *testing.T) {
 }
 
 func TestHeaderResponseDatetime(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ResponseDatetime(context.Background(), "valid")
 	if err != nil {
 		t.Fatalf("ResponseDatetime: %v", err)
@@ -329,7 +314,7 @@ func TestHeaderResponseDatetime(t *testing.T) {
 }
 
 func TestHeaderResponseDatetimeRFC1123(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ResponseDatetimeRFC1123(context.Background(), "valid")
 	if err != nil {
 		t.Fatalf("ResponseDatetimeRFC1123: %v", err)
@@ -361,7 +346,7 @@ func TestHeaderResponseDatetimeRFC1123(t *testing.T) {
 }
 
 func TestHeaderResponseDouble(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ResponseDouble(context.Background(), "positive")
 	if err != nil {
 		t.Fatalf("ResponseDouble: %v", err)
@@ -376,7 +361,7 @@ func TestHeaderResponseDouble(t *testing.T) {
 }
 
 func TestHeaderResponseDuration(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ResponseDuration(context.Background(), "valid")
 	if err != nil {
 		t.Fatalf("ResponseDuration: %v", err)
@@ -385,7 +370,7 @@ func TestHeaderResponseDuration(t *testing.T) {
 }
 
 func TestHeaderResponseEnum(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ResponseEnum(context.Background(), "valid")
 	if err != nil {
 		t.Fatalf("ResponseEnum: %v", err)
@@ -401,7 +386,7 @@ func TestHeaderResponseEnum(t *testing.T) {
 }
 
 func TestHeaderResponseExistingKey(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ResponseExistingKey(context.Background())
 	if err != nil {
 		t.Fatalf("ResponseExistingKey: %v", err)
@@ -410,7 +395,7 @@ func TestHeaderResponseExistingKey(t *testing.T) {
 }
 
 func TestHeaderResponseFloat(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ResponseFloat(context.Background(), "positive")
 	if err != nil {
 		t.Fatalf("ResponseFloat: %v", err)
@@ -425,7 +410,7 @@ func TestHeaderResponseFloat(t *testing.T) {
 }
 
 func TestHeaderResponseInteger(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ResponseInteger(context.Background(), "positive")
 	if err != nil {
 		t.Fatalf("ResponseInteger: %v", err)
@@ -440,7 +425,7 @@ func TestHeaderResponseInteger(t *testing.T) {
 }
 
 func TestHeaderResponseLong(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ResponseLong(context.Background(), "positive")
 	if err != nil {
 		t.Fatalf("ResponseLong: %v", err)
@@ -455,7 +440,7 @@ func TestHeaderResponseLong(t *testing.T) {
 }
 
 func TestHeaderResponseProtectedKey(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ResponseProtectedKey(context.Background())
 	if err != nil {
 		t.Fatalf("ResponseProtectedKey: %v", err)
@@ -464,7 +449,7 @@ func TestHeaderResponseProtectedKey(t *testing.T) {
 }
 
 func TestHeaderResponseString(t *testing.T) {
-	client := getHeaderClient(t)
+	client := headergroup.NewDefaultClient(nil).HeaderOperations()
 	result, err := client.ResponseString(context.Background(), "valid")
 	if err != nil {
 		t.Fatalf("ResponseString: %v", err)

--- a/test/autorest/httpinfrastructuregroup/httpclientfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpclientfailure_test.go
@@ -9,16 +9,8 @@ import (
 	"testing"
 )
 
-func getHTTPClientFailureOperations(t *testing.T) httpinfrastructuregroup.HTTPClientFailureOperations {
-	client, err := httpinfrastructuregroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create HTTPClientFailure client: %v", err)
-	}
-	return client.HTTPClientFailureOperations()
-}
-
 func TestHTTPClientFailureDelete400(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Delete400(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -29,7 +21,7 @@ func TestHTTPClientFailureDelete400(t *testing.T) {
 }
 
 func TestHTTPClientFailureDelete407(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Delete407(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -40,7 +32,7 @@ func TestHTTPClientFailureDelete407(t *testing.T) {
 }
 
 func TestHTTPClientFailureDelete417(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Delete417(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -51,7 +43,7 @@ func TestHTTPClientFailureDelete417(t *testing.T) {
 }
 
 func TestHTTPClientFailureGet400(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Get400(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -62,7 +54,7 @@ func TestHTTPClientFailureGet400(t *testing.T) {
 }
 
 func TestHTTPClientFailureGet402(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Get402(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -73,7 +65,7 @@ func TestHTTPClientFailureGet402(t *testing.T) {
 }
 
 func TestHTTPClientFailureGet403(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Get403(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -84,7 +76,7 @@ func TestHTTPClientFailureGet403(t *testing.T) {
 }
 
 func TestHTTPClientFailureGet411(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Get411(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -95,7 +87,7 @@ func TestHTTPClientFailureGet411(t *testing.T) {
 }
 
 func TestHTTPClientFailureGet412(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Get412(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -106,7 +98,7 @@ func TestHTTPClientFailureGet412(t *testing.T) {
 }
 
 func TestHTTPClientFailureGet416(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Get416(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -117,7 +109,7 @@ func TestHTTPClientFailureGet416(t *testing.T) {
 }
 
 func TestHTTPClientFailureHead400(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Head400(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -128,7 +120,7 @@ func TestHTTPClientFailureHead400(t *testing.T) {
 }
 
 func TestHTTPClientFailureHead401(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Head401(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -139,7 +131,7 @@ func TestHTTPClientFailureHead401(t *testing.T) {
 }
 
 func TestHTTPClientFailureHead410(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Head410(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -150,7 +142,7 @@ func TestHTTPClientFailureHead410(t *testing.T) {
 }
 
 func TestHTTPClientFailureHead429(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Head429(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -161,7 +153,7 @@ func TestHTTPClientFailureHead429(t *testing.T) {
 }
 
 func TestHTTPClientFailureOptions400(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Options400(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -172,7 +164,7 @@ func TestHTTPClientFailureOptions400(t *testing.T) {
 }
 
 func TestHTTPClientFailureOptions403(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Options403(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -183,7 +175,7 @@ func TestHTTPClientFailureOptions403(t *testing.T) {
 }
 
 func TestHTTPClientFailureOptions412(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Options412(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -194,7 +186,7 @@ func TestHTTPClientFailureOptions412(t *testing.T) {
 }
 
 func TestHTTPClientFailurePatch400(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Patch400(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -205,7 +197,7 @@ func TestHTTPClientFailurePatch400(t *testing.T) {
 }
 
 func TestHTTPClientFailurePatch405(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Patch405(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -216,7 +208,7 @@ func TestHTTPClientFailurePatch405(t *testing.T) {
 }
 
 func TestHTTPClientFailurePatch414(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Patch414(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -227,7 +219,7 @@ func TestHTTPClientFailurePatch414(t *testing.T) {
 }
 
 func TestHTTPClientFailurePost400(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Post400(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -238,7 +230,7 @@ func TestHTTPClientFailurePost400(t *testing.T) {
 }
 
 func TestHTTPClientFailurePost406(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Post406(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -249,7 +241,7 @@ func TestHTTPClientFailurePost406(t *testing.T) {
 }
 
 func TestHTTPClientFailurePost415(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Post415(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -260,7 +252,7 @@ func TestHTTPClientFailurePost415(t *testing.T) {
 }
 
 func TestHTTPClientFailurePut400(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Put400(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -271,7 +263,7 @@ func TestHTTPClientFailurePut400(t *testing.T) {
 }
 
 func TestHTTPClientFailurePut404(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Put404(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -282,7 +274,7 @@ func TestHTTPClientFailurePut404(t *testing.T) {
 }
 
 func TestHTTPClientFailurePut409(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Put409(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -293,7 +285,7 @@ func TestHTTPClientFailurePut409(t *testing.T) {
 }
 
 func TestHTTPClientFailurePut413(t *testing.T) {
-	client := getHTTPClientFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPClientFailureOperations()
 	result, err := client.Put413(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")

--- a/test/autorest/httpinfrastructuregroup/httpfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpfailure_test.go
@@ -9,16 +9,8 @@ import (
 	"testing"
 )
 
-func getHTTPFailureOperations(t *testing.T) httpinfrastructuregroup.HTTPFailureOperations {
-	client, err := httpinfrastructuregroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create HTTPFailure client: %v", err)
-	}
-	return client.HTTPFailureOperations()
-}
-
 func TestHTTPFailureGetEmptyError(t *testing.T) {
-	client := getHTTPFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPFailureOperations()
 	result, err := client.GetEmptyError(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -29,7 +21,7 @@ func TestHTTPFailureGetEmptyError(t *testing.T) {
 }
 
 func TestHTTPFailureGetNoModelEmpty(t *testing.T) {
-	client := getHTTPFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPFailureOperations()
 	result, err := client.GetNoModelEmpty(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -40,7 +32,7 @@ func TestHTTPFailureGetNoModelEmpty(t *testing.T) {
 }
 
 func TestHTTPFailureGetNoModelError(t *testing.T) {
-	client := getHTTPFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPFailureOperations()
 	result, err := client.GetNoModelError(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")

--- a/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
@@ -13,17 +13,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getMultipleResponseOperations(t *testing.T) httpinfrastructuregroup.MultipleResponsesOperations {
-	client, err := httpinfrastructuregroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create HTTPSuccess client: %v", err)
-	}
-	return client.MultipleResponsesOperations()
-}
-
 // Get200Model201ModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 func TestGet200Model201ModelDefaultError200Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200Model201ModelDefaultError200Valid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -40,7 +32,7 @@ func TestGet200Model201ModelDefaultError200Valid(t *testing.T) {
 
 // Get200Model201ModelDefaultError201Valid - Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}
 func TestGet200Model201ModelDefaultError201Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200Model201ModelDefaultError201Valid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -59,7 +51,7 @@ func TestGet200Model201ModelDefaultError201Valid(t *testing.T) {
 
 // Get200Model201ModelDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
 func TestGet200Model201ModelDefaultError400Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200Model201ModelDefaultError400Valid(context.Background())
 	r, ok := err.(httpinfrastructuregroup.Error)
 	if !ok {
@@ -76,7 +68,7 @@ func TestGet200Model201ModelDefaultError400Valid(t *testing.T) {
 
 // Get200Model204NoModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 func TestGet200Model204NoModelDefaultError200Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200Model204NoModelDefaultError200Valid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -88,7 +80,7 @@ func TestGet200Model204NoModelDefaultError200Valid(t *testing.T) {
 
 // Get200Model204NoModelDefaultError201Invalid - Send a 201 response with valid payload: {'statusCode': '201'}
 func TestGet200Model204NoModelDefaultError201Invalid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200Model204NoModelDefaultError201Invalid(context.Background())
 	r, ok := err.(httpinfrastructuregroup.Error)
 	if !ok {
@@ -102,7 +94,7 @@ func TestGet200Model204NoModelDefaultError201Invalid(t *testing.T) {
 
 // Get200Model204NoModelDefaultError202None - Send a 202 response with no payload:
 func TestGet200Model204NoModelDefaultError202None(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200Model204NoModelDefaultError202None(context.Background())
 	r, ok := err.(httpinfrastructuregroup.Error)
 	if !ok {
@@ -116,7 +108,7 @@ func TestGet200Model204NoModelDefaultError202None(t *testing.T) {
 
 // Get200Model204NoModelDefaultError204Valid - Send a 204 response with no payload
 func TestGet200Model204NoModelDefaultError204Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200Model204NoModelDefaultError204Valid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -129,7 +121,7 @@ func TestGet200Model204NoModelDefaultError204Valid(t *testing.T) {
 
 // Get200Model204NoModelDefaultError400Valid - Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}
 func TestGet200Model204NoModelDefaultError400Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200Model204NoModelDefaultError400Valid(context.Background())
 	r, ok := err.(httpinfrastructuregroup.Error)
 	if !ok {
@@ -151,7 +143,7 @@ func TestGet200ModelA200Invalid(t *testing.T) {
 
 // Get200ModelA200None - Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A
 func TestGet200ModelA200None(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200ModelA200None(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -163,7 +155,7 @@ func TestGet200ModelA200None(t *testing.T) {
 
 // Get200ModelA200Valid - Send a 200 response with payload {'statusCode': '200'}
 func TestGet200ModelA200Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200ModelA200Valid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -175,7 +167,7 @@ func TestGet200ModelA200Valid(t *testing.T) {
 
 // Get200ModelA201ModelC404ModelDDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 func TestGet200ModelA201ModelC404ModelDDefaultError200Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError200Valid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -191,7 +183,7 @@ func TestGet200ModelA201ModelC404ModelDDefaultError200Valid(t *testing.T) {
 
 // Get200ModelA201ModelC404ModelDDefaultError201Valid - Send a 200 response with valid payload: {'httpCode': '201'}
 func TestGet200ModelA201ModelC404ModelDDefaultError201Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError201Valid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -207,7 +199,7 @@ func TestGet200ModelA201ModelC404ModelDDefaultError201Valid(t *testing.T) {
 
 // Get200ModelA201ModelC404ModelDDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
 func TestGet200ModelA201ModelC404ModelDDefaultError400Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError400Valid(context.Background())
 	r, ok := err.(httpinfrastructuregroup.Error)
 	if !ok {
@@ -224,7 +216,7 @@ func TestGet200ModelA201ModelC404ModelDDefaultError400Valid(t *testing.T) {
 
 // Get200ModelA201ModelC404ModelDDefaultError404Valid - Send a 200 response with valid payload: {'httpStatusCode': '404'}
 func TestGet200ModelA201ModelC404ModelDDefaultError404Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError404Valid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -240,7 +232,7 @@ func TestGet200ModelA201ModelC404ModelDDefaultError404Valid(t *testing.T) {
 
 // Get200ModelA202Valid - Send a 202 response with payload {'statusCode': '202'}
 func TestGet200ModelA202Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200ModelA200Valid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -257,7 +249,7 @@ func TestGet200ModelA400Invalid(t *testing.T) {
 
 // Get200ModelA400None - Send a 400 response with no payload client should treat as an http error with no error model
 func TestGet200ModelA400None(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200ModelA400None(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -269,7 +261,7 @@ func TestGet200ModelA400None(t *testing.T) {
 
 // Get200ModelA400Valid - Send a 200 response with payload {'statusCode': '400'}
 func TestGet200ModelA400Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get200ModelA400Valid(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -281,7 +273,7 @@ func TestGet200ModelA400Valid(t *testing.T) {
 
 // Get202None204NoneDefaultError202None - Send a 202 response with no payload
 func TestGet202None204NoneDefaultError202None(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get202None204NoneDefaultError202None(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -291,7 +283,7 @@ func TestGet202None204NoneDefaultError202None(t *testing.T) {
 
 // Get202None204NoneDefaultError204None - Send a 204 response with no payload
 func TestGet202None204NoneDefaultError204None(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get202None204NoneDefaultError204None(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -301,7 +293,7 @@ func TestGet202None204NoneDefaultError204None(t *testing.T) {
 
 // Get202None204NoneDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
 func TestGet202None204NoneDefaultError400Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get202None204NoneDefaultError400Valid(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -313,7 +305,7 @@ func TestGet202None204NoneDefaultError400Valid(t *testing.T) {
 
 // Get202None204NoneDefaultNone202Invalid - Send a 202 response with an unexpected payload {'property': 'value'}
 func TestGet202None204NoneDefaultNone202Invalid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get202None204NoneDefaultNone202Invalid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -323,7 +315,7 @@ func TestGet202None204NoneDefaultNone202Invalid(t *testing.T) {
 
 // Get202None204NoneDefaultNone204None - Send a 204 response with no payload
 func TestGet202None204NoneDefaultNone204None(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get202None204NoneDefaultNone204None(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -333,7 +325,7 @@ func TestGet202None204NoneDefaultNone204None(t *testing.T) {
 
 // Get202None204NoneDefaultNone400Invalid - Send a 400 response with an unexpected payload {'property': 'value'}
 func TestGet202None204NoneDefaultNone400Invalid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get202None204NoneDefaultNone400Invalid(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -345,7 +337,7 @@ func TestGet202None204NoneDefaultNone400Invalid(t *testing.T) {
 
 // Get202None204NoneDefaultNone400None - Send a 400 response with no payload
 func TestGet202None204NoneDefaultNone400None(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.Get202None204NoneDefaultNone400None(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -357,7 +349,7 @@ func TestGet202None204NoneDefaultNone400None(t *testing.T) {
 
 // GetDefaultModelA200None - Send a 200 response with no payload
 func TestGetDefaultModelA200None(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.GetDefaultModelA200None(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -369,7 +361,7 @@ func TestGetDefaultModelA200None(t *testing.T) {
 
 // GetDefaultModelA200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 func TestGetDefaultModelA200Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.GetDefaultModelA200Valid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -381,7 +373,7 @@ func TestGetDefaultModelA200Valid(t *testing.T) {
 
 // GetDefaultModelA400None - Send a 400 response with no payload
 func TestGetDefaultModelA400None(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.GetDefaultModelA400None(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -393,7 +385,7 @@ func TestGetDefaultModelA400None(t *testing.T) {
 
 // GetDefaultModelA400Valid - Send a 400 response with valid payload: {'statusCode': '400'}
 func TestGetDefaultModelA400Valid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.GetDefaultModelA400Valid(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -410,7 +402,7 @@ func TestGetDefaultNone200Invalid(t *testing.T) {
 
 // GetDefaultNone200None - Send a 200 response with no payload
 func TestGetDefaultNone200None(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.GetDefaultNone200None(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -420,7 +412,7 @@ func TestGetDefaultNone200None(t *testing.T) {
 
 // GetDefaultNone400Invalid - Send a 400 response with valid payload: {'statusCode': '400'}
 func TestGetDefaultNone400Invalid(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.GetDefaultNone400Invalid(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -432,7 +424,7 @@ func TestGetDefaultNone400Invalid(t *testing.T) {
 
 // GetDefaultNone400None - Send a 400 response with no payload
 func TestGetDefaultNone400None(t *testing.T) {
-	client := getMultipleResponseOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).MultipleResponsesOperations()
 	result, err := client.GetDefaultNone400None(context.Background())
 	if err == nil {
 		t.Fatal("unexpected nil error")

--- a/test/autorest/httpinfrastructuregroup/httpredirects_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpredirects_test.go
@@ -11,16 +11,8 @@ import (
 	"testing"
 )
 
-func getHTTPRedirectsOperations(t *testing.T) httpinfrastructuregroup.HTTPRedirectsOperations {
-	client, err := httpinfrastructuregroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create HTTPRedirects client: %v", err)
-	}
-	return client.HTTPRedirectsOperations()
-}
-
 func TestHTTPRedirectsDelete307(t *testing.T) {
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Delete307(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -30,7 +22,7 @@ func TestHTTPRedirectsDelete307(t *testing.T) {
 
 func TestHTTPRedirectsGet300(t *testing.T) {
 	t.Skip("does not automatically redirect")
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Get300(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -46,7 +38,7 @@ func TestHTTPRedirectsGet300(t *testing.T) {
 }
 
 func TestHTTPRedirectsGet301(t *testing.T) {
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Get301(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -55,7 +47,7 @@ func TestHTTPRedirectsGet301(t *testing.T) {
 }
 
 func TestHTTPRedirectsGet302(t *testing.T) {
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Get302(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -64,7 +56,7 @@ func TestHTTPRedirectsGet302(t *testing.T) {
 }
 
 func TestHTTPRedirectsGet307(t *testing.T) {
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Get307(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -74,7 +66,7 @@ func TestHTTPRedirectsGet307(t *testing.T) {
 
 func TestHTTPRedirectsHead300(t *testing.T) {
 	t.Skip("does not automatically redirect")
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Head300(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -83,7 +75,7 @@ func TestHTTPRedirectsHead300(t *testing.T) {
 }
 
 func TestHTTPRedirectsHead301(t *testing.T) {
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Head301(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -92,7 +84,7 @@ func TestHTTPRedirectsHead301(t *testing.T) {
 }
 
 func TestHTTPRedirectsHead302(t *testing.T) {
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Head302(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -101,7 +93,7 @@ func TestHTTPRedirectsHead302(t *testing.T) {
 }
 
 func TestHTTPRedirectsHead307(t *testing.T) {
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Head307(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -111,7 +103,7 @@ func TestHTTPRedirectsHead307(t *testing.T) {
 
 func TestHTTPRedirectsOptions307(t *testing.T) {
 	t.Skip("receive a status code of 204 which is not expected")
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Options307(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -121,7 +113,7 @@ func TestHTTPRedirectsOptions307(t *testing.T) {
 
 func TestHTTPRedirectsPatch302(t *testing.T) {
 	t.Skip("HTTP client automatically redirects, test server doesn't expect it")
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Patch302(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -130,7 +122,7 @@ func TestHTTPRedirectsPatch302(t *testing.T) {
 }
 
 func TestHTTPRedirectsPatch307(t *testing.T) {
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Patch307(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -139,7 +131,7 @@ func TestHTTPRedirectsPatch307(t *testing.T) {
 }
 
 func TestHTTPRedirectsPost303(t *testing.T) {
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Post303(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -148,7 +140,7 @@ func TestHTTPRedirectsPost303(t *testing.T) {
 }
 
 func TestHTTPRedirectsPost307(t *testing.T) {
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Post307(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -158,7 +150,7 @@ func TestHTTPRedirectsPost307(t *testing.T) {
 
 func TestHTTPRedirectsPut301(t *testing.T) {
 	t.Skip("HTTP client automatically redirects, test server doesn't expect it")
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Put301(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -167,7 +159,7 @@ func TestHTTPRedirectsPut301(t *testing.T) {
 }
 
 func TestHTTPRedirectsPut307(t *testing.T) {
-	client := getHTTPRedirectsOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPRedirectsOperations()
 	result, err := client.Put307(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)

--- a/test/autorest/httpinfrastructuregroup/httpretry_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpretry_test.go
@@ -15,14 +15,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
-func getHTTPRetryOperations(t *testing.T) httpinfrastructuregroup.HTTPRetryOperations {
+func getHTTPRetryOperations() httpinfrastructuregroup.HTTPRetryOperations {
 	options := httpinfrastructuregroup.DefaultClientOptions()
 	options.Retry.RetryDelay = 10 * time.Millisecond
 	options.HTTPClient = httpClientWithCookieJar()
-	client, err := httpinfrastructuregroup.NewDefaultClient(&options)
-	if err != nil {
-		t.Fatalf("failed to create HTTPRetry client: %v", err)
-	}
+	client := httpinfrastructuregroup.NewDefaultClient(&options)
 	return client.HTTPRetryOperations()
 }
 
@@ -38,7 +35,7 @@ func httpClientWithCookieJar() azcore.Transport {
 }
 
 func TestHTTPRetryDelete503(t *testing.T) {
-	client := getHTTPRetryOperations(t)
+	client := getHTTPRetryOperations()
 	result, err := client.Delete503(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error but received: %v", err)
@@ -47,7 +44,7 @@ func TestHTTPRetryDelete503(t *testing.T) {
 }
 
 func TestHTTPRetryGet502(t *testing.T) {
-	client := getHTTPRetryOperations(t)
+	client := getHTTPRetryOperations()
 	result, err := client.Get502(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -56,7 +53,7 @@ func TestHTTPRetryGet502(t *testing.T) {
 }
 
 func TestHTTPRetryHead408(t *testing.T) {
-	client := getHTTPRetryOperations(t)
+	client := getHTTPRetryOperations()
 	result, err := client.Head408(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -66,7 +63,7 @@ func TestHTTPRetryHead408(t *testing.T) {
 
 func TestHTTPRetryOptions502(t *testing.T) {
 	t.Skip("options method not enabled by test server")
-	client := getHTTPRetryOperations(t)
+	client := getHTTPRetryOperations()
 	result, err := client.Options502(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -75,7 +72,7 @@ func TestHTTPRetryOptions502(t *testing.T) {
 }
 
 func TestHTTPRetryPatch500(t *testing.T) {
-	client := getHTTPRetryOperations(t)
+	client := getHTTPRetryOperations()
 	result, err := client.Patch500(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -84,7 +81,7 @@ func TestHTTPRetryPatch500(t *testing.T) {
 }
 
 func TestHTTPRetryPatch504(t *testing.T) {
-	client := getHTTPRetryOperations(t)
+	client := getHTTPRetryOperations()
 	result, err := client.Patch504(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -93,7 +90,7 @@ func TestHTTPRetryPatch504(t *testing.T) {
 }
 
 func TestHTTPRetryPost503(t *testing.T) {
-	client := getHTTPRetryOperations(t)
+	client := getHTTPRetryOperations()
 	result, err := client.Post503(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -102,7 +99,7 @@ func TestHTTPRetryPost503(t *testing.T) {
 }
 
 func TestHTTPRetryPut500(t *testing.T) {
-	client := getHTTPRetryOperations(t)
+	client := getHTTPRetryOperations()
 	result, err := client.Put500(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -111,7 +108,7 @@ func TestHTTPRetryPut500(t *testing.T) {
 }
 
 func TestHTTPRetryPut504(t *testing.T) {
-	client := getHTTPRetryOperations(t)
+	client := getHTTPRetryOperations()
 	result, err := client.Put504(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)

--- a/test/autorest/httpinfrastructuregroup/httpserverfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpserverfailure_test.go
@@ -9,16 +9,8 @@ import (
 	"testing"
 )
 
-func getHTTPServerFailureOperations(t *testing.T) httpinfrastructuregroup.HTTPServerFailureOperations {
-	client, err := httpinfrastructuregroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create HTTPServerFailure client: %v", err)
-	}
-	return client.HTTPServerFailureOperations()
-}
-
 func TestHTTPServerFailureDelete505(t *testing.T) {
-	client := getHTTPServerFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPServerFailureOperations()
 	result, err := client.Delete505(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -29,7 +21,7 @@ func TestHTTPServerFailureDelete505(t *testing.T) {
 }
 
 func TestHTTPServerFailureGet501(t *testing.T) {
-	client := getHTTPServerFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPServerFailureOperations()
 	result, err := client.Get501(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -40,7 +32,7 @@ func TestHTTPServerFailureGet501(t *testing.T) {
 }
 
 func TestHTTPServerFailureHead501(t *testing.T) {
-	client := getHTTPServerFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPServerFailureOperations()
 	result, err := client.Head501(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -51,7 +43,7 @@ func TestHTTPServerFailureHead501(t *testing.T) {
 }
 
 func TestHTTPServerFailurePost505(t *testing.T) {
-	client := getHTTPServerFailureOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPServerFailureOperations()
 	result, err := client.Post505(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")

--- a/test/autorest/httpinfrastructuregroup/httpsuccess_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpsuccess_test.go
@@ -11,16 +11,8 @@ import (
 	"testing"
 )
 
-func getHTTPSuccessOperations(t *testing.T) httpinfrastructuregroup.HTTPSuccessOperations {
-	client, err := httpinfrastructuregroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create HTTPSuccess client: %v", err)
-	}
-	return client.HTTPSuccessOperations()
-}
-
 func TestHTTPSuccessDelete200(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Delete200(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -29,7 +21,7 @@ func TestHTTPSuccessDelete200(t *testing.T) {
 }
 
 func TestHTTPSuccessDelete202(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Delete202(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -38,7 +30,7 @@ func TestHTTPSuccessDelete202(t *testing.T) {
 }
 
 func TestHTTPSuccessDelete204(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Delete204(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -47,7 +39,7 @@ func TestHTTPSuccessDelete204(t *testing.T) {
 }
 
 func TestHTTPSuccessGet200(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Get200(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -56,7 +48,7 @@ func TestHTTPSuccessGet200(t *testing.T) {
 }
 
 func TestHTTPSuccessHead200(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Head200(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -65,7 +57,7 @@ func TestHTTPSuccessHead200(t *testing.T) {
 }
 
 func TestHTTPSuccessHead204(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Head204(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -74,7 +66,7 @@ func TestHTTPSuccessHead204(t *testing.T) {
 }
 
 func TestHTTPSuccessHead404(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Head404(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -84,7 +76,7 @@ func TestHTTPSuccessHead404(t *testing.T) {
 
 func TestHTTPSuccessOptions200(t *testing.T) {
 	t.Skip("options method not enabled by test server")
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Options200(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -93,7 +85,7 @@ func TestHTTPSuccessOptions200(t *testing.T) {
 }
 
 func TestHTTPSuccessPatch200(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Patch200(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -102,7 +94,7 @@ func TestHTTPSuccessPatch200(t *testing.T) {
 }
 
 func TestHTTPSuccessPatch202(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Patch202(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -111,7 +103,7 @@ func TestHTTPSuccessPatch202(t *testing.T) {
 }
 
 func TestHTTPSuccessPatch204(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Patch204(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -120,7 +112,7 @@ func TestHTTPSuccessPatch204(t *testing.T) {
 }
 
 func TestHTTPSuccessPost200(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Post200(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -129,7 +121,7 @@ func TestHTTPSuccessPost200(t *testing.T) {
 }
 
 func TestHTTPSuccessPost201(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Post201(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -138,7 +130,7 @@ func TestHTTPSuccessPost201(t *testing.T) {
 }
 
 func TestHTTPSuccessPost202(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Post202(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -147,7 +139,7 @@ func TestHTTPSuccessPost202(t *testing.T) {
 }
 
 func TestHTTPSuccessPost204(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Post204(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -156,7 +148,7 @@ func TestHTTPSuccessPost204(t *testing.T) {
 }
 
 func TestHTTPSuccessPut200(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Put200(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -165,7 +157,7 @@ func TestHTTPSuccessPut200(t *testing.T) {
 }
 
 func TestHTTPSuccessPut201(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Put201(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -174,7 +166,7 @@ func TestHTTPSuccessPut201(t *testing.T) {
 }
 
 func TestHTTPSuccessPut202(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Put202(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
@@ -183,7 +175,7 @@ func TestHTTPSuccessPut202(t *testing.T) {
 }
 
 func TestHTTPSuccessPut204(t *testing.T) {
-	client := getHTTPSuccessOperations(t)
+	client := httpinfrastructuregroup.NewDefaultClient(nil).HTTPSuccessOperations()
 	result, err := client.Put204(context.Background())
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)

--- a/test/autorest/integergroup/integergroup_test.go
+++ b/test/autorest/integergroup/integergroup_test.go
@@ -13,16 +13,8 @@ import (
 	"time"
 )
 
-func getIntegerOperations(t *testing.T) integergroup.IntOperations {
-	client, err := integergroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create integer client: %v", err)
-	}
-	return client.IntOperations()
-}
-
 func TestIntGetInvalid(t *testing.T) {
-	client := getIntegerOperations(t)
+	client := integergroup.NewDefaultClient(nil).IntOperations()
 	result, err := client.GetInvalid(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -33,7 +25,7 @@ func TestIntGetInvalid(t *testing.T) {
 }
 
 func TestIntGetInvalidUnixTime(t *testing.T) {
-	client := getIntegerOperations(t)
+	client := integergroup.NewDefaultClient(nil).IntOperations()
 	result, err := client.GetInvalidUnixTime(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -44,7 +36,7 @@ func TestIntGetInvalidUnixTime(t *testing.T) {
 }
 
 func TestIntGetNull(t *testing.T) {
-	client := getIntegerOperations(t)
+	client := integergroup.NewDefaultClient(nil).IntOperations()
 	result, err := client.GetNull(context.Background())
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
@@ -54,7 +46,7 @@ func TestIntGetNull(t *testing.T) {
 }
 
 func TestIntGetNullUnixTime(t *testing.T) {
-	client := getIntegerOperations(t)
+	client := integergroup.NewDefaultClient(nil).IntOperations()
 	result, err := client.GetNullUnixTime(context.Background())
 	if err != nil {
 		t.Fatalf("GetNullUnixTime: %v", err)
@@ -64,7 +56,7 @@ func TestIntGetNullUnixTime(t *testing.T) {
 }
 
 func TestIntGetOverflowInt32(t *testing.T) {
-	client := getIntegerOperations(t)
+	client := integergroup.NewDefaultClient(nil).IntOperations()
 	result, err := client.GetOverflowInt32(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -75,7 +67,7 @@ func TestIntGetOverflowInt32(t *testing.T) {
 }
 
 func TestIntGetOverflowInt64(t *testing.T) {
-	client := getIntegerOperations(t)
+	client := integergroup.NewDefaultClient(nil).IntOperations()
 	result, err := client.GetOverflowInt64(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -86,7 +78,7 @@ func TestIntGetOverflowInt64(t *testing.T) {
 }
 
 func TestIntGetUnderflowInt32(t *testing.T) {
-	client := getIntegerOperations(t)
+	client := integergroup.NewDefaultClient(nil).IntOperations()
 	result, err := client.GetUnderflowInt32(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -97,7 +89,7 @@ func TestIntGetUnderflowInt32(t *testing.T) {
 }
 
 func TestIntGetUnderflowInt64(t *testing.T) {
-	client := getIntegerOperations(t)
+	client := integergroup.NewDefaultClient(nil).IntOperations()
 	result, err := client.GetUnderflowInt64(context.Background())
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -108,7 +100,7 @@ func TestIntGetUnderflowInt64(t *testing.T) {
 }
 
 func TestIntGetUnixTime(t *testing.T) {
-	client := getIntegerOperations(t)
+	client := integergroup.NewDefaultClient(nil).IntOperations()
 	result, err := client.GetUnixTime(context.Background())
 	if err != nil {
 		t.Fatalf("GetUnixTime: %v", err)
@@ -119,7 +111,7 @@ func TestIntGetUnixTime(t *testing.T) {
 }
 
 func TestIntPutMax32(t *testing.T) {
-	client := getIntegerOperations(t)
+	client := integergroup.NewDefaultClient(nil).IntOperations()
 	result, err := client.PutMax32(context.Background(), math.MaxInt32)
 	if err != nil {
 		t.Fatalf("PutMax32: %v", err)
@@ -128,7 +120,7 @@ func TestIntPutMax32(t *testing.T) {
 }
 
 func TestIntPutMax64(t *testing.T) {
-	client := getIntegerOperations(t)
+	client := integergroup.NewDefaultClient(nil).IntOperations()
 	result, err := client.PutMax64(context.Background(), math.MaxInt64)
 	if err != nil {
 		t.Fatalf("PutMax64: %v", err)
@@ -137,7 +129,7 @@ func TestIntPutMax64(t *testing.T) {
 }
 
 func TestIntPutMin32(t *testing.T) {
-	client := getIntegerOperations(t)
+	client := integergroup.NewDefaultClient(nil).IntOperations()
 	result, err := client.PutMin32(context.Background(), math.MinInt32)
 	if err != nil {
 		t.Fatalf("PutMin32: %v", err)
@@ -146,7 +138,7 @@ func TestIntPutMin32(t *testing.T) {
 }
 
 func TestIntPutMin64(t *testing.T) {
-	client := getIntegerOperations(t)
+	client := integergroup.NewDefaultClient(nil).IntOperations()
 	result, err := client.PutMin64(context.Background(), math.MinInt64)
 	if err != nil {
 		t.Fatalf("PutMin64: %v", err)
@@ -155,7 +147,7 @@ func TestIntPutMin64(t *testing.T) {
 }
 
 func TestIntPutUnixTimeDate(t *testing.T) {
-	client := getIntegerOperations(t)
+	client := integergroup.NewDefaultClient(nil).IntOperations()
 	t1 := time.Unix(1460505600, 0)
 	result, err := client.PutUnixTimeDate(context.Background(), t1)
 	if err != nil {

--- a/test/autorest/lrogroup/lroretrys_test.go
+++ b/test/autorest/lrogroup/lroretrys_test.go
@@ -13,19 +13,16 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getLRORetrysOperations(t *testing.T) lrogroup.LroRetrysOperations {
+func getLRORetrysOperations() lrogroup.LroRetrysOperations {
 	options := lrogroup.DefaultClientOptions()
 	options.Retry.RetryDelay = 10 * time.Millisecond
 	options.HTTPClient = httpClientWithCookieJar()
-	client, err := lrogroup.NewDefaultClient(&options)
-	if err != nil {
-		t.Fatalf("failed to create lro client: %v", err)
-	}
+	client := lrogroup.NewDefaultClient(&options)
 	return client.LroRetrysOperations()
 }
 
 func TestLRORetrysBeginDelete202Retry200(t *testing.T) {
-	op := getLRORetrysOperations(t)
+	op := getLRORetrysOperations()
 	resp, err := op.BeginDelete202Retry200(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -47,7 +44,7 @@ func TestLRORetrysBeginDelete202Retry200(t *testing.T) {
 }
 
 func TestLRORetrysBeginDeleteAsyncRelativeRetrySucceeded(t *testing.T) {
-	op := getLRORetrysOperations(t)
+	op := getLRORetrysOperations()
 	resp, err := op.BeginDeleteAsyncRelativeRetrySucceeded(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -69,7 +66,7 @@ func TestLRORetrysBeginDeleteAsyncRelativeRetrySucceeded(t *testing.T) {
 }
 
 func TestLRORetrysBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
-	op := getLRORetrysOperations(t)
+	op := getLRORetrysOperations()
 	resp, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +97,7 @@ func TestLRORetrysBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 }
 
 func TestLRORetrysBeginPost202Retry200(t *testing.T) {
-	op := getLRORetrysOperations(t)
+	op := getLRORetrysOperations()
 	resp, err := op.BeginPost202Retry200(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -122,7 +119,7 @@ func TestLRORetrysBeginPost202Retry200(t *testing.T) {
 }
 
 func TestLRORetrysBeginPostAsyncRelativeRetrySucceeded(t *testing.T) {
-	op := getLRORetrysOperations(t)
+	op := getLRORetrysOperations()
 	resp, err := op.BeginPostAsyncRelativeRetrySucceeded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -144,7 +141,7 @@ func TestLRORetrysBeginPostAsyncRelativeRetrySucceeded(t *testing.T) {
 }
 
 func TestLRORetrysBeginPut201CreatingSucceeded200(t *testing.T) {
-	op := getLRORetrysOperations(t)
+	op := getLRORetrysOperations()
 	resp, err := op.BeginPut201CreatingSucceeded200(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -175,7 +172,7 @@ func TestLRORetrysBeginPut201CreatingSucceeded200(t *testing.T) {
 }
 
 func TestLRORetrysBeginPutAsyncRelativeRetrySucceeded(t *testing.T) {
-	op := getLRORetrysOperations(t)
+	op := getLRORetrysOperations()
 	resp, err := op.BeginPutAsyncRelativeRetrySucceeded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -18,14 +18,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
-func getLROSOperations(t *testing.T) lrogroup.LrOSOperations {
+func getLROSOperations() lrogroup.LrOSOperations {
 	options := lrogroup.DefaultClientOptions()
 	options.Retry.RetryDelay = 10 * time.Millisecond
 	options.HTTPClient = httpClientWithCookieJar()
-	client, err := lrogroup.NewDefaultClient(&options)
-	if err != nil {
-		t.Fatalf("failed to create lro client: %v", err)
-	}
+	client := lrogroup.NewDefaultClient(&options)
 	return client.LrOSOperations()
 }
 
@@ -41,7 +38,7 @@ func httpClientWithCookieJar() azcore.Transport {
 }
 
 func TestLROResumeWrongPoller(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginDelete202NoRetry204(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -61,7 +58,7 @@ func TestLROResumeWrongPoller(t *testing.T) {
 }
 
 func TestLROBeginDelete202NoRetry204(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginDelete202NoRetry204(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -83,7 +80,7 @@ func TestLROBeginDelete202NoRetry204(t *testing.T) {
 }
 
 func TestLROBeginDelete202Retry200(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginDelete202Retry200(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -105,7 +102,7 @@ func TestLROBeginDelete202Retry200(t *testing.T) {
 }
 
 func TestLROBeginDelete204Succeeded(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginDelete204Succeeded(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -123,7 +120,7 @@ func TestLROBeginDelete204Succeeded(t *testing.T) {
 }
 
 func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginDeleteAsyncNoHeaderInRetry(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -145,7 +142,7 @@ func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
 }
 
 func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginDeleteAsyncNoRetrySucceeded(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -167,7 +164,7 @@ func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
 }
 
 func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginDeleteAsyncRetryFailed(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -195,7 +192,7 @@ func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
 }
 
 func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginDeleteAsyncRetrySucceeded(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -217,7 +214,7 @@ func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
 }
 
 func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginDeleteAsyncRetrycanceled(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -245,7 +242,7 @@ func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
 }
 
 func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginDeleteNoHeaderInRetry(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -267,7 +264,7 @@ func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
 }
 
 func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -289,7 +286,7 @@ func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 }
 
 func TestLROBeginDeleteProvisioning202DeletingFailed200(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginDeleteProvisioning202DeletingFailed200(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -310,7 +307,7 @@ func TestLROBeginDeleteProvisioning202DeletingFailed200(t *testing.T) {
 }
 
 func TestLROBeginDeleteProvisioning202Deletingcanceled200(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginDeleteProvisioning202Deletingcanceled200(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -331,7 +328,7 @@ func TestLROBeginDeleteProvisioning202Deletingcanceled200(t *testing.T) {
 }
 
 func TestLROBeginPost200WithPayload(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPost200WithPayload(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -357,7 +354,7 @@ func TestLROBeginPost200WithPayload(t *testing.T) {
 }
 
 func TestLROBeginPost202List(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPost202List(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -387,7 +384,7 @@ func TestLROBeginPost202List(t *testing.T) {
 }
 
 func TestLROBeginPost202NoRetry204(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPost202NoRetry204(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -409,7 +406,7 @@ func TestLROBeginPost202NoRetry204(t *testing.T) {
 }
 
 func TestLROBeginPost202Retry200(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPost202Retry200(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -431,7 +428,7 @@ func TestLROBeginPost202Retry200(t *testing.T) {
 }
 
 func TestLROBeginPostAsyncNoRetrySucceeded(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPostAsyncNoRetrySucceeded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -462,7 +459,7 @@ func TestLROBeginPostAsyncNoRetrySucceeded(t *testing.T) {
 }
 
 func TestLROBeginPostAsyncRetryFailed(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPostAsyncRetryFailed(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -490,7 +487,7 @@ func TestLROBeginPostAsyncRetryFailed(t *testing.T) {
 }
 
 func TestLROBeginPostAsyncRetrySucceeded(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPostAsyncRetrySucceeded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -521,7 +518,7 @@ func TestLROBeginPostAsyncRetrySucceeded(t *testing.T) {
 }
 
 func TestLROBeginPostAsyncRetrycanceled(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPostAsyncRetrycanceled(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -549,7 +546,7 @@ func TestLROBeginPostAsyncRetrycanceled(t *testing.T) {
 }
 
 func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPostDoubleHeadersFinalAzureHeaderGet(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -576,7 +573,7 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
 }
 
 func TestLROBeginPostDoubleHeadersFinalAzureHeaderGetDefault(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPostDoubleHeadersFinalAzureHeaderGetDefault(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -604,7 +601,7 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGetDefault(t *testing.T) {
 }
 
 func TestLROBeginPostDoubleHeadersFinalLocationGet(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPostDoubleHeadersFinalLocationGet(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -627,7 +624,7 @@ func TestLROBeginPostDoubleHeadersFinalLocationGet(t *testing.T) {
 }
 
 func TestLROBeginPut200Acceptedcanceled200(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPut200Acceptedcanceled200(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -655,7 +652,7 @@ func TestLROBeginPut200Acceptedcanceled200(t *testing.T) {
 }
 
 func TestLROBeginPut200Succeeded(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPut200Succeeded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -682,7 +679,7 @@ func TestLROBeginPut200Succeeded(t *testing.T) {
 }
 
 func TestLROBeginPut200SucceededNoState(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPut200SucceededNoState(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -707,7 +704,7 @@ func TestLROBeginPut200SucceededNoState(t *testing.T) {
 
 // TODO check if this test should actually be returning a 200 or a 204
 func TestLROBeginPut200UpdatingSucceeded204(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPut200UpdatingSucceeded204(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -738,7 +735,7 @@ func TestLROBeginPut200UpdatingSucceeded204(t *testing.T) {
 }
 
 func TestLROBeginPut201CreatingFailed200(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPut201CreatingFailed200(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -766,7 +763,7 @@ func TestLROBeginPut201CreatingFailed200(t *testing.T) {
 }
 
 func TestLROBeginPut201CreatingSucceeded200(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPut201CreatingSucceeded200(context.Background(), &lrogroup.LrOSPut201CreatingSucceeded200Options{Product: &lrogroup.Product{}})
 	if err != nil {
 		t.Fatal(err)
@@ -797,7 +794,7 @@ func TestLROBeginPut201CreatingSucceeded200(t *testing.T) {
 }
 
 func TestLROBeginPut202Retry200(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPut202Retry200(context.Background(), &lrogroup.LrOSPut202Retry200Options{Product: &lrogroup.Product{}})
 	if err != nil {
 		t.Fatal(err)
@@ -825,7 +822,7 @@ func TestLROBeginPut202Retry200(t *testing.T) {
 }
 
 func TestLROBeginPutAsyncNoHeaderInRetry(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPutAsyncNoHeaderInRetry(context.Background(), &lrogroup.LrOSPutAsyncNoHeaderInRetryOptions{Product: &lrogroup.Product{}})
 	if err != nil {
 		t.Fatal(err)
@@ -856,7 +853,7 @@ func TestLROBeginPutAsyncNoHeaderInRetry(t *testing.T) {
 }
 
 func TestLROBeginPutAsyncNoRetrySucceeded(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPutAsyncNoRetrySucceeded(context.Background(), &lrogroup.LrOSPutAsyncNoRetrySucceededOptions{Product: &lrogroup.Product{}})
 	if err != nil {
 		t.Fatal(err)
@@ -887,7 +884,7 @@ func TestLROBeginPutAsyncNoRetrySucceeded(t *testing.T) {
 }
 
 func TestLROBeginPutAsyncNoRetrycanceled(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPutAsyncNoRetrycanceled(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -915,7 +912,7 @@ func TestLROBeginPutAsyncNoRetrycanceled(t *testing.T) {
 }
 
 func TestLROBeginPutAsyncNonResource(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPutAsyncNonResource(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -941,7 +938,7 @@ func TestLROBeginPutAsyncNonResource(t *testing.T) {
 }
 
 func TestLROBeginPutAsyncRetryFailed(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPutAsyncRetryFailed(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -969,7 +966,7 @@ func TestLROBeginPutAsyncRetryFailed(t *testing.T) {
 }
 
 func TestLROBeginPutAsyncRetrySucceeded(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPutAsyncRetrySucceeded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1000,7 +997,7 @@ func TestLROBeginPutAsyncRetrySucceeded(t *testing.T) {
 }
 
 func TestLROBeginPutAsyncSubResource(t *testing.T) {
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPutAsyncSubResource(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1031,7 +1028,7 @@ func TestLROBeginPutAsyncSubResource(t *testing.T) {
 
 func TestLROBeginPutNoHeaderInRetry(t *testing.T) {
 	t.Skip("problem with put flow")
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPutNoHeaderInRetry(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1062,7 +1059,7 @@ func TestLROBeginPutNoHeaderInRetry(t *testing.T) {
 
 func TestLROBeginPutNonResource(t *testing.T) {
 	t.Skip("problem with put flow")
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPutNonResource(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1089,7 +1086,7 @@ func TestLROBeginPutNonResource(t *testing.T) {
 
 func TestLROBeginPutSubResource(t *testing.T) {
 	t.Skip("problem with put flow")
-	op := getLROSOperations(t)
+	op := getLROSOperations()
 	resp, err := op.BeginPutSubResource(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/lrogroup/lrosadsheader_test.go
+++ b/test/autorest/lrogroup/lrosadsheader_test.go
@@ -11,19 +11,16 @@ import (
 	"time"
 )
 
-func getLrosaDsOperations(t *testing.T) lrogroup.LrosaDsOperations {
+func getLrosaDsOperations() lrogroup.LrosaDsOperations {
 	options := lrogroup.DefaultClientOptions()
 	options.Retry.RetryDelay = 10 * time.Millisecond
 	options.HTTPClient = httpClientWithCookieJar()
-	client, err := lrogroup.NewDefaultClient(&options)
-	if err != nil {
-		t.Fatalf("failed to create lro client: %v", err)
-	}
+	client := lrogroup.NewDefaultClient(&options)
 	return client.LrosaDsOperations()
 }
 
 func TestLROSADSBeginDelete202NonRetry400(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginDelete202NonRetry400(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -47,7 +44,7 @@ func TestLROSADSBeginDelete202NonRetry400(t *testing.T) {
 }
 
 func TestLROSADSBeginDelete202RetryInvalidHeader(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	_, err := op.BeginDelete202RetryInvalidHeader(context.Background())
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -55,7 +52,7 @@ func TestLROSADSBeginDelete202RetryInvalidHeader(t *testing.T) {
 }
 
 func TestLROSADSBeginDelete204Succeeded(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginDelete204Succeeded(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -76,7 +73,7 @@ func TestLROSADSBeginDelete204Succeeded(t *testing.T) {
 }
 
 func TestLROSADSBeginDeleteAsyncRelativeRetry400(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginDeleteAsyncRelativeRetry400(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +97,7 @@ func TestLROSADSBeginDeleteAsyncRelativeRetry400(t *testing.T) {
 }
 
 func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidHeader(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	_, err := op.BeginDeleteAsyncRelativeRetryInvalidHeader(context.Background())
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -108,7 +105,7 @@ func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidHeader(t *testing.T) {
 }
 
 func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginDeleteAsyncRelativeRetryInvalidJSONPolling(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -132,7 +129,7 @@ func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 }
 
 func TestLROSADSBeginDeleteAsyncRelativeRetryNoStatus(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginDeleteAsyncRelativeRetryNoStatus(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -156,7 +153,7 @@ func TestLROSADSBeginDeleteAsyncRelativeRetryNoStatus(t *testing.T) {
 }
 
 func TestLROSADSBeginDeleteNonRetry400(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	_, err := op.BeginDeleteNonRetry400(context.Background())
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -164,7 +161,7 @@ func TestLROSADSBeginDeleteNonRetry400(t *testing.T) {
 }
 
 func TestLROSADSBeginPost202NoLocation(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	_, err := op.BeginPost202NoLocation(context.Background(), nil)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -172,7 +169,7 @@ func TestLROSADSBeginPost202NoLocation(t *testing.T) {
 }
 
 func TestLROSADSBeginPost202NonRetry400(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginPost202NonRetry400(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -196,7 +193,7 @@ func TestLROSADSBeginPost202NonRetry400(t *testing.T) {
 }
 
 func TestLROSADSBeginPost202RetryInvalidHeader(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	_, err := op.BeginPost202RetryInvalidHeader(context.Background(), nil)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -204,7 +201,7 @@ func TestLROSADSBeginPost202RetryInvalidHeader(t *testing.T) {
 }
 
 func TestLROSADSBeginPostAsyncRelativeRetry400(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginPostAsyncRelativeRetry400(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -228,7 +225,7 @@ func TestLROSADSBeginPostAsyncRelativeRetry400(t *testing.T) {
 }
 
 func TestLROSADSBeginPostAsyncRelativeRetryInvalidHeader(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	_, err := op.BeginPostAsyncRelativeRetryInvalidHeader(context.Background(), nil)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -236,7 +233,7 @@ func TestLROSADSBeginPostAsyncRelativeRetryInvalidHeader(t *testing.T) {
 }
 
 func TestLROSADSBeginPostAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginPostAsyncRelativeRetryInvalidJSONPolling(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -260,7 +257,7 @@ func TestLROSADSBeginPostAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 }
 
 func TestLROSADSBeginPostAsyncRelativeRetryNoPayload(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginPostAsyncRelativeRetryNoPayload(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -284,7 +281,7 @@ func TestLROSADSBeginPostAsyncRelativeRetryNoPayload(t *testing.T) {
 }
 
 func TestLROSADSBeginPostNonRetry400(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	_, err := op.BeginPostNonRetry400(context.Background(), nil)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -292,7 +289,7 @@ func TestLROSADSBeginPostNonRetry400(t *testing.T) {
 }
 
 func TestLROSADSBeginPut200InvalidJSON(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	_, err := op.BeginPut200InvalidJSON(context.Background(), nil)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -300,7 +297,7 @@ func TestLROSADSBeginPut200InvalidJSON(t *testing.T) {
 }
 
 func TestLROSADSBeginPutAsyncRelativeRetry400(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginPutAsyncRelativeRetry400(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -324,7 +321,7 @@ func TestLROSADSBeginPutAsyncRelativeRetry400(t *testing.T) {
 }
 
 func TestLROSADSBeginPutAsyncRelativeRetryInvalidHeader(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	_, err := op.BeginPutAsyncRelativeRetryInvalidHeader(context.Background(), nil)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
@@ -332,7 +329,7 @@ func TestLROSADSBeginPutAsyncRelativeRetryInvalidHeader(t *testing.T) {
 }
 
 func TestLROSADSBeginPutAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginPutAsyncRelativeRetryInvalidJSONPolling(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -356,7 +353,7 @@ func TestLROSADSBeginPutAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 }
 
 func TestLROSADSBeginPutAsyncRelativeRetryNoStatus(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginPutAsyncRelativeRetryNoStatus(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -380,7 +377,7 @@ func TestLROSADSBeginPutAsyncRelativeRetryNoStatus(t *testing.T) {
 }
 
 func TestLROSADSBeginPutAsyncRelativeRetryNoStatusPayload(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginPutAsyncRelativeRetryNoStatusPayload(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -404,7 +401,7 @@ func TestLROSADSBeginPutAsyncRelativeRetryNoStatusPayload(t *testing.T) {
 }
 
 func TestLROSADSBeginPutError201NoProvisioningStatePayload(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginPutError201NoProvisioningStatePayload(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -428,7 +425,7 @@ func TestLROSADSBeginPutError201NoProvisioningStatePayload(t *testing.T) {
 }
 
 func TestLROSADSBeginPutNonRetry201Creating400(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginPutNonRetry201Creating400(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -452,7 +449,7 @@ func TestLROSADSBeginPutNonRetry201Creating400(t *testing.T) {
 }
 
 func TestLROSADSBeginPutNonRetry201Creating400InvalidJSON(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	resp, err := op.BeginPutNonRetry201Creating400InvalidJSON(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -476,7 +473,7 @@ func TestLROSADSBeginPutNonRetry201Creating400InvalidJSON(t *testing.T) {
 }
 
 func TestLROSADSBeginPutNonRetry400(t *testing.T) {
-	op := getLrosaDsOperations(t)
+	op := getLrosaDsOperations()
 	_, err := op.BeginPutNonRetry400(context.Background(), nil)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")

--- a/test/autorest/lrogroup/lroscustomheader_test.go
+++ b/test/autorest/lrogroup/lroscustomheader_test.go
@@ -15,14 +15,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getLrOSCustomHeaderOperations(t *testing.T) lrogroup.LrOSCustomHeaderOperations {
+func getLrOSCustomHeaderOperations() lrogroup.LrOSCustomHeaderOperations {
 	options := lrogroup.DefaultClientOptions()
 	options.Retry.RetryDelay = 10 * time.Millisecond
 	options.HTTPClient = httpClientWithCookieJar()
-	client, err := lrogroup.NewDefaultClient(&options)
-	if err != nil {
-		t.Fatalf("failed to create lro client: %v", err)
-	}
+	client := lrogroup.NewDefaultClient(&options)
 	return client.LrOSCustomHeaderOperations()
 }
 
@@ -34,7 +31,7 @@ func ctxWithHTTPHeader() context.Context {
 
 // BeginPost202Retry200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
 func TestBeginPost202Retry200(t *testing.T) {
-	op := getLrOSCustomHeaderOperations(t)
+	op := getLrOSCustomHeaderOperations()
 	env, err := op.BeginPost202Retry200(ctxWithHTTPHeader(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -66,7 +63,7 @@ func TestBeginPost202Retry200(t *testing.T) {
 
 // BeginPostAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func TestBeginPostAsyncRetrySucceeded(t *testing.T) {
-	op := getLrOSCustomHeaderOperations(t)
+	op := getLrOSCustomHeaderOperations()
 	env, err := op.BeginPostAsyncRetrySucceeded(ctxWithHTTPHeader(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -98,7 +95,7 @@ func TestBeginPostAsyncRetrySucceeded(t *testing.T) {
 
 // BeginPut201CreatingSucceeded200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
 func TestBeginPut201CreatingSucceeded200(t *testing.T) {
-	op := getLrOSCustomHeaderOperations(t)
+	op := getLrOSCustomHeaderOperations()
 	env, err := op.BeginPut201CreatingSucceeded200(ctxWithHTTPHeader(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -138,7 +135,7 @@ func TestBeginPut201CreatingSucceeded200(t *testing.T) {
 
 // BeginPutAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func TestBeginPutAsyncRetrySucceeded(t *testing.T) {
-	op := getLrOSCustomHeaderOperations(t)
+	op := getLrOSCustomHeaderOperations()
 	env, err := op.BeginPutAsyncRetrySucceeded(ctxWithHTTPHeader(), nil)
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/migroup/migroup_test.go
+++ b/test/autorest/migroup/migroup_test.go
@@ -12,17 +12,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getMultipleInheritanceServiceClientOperations(t *testing.T) migroup.MultipleInheritanceServiceClientOperations {
-	client, err := migroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.MultipleInheritanceServiceClientOperations()
-}
-
 // GetCat - Get a cat with name 'Whiskers' where likesMilk, meows, and hisses is true
 func TestGetCat(t *testing.T) {
-	client := getMultipleInheritanceServiceClientOperations(t)
+	client := migroup.NewDefaultClient(nil).MultipleInheritanceServiceClientOperations()
 	result, err := client.GetCat(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -41,7 +33,7 @@ func TestGetCat(t *testing.T) {
 
 // GetFeline - Get a feline where meows and hisses are true
 func TestGetFeline(t *testing.T) {
-	client := getMultipleInheritanceServiceClientOperations(t)
+	client := migroup.NewDefaultClient(nil).MultipleInheritanceServiceClientOperations()
 	result, err := client.GetFeline(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -54,7 +46,7 @@ func TestGetFeline(t *testing.T) {
 
 // GetHorse - Get a horse with name 'Fred' and isAShowHorse true
 func TestGetHorse(t *testing.T) {
-	client := getMultipleInheritanceServiceClientOperations(t)
+	client := migroup.NewDefaultClient(nil).MultipleInheritanceServiceClientOperations()
 	result, err := client.GetHorse(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -69,7 +61,7 @@ func TestGetHorse(t *testing.T) {
 
 // GetKitten - Get a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet is false
 func TestGetKitten(t *testing.T) {
-	client := getMultipleInheritanceServiceClientOperations(t)
+	client := migroup.NewDefaultClient(nil).MultipleInheritanceServiceClientOperations()
 	result, err := client.GetKitten(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -91,7 +83,7 @@ func TestGetKitten(t *testing.T) {
 
 // GetPet - Get a pet with name 'Peanut'
 func TestGetPet(t *testing.T) {
-	client := getMultipleInheritanceServiceClientOperations(t)
+	client := migroup.NewDefaultClient(nil).MultipleInheritanceServiceClientOperations()
 	result, err := client.GetPet(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -103,7 +95,7 @@ func TestGetPet(t *testing.T) {
 
 // PutCat - Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true
 func TestPutCat(t *testing.T) {
-	client := getMultipleInheritanceServiceClientOperations(t)
+	client := migroup.NewDefaultClient(nil).MultipleInheritanceServiceClientOperations()
 	result, err := client.PutCat(context.Background(), migroup.Cat{
 		Feline: migroup.Feline{
 			Hisses: to.BoolPtr(false),
@@ -122,7 +114,7 @@ func TestPutCat(t *testing.T) {
 
 // PutFeline - Put a feline who hisses and doesn't meow
 func TestPutFeline(t *testing.T) {
-	client := getMultipleInheritanceServiceClientOperations(t)
+	client := migroup.NewDefaultClient(nil).MultipleInheritanceServiceClientOperations()
 	result, err := client.PutFeline(context.Background(), migroup.Feline{
 		Hisses: to.BoolPtr(true),
 		Meows:  to.BoolPtr(false),
@@ -135,7 +127,7 @@ func TestPutFeline(t *testing.T) {
 
 // PutHorse - Put a horse with name 'General' and isAShowHorse false
 func TestPutHorse(t *testing.T) {
-	client := getMultipleInheritanceServiceClientOperations(t)
+	client := migroup.NewDefaultClient(nil).MultipleInheritanceServiceClientOperations()
 	result, err := client.PutHorse(context.Background(), migroup.Horse{
 		Pet: migroup.Pet{
 			Name: to.StringPtr("General"),
@@ -150,7 +142,7 @@ func TestPutHorse(t *testing.T) {
 
 // PutKitten - Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is true
 func TestPutKitten(t *testing.T) {
-	client := getMultipleInheritanceServiceClientOperations(t)
+	client := migroup.NewDefaultClient(nil).MultipleInheritanceServiceClientOperations()
 	result, err := client.PutKitten(context.Background(), migroup.Kitten{
 		Cat: migroup.Cat{
 			Feline: migroup.Feline{
@@ -172,7 +164,7 @@ func TestPutKitten(t *testing.T) {
 
 // PutPet - Put a pet with name 'Butter'
 func TestPutPet(t *testing.T) {
-	client := getMultipleInheritanceServiceClientOperations(t)
+	client := migroup.NewDefaultClient(nil).MultipleInheritanceServiceClientOperations()
 	result, err := client.PutPet(context.Background(), migroup.Pet{
 		Name: to.StringPtr("Butter"),
 	})

--- a/test/autorest/morecustombaseurigroup/paths_test.go
+++ b/test/autorest/morecustombaseurigroup/paths_test.go
@@ -13,17 +13,14 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getMoreCustomBaseURIClient(t *testing.T) morecustombaseurigroup.PathsOperations {
-	client, err := morecustombaseurigroup.NewClient(to.StringPtr(":3000"), nil)
-	if err != nil {
-		t.Fatalf("failed to create more custom base URL client: %v", err)
-	}
+func getMoreCustomBaseURIClient() morecustombaseurigroup.PathsOperations {
+	client := morecustombaseurigroup.NewClient(to.StringPtr(":3000"), nil)
 	// dnsSuffix string, subscriptionID string
 	return client.PathsOperations("test12")
 }
 
 func TestGetEmpty(t *testing.T) {
-	client := getMoreCustomBaseURIClient(t)
+	client := getMoreCustomBaseURIClient()
 	// vault string, secret string, keyName string, options *PathsGetEmptyOptions
 	result, err := client.GetEmpty(context.Background(), "http://localhost", "", "key1", &morecustombaseurigroup.PathsGetEmptyOptions{
 		KeyVersion: to.StringPtr("v1"),

--- a/test/autorest/nonstringenumgroup/float_test.go
+++ b/test/autorest/nonstringenumgroup/float_test.go
@@ -11,17 +11,9 @@ import (
 	"testing"
 )
 
-func getFloatOperations(t *testing.T) nonstringenumgroup.FloatOperations {
-	client, err := nonstringenumgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return client.FloatOperations()
-}
-
 // Get - Get a float enum
 func TestFloatGet(t *testing.T) {
-	client := getFloatOperations(t)
+	client := nonstringenumgroup.NewDefaultClient(nil).FloatOperations()
 	result, err := client.Get(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -31,7 +23,7 @@ func TestFloatGet(t *testing.T) {
 
 // Put - Put a float enum
 func TestFloatPut(t *testing.T) {
-	client := getFloatOperations(t)
+	client := nonstringenumgroup.NewDefaultClient(nil).FloatOperations()
 	result, err := client.Put(context.Background(), &nonstringenumgroup.FloatPutOptions{
 		Input: nonstringenumgroup.FloatEnumTwoHundred4.ToPtr(),
 	})

--- a/test/autorest/nonstringenumgroup/int_test.go
+++ b/test/autorest/nonstringenumgroup/int_test.go
@@ -11,17 +11,9 @@ import (
 	"testing"
 )
 
-func getIntOperations(t *testing.T) nonstringenumgroup.IntOperations {
-	client, err := nonstringenumgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return client.IntOperations()
-}
-
 // Get - Get an int enum
 func TestIntGet(t *testing.T) {
-	client := getIntOperations(t)
+	client := nonstringenumgroup.NewDefaultClient(nil).IntOperations()
 	result, err := client.Get(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -31,7 +23,7 @@ func TestIntGet(t *testing.T) {
 
 // Put - Put an int enum
 func TestIntPut(t *testing.T) {
-	client := getIntOperations(t)
+	client := nonstringenumgroup.NewDefaultClient(nil).IntOperations()
 	result, err := client.Put(context.Background(), &nonstringenumgroup.IntPutOptions{
 		Input: nonstringenumgroup.IntEnumTwoHundred.ToPtr(),
 	})

--- a/test/autorest/numbergroup/numbergroup_test.go
+++ b/test/autorest/numbergroup/numbergroup_test.go
@@ -11,16 +11,8 @@ import (
 	"testing"
 )
 
-func getNumberClient(t *testing.T) numbergroup.NumberOperations {
-	client, err := numbergroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create number client: %v", err)
-	}
-	return client.NumberOperations()
-}
-
 func TestNumberGetBigDecimal(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.GetBigDecimal(context.Background())
 	if err != nil {
 		t.Fatalf("GetBigDecimal: %v", err)
@@ -31,7 +23,7 @@ func TestNumberGetBigDecimal(t *testing.T) {
 }
 
 func TestNumberGetBigDecimalNegativeDecimal(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.GetBigDecimalNegativeDecimal(context.Background())
 	if err != nil {
 		t.Fatalf("GetBigDecimalNegativeDecimal: %v", err)
@@ -42,7 +34,7 @@ func TestNumberGetBigDecimalNegativeDecimal(t *testing.T) {
 }
 
 func TestNumberGetBigDecimalPositiveDecimal(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.GetBigDecimalPositiveDecimal(context.Background())
 	if err != nil {
 		t.Fatalf("GetBigDecimalPositiveDecimal: %v", err)
@@ -53,7 +45,7 @@ func TestNumberGetBigDecimalPositiveDecimal(t *testing.T) {
 }
 
 func TestNumberGetBigDouble(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.GetBigDouble(context.Background())
 	if err != nil {
 		t.Fatalf("GetBigDouble: %v", err)
@@ -64,7 +56,7 @@ func TestNumberGetBigDouble(t *testing.T) {
 }
 
 func TestNumberGetBigDoubleNegativeDecimal(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.GetBigDoubleNegativeDecimal(context.Background())
 	if err != nil {
 		t.Fatalf("GetBigDoubleNegativeDecimal: %v", err)
@@ -75,7 +67,7 @@ func TestNumberGetBigDoubleNegativeDecimal(t *testing.T) {
 }
 
 func TestNumberGetBigDoublePositiveDecimal(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.GetBigDoublePositiveDecimal(context.Background())
 	if err != nil {
 		t.Fatalf("GetBigDoublePositiveDecimal: %v", err)
@@ -86,7 +78,7 @@ func TestNumberGetBigDoublePositiveDecimal(t *testing.T) {
 }
 
 func TestNumberGetBigFloat(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.GetBigFloat(context.Background())
 	if err != nil {
 		t.Fatalf("GetBigFloat: %v", err)
@@ -97,7 +89,7 @@ func TestNumberGetBigFloat(t *testing.T) {
 }
 
 func TestNumberGetInvalidDecimal(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.GetInvalidDecimal(context.Background())
 	if err == nil {
 		t.Fatalf("unexpected nil error")
@@ -108,7 +100,7 @@ func TestNumberGetInvalidDecimal(t *testing.T) {
 }
 
 func TestNumberGetInvalidDouble(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.GetInvalidDouble(context.Background())
 	if err == nil {
 		t.Fatalf("unexpected nil error")
@@ -119,7 +111,7 @@ func TestNumberGetInvalidDouble(t *testing.T) {
 }
 
 func TestNumberGetInvalidFloat(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.GetInvalidFloat(context.Background())
 	if err == nil {
 		t.Fatalf("unexpected nil error")
@@ -130,7 +122,7 @@ func TestNumberGetInvalidFloat(t *testing.T) {
 }
 
 func TestNumberGetNull(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.GetNull(context.Background())
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
@@ -140,7 +132,7 @@ func TestNumberGetNull(t *testing.T) {
 }
 
 func TestNumberGetSmallDecimal(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.GetSmallDecimal(context.Background())
 	if err != nil {
 		t.Fatalf("GetSmallDecimal: %v", err)
@@ -151,7 +143,7 @@ func TestNumberGetSmallDecimal(t *testing.T) {
 }
 
 func TestNumberGetSmallDouble(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.GetSmallDouble(context.Background())
 	if err != nil {
 		t.Fatalf("GetSmallDouble: %v", err)
@@ -162,7 +154,7 @@ func TestNumberGetSmallDouble(t *testing.T) {
 }
 
 func TestNumberGetSmallFloat(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.GetSmallFloat(context.Background())
 	if err != nil {
 		t.Fatalf("GetSmallFloat: %v", err)
@@ -173,7 +165,7 @@ func TestNumberGetSmallFloat(t *testing.T) {
 }
 
 func TestNumberPutBigDecimal(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.PutBigDecimal(context.Background(), 2.5976931e+101)
 	if err != nil {
 		t.Fatalf("PutBigDecimal: %v", err)
@@ -182,7 +174,7 @@ func TestNumberPutBigDecimal(t *testing.T) {
 }
 
 func TestNumberPutBigDecimalNegativeDecimal(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.PutBigDecimalNegativeDecimal(context.Background())
 	if err != nil {
 		t.Fatalf("PutBigDecimalNegativeDecimal: %v", err)
@@ -191,7 +183,7 @@ func TestNumberPutBigDecimalNegativeDecimal(t *testing.T) {
 }
 
 func TestNumberPutBigDecimalPositiveDecimal(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.PutBigDecimalPositiveDecimal(context.Background())
 	if err != nil {
 		t.Fatalf("PutBigDecimalPositiveDecimal: %v", err)
@@ -200,7 +192,7 @@ func TestNumberPutBigDecimalPositiveDecimal(t *testing.T) {
 }
 
 func TestNumberPutBigDouble(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.PutBigDouble(context.Background(), 2.5976931e+101)
 	if err != nil {
 		t.Fatalf("PutBigDouble: %v", err)
@@ -209,7 +201,7 @@ func TestNumberPutBigDouble(t *testing.T) {
 }
 
 func TestNumberPutBigDoubleNegativeDecimal(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.PutBigDoubleNegativeDecimal(context.Background())
 	if err != nil {
 		t.Fatalf("PutBigDoubleNegativeDecimal: %v", err)
@@ -218,7 +210,7 @@ func TestNumberPutBigDoubleNegativeDecimal(t *testing.T) {
 }
 
 func TestNumberPutBigDoublePositiveDecimal(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.PutBigDoublePositiveDecimal(context.Background())
 	if err != nil {
 		t.Fatalf("PutBigDeoublePositiveDecimal: %v", err)
@@ -227,7 +219,7 @@ func TestNumberPutBigDoublePositiveDecimal(t *testing.T) {
 }
 
 func TestNumberPutBigFloat(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.PutBigFloat(context.Background(), 3.402823e+20)
 	if err != nil {
 		t.Fatalf("PutBigFloat: %v", err)
@@ -236,7 +228,7 @@ func TestNumberPutBigFloat(t *testing.T) {
 }
 
 func TestNumberPutSmallDecimal(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.PutSmallDecimal(context.Background(), 2.5976931e-101)
 	if err != nil {
 		t.Fatalf("PutSmallDecimal: %v", err)
@@ -245,7 +237,7 @@ func TestNumberPutSmallDecimal(t *testing.T) {
 }
 
 func TestNumberPutSmallDouble(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.PutSmallDouble(context.Background(), 2.5976931e-101)
 	if err != nil {
 		t.Fatalf("PutSmallDouble: %v", err)
@@ -254,7 +246,7 @@ func TestNumberPutSmallDouble(t *testing.T) {
 }
 
 func TestNumberPutSmallFloat(t *testing.T) {
-	client := getNumberClient(t)
+	client := numbergroup.NewDefaultClient(nil).NumberOperations()
 	result, err := client.PutSmallFloat(context.Background(), 3.402823e-20)
 	if err != nil {
 		t.Fatalf("PutSmallFloat: %v", err)

--- a/test/autorest/optionalgroup/explicit_test.go
+++ b/test/autorest/optionalgroup/explicit_test.go
@@ -11,16 +11,8 @@ import (
 	"testing"
 )
 
-func getExplicitClient(t *testing.T) optionalgroup.ExplicitOperations {
-	client, err := optionalgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create explicit client: %v", err)
-	}
-	return client.ExplicitOperations()
-}
-
 func TestExplicitPostOptionalArrayHeader(t *testing.T) {
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostOptionalArrayHeader(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PostOptionalArrayHeader: %v", err)
@@ -29,7 +21,7 @@ func TestExplicitPostOptionalArrayHeader(t *testing.T) {
 }
 
 func TestExplicitPostOptionalArrayParameter(t *testing.T) {
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostOptionalArrayParameter(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PostOptionalArrayParameter: %v", err)
@@ -38,7 +30,7 @@ func TestExplicitPostOptionalArrayParameter(t *testing.T) {
 }
 
 func TestExplicitPostOptionalArrayProperty(t *testing.T) {
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostOptionalArrayProperty(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PostOptionalArrayProperty: %v", err)
@@ -47,7 +39,7 @@ func TestExplicitPostOptionalArrayProperty(t *testing.T) {
 }
 
 func TestExplicitPostOptionalClassParameter(t *testing.T) {
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostOptionalClassParameter(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PostOptionalClassParameter: %v", err)
@@ -56,7 +48,7 @@ func TestExplicitPostOptionalClassParameter(t *testing.T) {
 }
 
 func TestExplicitPostOptionalClassProperty(t *testing.T) {
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostOptionalClassProperty(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PostOptionalClassProperty: %v", err)
@@ -65,7 +57,7 @@ func TestExplicitPostOptionalClassProperty(t *testing.T) {
 }
 
 func TestExplicitPostOptionalIntegerHeader(t *testing.T) {
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostOptionalIntegerHeader(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PostOptionalIntegerHeader: %v", err)
@@ -74,7 +66,7 @@ func TestExplicitPostOptionalIntegerHeader(t *testing.T) {
 }
 
 func TestExplicitPostOptionalIntegerParameter(t *testing.T) {
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostOptionalIntegerParameter(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PostOptionalIntegerParameter: %v", err)
@@ -83,7 +75,7 @@ func TestExplicitPostOptionalIntegerParameter(t *testing.T) {
 }
 
 func TestExplicitPostOptionalIntegerProperty(t *testing.T) {
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostOptionalIntegerProperty(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PostOptionalIntegerProperty: %v", err)
@@ -92,7 +84,7 @@ func TestExplicitPostOptionalIntegerProperty(t *testing.T) {
 }
 
 func TestExplicitPostOptionalStringHeader(t *testing.T) {
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostOptionalStringHeader(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PostOptionalStringHeader: %v", err)
@@ -101,7 +93,7 @@ func TestExplicitPostOptionalStringHeader(t *testing.T) {
 }
 
 func TestExplicitPostOptionalStringParameter(t *testing.T) {
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostOptionalStringParameter(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PostOptionalStringParameter: %v", err)
@@ -110,7 +102,7 @@ func TestExplicitPostOptionalStringParameter(t *testing.T) {
 }
 
 func TestExplicitPostOptionalStringProperty(t *testing.T) {
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostOptionalStringProperty(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PostOptionalStringProperty: %v", err)
@@ -121,7 +113,7 @@ func TestExplicitPostOptionalStringProperty(t *testing.T) {
 // TODO the goal of this test is to throw an exception but nils are acceptable for  []strings in go
 func TestExplicitPostRequiredArrayHeader(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostRequiredArrayHeader(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -134,7 +126,7 @@ func TestExplicitPostRequiredArrayHeader(t *testing.T) {
 // TODO the goal of this test is to throw an exception but nils are acceptable for  []strings in go
 func TestExplicitPostRequiredArrayParameter(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostRequiredArrayParameter(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -146,7 +138,7 @@ func TestExplicitPostRequiredArrayParameter(t *testing.T) {
 
 func TestExplicitPostRequiredArrayProperty(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostRequiredArrayProperty(context.Background(), optionalgroup.ArrayWrapper{Value: nil})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -159,7 +151,7 @@ func TestExplicitPostRequiredArrayProperty(t *testing.T) {
 // TODO check this test
 func TestExplicitPostRequiredClassParameter(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostRequiredClassParameter(context.Background(), optionalgroup.Product{})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -171,7 +163,7 @@ func TestExplicitPostRequiredClassParameter(t *testing.T) {
 
 func TestExplicitPostRequiredClassProperty(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostRequiredClassProperty(context.Background(), optionalgroup.ClassWrapper{})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -184,7 +176,7 @@ func TestExplicitPostRequiredClassProperty(t *testing.T) {
 // TODO check this test is does pass if we query the endpoint but that is not the expected behavior
 func TestExplicitPostRequiredIntegerHeader(t *testing.T) {
 	t.Skip("cannot set nil for int32 in Go")
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostRequiredIntegerHeader(context.Background(), 0)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -197,7 +189,7 @@ func TestExplicitPostRequiredIntegerHeader(t *testing.T) {
 // TODO check this test is does pass if we query the endpoint but that is not the expected behavior
 func TestExplicitPostRequiredIntegerParameter(t *testing.T) {
 	t.Skip("cannot set nil for int32 in Go")
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostRequiredIntegerParameter(context.Background(), 0)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -210,7 +202,7 @@ func TestExplicitPostRequiredIntegerParameter(t *testing.T) {
 // TODO check this test is does pass if we query the endpoint but that is not the expected behavior
 func TestExplicitPostRequiredIntegerProperty(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostRequiredIntegerProperty(context.Background(), optionalgroup.IntWrapper{})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -223,7 +215,7 @@ func TestExplicitPostRequiredIntegerProperty(t *testing.T) {
 // TODO check this test is does pass if we query the endpoint but that is not the expected behavior
 func TestExplicitPostRequiredStringHeader(t *testing.T) {
 	t.Skip("cannot set nil for string in Go")
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostRequiredStringHeader(context.Background(), "")
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -236,7 +228,7 @@ func TestExplicitPostRequiredStringHeader(t *testing.T) {
 // TODO check this test is does pass if we query the endpoint but that is not the expected behavior
 func TestExplicitPostRequiredStringParameter(t *testing.T) {
 	t.Skip("cannot set nil for string in Go")
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostRequiredStringParameter(context.Background(), "")
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
@@ -249,7 +241,7 @@ func TestExplicitPostRequiredStringParameter(t *testing.T) {
 // TODO check this test is does pass if we query the endpoint but that is not the expected behavior
 func TestExplicitPostRequiredStringProperty(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
-	client := getExplicitClient(t)
+	client := optionalgroup.NewDefaultClient(nil).ExplicitOperations()
 	result, err := client.PostRequiredStringProperty(context.Background(), optionalgroup.StringWrapper{})
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")

--- a/test/autorest/optionalgroup/implicit_test.go
+++ b/test/autorest/optionalgroup/implicit_test.go
@@ -11,16 +11,13 @@ import (
 	"testing"
 )
 
-func getImplicitClient(t *testing.T) optionalgroup.ImplicitOperations {
-	client, err := optionalgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create implicit client: %v", err)
-	}
+func getImplicitClient() optionalgroup.ImplicitOperations {
+	client := optionalgroup.NewDefaultClient(nil)
 	return client.ImplicitOperations("", "", nil)
 }
 
 func TestImplicitGetOptionalGlobalQuery(t *testing.T) {
-	client := getImplicitClient(t)
+	client := getImplicitClient()
 	result, err := client.GetOptionalGlobalQuery(context.Background())
 	if err != nil {
 		t.Fatalf("GetOptionalGlobalQuery: %v", err)
@@ -30,7 +27,7 @@ func TestImplicitGetOptionalGlobalQuery(t *testing.T) {
 
 func TestImplicitGetRequiredGlobalPath(t *testing.T) {
 	t.Skip("Cannot set nil for string parameter so test invalid for Go")
-	client := getImplicitClient(t)
+	client := getImplicitClient()
 	result, err := client.GetRequiredGlobalPath(context.Background())
 	if err != nil {
 		t.Fatalf("GetRequiredGlobalPath: %v", err)
@@ -40,7 +37,7 @@ func TestImplicitGetRequiredGlobalPath(t *testing.T) {
 
 func TestImplicitGetRequiredGlobalQuery(t *testing.T) {
 	t.Skip("Cannot set nil for string parameter so test invalid for Go")
-	client := getImplicitClient(t)
+	client := getImplicitClient()
 	result, err := client.GetRequiredGlobalQuery(context.Background())
 	if err != nil {
 		t.Fatalf("GetRequiredGlobalQuery: %v", err)
@@ -50,7 +47,7 @@ func TestImplicitGetRequiredGlobalQuery(t *testing.T) {
 
 func TestImplicitGetRequiredPath(t *testing.T) {
 	t.Skip("Cannot set nil for string parameter so test invalid for Go")
-	client := getImplicitClient(t)
+	client := getImplicitClient()
 	result, err := client.GetRequiredPath(context.Background(), "")
 	if err != nil {
 		t.Fatalf("GetRequiredPath: %v", err)
@@ -59,7 +56,7 @@ func TestImplicitGetRequiredPath(t *testing.T) {
 }
 
 func TestImplicitPutOptionalBody(t *testing.T) {
-	client := getImplicitClient(t)
+	client := getImplicitClient()
 	result, err := client.PutOptionalBody(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PutOptionalBody: %v", err)
@@ -68,7 +65,7 @@ func TestImplicitPutOptionalBody(t *testing.T) {
 }
 
 func TestImplicitPutOptionalHeader(t *testing.T) {
-	client := getImplicitClient(t)
+	client := getImplicitClient()
 	result, err := client.PutOptionalHeader(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PutOptionalHeader: %v", err)
@@ -77,7 +74,7 @@ func TestImplicitPutOptionalHeader(t *testing.T) {
 }
 
 func TestImplicitPutOptionalQuery(t *testing.T) {
-	client := getImplicitClient(t)
+	client := getImplicitClient()
 	result, err := client.PutOptionalQuery(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PutOptionalQuery: %v", err)

--- a/test/autorest/paginggroup/paginggroup_test.go
+++ b/test/autorest/paginggroup/paginggroup_test.go
@@ -15,14 +15,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
-func getPagingOperations(t *testing.T) paginggroup.PagingOperations {
+func getPagingOperations() paginggroup.PagingOperations {
 	options := paginggroup.DefaultClientOptions()
 	options.Retry.RetryDelay = 10 * time.Millisecond
 	options.HTTPClient = httpClientWithCookieJar()
-	client, err := paginggroup.NewClient("http://localhost:3000", &options)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
+	client := paginggroup.NewDefaultClient(&options)
 	return client.PagingOperations()
 }
 
@@ -39,7 +36,7 @@ func httpClientWithCookieJar() azcore.Transport {
 
 // GetMultiplePages - A paging operation that includes a nextLink that has 10 pages
 func TestGetMultiplePages(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	page, err := client.GetMultiplePages(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -65,7 +62,7 @@ func TestGetMultiplePages(t *testing.T) {
 
 // GetMultiplePagesFailure - A paging operation that receives a 400 on the second call
 func TestGetMultiplePagesFailure(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	page, err := client.GetMultiplePagesFailure()
 	if err != nil {
 		t.Fatal(err)
@@ -91,7 +88,7 @@ func TestGetMultiplePagesFailure(t *testing.T) {
 
 // GetMultiplePagesFailureURI - A paging operation that receives an invalid nextLink
 func TestGetMultiplePagesFailureURI(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	page, err := client.GetMultiplePagesFailureURI()
 	if err != nil {
 		t.Fatal(err)
@@ -117,7 +114,7 @@ func TestGetMultiplePagesFailureURI(t *testing.T) {
 
 // GetMultiplePagesFragmentNextLink - A paging operation that doesn't return a full URL, just a fragment
 func TestGetMultiplePagesFragmentNextLink(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	page, err := client.GetMultiplePagesFragmentNextLink("1.6", "test_user")
 	if err != nil {
 		t.Fatal(err)
@@ -143,7 +140,7 @@ func TestGetMultiplePagesFragmentNextLink(t *testing.T) {
 
 // GetMultiplePagesFragmentWithGroupingNextLink - A paging operation that doesn't return a full URL, just a fragment with parameters grouped
 func TestGetMultiplePagesFragmentWithGroupingNextLink(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	page, err := client.GetMultiplePagesFragmentWithGroupingNextLink(paginggroup.CustomParameterGroup{
 		ApiVersion: "1.6",
 		Tenant:     "test_user",
@@ -172,7 +169,7 @@ func TestGetMultiplePagesFragmentWithGroupingNextLink(t *testing.T) {
 
 // GetMultiplePagesLro - A long-running paging operation that includes a nextLink that has 10 pages
 func TestGetMultiplePagesLro(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	resp, err := client.BeginGetMultiplePagesLro(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -209,7 +206,7 @@ func TestGetMultiplePagesLro(t *testing.T) {
 
 // GetMultiplePagesRetryFirst - A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages
 func TestGetMultiplePagesRetryFirst(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	page, err := client.GetMultiplePagesRetryFirst()
 	if err != nil {
 		t.Fatal(err)
@@ -235,7 +232,7 @@ func TestGetMultiplePagesRetryFirst(t *testing.T) {
 
 // GetMultiplePagesRetrySecond - A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
 func TestGetMultiplePagesRetrySecond(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	page, err := client.GetMultiplePagesRetrySecond()
 	if err != nil {
 		t.Fatal(err)
@@ -261,7 +258,7 @@ func TestGetMultiplePagesRetrySecond(t *testing.T) {
 
 // GetMultiplePagesWithOffset - A paging operation that includes a nextLink that has 10 pages
 func TestGetMultiplePagesWithOffset(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	page, err := client.GetMultiplePagesWithOffset(paginggroup.PagingGetMultiplePagesWithOffsetOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -287,7 +284,7 @@ func TestGetMultiplePagesWithOffset(t *testing.T) {
 
 // GetNoItemNamePages - A paging operation that must return result of the default 'value' node.
 func TestGetNoItemNamePages(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	page, err := client.GetNoItemNamePages()
 	if err != nil {
 		t.Fatal(err)
@@ -313,7 +310,7 @@ func TestGetNoItemNamePages(t *testing.T) {
 
 // GetNullNextLinkNamePages - A paging operation that must ignore any kind of nextLink, and stop after page 1.
 func TestGetNullNextLinkNamePages(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	resp, err := client.GetNullNextLinkNamePages(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -325,7 +322,7 @@ func TestGetNullNextLinkNamePages(t *testing.T) {
 
 // GetOdataMultiplePages - A paging operation that includes a nextLink in odata format that has 10 pages
 func TestGetOdataMultiplePages(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	page, err := client.GetOdataMultiplePages(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -351,7 +348,7 @@ func TestGetOdataMultiplePages(t *testing.T) {
 
 // GetPagingModelWithItemNameWithXmsClientName - A paging operation that returns a paging model whose item name is is overriden by x-ms-client-name 'indexes'.
 func TestGetPagingModelWithItemNameWithXmsClientName(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	page, err := client.GetPagingModelWithItemNameWithXmsClientName()
 	if err != nil {
 		t.Fatal(err)
@@ -377,7 +374,7 @@ func TestGetPagingModelWithItemNameWithXmsClientName(t *testing.T) {
 
 // GetSinglePages - A paging operation that finishes on the first call without a nextlink
 func TestGetSinglePages(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	page, err := client.GetSinglePages()
 	if err != nil {
 		t.Fatal(err)
@@ -403,7 +400,7 @@ func TestGetSinglePages(t *testing.T) {
 
 // GetSinglePagesFailure - A paging operation that receives a 400 on the first call
 func TestGetSinglePagesFailure(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	page, err := client.GetSinglePagesFailure()
 	if err != nil {
 		t.Fatal(err)
@@ -429,7 +426,7 @@ func TestGetSinglePagesFailure(t *testing.T) {
 
 // GetWithQueryParams - A paging operation that includes a next operation. It has a different query parameter from it's next operation nextOperationWithQueryParams. Returns a ProductResult
 func TestGetWithQueryParams(t *testing.T) {
-	client := getPagingOperations(t)
+	client := getPagingOperations()
 	page, err := client.GetWithQueryParams(100)
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/paramgroupinggroup/paramgroupinggroup_test.go
+++ b/test/autorest/paramgroupinggroup/paramgroupinggroup_test.go
@@ -11,17 +11,9 @@ import (
 	"testing"
 )
 
-func getParamGroupingOperations(t *testing.T) paramgroupinggroup.ParameterGroupingOperations {
-	client, err := paramgroupinggroup.NewClient("http://localhost:3000", nil)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return client.ParameterGroupingOperations()
-}
-
 // PostMultiParamGroups - Post parameters from multiple different parameter groups
 func TestPostMultiParamGroups(t *testing.T) {
-	client := getParamGroupingOperations(t)
+	client := paramgroupinggroup.NewDefaultClient(nil).ParameterGroupingOperations()
 	result, err := client.PostMultiParamGroups(context.Background(), nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -31,7 +23,7 @@ func TestPostMultiParamGroups(t *testing.T) {
 
 // PostOptional - Post a bunch of optional parameters grouped
 func TestPostOptional(t *testing.T) {
-	client := getParamGroupingOperations(t)
+	client := paramgroupinggroup.NewDefaultClient(nil).ParameterGroupingOperations()
 	result, err := client.PostOptional(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -41,7 +33,7 @@ func TestPostOptional(t *testing.T) {
 
 // PostRequired - Post a bunch of required parameters grouped
 func TestPostRequired(t *testing.T) {
-	client := getParamGroupingOperations(t)
+	client := paramgroupinggroup.NewDefaultClient(nil).ParameterGroupingOperations()
 	result, err := client.PostRequired(context.Background(), paramgroupinggroup.ParameterGroupingPostRequiredParameters{
 		Body:          1234,
 		PathParameter: "path",
@@ -54,7 +46,7 @@ func TestPostRequired(t *testing.T) {
 
 // PostSharedParameterGroupObject - Post parameters with a shared parameter group object
 func TestPostSharedParameterGroupObject(t *testing.T) {
-	client := getParamGroupingOperations(t)
+	client := paramgroupinggroup.NewDefaultClient(nil).ParameterGroupingOperations()
 	result, err := client.PostSharedParameterGroupObject(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/stringgroup/enum_test.go
+++ b/test/autorest/stringgroup/enum_test.go
@@ -11,16 +11,8 @@ import (
 	"testing"
 )
 
-func getEnumClient(t *testing.T) stringgroup.EnumOperations {
-	client, err := stringgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create enum client: %v", err)
-	}
-	return client.EnumOperations()
-}
-
 func TestEnumGetNotExpandable(t *testing.T) {
-	client := getEnumClient(t)
+	client := stringgroup.NewDefaultClient(nil).EnumOperations()
 	result, err := client.GetNotExpandable(context.Background())
 	if err != nil {
 		t.Fatalf("GetNotExpandable: %v", err)
@@ -30,7 +22,7 @@ func TestEnumGetNotExpandable(t *testing.T) {
 }
 
 func TestEnumGetReferenced(t *testing.T) {
-	client := getEnumClient(t)
+	client := stringgroup.NewDefaultClient(nil).EnumOperations()
 	result, err := client.GetReferenced(context.Background())
 	if err != nil {
 		t.Fatalf("GetReferenced: %v", err)
@@ -40,7 +32,7 @@ func TestEnumGetReferenced(t *testing.T) {
 }
 
 func TestEnumGetReferencedConstant(t *testing.T) {
-	client := getEnumClient(t)
+	client := stringgroup.NewDefaultClient(nil).EnumOperations()
 	result, err := client.GetReferencedConstant(context.Background())
 	if err != nil {
 		t.Fatalf("GetReferencedConstant: %v", err)
@@ -51,7 +43,7 @@ func TestEnumGetReferencedConstant(t *testing.T) {
 }
 
 func TestEnumPutNotExpandable(t *testing.T) {
-	client := getEnumClient(t)
+	client := stringgroup.NewDefaultClient(nil).EnumOperations()
 	result, err := client.PutNotExpandable(context.Background(), stringgroup.ColorsRedColor)
 	if err != nil {
 		t.Fatalf("PutNotExpandable: %v", err)
@@ -60,7 +52,7 @@ func TestEnumPutNotExpandable(t *testing.T) {
 }
 
 func TestEnumPutReferenced(t *testing.T) {
-	client := getEnumClient(t)
+	client := stringgroup.NewDefaultClient(nil).EnumOperations()
 	result, err := client.PutReferenced(context.Background(), stringgroup.ColorsRedColor)
 	if err != nil {
 		t.Fatalf("PutReferenced: %v", err)
@@ -69,7 +61,7 @@ func TestEnumPutReferenced(t *testing.T) {
 }
 
 func TestEnumPutReferencedConstant(t *testing.T) {
-	client := getEnumClient(t)
+	client := stringgroup.NewDefaultClient(nil).EnumOperations()
 	val := string(stringgroup.ColorsGreenColor)
 	result, err := client.PutReferencedConstant(context.Background(), stringgroup.RefColorConstant{ColorConstant: &val})
 	if err != nil {

--- a/test/autorest/stringgroup/string_test.go
+++ b/test/autorest/stringgroup/string_test.go
@@ -13,16 +13,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getStringClient(t *testing.T) stringgroup.StringOperations {
-	client, err := stringgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create string client: %v", err)
-	}
-	return client.StringOperations()
-}
-
 func TestStringGetMBCS(t *testing.T) {
-	client := getStringClient(t)
+	client := stringgroup.NewDefaultClient(nil).StringOperations()
 	result, err := client.GetMBCS(context.Background())
 	if err != nil {
 		t.Fatalf("GetMBCS: %v", err)
@@ -32,7 +24,7 @@ func TestStringGetMBCS(t *testing.T) {
 }
 
 func TestStringPutMBCS(t *testing.T) {
-	client := getStringClient(t)
+	client := stringgroup.NewDefaultClient(nil).StringOperations()
 	result, err := client.PutMBCS(context.Background())
 	if err != nil {
 		t.Fatalf("PutMBCS: %v", err)
@@ -41,7 +33,7 @@ func TestStringPutMBCS(t *testing.T) {
 }
 
 func TestStringGetBase64Encoded(t *testing.T) {
-	client := getStringClient(t)
+	client := stringgroup.NewDefaultClient(nil).StringOperations()
 	result, err := client.GetBase64Encoded(context.Background())
 	if err != nil {
 		t.Fatalf("GetBase64Encoded: %v", err)
@@ -52,7 +44,7 @@ func TestStringGetBase64Encoded(t *testing.T) {
 }
 
 func TestStringGetBase64URLEncoded(t *testing.T) {
-	client := getStringClient(t)
+	client := stringgroup.NewDefaultClient(nil).StringOperations()
 	result, err := client.GetBase64URLEncoded(context.Background())
 	if err != nil {
 		t.Fatalf("GetBase64URLEncoded: %v", err)
@@ -62,7 +54,7 @@ func TestStringGetBase64URLEncoded(t *testing.T) {
 }
 
 func TestStringGetEmpty(t *testing.T) {
-	client := getStringClient(t)
+	client := stringgroup.NewDefaultClient(nil).StringOperations()
 	result, err := client.GetEmpty(context.Background())
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
@@ -72,7 +64,7 @@ func TestStringGetEmpty(t *testing.T) {
 }
 
 func TestStringGetNotProvided(t *testing.T) {
-	client := getStringClient(t)
+	client := stringgroup.NewDefaultClient(nil).StringOperations()
 	result, err := client.GetNotProvided(context.Background())
 	if err != nil {
 		t.Fatalf("GetNotProvided: %v", err)
@@ -81,7 +73,7 @@ func TestStringGetNotProvided(t *testing.T) {
 }
 
 func TestStringGetNull(t *testing.T) {
-	client := getStringClient(t)
+	client := stringgroup.NewDefaultClient(nil).StringOperations()
 	result, err := client.GetNull(context.Background())
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
@@ -90,7 +82,7 @@ func TestStringGetNull(t *testing.T) {
 }
 
 func TestStringGetNullBase64URLEncoded(t *testing.T) {
-	client := getStringClient(t)
+	client := stringgroup.NewDefaultClient(nil).StringOperations()
 	result, err := client.GetNullBase64URLEncoded(context.Background())
 	if err != nil {
 		t.Fatalf("GetNullBase64URLEncoded: %v", err)
@@ -100,7 +92,7 @@ func TestStringGetNullBase64URLEncoded(t *testing.T) {
 }
 
 func TestStringGetWhitespace(t *testing.T) {
-	client := getStringClient(t)
+	client := stringgroup.NewDefaultClient(nil).StringOperations()
 	result, err := client.GetWhitespace(context.Background())
 	if err != nil {
 		t.Fatalf("GetWhitespace: %v", err)
@@ -110,7 +102,7 @@ func TestStringGetWhitespace(t *testing.T) {
 }
 
 func TestStringPutBase64URLEncoded(t *testing.T) {
-	client := getStringClient(t)
+	client := stringgroup.NewDefaultClient(nil).StringOperations()
 	result, err := client.PutBase64URLEncoded(context.Background(), []byte("a string that gets encoded with base64url"))
 	if err != nil {
 		t.Fatalf("PutBase64URLEncoded: %v", err)
@@ -119,7 +111,7 @@ func TestStringPutBase64URLEncoded(t *testing.T) {
 }
 
 func TestStringPutEmpty(t *testing.T) {
-	client := getStringClient(t)
+	client := stringgroup.NewDefaultClient(nil).StringOperations()
 	result, err := client.PutEmpty(context.Background())
 	if err != nil {
 		t.Fatalf("PutEmpty: %v", err)
@@ -128,7 +120,7 @@ func TestStringPutEmpty(t *testing.T) {
 }
 
 func TestStringPutNull(t *testing.T) {
-	client := getStringClient(t)
+	client := stringgroup.NewDefaultClient(nil).StringOperations()
 	result, err := client.PutNull(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PutNull: %v", err)
@@ -137,7 +129,7 @@ func TestStringPutNull(t *testing.T) {
 }
 
 func TestStringPutWhitespace(t *testing.T) {
-	client := getStringClient(t)
+	client := stringgroup.NewDefaultClient(nil).StringOperations()
 	result, err := client.PutWhitespace(context.Background())
 	if err != nil {
 		t.Fatalf("PutWhitespace: %v", err)

--- a/test/autorest/urlgroup/pathitems_test.go
+++ b/test/autorest/urlgroup/pathitems_test.go
@@ -13,16 +13,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getPathItemsClient(t *testing.T) *urlgroup.Client {
-	client, err := urlgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create enum client: %v", err)
-	}
-	return client
-}
-
 func TestGetAllWithValues(t *testing.T) {
-	client := getPathItemsClient(t)
+	client := urlgroup.NewDefaultClient(nil)
 	grp := client.PathItemsOperations("globalStringPath", to.StringPtr("globalStringQuery"))
 	result, err := grp.GetAllWithValues(context.Background(), "pathItemStringPath", "localStringPath", &urlgroup.PathItemsGetAllWithValuesOptions{
 		LocalStringQuery:    to.StringPtr("localStringQuery"),
@@ -35,7 +27,7 @@ func TestGetAllWithValues(t *testing.T) {
 }
 
 func TestGetGlobalAndLocalQueryNull(t *testing.T) {
-	client := getPathItemsClient(t)
+	client := urlgroup.NewDefaultClient(nil)
 	grp := client.PathItemsOperations("globalStringPath", nil)
 	result, err := grp.GetGlobalAndLocalQueryNull(context.Background(), "pathItemStringPath", "localStringPath", &urlgroup.PathItemsGetGlobalAndLocalQueryNullOptions{
 		PathItemStringQuery: to.StringPtr("pathItemStringQuery"),
@@ -47,7 +39,7 @@ func TestGetGlobalAndLocalQueryNull(t *testing.T) {
 }
 
 func TestGetGlobalQueryNull(t *testing.T) {
-	client := getPathItemsClient(t)
+	client := urlgroup.NewDefaultClient(nil)
 	grp := client.PathItemsOperations("globalStringPath", nil)
 	result, err := grp.GetGlobalQueryNull(context.Background(), "pathItemStringPath", "localStringPath", &urlgroup.PathItemsGetGlobalQueryNullOptions{
 		LocalStringQuery:    to.StringPtr("localStringQuery"),
@@ -60,7 +52,7 @@ func TestGetGlobalQueryNull(t *testing.T) {
 }
 
 func TestGetLocalPathItemQueryNull(t *testing.T) {
-	client := getPathItemsClient(t)
+	client := urlgroup.NewDefaultClient(nil)
 	grp := client.PathItemsOperations("globalStringPath", to.StringPtr("globalStringQuery"))
 	result, err := grp.GetLocalPathItemQueryNull(context.Background(), "pathItemStringPath", "localStringPath", nil)
 	if err != nil {

--- a/test/autorest/urlgroup/paths_test.go
+++ b/test/autorest/urlgroup/paths_test.go
@@ -12,16 +12,8 @@ import (
 	"time"
 )
 
-func getPathsOperations(t *testing.T) urlgroup.PathsOperations {
-	client, err := urlgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create enum client: %v", err)
-	}
-	return client.PathsOperations()
-}
-
 func TestArrayCSVInPath(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.ArrayCSVInPath(context.Background(), []string{"ArrayPath1", "begin!*'();:@ &=+$,/?#[]end", "", ""})
 	if err != nil {
 		t.Fatal(err)
@@ -30,7 +22,7 @@ func TestArrayCSVInPath(t *testing.T) {
 }
 
 func TestPathsBase64URL(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.Base64URL(context.Background(), []byte("lorem"))
 	if err != nil {
 		t.Fatal(err)
@@ -39,7 +31,7 @@ func TestPathsBase64URL(t *testing.T) {
 }
 
 func TestPathsByteEmpty(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.ByteEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -48,7 +40,7 @@ func TestPathsByteEmpty(t *testing.T) {
 }
 
 func TestPathsByteMultiByte(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.ByteMultiByte(context.Background(), []byte("啊齄丂狛狜隣郎隣兀﨩"))
 	if err != nil {
 		t.Fatal(err)
@@ -58,7 +50,7 @@ func TestPathsByteMultiByte(t *testing.T) {
 
 // TODO: check
 func TestPathsByteNull(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	_, err := client.ByteNull(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Did not receive an error, but expected one")
@@ -66,7 +58,7 @@ func TestPathsByteNull(t *testing.T) {
 }
 
 func TestPathsDateNull(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	var time time.Time
 	result, err := client.DateNull(context.Background(), time)
 	if err != nil {
@@ -76,7 +68,7 @@ func TestPathsDateNull(t *testing.T) {
 }
 
 func TestPathsDateTimeNull(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	var time time.Time
 	result, err := client.DateTimeNull(context.Background(), time)
 	if err != nil {
@@ -86,7 +78,7 @@ func TestPathsDateTimeNull(t *testing.T) {
 }
 
 func TestPathsDateTimeValid(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.DateTimeValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -95,7 +87,7 @@ func TestPathsDateTimeValid(t *testing.T) {
 }
 
 func TestPathsDateValid(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.DateValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -104,7 +96,7 @@ func TestPathsDateValid(t *testing.T) {
 }
 
 func TestPathsDoubleDecimalNegative(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.DoubleDecimalNegative(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -113,7 +105,7 @@ func TestPathsDoubleDecimalNegative(t *testing.T) {
 }
 
 func TestPathsDoubleDecimalPositive(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.DoubleDecimalPositive(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -122,7 +114,7 @@ func TestPathsDoubleDecimalPositive(t *testing.T) {
 }
 
 func TestPathsEnumNull(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	var color urlgroup.UriColor
 	_, err := client.EnumNull(context.Background(), color)
 	if err == nil {
@@ -131,7 +123,7 @@ func TestPathsEnumNull(t *testing.T) {
 }
 
 func TestPathsEnumValid(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	color := urlgroup.UriColorGreenColor
 	result, err := client.EnumValid(context.Background(), color)
 	if err != nil {
@@ -141,7 +133,7 @@ func TestPathsEnumValid(t *testing.T) {
 }
 
 func TestPathsFloatScientificNegative(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.FloatScientificNegative(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -150,7 +142,7 @@ func TestPathsFloatScientificNegative(t *testing.T) {
 }
 
 func TestPathsFloatScientificPositive(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.FloatScientificPositive(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -159,7 +151,7 @@ func TestPathsFloatScientificPositive(t *testing.T) {
 }
 
 func TestPathsGetBooleanFalse(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.GetBooleanFalse(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -168,7 +160,7 @@ func TestPathsGetBooleanFalse(t *testing.T) {
 }
 
 func TestPathsGetBooleanTrue(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.GetBooleanTrue(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -177,7 +169,7 @@ func TestPathsGetBooleanTrue(t *testing.T) {
 }
 
 func TestPathsGetIntNegativeOneMillion(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.GetIntNegativeOneMillion(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -186,7 +178,7 @@ func TestPathsGetIntNegativeOneMillion(t *testing.T) {
 }
 
 func TestPathsGetIntOneMillion(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.GetIntOneMillion(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -195,7 +187,7 @@ func TestPathsGetIntOneMillion(t *testing.T) {
 }
 
 func TestPathsGetNegativeTenBillion(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.GetNegativeTenBillion(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -204,7 +196,7 @@ func TestPathsGetNegativeTenBillion(t *testing.T) {
 }
 
 func TestPathsGetTenBillion(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.GetTenBillion(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -213,7 +205,7 @@ func TestPathsGetTenBillion(t *testing.T) {
 }
 
 func TestPathsStringEmpty(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.StringEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -222,7 +214,7 @@ func TestPathsStringEmpty(t *testing.T) {
 }
 
 func TestPathsStringNull(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	var s string
 	_, err := client.StringNull(context.Background(), s)
 	if err == nil {
@@ -231,7 +223,7 @@ func TestPathsStringNull(t *testing.T) {
 }
 
 func TestPathsStringURLEncoded(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.StringURLEncoded(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -240,7 +232,7 @@ func TestPathsStringURLEncoded(t *testing.T) {
 }
 
 func TestPathsStringURLNonEncoded(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.StringURLNonEncoded(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -249,7 +241,7 @@ func TestPathsStringURLNonEncoded(t *testing.T) {
 }
 
 func TestPathsStringUnicode(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	result, err := client.StringUnicode(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -258,7 +250,7 @@ func TestPathsStringUnicode(t *testing.T) {
 }
 
 func TestPathsUnixTimeURL(t *testing.T) {
-	client := getPathsOperations(t)
+	client := urlgroup.NewDefaultClient(nil).PathsOperations()
 	d, err := time.Parse("2006-01-02", "2016-04-13")
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/urlgroup/queries_test.go
+++ b/test/autorest/urlgroup/queries_test.go
@@ -11,17 +11,9 @@ import (
 	"testing"
 )
 
-func getQueriesClient(t *testing.T) urlgroup.QueriesOperations {
-	client, err := urlgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create enum client: %v", err)
-	}
-	return client.QueriesOperations()
-}
-
 // ArrayStringCSVEmpty - Get an empty array [] of string using the csv-array format
 func TestArrayStringCSVEmpty(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.ArrayStringCSVEmpty(context.Background(), &urlgroup.QueriesArrayStringCSVEmptyOptions{
 		ArrayQuery: &[]string{},
 	})
@@ -33,7 +25,7 @@ func TestArrayStringCSVEmpty(t *testing.T) {
 
 // ArrayStringCSVNull - Get a null array of string using the csv-array format
 func TestArrayStringCSVNull(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.ArrayStringCSVNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -43,7 +35,7 @@ func TestArrayStringCSVNull(t *testing.T) {
 
 // ArrayStringCSVValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
 func TestArrayStringCsvValid(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.ArrayStringCSVValid(context.Background(), &urlgroup.QueriesArrayStringCSVValidOptions{
 		ArrayQuery: &[]string{"ArrayQuery1", "begin!*'();:@ &=+$,/?#[]end", "", ""},
 	})
@@ -55,7 +47,7 @@ func TestArrayStringCsvValid(t *testing.T) {
 
 // ArrayStringPipesValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array format
 func TestArrayStringPipesValid(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.ArrayStringPipesValid(context.Background(), &urlgroup.QueriesArrayStringPipesValidOptions{
 		ArrayQuery: &[]string{"ArrayQuery1", "begin!*'();:@ &=+$,/?#[]end", "", ""},
 	})
@@ -67,7 +59,7 @@ func TestArrayStringPipesValid(t *testing.T) {
 
 // ArrayStringSsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format
 func TestArrayStringSsvValid(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.ArrayStringSsvValid(context.Background(), &urlgroup.QueriesArrayStringSsvValidOptions{
 		ArrayQuery: &[]string{"ArrayQuery1", "begin!*'();:@ &=+$,/?#[]end", "", ""},
 	})
@@ -79,7 +71,7 @@ func TestArrayStringSsvValid(t *testing.T) {
 
 // ArrayStringTsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array format
 func TestArrayStringTsvValid(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.ArrayStringTsvValid(context.Background(), &urlgroup.QueriesArrayStringTsvValidOptions{
 		ArrayQuery: &[]string{"ArrayQuery1", "begin!*'();:@ &=+$,/?#[]end", "", ""},
 	})
@@ -91,7 +83,7 @@ func TestArrayStringTsvValid(t *testing.T) {
 
 // ByteEmpty - Get '' as byte array
 func TestByteEmpty(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.ByteEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -101,7 +93,7 @@ func TestByteEmpty(t *testing.T) {
 
 // ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
 func TestByteMultiByte(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.ByteMultiByte(context.Background(), &urlgroup.QueriesByteMultiByteOptions{
 		ByteQuery: toByteSlicePtr([]byte("啊齄丂狛狜隣郎隣兀﨩")),
 	})
@@ -113,7 +105,7 @@ func TestByteMultiByte(t *testing.T) {
 
 // ByteNull - Get null as byte array (no query parameters in uri)
 func TestByteNull(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.ByteNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -123,7 +115,7 @@ func TestByteNull(t *testing.T) {
 
 // DateNull - Get null as date - this should result in no query parameters in uri
 func TestDateNull(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.DateNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -133,7 +125,7 @@ func TestDateNull(t *testing.T) {
 
 // DateTimeNull - Get null as date-time, should result in no query parameters in uri
 func TestDateTimeNull(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.DateTimeNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -143,7 +135,7 @@ func TestDateTimeNull(t *testing.T) {
 
 // DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
 func TestDateTimeValid(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.DateTimeValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -153,7 +145,7 @@ func TestDateTimeValid(t *testing.T) {
 
 // DateValid - Get '2012-01-01' as date
 func TestDateValid(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.DateValid(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -163,7 +155,7 @@ func TestDateValid(t *testing.T) {
 
 // DoubleDecimalNegative - Get '-9999999.999' numeric value
 func TestDoubleDecimalNegative(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.DoubleDecimalNegative(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -173,7 +165,7 @@ func TestDoubleDecimalNegative(t *testing.T) {
 
 // DoubleDecimalPositive - Get '9999999.999' numeric value
 func TestDoubleDecimalPositive(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.DoubleDecimalPositive(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -183,7 +175,7 @@ func TestDoubleDecimalPositive(t *testing.T) {
 
 // DoubleNull - Get null numeric value (no query parameter)
 func TestDoubleNull(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.DoubleNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -193,7 +185,7 @@ func TestDoubleNull(t *testing.T) {
 
 // EnumNull - Get null (no query parameter in url)
 func TestEnumNull(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.EnumNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -203,7 +195,7 @@ func TestEnumNull(t *testing.T) {
 
 // EnumValid - Get using uri with query parameter 'green color'
 func TestEnumValid(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.EnumValid(context.Background(), &urlgroup.QueriesEnumValidOptions{
 		EnumQuery: urlgroup.UriColorGreenColor.ToPtr(),
 	})
@@ -215,7 +207,7 @@ func TestEnumValid(t *testing.T) {
 
 // FloatNull - Get null numeric value (no query parameter)
 func TestFloatNull(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.FloatNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -225,7 +217,7 @@ func TestFloatNull(t *testing.T) {
 
 // FloatScientificNegative - Get '-1.034E-20' numeric value
 func TestFloatScientificNegative(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.FloatScientificNegative(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -235,7 +227,7 @@ func TestFloatScientificNegative(t *testing.T) {
 
 // FloatScientificPositive - Get '1.034E+20' numeric value
 func TestFloatScientificPositive(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.FloatScientificPositive(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -245,7 +237,7 @@ func TestFloatScientificPositive(t *testing.T) {
 
 // GetBooleanFalse - Get false Boolean value on path
 func TestGetBooleanFalse(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.GetBooleanFalse(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -255,7 +247,7 @@ func TestGetBooleanFalse(t *testing.T) {
 
 // GetBooleanNull - Get null Boolean value on query (query string should be absent)
 func TestGetBooleanNull(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.GetBooleanNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -265,7 +257,7 @@ func TestGetBooleanNull(t *testing.T) {
 
 // GetBooleanTrue - Get true Boolean value on path
 func TestGetBooleanTrue(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.GetBooleanTrue(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -275,7 +267,7 @@ func TestGetBooleanTrue(t *testing.T) {
 
 // GetIntNegativeOneMillion - Get '-1000000' integer value
 func TestGetIntNegativeOneMillion(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.GetIntNegativeOneMillion(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -285,7 +277,7 @@ func TestGetIntNegativeOneMillion(t *testing.T) {
 
 // GetIntNull - Get null integer value (no query parameter)
 func TestGetIntNull(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.GetIntNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -295,7 +287,7 @@ func TestGetIntNull(t *testing.T) {
 
 // GetIntOneMillion - Get '1000000' integer value
 func TestGetIntOneMillion(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.GetIntOneMillion(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -305,7 +297,7 @@ func TestGetIntOneMillion(t *testing.T) {
 
 // GetLongNull - Get 'null 64 bit integer value (no query param in uri)
 func TestGetLongNull(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.GetLongNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -315,7 +307,7 @@ func TestGetLongNull(t *testing.T) {
 
 // GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
 func TestGetNegativeTenBillion(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.GetNegativeTenBillion(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -325,7 +317,7 @@ func TestGetNegativeTenBillion(t *testing.T) {
 
 // GetTenBillion - Get '10000000000' 64 bit integer value
 func TestGetTenBillion(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.GetTenBillion(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -335,7 +327,7 @@ func TestGetTenBillion(t *testing.T) {
 
 // StringEmpty - Get ''
 func TestStringEmpty(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.StringEmpty(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -345,7 +337,7 @@ func TestStringEmpty(t *testing.T) {
 
 // StringNull - Get null (no query parameter in url)
 func TestStringNull(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.StringNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -355,7 +347,7 @@ func TestStringNull(t *testing.T) {
 
 // StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
 func TestStringURLEncoded(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.StringURLEncoded(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -365,7 +357,7 @@ func TestStringURLEncoded(t *testing.T) {
 
 // StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
 func TestStringUnicode(t *testing.T) {
-	client := getQueriesClient(t)
+	client := urlgroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.StringUnicode(context.Background())
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/urlmultigroup/urlmultigroup_test.go
+++ b/test/autorest/urlmultigroup/urlmultigroup_test.go
@@ -12,16 +12,8 @@ import (
 	"testing"
 )
 
-func getURLMultiOperations(t *testing.T) urlmultigroup.QueriesOperations {
-	client, err := urlmultigroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create urlmulti client: %v", err)
-	}
-	return client.QueriesOperations()
-}
-
 func TestURLMultiArrayStringMultiEmpty(t *testing.T) {
-	client := getURLMultiOperations(t)
+	client := urlmultigroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.ArrayStringMultiEmpty(context.Background(), &urlmultigroup.QueriesArrayStringMultiEmptyOptions{
 		ArrayQuery: &[]string{},
 	})
@@ -32,7 +24,7 @@ func TestURLMultiArrayStringMultiEmpty(t *testing.T) {
 }
 
 func TestURLMultiArrayStringMultiNull(t *testing.T) {
-	client := getURLMultiOperations(t)
+	client := urlmultigroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.ArrayStringMultiNull(context.Background(), &urlmultigroup.QueriesArrayStringMultiNullOptions{
 		ArrayQuery: nil,
 	})
@@ -44,7 +36,7 @@ func TestURLMultiArrayStringMultiNull(t *testing.T) {
 
 func TestURLMultiArrayStringMultiValid(t *testing.T) {
 	t.Skip("Cannot set nil for string value in string slice")
-	client := getURLMultiOperations(t)
+	client := urlmultigroup.NewDefaultClient(nil).QueriesOperations()
 	result, err := client.ArrayStringMultiValid(context.Background(), &urlmultigroup.QueriesArrayStringMultiValidOptions{
 		ArrayQuery: &[]string{"ArrayQuery1", url.QueryEscape("begin!*'();:@ &=+$,/?#[]end"), "", ""},
 	})

--- a/test/autorest/validationgroup/validationgroup_test.go
+++ b/test/autorest/validationgroup/validationgroup_test.go
@@ -13,16 +13,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getValidationOperations(t *testing.T) validationgroup.AutoRestValidationTestOperations {
-	client, err := validationgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create validation client: %v", err)
-	}
-	return client.AutoRestValidationTestOperations("")
-}
-
 func TestValidationGetWithConstantInPath(t *testing.T) {
-	client := getValidationOperations(t)
+	client := validationgroup.NewDefaultClient(nil).AutoRestValidationTestOperations("")
 	result, err := client.GetWithConstantInPath(context.Background())
 	if err != nil {
 		t.Fatalf("GetWithConstantInPath: %v", err)
@@ -31,7 +23,7 @@ func TestValidationGetWithConstantInPath(t *testing.T) {
 }
 
 func TestValidationPostWithConstantInBody(t *testing.T) {
-	client := getValidationOperations(t)
+	client := validationgroup.NewDefaultClient(nil).AutoRestValidationTestOperations("")
 	result, err := client.PostWithConstantInBody(context.Background(), &validationgroup.AutoRestValidationTestPostWithConstantInBodyOptions{Body: &validationgroup.Product{
 		Child: &validationgroup.ChildProduct{
 			ConstProperty: to.StringPtr("constant")},
@@ -48,7 +40,7 @@ func TestValidationPostWithConstantInBody(t *testing.T) {
 
 func TestValidationValidationOfBody(t *testing.T) {
 	t.Skip("need to confirm if this test will remain in the testserver and what values it's expecting")
-	client := getValidationOperations(t)
+	client := validationgroup.NewDefaultClient(nil).AutoRestValidationTestOperations("")
 	result, err := client.ValidationOfBody(context.Background(), "123", 150, &validationgroup.AutoRestValidationTestValidationOfBodyOptions{
 		Body: &validationgroup.Product{
 			DisplayNames: &[]string{

--- a/test/autorest/xmlgroup/xmlgroup_test.go
+++ b/test/autorest/xmlgroup/xmlgroup_test.go
@@ -14,14 +14,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 )
 
-func getXMLClient(t *testing.T) xmlgroup.XMLOperations {
-	client, err := xmlgroup.NewDefaultClient(nil)
-	if err != nil {
-		t.Fatalf("failed to create byte client: %v", err)
-	}
-	return client.XMLOperations()
-}
-
 func toTimePtr(layout string, value string) *time.Time {
 	t, err := time.Parse(layout, value)
 	if err != nil {
@@ -31,7 +23,7 @@ func toTimePtr(layout string, value string) *time.Time {
 }
 
 func TestGetACLs(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.GetACLs(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -51,7 +43,7 @@ func TestGetACLs(t *testing.T) {
 }
 
 func TestGetComplexTypeRefNoMeta(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.GetComplexTypeRefNoMeta(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +59,7 @@ func TestGetComplexTypeRefNoMeta(t *testing.T) {
 }
 
 func TestGetComplexTypeRefWithMeta(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.GetComplexTypeRefWithMeta(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -82,7 +74,7 @@ func TestGetComplexTypeRefWithMeta(t *testing.T) {
 }
 
 func TestGetEmptyChildElement(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.GetEmptyChildElement(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -97,7 +89,7 @@ func TestGetEmptyChildElement(t *testing.T) {
 }
 
 func TestGetEmptyList(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.GetEmptyList(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -108,7 +100,7 @@ func TestGetEmptyList(t *testing.T) {
 }
 
 func TestGetEmptyRootList(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.GetEmptyRootList(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -120,7 +112,7 @@ func TestGetEmptyRootList(t *testing.T) {
 }
 
 func TestGetEmptyWrappedLists(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.GetEmptyWrappedLists(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -131,7 +123,7 @@ func TestGetEmptyWrappedLists(t *testing.T) {
 }
 
 func TestGetHeaders(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.GetHeaders(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -140,7 +132,7 @@ func TestGetHeaders(t *testing.T) {
 }
 
 func TestGetRootList(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.GetRootList(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -162,7 +154,7 @@ func TestGetRootList(t *testing.T) {
 }
 
 func TestGetRootListSingleItem(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.GetRootListSingleItem(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -179,7 +171,7 @@ func TestGetRootListSingleItem(t *testing.T) {
 }
 
 func TestGetServiceProperties(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.GetServiceProperties(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -219,7 +211,7 @@ func TestGetServiceProperties(t *testing.T) {
 }
 
 func TestGetSimple(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.GetSimple(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -245,7 +237,7 @@ func TestGetSimple(t *testing.T) {
 }
 
 func TestGetWrappedLists(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.GetWrappedLists(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -259,7 +251,7 @@ func TestGetWrappedLists(t *testing.T) {
 }
 
 func TestJSONInput(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.JSONInput(context.Background(), xmlgroup.JSONInput{
 		ID: to.Int32Ptr(42),
 	})
@@ -270,7 +262,7 @@ func TestJSONInput(t *testing.T) {
 }
 
 func TestJSONOutput(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.JSONOutput(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -282,7 +274,7 @@ func TestJSONOutput(t *testing.T) {
 }
 
 func TestListBlobs(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.ListBlobs(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -409,7 +401,7 @@ func TestListBlobs(t *testing.T) {
 }
 
 func TestListContainers(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.ListContainers(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -448,7 +440,7 @@ func TestListContainers(t *testing.T) {
 }
 
 func TestPutACLs(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.PutACLs(context.Background(), []xmlgroup.SignedIDentifier{
 		{
 			ID: to.StringPtr("MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="),
@@ -466,7 +458,7 @@ func TestPutACLs(t *testing.T) {
 }
 
 func TestPutComplexTypeRefNoMeta(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.PutComplexTypeRefNoMeta(context.Background(), xmlgroup.RootWithRefAndNoMeta{
 		RefToModel: &xmlgroup.ComplexTypeNoMeta{
 			ID: to.StringPtr("myid"),
@@ -480,7 +472,7 @@ func TestPutComplexTypeRefNoMeta(t *testing.T) {
 }
 
 func TestPutComplexTypeRefWithMeta(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.PutComplexTypeRefWithMeta(context.Background(), xmlgroup.RootWithRefAndMeta{
 		RefToModel: &xmlgroup.ComplexTypeWithMeta{
 			ID: to.StringPtr("myid"),
@@ -494,7 +486,7 @@ func TestPutComplexTypeRefWithMeta(t *testing.T) {
 }
 
 func TestPutEmptyChildElement(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.PutEmptyChildElement(context.Background(), xmlgroup.Banana{
 		Name:       to.StringPtr("Unknown Banana"),
 		Expiration: toTimePtr(time.RFC3339Nano, "2012-02-24T00:53:52.789Z"),
@@ -507,7 +499,7 @@ func TestPutEmptyChildElement(t *testing.T) {
 }
 
 func TestPutEmptyList(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.PutEmptyList(context.Background(), xmlgroup.Slideshow{
 		Slides: &[]xmlgroup.Slide{},
 	})
@@ -518,7 +510,7 @@ func TestPutEmptyList(t *testing.T) {
 }
 
 func TestPutEmptyRootList(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.PutEmptyRootList(context.Background(), []xmlgroup.Banana{})
 	if err != nil {
 		t.Fatal(err)
@@ -527,7 +519,7 @@ func TestPutEmptyRootList(t *testing.T) {
 }
 
 func TestPutEmptyWrappedLists(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.PutEmptyWrappedLists(context.Background(), xmlgroup.AppleBarrel{
 		BadApples:  &[]string{},
 		GoodApples: &[]string{},
@@ -539,7 +531,7 @@ func TestPutEmptyWrappedLists(t *testing.T) {
 }
 
 func TestPutRootList(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.PutRootList(context.Background(), []xmlgroup.Banana{
 		{
 			Name:       to.StringPtr("Cavendish"),
@@ -559,7 +551,7 @@ func TestPutRootList(t *testing.T) {
 }
 
 func TestPutRootListSingleItem(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.PutRootListSingleItem(context.Background(), []xmlgroup.Banana{
 		{
 			Name:       to.StringPtr("Cavendish"),
@@ -574,7 +566,7 @@ func TestPutRootListSingleItem(t *testing.T) {
 }
 
 func TestPutServiceProperties(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.PutServiceProperties(context.Background(), xmlgroup.StorageServiceProperties{
 		HourMetrics: &xmlgroup.Metrics{
 			Version:     to.StringPtr("1.0"),
@@ -612,7 +604,7 @@ func TestPutServiceProperties(t *testing.T) {
 }
 
 func TestPutSimple(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.PutSimple(context.Background(), xmlgroup.Slideshow{
 		Author: to.StringPtr("Yours Truly"),
 		Date:   to.StringPtr("Date of publication"),
@@ -636,7 +628,7 @@ func TestPutSimple(t *testing.T) {
 }
 
 func TestPutWrappedLists(t *testing.T) {
-	client := getXMLClient(t)
+	client := xmlgroup.NewDefaultClient(nil).XMLOperations()
 	result, err := client.PutWrappedLists(context.Background(), xmlgroup.AppleBarrel{
 		BadApples:  &[]string{"Red Delicious"},
 		GoodApples: &[]string{"Fuji", "Gala"},

--- a/test/network/2020-03-01/armnetwork/applicationgateways.go
+++ b/test/network/2020-03-01/armnetwork/applicationgateways.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -123,7 +124,7 @@ func (client *applicationGatewaysOperations) backendHealthCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +206,7 @@ func (client *applicationGatewaysOperations) backendHealthOnDemandCreateRequest(
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +288,7 @@ func (client *applicationGatewaysOperations) createOrUpdateCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -366,7 +367,7 @@ func (client *applicationGatewaysOperations) deleteCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -421,7 +422,7 @@ func (client *applicationGatewaysOperations) getCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -476,7 +477,7 @@ func (client *applicationGatewaysOperations) getSslPredefinedPolicyCreateRequest
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default/predefinedPolicies/{predefinedPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{predefinedPolicyName}", url.PathEscape(predefinedPolicyName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -537,7 +538,7 @@ func (client *applicationGatewaysOperations) listCreateRequest(resourceGroupName
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +598,7 @@ func (client *applicationGatewaysOperations) listAllCreateRequest() (*azcore.Req
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -651,7 +652,7 @@ func (client *applicationGatewaysOperations) listAvailableRequestHeadersCreateRe
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableRequestHeaders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -705,7 +706,7 @@ func (client *applicationGatewaysOperations) listAvailableResponseHeadersCreateR
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableResponseHeaders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -759,7 +760,7 @@ func (client *applicationGatewaysOperations) listAvailableServerVariablesCreateR
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableServerVariables"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -813,7 +814,7 @@ func (client *applicationGatewaysOperations) listAvailableSslOptionsCreateReques
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -873,7 +874,7 @@ func (client *applicationGatewaysOperations) listAvailableSslPredefinedPoliciesC
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default/predefinedPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -927,7 +928,7 @@ func (client *applicationGatewaysOperations) listAvailableWafRuleSetsCreateReque
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableWafRuleSets"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1007,7 +1008,7 @@ func (client *applicationGatewaysOperations) startCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1086,7 +1087,7 @@ func (client *applicationGatewaysOperations) stopCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1141,7 +1142,7 @@ func (client *applicationGatewaysOperations) updateTagsCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/applicationgateways.go
+++ b/test/network/2020-03-01/armnetwork/applicationgateways.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -116,11 +115,15 @@ func (client *applicationGatewaysOperations) ResumeBackendHealth(token string) (
 
 // backendHealthCreateRequest creates the BackendHealth request.
 func (client *applicationGatewaysOperations) backendHealthCreateRequest(resourceGroupName string, applicationGatewayName string, applicationGatewaysBackendHealthOptions *ApplicationGatewaysBackendHealthOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/backendhealth"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -194,11 +197,15 @@ func (client *applicationGatewaysOperations) ResumeBackendHealthOnDemand(token s
 
 // backendHealthOnDemandCreateRequest creates the BackendHealthOnDemand request.
 func (client *applicationGatewaysOperations) backendHealthOnDemandCreateRequest(resourceGroupName string, applicationGatewayName string, probeRequest ApplicationGatewayOnDemandProbe, applicationGatewaysBackendHealthOnDemandOptions *ApplicationGatewaysBackendHealthOnDemandOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/getBackendHealthOnDemand"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -272,11 +279,15 @@ func (client *applicationGatewaysOperations) ResumeCreateOrUpdate(token string) 
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *applicationGatewaysOperations) createOrUpdateCreateRequest(resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -347,11 +358,15 @@ func (client *applicationGatewaysOperations) ResumeDelete(token string) (HTTPPol
 
 // deleteCreateRequest creates the Delete request.
 func (client *applicationGatewaysOperations) deleteCreateRequest(resourceGroupName string, applicationGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -398,11 +413,15 @@ func (client *applicationGatewaysOperations) Get(ctx context.Context, resourceGr
 
 // getCreateRequest creates the Get request.
 func (client *applicationGatewaysOperations) getCreateRequest(resourceGroupName string, applicationGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -450,10 +469,14 @@ func (client *applicationGatewaysOperations) GetSslPredefinedPolicy(ctx context.
 
 // getSslPredefinedPolicyCreateRequest creates the GetSslPredefinedPolicy request.
 func (client *applicationGatewaysOperations) getSslPredefinedPolicyCreateRequest(predefinedPolicyName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default/predefinedPolicies/{predefinedPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{predefinedPolicyName}", url.PathEscape(predefinedPolicyName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -507,10 +530,14 @@ func (client *applicationGatewaysOperations) List(resourceGroupName string) (App
 
 // listCreateRequest creates the List request.
 func (client *applicationGatewaysOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -564,9 +591,13 @@ func (client *applicationGatewaysOperations) ListAll() (ApplicationGatewayListRe
 
 // listAllCreateRequest creates the ListAll request.
 func (client *applicationGatewaysOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -614,9 +645,13 @@ func (client *applicationGatewaysOperations) ListAvailableRequestHeaders(ctx con
 
 // listAvailableRequestHeadersCreateRequest creates the ListAvailableRequestHeaders request.
 func (client *applicationGatewaysOperations) listAvailableRequestHeadersCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableRequestHeaders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -664,9 +699,13 @@ func (client *applicationGatewaysOperations) ListAvailableResponseHeaders(ctx co
 
 // listAvailableResponseHeadersCreateRequest creates the ListAvailableResponseHeaders request.
 func (client *applicationGatewaysOperations) listAvailableResponseHeadersCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableResponseHeaders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -714,9 +753,13 @@ func (client *applicationGatewaysOperations) ListAvailableServerVariables(ctx co
 
 // listAvailableServerVariablesCreateRequest creates the ListAvailableServerVariables request.
 func (client *applicationGatewaysOperations) listAvailableServerVariablesCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableServerVariables"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -764,9 +807,13 @@ func (client *applicationGatewaysOperations) ListAvailableSslOptions(ctx context
 
 // listAvailableSslOptionsCreateRequest creates the ListAvailableSslOptions request.
 func (client *applicationGatewaysOperations) listAvailableSslOptionsCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -820,9 +867,13 @@ func (client *applicationGatewaysOperations) ListAvailableSslPredefinedPolicies(
 
 // listAvailableSslPredefinedPoliciesCreateRequest creates the ListAvailableSslPredefinedPolicies request.
 func (client *applicationGatewaysOperations) listAvailableSslPredefinedPoliciesCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default/predefinedPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -870,9 +921,13 @@ func (client *applicationGatewaysOperations) ListAvailableWafRuleSets(ctx contex
 
 // listAvailableWafRuleSetsCreateRequest creates the ListAvailableWafRuleSets request.
 func (client *applicationGatewaysOperations) listAvailableWafRuleSetsCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableWafRuleSets"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -944,11 +999,15 @@ func (client *applicationGatewaysOperations) ResumeStart(token string) (HTTPPoll
 
 // startCreateRequest creates the Start request.
 func (client *applicationGatewaysOperations) startCreateRequest(resourceGroupName string, applicationGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/start"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1019,11 +1078,15 @@ func (client *applicationGatewaysOperations) ResumeStop(token string) (HTTPPolle
 
 // stopCreateRequest creates the Stop request.
 func (client *applicationGatewaysOperations) stopCreateRequest(resourceGroupName string, applicationGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/stop"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1070,11 +1133,15 @@ func (client *applicationGatewaysOperations) UpdateTags(ctx context.Context, res
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *applicationGatewaysOperations) updateTagsCreateRequest(resourceGroupName string, applicationGatewayName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/applicationsecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/applicationsecuritygroups.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *applicationSecurityGroupsOperations) ResumeCreateOrUpdate(token st
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *applicationSecurityGroupsOperations) createOrUpdateCreateRequest(resourceGroupName string, applicationSecurityGroupName string, parameters ApplicationSecurityGroup) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *applicationSecurityGroupsOperations) ResumeDelete(token string) (H
 
 // deleteCreateRequest creates the Delete request.
 func (client *applicationSecurityGroupsOperations) deleteCreateRequest(resourceGroupName string, applicationSecurityGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *applicationSecurityGroupsOperations) Get(ctx context.Context, reso
 
 // getCreateRequest creates the Get request.
 func (client *applicationSecurityGroupsOperations) getCreateRequest(resourceGroupName string, applicationSecurityGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -270,10 +281,14 @@ func (client *applicationSecurityGroupsOperations) List(resourceGroupName string
 
 // listCreateRequest creates the List request.
 func (client *applicationSecurityGroupsOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -327,9 +342,13 @@ func (client *applicationSecurityGroupsOperations) ListAll() (ApplicationSecurit
 
 // listAllCreateRequest creates the ListAll request.
 func (client *applicationSecurityGroupsOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -377,11 +396,15 @@ func (client *applicationSecurityGroupsOperations) UpdateTags(ctx context.Contex
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *applicationSecurityGroupsOperations) updateTagsCreateRequest(resourceGroupName string, applicationSecurityGroupName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/applicationsecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/applicationsecuritygroups.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *applicationSecurityGroupsOperations) createOrUpdateCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *applicationSecurityGroupsOperations) deleteCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *applicationSecurityGroupsOperations) getCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *applicationSecurityGroupsOperations) listCreateRequest(resourceGro
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +349,7 @@ func (client *applicationSecurityGroupsOperations) listAllCreateRequest() (*azco
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +405,7 @@ func (client *applicationSecurityGroupsOperations) updateTagsCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/availabledelegations.go
+++ b/test/network/2020-03-01/armnetwork/availabledelegations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -57,7 +58,7 @@ func (client *availableDelegationsOperations) listCreateRequest(location string)
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/availableDelegations"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/availabledelegations.go
+++ b/test/network/2020-03-01/armnetwork/availabledelegations.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -51,10 +50,14 @@ func (client *availableDelegationsOperations) List(location string) (AvailableDe
 
 // listCreateRequest creates the List request.
 func (client *availableDelegationsOperations) listCreateRequest(location string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/availableDelegations"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/availableendpointservices.go
+++ b/test/network/2020-03-01/armnetwork/availableendpointservices.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -57,7 +58,7 @@ func (client *availableEndpointServicesOperations) listCreateRequest(location st
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/virtualNetworkAvailableEndpointServices"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/availableendpointservices.go
+++ b/test/network/2020-03-01/armnetwork/availableendpointservices.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -51,10 +50,14 @@ func (client *availableEndpointServicesOperations) List(location string) (Endpoi
 
 // listCreateRequest creates the List request.
 func (client *availableEndpointServicesOperations) listCreateRequest(location string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/virtualNetworkAvailableEndpointServices"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/availableprivateendpointtypes.go
+++ b/test/network/2020-03-01/armnetwork/availableprivateendpointtypes.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -59,7 +60,7 @@ func (client *availablePrivateEndpointTypesOperations) listCreateRequest(locatio
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/availablePrivateEndpointTypes"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +122,7 @@ func (client *availablePrivateEndpointTypesOperations) listByResourceGroupCreate
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/availableprivateendpointtypes.go
+++ b/test/network/2020-03-01/armnetwork/availableprivateendpointtypes.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -53,10 +52,14 @@ func (client *availablePrivateEndpointTypesOperations) List(location string) (Av
 
 // listCreateRequest creates the List request.
 func (client *availablePrivateEndpointTypesOperations) listCreateRequest(location string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/availablePrivateEndpointTypes"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -110,11 +113,15 @@ func (client *availablePrivateEndpointTypesOperations) ListByResourceGroup(locat
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *availablePrivateEndpointTypesOperations) listByResourceGroupCreateRequest(location string, resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/availablePrivateEndpointTypes"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/availableresourcegroupdelegations.go
+++ b/test/network/2020-03-01/armnetwork/availableresourcegroupdelegations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -58,7 +59,7 @@ func (client *availableResourceGroupDelegationsOperations) listCreateRequest(loc
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/availableresourcegroupdelegations.go
+++ b/test/network/2020-03-01/armnetwork/availableresourcegroupdelegations.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -51,11 +50,15 @@ func (client *availableResourceGroupDelegationsOperations) List(location string,
 
 // listCreateRequest creates the List request.
 func (client *availableResourceGroupDelegationsOperations) listCreateRequest(location string, resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/availableDelegations"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/availableservicealiases.go
+++ b/test/network/2020-03-01/armnetwork/availableservicealiases.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -59,7 +60,7 @@ func (client *availableServiceAliasesOperations) listCreateRequest(location stri
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/availableServiceAliases"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +122,7 @@ func (client *availableServiceAliasesOperations) listByResourceGroupCreateReques
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/availableservicealiases.go
+++ b/test/network/2020-03-01/armnetwork/availableservicealiases.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -53,10 +52,14 @@ func (client *availableServiceAliasesOperations) List(location string) (Availabl
 
 // listCreateRequest creates the List request.
 func (client *availableServiceAliasesOperations) listCreateRequest(location string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/availableServiceAliases"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -110,11 +113,15 @@ func (client *availableServiceAliasesOperations) ListByResourceGroup(resourceGro
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *availableServiceAliasesOperations) listByResourceGroupCreateRequest(resourceGroupName string, location string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/availableServiceAliases"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/azurefirewallfqdntags.go
+++ b/test/network/2020-03-01/armnetwork/azurefirewallfqdntags.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -51,9 +50,13 @@ func (client *azureFirewallFqdnTagsOperations) ListAll() (AzureFirewallFqdnTagLi
 
 // listAllCreateRequest creates the ListAll request.
 func (client *azureFirewallFqdnTagsOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewallFqdnTags"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/azurefirewallfqdntags.go
+++ b/test/network/2020-03-01/armnetwork/azurefirewallfqdntags.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -56,7 +57,7 @@ func (client *azureFirewallFqdnTagsOperations) listAllCreateRequest() (*azcore.R
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewallFqdnTags"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/azurefirewalls.go
+++ b/test/network/2020-03-01/armnetwork/azurefirewalls.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -95,7 +96,7 @@ func (client *azureFirewallsOperations) createOrUpdateCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +175,7 @@ func (client *azureFirewallsOperations) deleteCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +230,7 @@ func (client *azureFirewallsOperations) getCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +291,7 @@ func (client *azureFirewallsOperations) listCreateRequest(resourceGroupName stri
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +351,7 @@ func (client *azureFirewallsOperations) listAllCreateRequest() (*azcore.Request,
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +431,7 @@ func (client *azureFirewallsOperations) updateTagsCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/azurefirewalls.go
+++ b/test/network/2020-03-01/armnetwork/azurefirewalls.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -88,11 +87,15 @@ func (client *azureFirewallsOperations) ResumeCreateOrUpdate(token string) (Azur
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *azureFirewallsOperations) createOrUpdateCreateRequest(resourceGroupName string, azureFirewallName string, parameters AzureFirewall) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -163,11 +166,15 @@ func (client *azureFirewallsOperations) ResumeDelete(token string) (HTTPPoller, 
 
 // deleteCreateRequest creates the Delete request.
 func (client *azureFirewallsOperations) deleteCreateRequest(resourceGroupName string, azureFirewallName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -214,11 +221,15 @@ func (client *azureFirewallsOperations) Get(ctx context.Context, resourceGroupNa
 
 // getCreateRequest creates the Get request.
 func (client *azureFirewallsOperations) getCreateRequest(resourceGroupName string, azureFirewallName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -272,10 +283,14 @@ func (client *azureFirewallsOperations) List(resourceGroupName string) (AzureFir
 
 // listCreateRequest creates the List request.
 func (client *azureFirewallsOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -329,9 +344,13 @@ func (client *azureFirewallsOperations) ListAll() (AzureFirewallListResultPager,
 
 // listAllCreateRequest creates the ListAll request.
 func (client *azureFirewallsOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -403,11 +422,15 @@ func (client *azureFirewallsOperations) ResumeUpdateTags(token string) (AzureFir
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *azureFirewallsOperations) updateTagsCreateRequest(resourceGroupName string, azureFirewallName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/bastionhosts.go
+++ b/test/network/2020-03-01/armnetwork/bastionhosts.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -91,7 +92,7 @@ func (client *bastionHostsOperations) createOrUpdateCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *bastionHostsOperations) deleteCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +226,7 @@ func (client *bastionHostsOperations) getCreateRequest(resourceGroupName string,
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +286,7 @@ func (client *bastionHostsOperations) listCreateRequest() (*azcore.Request, erro
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/bastionHosts"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -346,7 +347,7 @@ func (client *bastionHostsOperations) listByResourceGroupCreateRequest(resourceG
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/bastionhosts.go
+++ b/test/network/2020-03-01/armnetwork/bastionhosts.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -84,11 +83,15 @@ func (client *bastionHostsOperations) ResumeCreateOrUpdate(token string) (Bastio
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *bastionHostsOperations) createOrUpdateCreateRequest(resourceGroupName string, bastionHostName string, parameters BastionHost) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -159,11 +162,15 @@ func (client *bastionHostsOperations) ResumeDelete(token string) (HTTPPoller, er
 
 // deleteCreateRequest creates the Delete request.
 func (client *bastionHostsOperations) deleteCreateRequest(resourceGroupName string, bastionHostName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,11 +217,15 @@ func (client *bastionHostsOperations) Get(ctx context.Context, resourceGroupName
 
 // getCreateRequest creates the Get request.
 func (client *bastionHostsOperations) getCreateRequest(resourceGroupName string, bastionHostName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -268,9 +279,13 @@ func (client *bastionHostsOperations) List() (BastionHostListResultPager, error)
 
 // listCreateRequest creates the List request.
 func (client *bastionHostsOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/bastionHosts"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -324,10 +339,14 @@ func (client *bastionHostsOperations) ListByResourceGroup(resourceGroupName stri
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *bastionHostsOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/bgpservicecommunities.go
+++ b/test/network/2020-03-01/armnetwork/bgpservicecommunities.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -56,7 +57,7 @@ func (client *bgpServiceCommunitiesOperations) listCreateRequest() (*azcore.Requ
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/bgpServiceCommunities"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/bgpservicecommunities.go
+++ b/test/network/2020-03-01/armnetwork/bgpservicecommunities.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -51,9 +50,13 @@ func (client *bgpServiceCommunitiesOperations) List() (BgpServiceCommunityListRe
 
 // listCreateRequest creates the List request.
 func (client *bgpServiceCommunitiesOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/bgpServiceCommunities"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/client.go
+++ b/test/network/2020-03-01/armnetwork/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const scope = "https://management.azure.com//.default"
@@ -50,7 +49,7 @@ func (c *ClientOptions) telemetryOptions() azcore.TelemetryOptions {
 
 // Client - Network Client
 type Client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
@@ -58,12 +57,12 @@ type Client struct {
 const DefaultEndpoint = "https://management.azure.com"
 
 // NewDefaultClient creates an instance of the Client type using the DefaultEndpoint.
-func NewDefaultClient(cred azcore.Credential, options *ClientOptions) (*Client, error) {
+func NewDefaultClient(cred azcore.Credential, options *ClientOptions) *Client {
 	return NewClient(DefaultEndpoint, cred, options)
 }
 
 // NewClient creates an instance of the Client type with the specified endpoint.
-func NewClient(endpoint string, cred azcore.Credential, options *ClientOptions) (*Client, error) {
+func NewClient(endpoint string, cred azcore.Credential, options *ClientOptions) *Client {
 	if options == nil {
 		o := DefaultClientOptions()
 		options = &o
@@ -82,15 +81,8 @@ func NewClient(endpoint string, cred azcore.Credential, options *ClientOptions) 
 }
 
 // NewClientWithPipeline creates an instance of the Client type with the specified endpoint and pipeline.
-func NewClientWithPipeline(endpoint string, p azcore.Pipeline) (*Client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &Client{u: u, p: p}, nil
+func NewClientWithPipeline(endpoint string, p azcore.Pipeline) *Client {
+	return &Client{u: endpoint, p: p}
 }
 
 // ApplicationGatewaysOperations returns the ApplicationGatewaysOperations associated with this client.

--- a/test/network/2020-03-01/armnetwork/connectionmonitors.go
+++ b/test/network/2020-03-01/armnetwork/connectionmonitors.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -103,7 +104,7 @@ func (client *connectionMonitorsOperations) createOrUpdateCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +184,7 @@ func (client *connectionMonitorsOperations) deleteCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +240,7 @@ func (client *connectionMonitorsOperations) getCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +296,7 @@ func (client *connectionMonitorsOperations) listCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +377,7 @@ func (client *connectionMonitorsOperations) queryCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +457,7 @@ func (client *connectionMonitorsOperations) startCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -536,7 +537,7 @@ func (client *connectionMonitorsOperations) stopCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -592,7 +593,7 @@ func (client *connectionMonitorsOperations) updateTagsCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/connectionmonitors.go
+++ b/test/network/2020-03-01/armnetwork/connectionmonitors.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -95,12 +94,16 @@ func (client *connectionMonitorsOperations) ResumeCreateOrUpdate(token string) (
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *connectionMonitorsOperations) createOrUpdateCreateRequest(resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters ConnectionMonitor) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -171,12 +174,16 @@ func (client *connectionMonitorsOperations) ResumeDelete(token string) (HTTPPoll
 
 // deleteCreateRequest creates the Delete request.
 func (client *connectionMonitorsOperations) deleteCreateRequest(resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -223,12 +230,16 @@ func (client *connectionMonitorsOperations) Get(ctx context.Context, resourceGro
 
 // getCreateRequest creates the Get request.
 func (client *connectionMonitorsOperations) getCreateRequest(resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -276,11 +287,15 @@ func (client *connectionMonitorsOperations) List(ctx context.Context, resourceGr
 
 // listCreateRequest creates the List request.
 func (client *connectionMonitorsOperations) listCreateRequest(resourceGroupName string, networkWatcherName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -352,12 +367,16 @@ func (client *connectionMonitorsOperations) ResumeQuery(token string) (Connectio
 
 // queryCreateRequest creates the Query request.
 func (client *connectionMonitorsOperations) queryCreateRequest(resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}/query"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -428,12 +447,16 @@ func (client *connectionMonitorsOperations) ResumeStart(token string) (HTTPPolle
 
 // startCreateRequest creates the Start request.
 func (client *connectionMonitorsOperations) startCreateRequest(resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}/start"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -504,12 +527,16 @@ func (client *connectionMonitorsOperations) ResumeStop(token string) (HTTPPoller
 
 // stopCreateRequest creates the Stop request.
 func (client *connectionMonitorsOperations) stopCreateRequest(resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}/stop"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -556,12 +583,16 @@ func (client *connectionMonitorsOperations) UpdateTags(ctx context.Context, reso
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *connectionMonitorsOperations) updateTagsCreateRequest(resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionMonitorName}", url.PathEscape(connectionMonitorName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/ddoscustompolicies.go
+++ b/test/network/2020-03-01/armnetwork/ddoscustompolicies.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -81,11 +80,15 @@ func (client *ddosCustomPoliciesOperations) ResumeCreateOrUpdate(token string) (
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *ddosCustomPoliciesOperations) createOrUpdateCreateRequest(resourceGroupName string, ddosCustomPolicyName string, parameters DdosCustomPolicy) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosCustomPolicies/{ddosCustomPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -156,11 +159,15 @@ func (client *ddosCustomPoliciesOperations) ResumeDelete(token string) (HTTPPoll
 
 // deleteCreateRequest creates the Delete request.
 func (client *ddosCustomPoliciesOperations) deleteCreateRequest(resourceGroupName string, ddosCustomPolicyName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosCustomPolicies/{ddosCustomPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -207,11 +214,15 @@ func (client *ddosCustomPoliciesOperations) Get(ctx context.Context, resourceGro
 
 // getCreateRequest creates the Get request.
 func (client *ddosCustomPoliciesOperations) getCreateRequest(resourceGroupName string, ddosCustomPolicyName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosCustomPolicies/{ddosCustomPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -259,11 +270,15 @@ func (client *ddosCustomPoliciesOperations) UpdateTags(ctx context.Context, reso
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *ddosCustomPoliciesOperations) updateTagsCreateRequest(resourceGroupName string, ddosCustomPolicyName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosCustomPolicies/{ddosCustomPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/ddoscustompolicies.go
+++ b/test/network/2020-03-01/armnetwork/ddoscustompolicies.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -88,7 +89,7 @@ func (client *ddosCustomPoliciesOperations) createOrUpdateCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +168,7 @@ func (client *ddosCustomPoliciesOperations) deleteCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +223,7 @@ func (client *ddosCustomPoliciesOperations) getCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +279,7 @@ func (client *ddosCustomPoliciesOperations) updateTagsCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/ddosprotectionplans.go
+++ b/test/network/2020-03-01/armnetwork/ddosprotectionplans.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *ddosProtectionPlansOperations) ResumeCreateOrUpdate(token string) 
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *ddosProtectionPlansOperations) createOrUpdateCreateRequest(resourceGroupName string, ddosProtectionPlanName string, parameters DdosProtectionPlan) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans/{ddosProtectionPlanName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *ddosProtectionPlansOperations) ResumeDelete(token string) (HTTPPol
 
 // deleteCreateRequest creates the Delete request.
 func (client *ddosProtectionPlansOperations) deleteCreateRequest(resourceGroupName string, ddosProtectionPlanName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans/{ddosProtectionPlanName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *ddosProtectionPlansOperations) Get(ctx context.Context, resourceGr
 
 // getCreateRequest creates the Get request.
 func (client *ddosProtectionPlansOperations) getCreateRequest(resourceGroupName string, ddosProtectionPlanName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans/{ddosProtectionPlanName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -270,9 +281,13 @@ func (client *ddosProtectionPlansOperations) List() (DdosProtectionPlanListResul
 
 // listCreateRequest creates the List request.
 func (client *ddosProtectionPlansOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ddosProtectionPlans"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -326,10 +341,14 @@ func (client *ddosProtectionPlansOperations) ListByResourceGroup(resourceGroupNa
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *ddosProtectionPlansOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -377,11 +396,15 @@ func (client *ddosProtectionPlansOperations) UpdateTags(ctx context.Context, res
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *ddosProtectionPlansOperations) updateTagsCreateRequest(resourceGroupName string, ddosProtectionPlanName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans/{ddosProtectionPlanName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/ddosprotectionplans.go
+++ b/test/network/2020-03-01/armnetwork/ddosprotectionplans.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *ddosProtectionPlansOperations) createOrUpdateCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *ddosProtectionPlansOperations) deleteCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *ddosProtectionPlansOperations) getCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +288,7 @@ func (client *ddosProtectionPlansOperations) listCreateRequest() (*azcore.Reques
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ddosProtectionPlans"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +349,7 @@ func (client *ddosProtectionPlansOperations) listByResourceGroupCreateRequest(re
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +405,7 @@ func (client *ddosProtectionPlansOperations) updateTagsCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/defaultsecurityrules.go
+++ b/test/network/2020-03-01/armnetwork/defaultsecurityrules.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -56,7 +57,7 @@ func (client *defaultSecurityRulesOperations) getCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{defaultSecurityRuleName}", url.PathEscape(defaultSecurityRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func (client *defaultSecurityRulesOperations) listCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/defaultsecurityrules.go
+++ b/test/network/2020-03-01/armnetwork/defaultsecurityrules.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -48,12 +47,16 @@ func (client *defaultSecurityRulesOperations) Get(ctx context.Context, resourceG
 
 // getCreateRequest creates the Get request.
 func (client *defaultSecurityRulesOperations) getCreateRequest(resourceGroupName string, networkSecurityGroupName string, defaultSecurityRuleName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/defaultSecurityRules/{defaultSecurityRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{defaultSecurityRuleName}", url.PathEscape(defaultSecurityRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -107,11 +110,15 @@ func (client *defaultSecurityRulesOperations) List(resourceGroupName string, net
 
 // listCreateRequest creates the List request.
 func (client *defaultSecurityRulesOperations) listCreateRequest(resourceGroupName string, networkSecurityGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/defaultSecurityRules"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecircuitauthorizations.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecircuitauthorizations.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *expressRouteCircuitAuthorizationsOperations) ResumeCreateOrUpdate(
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *expressRouteCircuitAuthorizationsOperations) createOrUpdateCreateRequest(resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/authorizations/{authorizationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{authorizationName}", url.PathEscape(authorizationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *expressRouteCircuitAuthorizationsOperations) ResumeDelete(token st
 
 // deleteCreateRequest creates the Delete request.
 func (client *expressRouteCircuitAuthorizationsOperations) deleteCreateRequest(resourceGroupName string, circuitName string, authorizationName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/authorizations/{authorizationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{authorizationName}", url.PathEscape(authorizationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *expressRouteCircuitAuthorizationsOperations) Get(ctx context.Conte
 
 // getCreateRequest creates the Get request.
 func (client *expressRouteCircuitAuthorizationsOperations) getCreateRequest(resourceGroupName string, circuitName string, authorizationName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/authorizations/{authorizationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{authorizationName}", url.PathEscape(authorizationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *expressRouteCircuitAuthorizationsOperations) List(resourceGroupNam
 
 // listCreateRequest creates the List request.
 func (client *expressRouteCircuitAuthorizationsOperations) listCreateRequest(resourceGroupName string, circuitName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/authorizations"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecircuitauthorizations.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecircuitauthorizations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *expressRouteCircuitAuthorizationsOperations) createOrUpdateCreateR
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{authorizationName}", url.PathEscape(authorizationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *expressRouteCircuitAuthorizationsOperations) deleteCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{authorizationName}", url.PathEscape(authorizationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *expressRouteCircuitAuthorizationsOperations) getCreateRequest(reso
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{authorizationName}", url.PathEscape(authorizationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *expressRouteCircuitAuthorizationsOperations) listCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecircuitconnections.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -91,7 +92,7 @@ func (client *expressRouteCircuitConnectionsOperations) createOrUpdateCreateRequ
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *expressRouteCircuitConnectionsOperations) deleteCreateRequest(reso
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +230,7 @@ func (client *expressRouteCircuitConnectionsOperations) getCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +293,7 @@ func (client *expressRouteCircuitConnectionsOperations) listCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecircuitconnections.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,13 +81,17 @@ func (client *expressRouteCircuitConnectionsOperations) ResumeCreateOrUpdate(tok
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *expressRouteCircuitConnectionsOperations) createOrUpdateCreateRequest(resourceGroupName string, circuitName string, peeringName string, connectionName string, expressRouteCircuitConnectionParameters ExpressRouteCircuitConnection) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/connections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -159,13 +162,17 @@ func (client *expressRouteCircuitConnectionsOperations) ResumeDelete(token strin
 
 // deleteCreateRequest creates the Delete request.
 func (client *expressRouteCircuitConnectionsOperations) deleteCreateRequest(resourceGroupName string, circuitName string, peeringName string, connectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/connections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,13 +219,17 @@ func (client *expressRouteCircuitConnectionsOperations) Get(ctx context.Context,
 
 // getCreateRequest creates the Get request.
 func (client *expressRouteCircuitConnectionsOperations) getCreateRequest(resourceGroupName string, circuitName string, peeringName string, connectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/connections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -272,12 +283,16 @@ func (client *expressRouteCircuitConnectionsOperations) List(resourceGroupName s
 
 // listCreateRequest creates the List request.
 func (client *expressRouteCircuitConnectionsOperations) listCreateRequest(resourceGroupName string, circuitName string, peeringName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/connections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecircuitpeerings.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecircuitpeerings.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *expressRouteCircuitPeeringsOperations) ResumeCreateOrUpdate(token 
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *expressRouteCircuitPeeringsOperations) createOrUpdateCreateRequest(resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *expressRouteCircuitPeeringsOperations) ResumeDelete(token string) 
 
 // deleteCreateRequest creates the Delete request.
 func (client *expressRouteCircuitPeeringsOperations) deleteCreateRequest(resourceGroupName string, circuitName string, peeringName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *expressRouteCircuitPeeringsOperations) Get(ctx context.Context, re
 
 // getCreateRequest creates the Get request.
 func (client *expressRouteCircuitPeeringsOperations) getCreateRequest(resourceGroupName string, circuitName string, peeringName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *expressRouteCircuitPeeringsOperations) List(resourceGroupName stri
 
 // listCreateRequest creates the List request.
 func (client *expressRouteCircuitPeeringsOperations) listCreateRequest(resourceGroupName string, circuitName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecircuitpeerings.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecircuitpeerings.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *expressRouteCircuitPeeringsOperations) createOrUpdateCreateRequest
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *expressRouteCircuitPeeringsOperations) deleteCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *expressRouteCircuitPeeringsOperations) getCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *expressRouteCircuitPeeringsOperations) listCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecircuits.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecircuits.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -102,11 +101,15 @@ func (client *expressRouteCircuitsOperations) ResumeCreateOrUpdate(token string)
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *expressRouteCircuitsOperations) createOrUpdateCreateRequest(resourceGroupName string, circuitName string, parameters ExpressRouteCircuit) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -177,11 +180,15 @@ func (client *expressRouteCircuitsOperations) ResumeDelete(token string) (HTTPPo
 
 // deleteCreateRequest creates the Delete request.
 func (client *expressRouteCircuitsOperations) deleteCreateRequest(resourceGroupName string, circuitName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -228,11 +235,15 @@ func (client *expressRouteCircuitsOperations) Get(ctx context.Context, resourceG
 
 // getCreateRequest creates the Get request.
 func (client *expressRouteCircuitsOperations) getCreateRequest(resourceGroupName string, circuitName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -280,12 +291,16 @@ func (client *expressRouteCircuitsOperations) GetPeeringStats(ctx context.Contex
 
 // getPeeringStatsCreateRequest creates the GetPeeringStats request.
 func (client *expressRouteCircuitsOperations) getPeeringStatsCreateRequest(resourceGroupName string, circuitName string, peeringName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/stats"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -333,11 +348,15 @@ func (client *expressRouteCircuitsOperations) GetStats(ctx context.Context, reso
 
 // getStatsCreateRequest creates the GetStats request.
 func (client *expressRouteCircuitsOperations) getStatsCreateRequest(resourceGroupName string, circuitName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/stats"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -391,10 +410,14 @@ func (client *expressRouteCircuitsOperations) List(resourceGroupName string) (Ex
 
 // listCreateRequest creates the List request.
 func (client *expressRouteCircuitsOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -448,9 +471,13 @@ func (client *expressRouteCircuitsOperations) ListAll() (ExpressRouteCircuitList
 
 // listAllCreateRequest creates the ListAll request.
 func (client *expressRouteCircuitsOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteCircuits"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -522,13 +549,17 @@ func (client *expressRouteCircuitsOperations) ResumeListArpTable(token string) (
 
 // listArpTableCreateRequest creates the ListArpTable request.
 func (client *expressRouteCircuitsOperations) listArpTableCreateRequest(resourceGroupName string, circuitName string, peeringName string, devicePath string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/arpTables/{devicePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -599,13 +630,17 @@ func (client *expressRouteCircuitsOperations) ResumeListRoutesTable(token string
 
 // listRoutesTableCreateRequest creates the ListRoutesTable request.
 func (client *expressRouteCircuitsOperations) listRoutesTableCreateRequest(resourceGroupName string, circuitName string, peeringName string, devicePath string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/routeTables/{devicePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -676,13 +711,17 @@ func (client *expressRouteCircuitsOperations) ResumeListRoutesTableSummary(token
 
 // listRoutesTableSummaryCreateRequest creates the ListRoutesTableSummary request.
 func (client *expressRouteCircuitsOperations) listRoutesTableSummaryCreateRequest(resourceGroupName string, circuitName string, peeringName string, devicePath string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/routeTablesSummary/{devicePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -729,11 +768,15 @@ func (client *expressRouteCircuitsOperations) UpdateTags(ctx context.Context, re
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *expressRouteCircuitsOperations) updateTagsCreateRequest(resourceGroupName string, circuitName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecircuits.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecircuits.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -109,7 +110,7 @@ func (client *expressRouteCircuitsOperations) createOrUpdateCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +189,7 @@ func (client *expressRouteCircuitsOperations) deleteCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +244,7 @@ func (client *expressRouteCircuitsOperations) getCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +301,7 @@ func (client *expressRouteCircuitsOperations) getPeeringStatsCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -356,7 +357,7 @@ func (client *expressRouteCircuitsOperations) getStatsCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -417,7 +418,7 @@ func (client *expressRouteCircuitsOperations) listCreateRequest(resourceGroupNam
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -477,7 +478,7 @@ func (client *expressRouteCircuitsOperations) listAllCreateRequest() (*azcore.Re
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteCircuits"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -559,7 +560,7 @@ func (client *expressRouteCircuitsOperations) listArpTableCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -640,7 +641,7 @@ func (client *expressRouteCircuitsOperations) listRoutesTableCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -721,7 +722,7 @@ func (client *expressRouteCircuitsOperations) listRoutesTableSummaryCreateReques
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -776,7 +777,7 @@ func (client *expressRouteCircuitsOperations) updateTagsCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressrouteconnections.go
+++ b/test/network/2020-03-01/armnetwork/expressrouteconnections.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -89,7 +90,7 @@ func (client *expressRouteConnectionsOperations) createOrUpdateCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +170,7 @@ func (client *expressRouteConnectionsOperations) deleteCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +226,7 @@ func (client *expressRouteConnectionsOperations) getCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +282,7 @@ func (client *expressRouteConnectionsOperations) listCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressrouteconnections.go
+++ b/test/network/2020-03-01/armnetwork/expressrouteconnections.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -81,12 +80,16 @@ func (client *expressRouteConnectionsOperations) ResumeCreateOrUpdate(token stri
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *expressRouteConnectionsOperations) createOrUpdateCreateRequest(resourceGroupName string, expressRouteGatewayName string, connectionName string, putExpressRouteConnectionParameters ExpressRouteConnection) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/expressRouteConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -157,12 +160,16 @@ func (client *expressRouteConnectionsOperations) ResumeDelete(token string) (HTT
 
 // deleteCreateRequest creates the Delete request.
 func (client *expressRouteConnectionsOperations) deleteCreateRequest(resourceGroupName string, expressRouteGatewayName string, connectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/expressRouteConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -209,12 +216,16 @@ func (client *expressRouteConnectionsOperations) Get(ctx context.Context, resour
 
 // getCreateRequest creates the Get request.
 func (client *expressRouteConnectionsOperations) getCreateRequest(resourceGroupName string, expressRouteGatewayName string, connectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/expressRouteConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -262,11 +273,15 @@ func (client *expressRouteConnectionsOperations) List(ctx context.Context, resou
 
 // listCreateRequest creates the List request.
 func (client *expressRouteConnectionsOperations) listCreateRequest(resourceGroupName string, expressRouteGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/expressRouteConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecrossconnectionpeerings.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecrossconnectionpeerings.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *expressRouteCrossConnectionPeeringsOperations) createOrUpdateCreat
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *expressRouteCrossConnectionPeeringsOperations) deleteCreateRequest
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *expressRouteCrossConnectionPeeringsOperations) getCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *expressRouteCrossConnectionPeeringsOperations) listCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecrossconnectionpeerings.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecrossconnectionpeerings.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *expressRouteCrossConnectionPeeringsOperations) ResumeCreateOrUpdat
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *expressRouteCrossConnectionPeeringsOperations) createOrUpdateCreateRequest(resourceGroupName string, crossConnectionName string, peeringName string, peeringParameters ExpressRouteCrossConnectionPeering) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *expressRouteCrossConnectionPeeringsOperations) ResumeDelete(token 
 
 // deleteCreateRequest creates the Delete request.
 func (client *expressRouteCrossConnectionPeeringsOperations) deleteCreateRequest(resourceGroupName string, crossConnectionName string, peeringName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *expressRouteCrossConnectionPeeringsOperations) Get(ctx context.Con
 
 // getCreateRequest creates the Get request.
 func (client *expressRouteCrossConnectionPeeringsOperations) getCreateRequest(resourceGroupName string, crossConnectionName string, peeringName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *expressRouteCrossConnectionPeeringsOperations) List(resourceGroupN
 
 // listCreateRequest creates the List request.
 func (client *expressRouteCrossConnectionPeeringsOperations) listCreateRequest(resourceGroupName string, crossConnectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecrossconnections.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecrossconnections.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -94,11 +93,15 @@ func (client *expressRouteCrossConnectionsOperations) ResumeCreateOrUpdate(token
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *expressRouteCrossConnectionsOperations) createOrUpdateCreateRequest(resourceGroupName string, crossConnectionName string, parameters ExpressRouteCrossConnection) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -145,11 +148,15 @@ func (client *expressRouteCrossConnectionsOperations) Get(ctx context.Context, r
 
 // getCreateRequest creates the Get request.
 func (client *expressRouteCrossConnectionsOperations) getCreateRequest(resourceGroupName string, crossConnectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -203,9 +210,13 @@ func (client *expressRouteCrossConnectionsOperations) List() (ExpressRouteCrossC
 
 // listCreateRequest creates the List request.
 func (client *expressRouteCrossConnectionsOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteCrossConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -277,13 +288,17 @@ func (client *expressRouteCrossConnectionsOperations) ResumeListArpTable(token s
 
 // listArpTableCreateRequest creates the ListArpTable request.
 func (client *expressRouteCrossConnectionsOperations) listArpTableCreateRequest(resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}/arpTables/{devicePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -336,10 +351,14 @@ func (client *expressRouteCrossConnectionsOperations) ListByResourceGroup(resour
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *expressRouteCrossConnectionsOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -411,13 +430,17 @@ func (client *expressRouteCrossConnectionsOperations) ResumeListRoutesTable(toke
 
 // listRoutesTableCreateRequest creates the ListRoutesTable request.
 func (client *expressRouteCrossConnectionsOperations) listRoutesTableCreateRequest(resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}/routeTables/{devicePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -488,13 +511,17 @@ func (client *expressRouteCrossConnectionsOperations) ResumeListRoutesTableSumma
 
 // listRoutesTableSummaryCreateRequest creates the ListRoutesTableSummary request.
 func (client *expressRouteCrossConnectionsOperations) listRoutesTableSummaryCreateRequest(resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}/routeTablesSummary/{devicePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -541,11 +568,15 @@ func (client *expressRouteCrossConnectionsOperations) UpdateTags(ctx context.Con
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *expressRouteCrossConnectionsOperations) updateTagsCreateRequest(resourceGroupName string, crossConnectionName string, crossConnectionParameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutecrossconnections.go
+++ b/test/network/2020-03-01/armnetwork/expressroutecrossconnections.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -101,7 +102,7 @@ func (client *expressRouteCrossConnectionsOperations) createOrUpdateCreateReques
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +157,7 @@ func (client *expressRouteCrossConnectionsOperations) getCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +217,7 @@ func (client *expressRouteCrossConnectionsOperations) listCreateRequest() (*azco
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteCrossConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +299,7 @@ func (client *expressRouteCrossConnectionsOperations) listArpTableCreateRequest(
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +359,7 @@ func (client *expressRouteCrossConnectionsOperations) listByResourceGroupCreateR
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +441,7 @@ func (client *expressRouteCrossConnectionsOperations) listRoutesTableCreateReque
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -521,7 +522,7 @@ func (client *expressRouteCrossConnectionsOperations) listRoutesTableSummaryCrea
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{devicePath}", url.PathEscape(devicePath))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -576,7 +577,7 @@ func (client *expressRouteCrossConnectionsOperations) updateTagsCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutegateways.go
+++ b/test/network/2020-03-01/armnetwork/expressroutegateways.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *expressRouteGatewaysOperations) createOrUpdateCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +170,7 @@ func (client *expressRouteGatewaysOperations) deleteCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +225,7 @@ func (client *expressRouteGatewaysOperations) getCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +280,7 @@ func (client *expressRouteGatewaysOperations) listByResourceGroupCreateRequest(r
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -333,7 +334,7 @@ func (client *expressRouteGatewaysOperations) listBySubscriptionCreateRequest() 
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutegateways.go
+++ b/test/network/2020-03-01/armnetwork/expressroutegateways.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -83,11 +82,15 @@ func (client *expressRouteGatewaysOperations) ResumeCreateOrUpdate(token string)
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *expressRouteGatewaysOperations) createOrUpdateCreateRequest(resourceGroupName string, expressRouteGatewayName string, putExpressRouteGatewayParameters ExpressRouteGateway) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,11 +161,15 @@ func (client *expressRouteGatewaysOperations) ResumeDelete(token string) (HTTPPo
 
 // deleteCreateRequest creates the Delete request.
 func (client *expressRouteGatewaysOperations) deleteCreateRequest(resourceGroupName string, expressRouteGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -209,11 +216,15 @@ func (client *expressRouteGatewaysOperations) Get(ctx context.Context, resourceG
 
 // getCreateRequest creates the Get request.
 func (client *expressRouteGatewaysOperations) getCreateRequest(resourceGroupName string, expressRouteGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -261,10 +272,14 @@ func (client *expressRouteGatewaysOperations) ListByResourceGroup(ctx context.Co
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *expressRouteGatewaysOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -312,9 +327,13 @@ func (client *expressRouteGatewaysOperations) ListBySubscription(ctx context.Con
 
 // listBySubscriptionCreateRequest creates the ListBySubscription request.
 func (client *expressRouteGatewaysOperations) listBySubscriptionCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutelinks.go
+++ b/test/network/2020-03-01/armnetwork/expressroutelinks.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -48,12 +47,16 @@ func (client *expressRouteLinksOperations) Get(ctx context.Context, resourceGrou
 
 // getCreateRequest creates the Get request.
 func (client *expressRouteLinksOperations) getCreateRequest(resourceGroupName string, expressRoutePortName string, linkName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}/links/{linkName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
 	urlPath = strings.ReplaceAll(urlPath, "{linkName}", url.PathEscape(linkName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -107,11 +110,15 @@ func (client *expressRouteLinksOperations) List(resourceGroupName string, expres
 
 // listCreateRequest creates the List request.
 func (client *expressRouteLinksOperations) listCreateRequest(resourceGroupName string, expressRoutePortName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}/links"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressroutelinks.go
+++ b/test/network/2020-03-01/armnetwork/expressroutelinks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -56,7 +57,7 @@ func (client *expressRouteLinksOperations) getCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
 	urlPath = strings.ReplaceAll(urlPath, "{linkName}", url.PathEscape(linkName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func (client *expressRouteLinksOperations) listCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressrouteports.go
+++ b/test/network/2020-03-01/armnetwork/expressrouteports.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *expressRoutePortsOperations) ResumeCreateOrUpdate(token string) (E
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *expressRoutePortsOperations) createOrUpdateCreateRequest(resourceGroupName string, expressRoutePortName string, parameters ExpressRoutePort) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *expressRoutePortsOperations) ResumeDelete(token string) (HTTPPolle
 
 // deleteCreateRequest creates the Delete request.
 func (client *expressRoutePortsOperations) deleteCreateRequest(resourceGroupName string, expressRoutePortName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *expressRoutePortsOperations) Get(ctx context.Context, resourceGrou
 
 // getCreateRequest creates the Get request.
 func (client *expressRoutePortsOperations) getCreateRequest(resourceGroupName string, expressRoutePortName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -270,9 +281,13 @@ func (client *expressRoutePortsOperations) List() (ExpressRoutePortListResultPag
 
 // listCreateRequest creates the List request.
 func (client *expressRoutePortsOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ExpressRoutePorts"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -326,10 +341,14 @@ func (client *expressRoutePortsOperations) ListByResourceGroup(resourceGroupName
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *expressRoutePortsOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -377,11 +396,15 @@ func (client *expressRoutePortsOperations) UpdateTags(ctx context.Context, resou
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *expressRoutePortsOperations) updateTagsCreateRequest(resourceGroupName string, expressRoutePortName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressrouteports.go
+++ b/test/network/2020-03-01/armnetwork/expressrouteports.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *expressRoutePortsOperations) createOrUpdateCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *expressRoutePortsOperations) deleteCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *expressRoutePortsOperations) getCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +288,7 @@ func (client *expressRoutePortsOperations) listCreateRequest() (*azcore.Request,
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ExpressRoutePorts"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +349,7 @@ func (client *expressRoutePortsOperations) listByResourceGroupCreateRequest(reso
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +405,7 @@ func (client *expressRoutePortsOperations) updateTagsCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressrouteportslocations.go
+++ b/test/network/2020-03-01/armnetwork/expressrouteportslocations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -54,7 +55,7 @@ func (client *expressRoutePortsLocationsOperations) getCreateRequest(locationNam
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ExpressRoutePortsLocations/{locationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{locationName}", url.PathEscape(locationName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +115,7 @@ func (client *expressRoutePortsLocationsOperations) listCreateRequest() (*azcore
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ExpressRoutePortsLocations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressrouteportslocations.go
+++ b/test/network/2020-03-01/armnetwork/expressrouteportslocations.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -48,10 +47,14 @@ func (client *expressRoutePortsLocationsOperations) Get(ctx context.Context, loc
 
 // getCreateRequest creates the Get request.
 func (client *expressRoutePortsLocationsOperations) getCreateRequest(locationName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ExpressRoutePortsLocations/{locationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{locationName}", url.PathEscape(locationName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -105,9 +108,13 @@ func (client *expressRoutePortsLocationsOperations) List() (ExpressRoutePortsLoc
 
 // listCreateRequest creates the List request.
 func (client *expressRoutePortsLocationsOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ExpressRoutePortsLocations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressrouteserviceproviders.go
+++ b/test/network/2020-03-01/armnetwork/expressrouteserviceproviders.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -51,9 +50,13 @@ func (client *expressRouteServiceProvidersOperations) List() (ExpressRouteServic
 
 // listCreateRequest creates the List request.
 func (client *expressRouteServiceProvidersOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteServiceProviders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/expressrouteserviceproviders.go
+++ b/test/network/2020-03-01/armnetwork/expressrouteserviceproviders.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -56,7 +57,7 @@ func (client *expressRouteServiceProvidersOperations) listCreateRequest() (*azco
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteServiceProviders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/firewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/firewallpolicies.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -91,7 +92,7 @@ func (client *firewallPoliciesOperations) createOrUpdateCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *firewallPoliciesOperations) deleteCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +226,7 @@ func (client *firewallPoliciesOperations) getCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +290,7 @@ func (client *firewallPoliciesOperations) listCreateRequest(resourceGroupName st
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +350,7 @@ func (client *firewallPoliciesOperations) listAllCreateRequest() (*azcore.Reques
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/firewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/firewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/firewallpolicies.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -84,11 +83,15 @@ func (client *firewallPoliciesOperations) ResumeCreateOrUpdate(token string) (Fi
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *firewallPoliciesOperations) createOrUpdateCreateRequest(resourceGroupName string, firewallPolicyName string, parameters FirewallPolicy) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -159,11 +162,15 @@ func (client *firewallPoliciesOperations) ResumeDelete(token string) (HTTPPoller
 
 // deleteCreateRequest creates the Delete request.
 func (client *firewallPoliciesOperations) deleteCreateRequest(resourceGroupName string, firewallPolicyName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,11 +217,15 @@ func (client *firewallPoliciesOperations) Get(ctx context.Context, resourceGroup
 
 // getCreateRequest creates the Get request.
 func (client *firewallPoliciesOperations) getCreateRequest(resourceGroupName string, firewallPolicyName string, firewallPoliciesGetOptions *FirewallPoliciesGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -271,10 +282,14 @@ func (client *firewallPoliciesOperations) List(resourceGroupName string) (Firewa
 
 // listCreateRequest creates the List request.
 func (client *firewallPoliciesOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -328,9 +343,13 @@ func (client *firewallPoliciesOperations) ListAll() (FirewallPolicyListResultPag
 
 // listAllCreateRequest creates the ListAll request.
 func (client *firewallPoliciesOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/firewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/firewallpolicyrulegroups.go
+++ b/test/network/2020-03-01/armnetwork/firewallpolicyrulegroups.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *firewallPolicyRuleGroupsOperations) createOrUpdateCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleGroupName}", url.PathEscape(ruleGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *firewallPolicyRuleGroupsOperations) deleteCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleGroupName}", url.PathEscape(ruleGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *firewallPolicyRuleGroupsOperations) getCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleGroupName}", url.PathEscape(ruleGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *firewallPolicyRuleGroupsOperations) listCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/firewallpolicyrulegroups.go
+++ b/test/network/2020-03-01/armnetwork/firewallpolicyrulegroups.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *firewallPolicyRuleGroupsOperations) ResumeCreateOrUpdate(token str
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *firewallPolicyRuleGroupsOperations) createOrUpdateCreateRequest(resourceGroupName string, firewallPolicyName string, ruleGroupName string, parameters FirewallPolicyRuleGroup) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleGroups/{ruleGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleGroupName}", url.PathEscape(ruleGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *firewallPolicyRuleGroupsOperations) ResumeDelete(token string) (HT
 
 // deleteCreateRequest creates the Delete request.
 func (client *firewallPolicyRuleGroupsOperations) deleteCreateRequest(resourceGroupName string, firewallPolicyName string, ruleGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleGroups/{ruleGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleGroupName}", url.PathEscape(ruleGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *firewallPolicyRuleGroupsOperations) Get(ctx context.Context, resou
 
 // getCreateRequest creates the Get request.
 func (client *firewallPolicyRuleGroupsOperations) getCreateRequest(resourceGroupName string, firewallPolicyName string, ruleGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleGroups/{ruleGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleGroupName}", url.PathEscape(ruleGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *firewallPolicyRuleGroupsOperations) List(resourceGroupName string,
 
 // listCreateRequest creates the List request.
 func (client *firewallPolicyRuleGroupsOperations) listCreateRequest(resourceGroupName string, firewallPolicyName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/flowlogs.go
+++ b/test/network/2020-03-01/armnetwork/flowlogs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *flowLogsOperations) createOrUpdateCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{flowLogName}", url.PathEscape(flowLogName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *flowLogsOperations) deleteCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{flowLogName}", url.PathEscape(flowLogName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *flowLogsOperations) getCreateRequest(resourceGroupName string, net
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{flowLogName}", url.PathEscape(flowLogName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *flowLogsOperations) listCreateRequest(resourceGroupName string, ne
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/flowlogs.go
+++ b/test/network/2020-03-01/armnetwork/flowlogs.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *flowLogsOperations) ResumeCreateOrUpdate(token string) (FlowLogPol
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *flowLogsOperations) createOrUpdateCreateRequest(resourceGroupName string, networkWatcherName string, flowLogName string, parameters FlowLog) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/flowLogs/{flowLogName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{flowLogName}", url.PathEscape(flowLogName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *flowLogsOperations) ResumeDelete(token string) (HTTPPoller, error)
 
 // deleteCreateRequest creates the Delete request.
 func (client *flowLogsOperations) deleteCreateRequest(resourceGroupName string, networkWatcherName string, flowLogName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/flowLogs/{flowLogName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{flowLogName}", url.PathEscape(flowLogName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *flowLogsOperations) Get(ctx context.Context, resourceGroupName str
 
 // getCreateRequest creates the Get request.
 func (client *flowLogsOperations) getCreateRequest(resourceGroupName string, networkWatcherName string, flowLogName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/flowLogs/{flowLogName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{flowLogName}", url.PathEscape(flowLogName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *flowLogsOperations) List(resourceGroupName string, networkWatcherN
 
 // listCreateRequest creates the List request.
 func (client *flowLogsOperations) listCreateRequest(resourceGroupName string, networkWatcherName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/flowLogs"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/hubvirtualnetworkconnections.go
+++ b/test/network/2020-03-01/armnetwork/hubvirtualnetworkconnections.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -56,7 +57,7 @@ func (client *hubVirtualNetworkConnectionsOperations) getCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func (client *hubVirtualNetworkConnectionsOperations) listCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/hubvirtualnetworkconnections.go
+++ b/test/network/2020-03-01/armnetwork/hubvirtualnetworkconnections.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -48,12 +47,16 @@ func (client *hubVirtualNetworkConnectionsOperations) Get(ctx context.Context, r
 
 // getCreateRequest creates the Get request.
 func (client *hubVirtualNetworkConnectionsOperations) getCreateRequest(resourceGroupName string, virtualHubName string, connectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/hubVirtualNetworkConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -107,11 +110,15 @@ func (client *hubVirtualNetworkConnectionsOperations) List(resourceGroupName str
 
 // listCreateRequest creates the List request.
 func (client *hubVirtualNetworkConnectionsOperations) listCreateRequest(resourceGroupName string, virtualHubName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/hubVirtualNetworkConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/inboundnatrules.go
+++ b/test/network/2020-03-01/armnetwork/inboundnatrules.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *inboundNatRulesOperations) ResumeCreateOrUpdate(token string) (Inb
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *inboundNatRulesOperations) createOrUpdateCreateRequest(resourceGroupName string, loadBalancerName string, inboundNatRuleName string, inboundNatRuleParameters InboundNatRule) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules/{inboundNatRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{inboundNatRuleName}", url.PathEscape(inboundNatRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *inboundNatRulesOperations) ResumeDelete(token string) (HTTPPoller,
 
 // deleteCreateRequest creates the Delete request.
 func (client *inboundNatRulesOperations) deleteCreateRequest(resourceGroupName string, loadBalancerName string, inboundNatRuleName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules/{inboundNatRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{inboundNatRuleName}", url.PathEscape(inboundNatRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *inboundNatRulesOperations) Get(ctx context.Context, resourceGroupN
 
 // getCreateRequest creates the Get request.
 func (client *inboundNatRulesOperations) getCreateRequest(resourceGroupName string, loadBalancerName string, inboundNatRuleName string, inboundNatRulesGetOptions *InboundNatRulesGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules/{inboundNatRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{inboundNatRuleName}", url.PathEscape(inboundNatRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -272,11 +283,15 @@ func (client *inboundNatRulesOperations) List(resourceGroupName string, loadBala
 
 // listCreateRequest creates the List request.
 func (client *inboundNatRulesOperations) listCreateRequest(resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/inboundnatrules.go
+++ b/test/network/2020-03-01/armnetwork/inboundnatrules.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *inboundNatRulesOperations) createOrUpdateCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{inboundNatRuleName}", url.PathEscape(inboundNatRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *inboundNatRulesOperations) deleteCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{inboundNatRuleName}", url.PathEscape(inboundNatRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *inboundNatRulesOperations) getCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{inboundNatRuleName}", url.PathEscape(inboundNatRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +292,7 @@ func (client *inboundNatRulesOperations) listCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/ipallocations.go
+++ b/test/network/2020-03-01/armnetwork/ipallocations.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *ipAllocationsOperations) ResumeCreateOrUpdate(token string) (IPAll
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *ipAllocationsOperations) createOrUpdateCreateRequest(resourceGroupName string, ipAllocationName string, parameters IPAllocation) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations/{ipAllocationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *ipAllocationsOperations) ResumeDelete(token string) (HTTPPoller, e
 
 // deleteCreateRequest creates the Delete request.
 func (client *ipAllocationsOperations) deleteCreateRequest(resourceGroupName string, ipAllocationName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations/{ipAllocationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *ipAllocationsOperations) Get(ctx context.Context, resourceGroupNam
 
 // getCreateRequest creates the Get request.
 func (client *ipAllocationsOperations) getCreateRequest(resourceGroupName string, ipAllocationName string, ipAllocationsGetOptions *IPAllocationsGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations/{ipAllocationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -273,9 +284,13 @@ func (client *ipAllocationsOperations) List() (IPAllocationListResultPager, erro
 
 // listCreateRequest creates the List request.
 func (client *ipAllocationsOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/IpAllocations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -329,10 +344,14 @@ func (client *ipAllocationsOperations) ListByResourceGroup(resourceGroupName str
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *ipAllocationsOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -380,11 +399,15 @@ func (client *ipAllocationsOperations) UpdateTags(ctx context.Context, resourceG
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *ipAllocationsOperations) updateTagsCreateRequest(resourceGroupName string, ipAllocationName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations/{ipAllocationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/ipallocations.go
+++ b/test/network/2020-03-01/armnetwork/ipallocations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *ipAllocationsOperations) createOrUpdateCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *ipAllocationsOperations) deleteCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *ipAllocationsOperations) getCreateRequest(resourceGroupName string
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +291,7 @@ func (client *ipAllocationsOperations) listCreateRequest() (*azcore.Request, err
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/IpAllocations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +352,7 @@ func (client *ipAllocationsOperations) listByResourceGroupCreateRequest(resource
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +408,7 @@ func (client *ipAllocationsOperations) updateTagsCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/ipgroups.go
+++ b/test/network/2020-03-01/armnetwork/ipgroups.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *ipGroupsOperations) ResumeCreateOrUpdate(token string) (IPGroupPol
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *ipGroupsOperations) createOrUpdateCreateRequest(resourceGroupName string, ipGroupsName string, parameters IPGroup) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups/{ipGroupsName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *ipGroupsOperations) ResumeDelete(token string) (HTTPPoller, error)
 
 // deleteCreateRequest creates the Delete request.
 func (client *ipGroupsOperations) deleteCreateRequest(resourceGroupName string, ipGroupsName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups/{ipGroupsName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *ipGroupsOperations) Get(ctx context.Context, resourceGroupName str
 
 // getCreateRequest creates the Get request.
 func (client *ipGroupsOperations) getCreateRequest(resourceGroupName string, ipGroupsName string, ipGroupsGetOptions *IPGroupsGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups/{ipGroupsName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -273,9 +284,13 @@ func (client *ipGroupsOperations) List() (IPGroupListResultPager, error) {
 
 // listCreateRequest creates the List request.
 func (client *ipGroupsOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ipGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -329,10 +344,14 @@ func (client *ipGroupsOperations) ListByResourceGroup(resourceGroupName string) 
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *ipGroupsOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -380,11 +399,15 @@ func (client *ipGroupsOperations) UpdateGroups(ctx context.Context, resourceGrou
 
 // updateGroupsCreateRequest creates the UpdateGroups request.
 func (client *ipGroupsOperations) updateGroupsCreateRequest(resourceGroupName string, ipGroupsName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups/{ipGroupsName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/ipgroups.go
+++ b/test/network/2020-03-01/armnetwork/ipgroups.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *ipGroupsOperations) createOrUpdateCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *ipGroupsOperations) deleteCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *ipGroupsOperations) getCreateRequest(resourceGroupName string, ipG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +291,7 @@ func (client *ipGroupsOperations) listCreateRequest() (*azcore.Request, error) {
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ipGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +352,7 @@ func (client *ipGroupsOperations) listByResourceGroupCreateRequest(resourceGroup
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +408,7 @@ func (client *ipGroupsOperations) updateGroupsCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancerbackendaddresspools.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancerbackendaddresspools.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -56,7 +57,7 @@ func (client *loadBalancerBackendAddressPoolsOperations) getCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{backendAddressPoolName}", url.PathEscape(backendAddressPoolName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func (client *loadBalancerBackendAddressPoolsOperations) listCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancerbackendaddresspools.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancerbackendaddresspools.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -48,12 +47,16 @@ func (client *loadBalancerBackendAddressPoolsOperations) Get(ctx context.Context
 
 // getCreateRequest creates the Get request.
 func (client *loadBalancerBackendAddressPoolsOperations) getCreateRequest(resourceGroupName string, loadBalancerName string, backendAddressPoolName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools/{backendAddressPoolName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{backendAddressPoolName}", url.PathEscape(backendAddressPoolName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -107,11 +110,15 @@ func (client *loadBalancerBackendAddressPoolsOperations) List(resourceGroupName 
 
 // listCreateRequest creates the List request.
 func (client *loadBalancerBackendAddressPoolsOperations) listCreateRequest(resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancerfrontendipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancerfrontendipconfigurations.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -48,12 +47,16 @@ func (client *loadBalancerFrontendIPConfigurationsOperations) Get(ctx context.Co
 
 // getCreateRequest creates the Get request.
 func (client *loadBalancerFrontendIPConfigurationsOperations) getCreateRequest(resourceGroupName string, loadBalancerName string, frontendIPConfigurationName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/frontendIPConfigurations/{frontendIPConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{frontendIPConfigurationName}", url.PathEscape(frontendIPConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -107,11 +110,15 @@ func (client *loadBalancerFrontendIPConfigurationsOperations) List(resourceGroup
 
 // listCreateRequest creates the List request.
 func (client *loadBalancerFrontendIPConfigurationsOperations) listCreateRequest(resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/frontendIPConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancerfrontendipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancerfrontendipconfigurations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -56,7 +57,7 @@ func (client *loadBalancerFrontendIPConfigurationsOperations) getCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{frontendIPConfigurationName}", url.PathEscape(frontendIPConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func (client *loadBalancerFrontendIPConfigurationsOperations) listCreateRequest(
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancerloadbalancingrules.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancerloadbalancingrules.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -56,7 +57,7 @@ func (client *loadBalancerLoadBalancingRulesOperations) getCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancingRuleName}", url.PathEscape(loadBalancingRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func (client *loadBalancerLoadBalancingRulesOperations) listCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancerloadbalancingrules.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancerloadbalancingrules.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -48,12 +47,16 @@ func (client *loadBalancerLoadBalancingRulesOperations) Get(ctx context.Context,
 
 // getCreateRequest creates the Get request.
 func (client *loadBalancerLoadBalancingRulesOperations) getCreateRequest(resourceGroupName string, loadBalancerName string, loadBalancingRuleName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/loadBalancingRules/{loadBalancingRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancingRuleName}", url.PathEscape(loadBalancingRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -107,11 +110,15 @@ func (client *loadBalancerLoadBalancingRulesOperations) List(resourceGroupName s
 
 // listCreateRequest creates the List request.
 func (client *loadBalancerLoadBalancingRulesOperations) listCreateRequest(resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/loadBalancingRules"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancernetworkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancernetworkinterfaces.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -58,7 +59,7 @@ func (client *loadBalancerNetworkInterfacesOperations) listCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancernetworkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancernetworkinterfaces.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -51,11 +50,15 @@ func (client *loadBalancerNetworkInterfacesOperations) List(resourceGroupName st
 
 // listCreateRequest creates the List request.
 func (client *loadBalancerNetworkInterfacesOperations) listCreateRequest(resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/networkInterfaces"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalanceroutboundrules.go
+++ b/test/network/2020-03-01/armnetwork/loadbalanceroutboundrules.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -56,7 +57,7 @@ func (client *loadBalancerOutboundRulesOperations) getCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{outboundRuleName}", url.PathEscape(outboundRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func (client *loadBalancerOutboundRulesOperations) listCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalanceroutboundrules.go
+++ b/test/network/2020-03-01/armnetwork/loadbalanceroutboundrules.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -48,12 +47,16 @@ func (client *loadBalancerOutboundRulesOperations) Get(ctx context.Context, reso
 
 // getCreateRequest creates the Get request.
 func (client *loadBalancerOutboundRulesOperations) getCreateRequest(resourceGroupName string, loadBalancerName string, outboundRuleName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/outboundRules/{outboundRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{outboundRuleName}", url.PathEscape(outboundRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -107,11 +110,15 @@ func (client *loadBalancerOutboundRulesOperations) List(resourceGroupName string
 
 // listCreateRequest creates the List request.
 func (client *loadBalancerOutboundRulesOperations) listCreateRequest(resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/outboundRules"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancerprobes.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancerprobes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -56,7 +57,7 @@ func (client *loadBalancerProbesOperations) getCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{probeName}", url.PathEscape(probeName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func (client *loadBalancerProbesOperations) listCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancerprobes.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancerprobes.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -48,12 +47,16 @@ func (client *loadBalancerProbesOperations) Get(ctx context.Context, resourceGro
 
 // getCreateRequest creates the Get request.
 func (client *loadBalancerProbesOperations) getCreateRequest(resourceGroupName string, loadBalancerName string, probeName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/probes/{probeName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{probeName}", url.PathEscape(probeName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -107,11 +110,15 @@ func (client *loadBalancerProbesOperations) List(resourceGroupName string, loadB
 
 // listCreateRequest creates the List request.
 func (client *loadBalancerProbesOperations) listCreateRequest(resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/probes"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *loadBalancersOperations) createOrUpdateCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *loadBalancersOperations) deleteCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *loadBalancersOperations) getCreateRequest(resourceGroupName string
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +292,7 @@ func (client *loadBalancersOperations) listCreateRequest(resourceGroupName strin
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +352,7 @@ func (client *loadBalancersOperations) listAllCreateRequest() (*azcore.Request, 
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/loadBalancers"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +408,7 @@ func (client *loadBalancersOperations) updateTagsCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/loadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/loadbalancers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *loadBalancersOperations) ResumeCreateOrUpdate(token string) (LoadB
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *loadBalancersOperations) createOrUpdateCreateRequest(resourceGroupName string, loadBalancerName string, parameters LoadBalancer) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *loadBalancersOperations) ResumeDelete(token string) (HTTPPoller, e
 
 // deleteCreateRequest creates the Delete request.
 func (client *loadBalancersOperations) deleteCreateRequest(resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *loadBalancersOperations) Get(ctx context.Context, resourceGroupNam
 
 // getCreateRequest creates the Get request.
 func (client *loadBalancersOperations) getCreateRequest(resourceGroupName string, loadBalancerName string, loadBalancersGetOptions *LoadBalancersGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -273,10 +284,14 @@ func (client *loadBalancersOperations) List(resourceGroupName string) (LoadBalan
 
 // listCreateRequest creates the List request.
 func (client *loadBalancersOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -330,9 +345,13 @@ func (client *loadBalancersOperations) ListAll() (LoadBalancerListResultPager, e
 
 // listAllCreateRequest creates the ListAll request.
 func (client *loadBalancersOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/loadBalancers"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -380,11 +399,15 @@ func (client *loadBalancersOperations) UpdateTags(ctx context.Context, resourceG
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *loadBalancersOperations) updateTagsCreateRequest(resourceGroupName string, loadBalancerName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/localnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/localnetworkgateways.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -91,7 +92,7 @@ func (client *localNetworkGatewaysOperations) createOrUpdateCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *localNetworkGatewaysOperations) deleteCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +226,7 @@ func (client *localNetworkGatewaysOperations) getCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +287,7 @@ func (client *localNetworkGatewaysOperations) listCreateRequest(resourceGroupNam
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +343,7 @@ func (client *localNetworkGatewaysOperations) updateTagsCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/localnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/localnetworkgateways.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -84,11 +83,15 @@ func (client *localNetworkGatewaysOperations) ResumeCreateOrUpdate(token string)
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *localNetworkGatewaysOperations) createOrUpdateCreateRequest(resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways/{localNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -159,11 +162,15 @@ func (client *localNetworkGatewaysOperations) ResumeDelete(token string) (HTTPPo
 
 // deleteCreateRequest creates the Delete request.
 func (client *localNetworkGatewaysOperations) deleteCreateRequest(resourceGroupName string, localNetworkGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways/{localNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,11 +217,15 @@ func (client *localNetworkGatewaysOperations) Get(ctx context.Context, resourceG
 
 // getCreateRequest creates the Get request.
 func (client *localNetworkGatewaysOperations) getCreateRequest(resourceGroupName string, localNetworkGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways/{localNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -268,10 +279,14 @@ func (client *localNetworkGatewaysOperations) List(resourceGroupName string) (Lo
 
 // listCreateRequest creates the List request.
 func (client *localNetworkGatewaysOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -319,11 +334,15 @@ func (client *localNetworkGatewaysOperations) UpdateTags(ctx context.Context, re
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *localNetworkGatewaysOperations) updateTagsCreateRequest(resourceGroupName string, localNetworkGatewayName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways/{localNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/natgateways.go
+++ b/test/network/2020-03-01/armnetwork/natgateways.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *natGatewaysOperations) ResumeCreateOrUpdate(token string) (NatGate
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *natGatewaysOperations) createOrUpdateCreateRequest(resourceGroupName string, natGatewayName string, parameters NatGateway) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways/{natGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *natGatewaysOperations) ResumeDelete(token string) (HTTPPoller, err
 
 // deleteCreateRequest creates the Delete request.
 func (client *natGatewaysOperations) deleteCreateRequest(resourceGroupName string, natGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways/{natGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *natGatewaysOperations) Get(ctx context.Context, resourceGroupName 
 
 // getCreateRequest creates the Get request.
 func (client *natGatewaysOperations) getCreateRequest(resourceGroupName string, natGatewayName string, natGatewaysGetOptions *NatGatewaysGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways/{natGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -273,10 +284,14 @@ func (client *natGatewaysOperations) List(resourceGroupName string) (NatGatewayL
 
 // listCreateRequest creates the List request.
 func (client *natGatewaysOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -330,9 +345,13 @@ func (client *natGatewaysOperations) ListAll() (NatGatewayListResultPager, error
 
 // listAllCreateRequest creates the ListAll request.
 func (client *natGatewaysOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/natGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -380,11 +399,15 @@ func (client *natGatewaysOperations) UpdateTags(ctx context.Context, resourceGro
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *natGatewaysOperations) updateTagsCreateRequest(resourceGroupName string, natGatewayName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways/{natGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/natgateways.go
+++ b/test/network/2020-03-01/armnetwork/natgateways.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *natGatewaysOperations) createOrUpdateCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *natGatewaysOperations) deleteCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *natGatewaysOperations) getCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +292,7 @@ func (client *natGatewaysOperations) listCreateRequest(resourceGroupName string)
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +352,7 @@ func (client *natGatewaysOperations) listAllCreateRequest() (*azcore.Request, er
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/natGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +408,7 @@ func (client *natGatewaysOperations) updateTagsCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkinterfaceipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/networkinterfaceipconfigurations.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -48,12 +47,16 @@ func (client *networkInterfaceIPConfigurationsOperations) Get(ctx context.Contex
 
 // getCreateRequest creates the Get request.
 func (client *networkInterfaceIPConfigurationsOperations) getCreateRequest(resourceGroupName string, networkInterfaceName string, ipConfigurationName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/ipConfigurations/{ipConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipConfigurationName}", url.PathEscape(ipConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -107,11 +110,15 @@ func (client *networkInterfaceIPConfigurationsOperations) List(resourceGroupName
 
 // listCreateRequest creates the List request.
 func (client *networkInterfaceIPConfigurationsOperations) listCreateRequest(resourceGroupName string, networkInterfaceName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/ipConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkinterfaceipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/networkinterfaceipconfigurations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -56,7 +57,7 @@ func (client *networkInterfaceIPConfigurationsOperations) getCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipConfigurationName}", url.PathEscape(ipConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func (client *networkInterfaceIPConfigurationsOperations) listCreateRequest(reso
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkinterfaceloadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/networkinterfaceloadbalancers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -51,11 +50,15 @@ func (client *networkInterfaceLoadBalancersOperations) List(resourceGroupName st
 
 // listCreateRequest creates the List request.
 func (client *networkInterfaceLoadBalancersOperations) listCreateRequest(resourceGroupName string, networkInterfaceName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/loadBalancers"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkinterfaceloadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/networkinterfaceloadbalancers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -58,7 +59,7 @@ func (client *networkInterfaceLoadBalancersOperations) listCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/networkinterfaces.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -111,7 +112,7 @@ func (client *networkInterfacesOperations) createOrUpdateCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +191,7 @@ func (client *networkInterfacesOperations) deleteCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +246,7 @@ func (client *networkInterfacesOperations) getCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +329,7 @@ func (client *networkInterfacesOperations) getEffectiveRouteTableCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -386,7 +387,7 @@ func (client *networkInterfacesOperations) getVirtualMachineScaleSetIPConfigurat
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipConfigurationName}", url.PathEscape(ipConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +448,7 @@ func (client *networkInterfacesOperations) getVirtualMachineScaleSetNetworkInter
 	urlPath = strings.ReplaceAll(urlPath, "{virtualmachineIndex}", url.PathEscape(virtualmachineIndex))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -511,7 +512,7 @@ func (client *networkInterfacesOperations) listCreateRequest(resourceGroupName s
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -571,7 +572,7 @@ func (client *networkInterfacesOperations) listAllCreateRequest() (*azcore.Reque
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkInterfaces"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -651,7 +652,7 @@ func (client *networkInterfacesOperations) listEffectiveNetworkSecurityGroupsCre
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -714,7 +715,7 @@ func (client *networkInterfacesOperations) listVirtualMachineScaleSetIPConfigura
 	urlPath = strings.ReplaceAll(urlPath, "{virtualmachineIndex}", url.PathEscape(virtualmachineIndex))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -779,7 +780,7 @@ func (client *networkInterfacesOperations) listVirtualMachineScaleSetNetworkInte
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -842,7 +843,7 @@ func (client *networkInterfacesOperations) listVirtualMachineScaleSetVMNetworkIn
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualmachineIndex}", url.PathEscape(virtualmachineIndex))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -898,7 +899,7 @@ func (client *networkInterfacesOperations) updateTagsCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/networkinterfaces.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -104,11 +103,15 @@ func (client *networkInterfacesOperations) ResumeCreateOrUpdate(token string) (N
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *networkInterfacesOperations) createOrUpdateCreateRequest(resourceGroupName string, networkInterfaceName string, parameters NetworkInterface) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -179,11 +182,15 @@ func (client *networkInterfacesOperations) ResumeDelete(token string) (HTTPPolle
 
 // deleteCreateRequest creates the Delete request.
 func (client *networkInterfacesOperations) deleteCreateRequest(resourceGroupName string, networkInterfaceName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -230,11 +237,15 @@ func (client *networkInterfacesOperations) Get(ctx context.Context, resourceGrou
 
 // getCreateRequest creates the Get request.
 func (client *networkInterfacesOperations) getCreateRequest(resourceGroupName string, networkInterfaceName string, networkInterfacesGetOptions *NetworkInterfacesGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -309,11 +320,15 @@ func (client *networkInterfacesOperations) ResumeGetEffectiveRouteTable(token st
 
 // getEffectiveRouteTableCreateRequest creates the GetEffectiveRouteTable request.
 func (client *networkInterfacesOperations) getEffectiveRouteTableCreateRequest(resourceGroupName string, networkInterfaceName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/effectiveRouteTable"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -360,6 +375,10 @@ func (client *networkInterfacesOperations) GetVirtualMachineScaleSetIPConfigurat
 
 // getVirtualMachineScaleSetIPConfigurationCreateRequest creates the GetVirtualMachineScaleSetIPConfiguration request.
 func (client *networkInterfacesOperations) getVirtualMachineScaleSetIPConfigurationCreateRequest(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, networkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions *NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}/ipConfigurations/{ipConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
@@ -367,7 +386,7 @@ func (client *networkInterfacesOperations) getVirtualMachineScaleSetIPConfigurat
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipConfigurationName}", url.PathEscape(ipConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -418,13 +437,17 @@ func (client *networkInterfacesOperations) GetVirtualMachineScaleSetNetworkInter
 
 // getVirtualMachineScaleSetNetworkInterfaceCreateRequest creates the GetVirtualMachineScaleSetNetworkInterface request.
 func (client *networkInterfacesOperations) getVirtualMachineScaleSetNetworkInterfaceCreateRequest(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, networkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions *NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualmachineIndex}", url.PathEscape(virtualmachineIndex))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -481,10 +504,14 @@ func (client *networkInterfacesOperations) List(resourceGroupName string) (Netwo
 
 // listCreateRequest creates the List request.
 func (client *networkInterfacesOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -538,9 +565,13 @@ func (client *networkInterfacesOperations) ListAll() (NetworkInterfaceListResult
 
 // listAllCreateRequest creates the ListAll request.
 func (client *networkInterfacesOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkInterfaces"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -612,11 +643,15 @@ func (client *networkInterfacesOperations) ResumeListEffectiveNetworkSecurityGro
 
 // listEffectiveNetworkSecurityGroupsCreateRequest creates the ListEffectiveNetworkSecurityGroups request.
 func (client *networkInterfacesOperations) listEffectiveNetworkSecurityGroupsCreateRequest(resourceGroupName string, networkInterfaceName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/effectiveNetworkSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -669,13 +704,17 @@ func (client *networkInterfacesOperations) ListVirtualMachineScaleSetIPConfigura
 
 // listVirtualMachineScaleSetIPConfigurationsCreateRequest creates the ListVirtualMachineScaleSetIPConfigurations request.
 func (client *networkInterfacesOperations) listVirtualMachineScaleSetIPConfigurationsCreateRequest(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, networkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions *NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}/ipConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualmachineIndex}", url.PathEscape(virtualmachineIndex))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -732,11 +771,15 @@ func (client *networkInterfacesOperations) ListVirtualMachineScaleSetNetworkInte
 
 // listVirtualMachineScaleSetNetworkInterfacesCreateRequest creates the ListVirtualMachineScaleSetNetworkInterfaces request.
 func (client *networkInterfacesOperations) listVirtualMachineScaleSetNetworkInterfacesCreateRequest(resourceGroupName string, virtualMachineScaleSetName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/networkInterfaces"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -790,12 +833,16 @@ func (client *networkInterfacesOperations) ListVirtualMachineScaleSetVMNetworkIn
 
 // listVirtualMachineScaleSetVMNetworkInterfacesCreateRequest creates the ListVirtualMachineScaleSetVMNetworkInterfaces request.
 func (client *networkInterfacesOperations) listVirtualMachineScaleSetVMNetworkInterfacesCreateRequest(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualmachineIndex}", url.PathEscape(virtualmachineIndex))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -843,11 +890,15 @@ func (client *networkInterfacesOperations) UpdateTags(ctx context.Context, resou
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *networkInterfacesOperations) updateTagsCreateRequest(resourceGroupName string, networkInterfaceName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkinterfacetapconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/networkinterfacetapconfigurations.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *networkInterfaceTapConfigurationsOperations) ResumeCreateOrUpdate(
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *networkInterfaceTapConfigurationsOperations) createOrUpdateCreateRequest(resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters NetworkInterfaceTapConfiguration) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations/{tapConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapConfigurationName}", url.PathEscape(tapConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *networkInterfaceTapConfigurationsOperations) ResumeDelete(token st
 
 // deleteCreateRequest creates the Delete request.
 func (client *networkInterfaceTapConfigurationsOperations) deleteCreateRequest(resourceGroupName string, networkInterfaceName string, tapConfigurationName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations/{tapConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapConfigurationName}", url.PathEscape(tapConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *networkInterfaceTapConfigurationsOperations) Get(ctx context.Conte
 
 // getCreateRequest creates the Get request.
 func (client *networkInterfaceTapConfigurationsOperations) getCreateRequest(resourceGroupName string, networkInterfaceName string, tapConfigurationName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations/{tapConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapConfigurationName}", url.PathEscape(tapConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *networkInterfaceTapConfigurationsOperations) List(resourceGroupNam
 
 // listCreateRequest creates the List request.
 func (client *networkInterfaceTapConfigurationsOperations) listCreateRequest(resourceGroupName string, networkInterfaceName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkinterfacetapconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/networkinterfacetapconfigurations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *networkInterfaceTapConfigurationsOperations) createOrUpdateCreateR
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapConfigurationName}", url.PathEscape(tapConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *networkInterfaceTapConfigurationsOperations) deleteCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapConfigurationName}", url.PathEscape(tapConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *networkInterfaceTapConfigurationsOperations) getCreateRequest(reso
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapConfigurationName}", url.PathEscape(tapConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *networkInterfaceTapConfigurationsOperations) listCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkmanagementclient.go
+++ b/test/network/2020-03-01/armnetwork/networkmanagementclient.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -76,7 +77,7 @@ func (client *networkManagementClientOperations) checkDnsNameAvailabilityCreateR
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/CheckDnsNameAvailability"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +158,7 @@ func (client *networkManagementClientOperations) deleteBastionShareableLinkCreat
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +219,7 @@ func (client *networkManagementClientOperations) disconnectActiveSessionsCreateR
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +299,7 @@ func (client *networkManagementClientOperations) generatevirtualwanvpnserverconf
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWanName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +379,7 @@ func (client *networkManagementClientOperations) getActiveSessionsCreateRequest(
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -448,7 +449,7 @@ func (client *networkManagementClientOperations) getBastionShareableLinkCreateRe
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -529,7 +530,7 @@ func (client *networkManagementClientOperations) putBastionShareableLinkCreateRe
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -593,7 +594,7 @@ func (client *networkManagementClientOperations) supportedSecurityProvidersCreat
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWanName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkmanagementclient.go
+++ b/test/network/2020-03-01/armnetwork/networkmanagementclient.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -70,10 +69,14 @@ func (client *networkManagementClientOperations) CheckDNSNameAvailability(ctx co
 
 // checkDnsNameAvailabilityCreateRequest creates the CheckDNSNameAvailability request.
 func (client *networkManagementClientOperations) checkDnsNameAvailabilityCreateRequest(location string, domainNameLabel string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/CheckDnsNameAvailability"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -146,11 +149,15 @@ func (client *networkManagementClientOperations) ResumeDeleteBastionShareableLin
 
 // deleteBastionShareableLinkCreateRequest creates the DeleteBastionShareableLink request.
 func (client *networkManagementClientOperations) deleteBastionShareableLinkCreateRequest(resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/deleteShareableLinks"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -203,11 +210,15 @@ func (client *networkManagementClientOperations) DisconnectActiveSessions(resour
 
 // disconnectActiveSessionsCreateRequest creates the DisconnectActiveSessions request.
 func (client *networkManagementClientOperations) disconnectActiveSessionsCreateRequest(resourceGroupName string, bastionHostName string, sessionIds SessionIDs) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/disconnectActiveSessions"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -279,11 +290,15 @@ func (client *networkManagementClientOperations) ResumeGeneratevirtualwanvpnserv
 
 // generatevirtualwanvpnserverconfigurationvpnprofileCreateRequest creates the Generatevirtualwanvpnserverconfigurationvpnprofile request.
 func (client *networkManagementClientOperations) generatevirtualwanvpnserverconfigurationvpnprofileCreateRequest(resourceGroupName string, virtualWanName string, vpnClientParams VirtualWanVpnProfileParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/GenerateVpnProfile"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWanName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -355,11 +370,15 @@ func (client *networkManagementClientOperations) ResumeGetActiveSessions(token s
 
 // getActiveSessionsCreateRequest creates the GetActiveSessions request.
 func (client *networkManagementClientOperations) getActiveSessionsCreateRequest(resourceGroupName string, bastionHostName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/getActiveSessions"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -421,11 +440,15 @@ func (client *networkManagementClientOperations) GetBastionShareableLink(resourc
 
 // getBastionShareableLinkCreateRequest creates the GetBastionShareableLink request.
 func (client *networkManagementClientOperations) getBastionShareableLinkCreateRequest(resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/getShareableLinks"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -498,11 +521,15 @@ func (client *networkManagementClientOperations) ResumePutBastionShareableLink(t
 
 // putBastionShareableLinkCreateRequest creates the PutBastionShareableLink request.
 func (client *networkManagementClientOperations) putBastionShareableLinkCreateRequest(resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/createShareableLinks"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -558,11 +585,15 @@ func (client *networkManagementClientOperations) SupportedSecurityProviders(ctx 
 
 // supportedSecurityProvidersCreateRequest creates the SupportedSecurityProviders request.
 func (client *networkManagementClientOperations) supportedSecurityProvidersCreateRequest(resourceGroupName string, virtualWanName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/supportedSecurityProviders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWanName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkprofiles.go
+++ b/test/network/2020-03-01/armnetwork/networkprofiles.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -67,7 +68,7 @@ func (client *networkProfilesOperations) createOrUpdateCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +148,7 @@ func (client *networkProfilesOperations) deleteCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +203,7 @@ func (client *networkProfilesOperations) getCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +267,7 @@ func (client *networkProfilesOperations) listCreateRequest(resourceGroupName str
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +327,7 @@ func (client *networkProfilesOperations) listAllCreateRequest() (*azcore.Request
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkProfiles"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +383,7 @@ func (client *networkProfilesOperations) updateTagsCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkprofiles.go
+++ b/test/network/2020-03-01/armnetwork/networkprofiles.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -60,11 +59,15 @@ func (client *networkProfilesOperations) CreateOrUpdate(ctx context.Context, res
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *networkProfilesOperations) createOrUpdateCreateRequest(resourceGroupName string, networkProfileName string, parameters NetworkProfile) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles/{networkProfileName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -136,11 +139,15 @@ func (client *networkProfilesOperations) ResumeDelete(token string) (HTTPPoller,
 
 // deleteCreateRequest creates the Delete request.
 func (client *networkProfilesOperations) deleteCreateRequest(resourceGroupName string, networkProfileName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles/{networkProfileName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -187,11 +194,15 @@ func (client *networkProfilesOperations) Get(ctx context.Context, resourceGroupN
 
 // getCreateRequest creates the Get request.
 func (client *networkProfilesOperations) getCreateRequest(resourceGroupName string, networkProfileName string, networkProfilesGetOptions *NetworkProfilesGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles/{networkProfileName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -248,10 +259,14 @@ func (client *networkProfilesOperations) List(resourceGroupName string) (Network
 
 // listCreateRequest creates the List request.
 func (client *networkProfilesOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -305,9 +320,13 @@ func (client *networkProfilesOperations) ListAll() (NetworkProfileListResultPage
 
 // listAllCreateRequest creates the ListAll request.
 func (client *networkProfilesOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkProfiles"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -355,11 +374,15 @@ func (client *networkProfilesOperations) UpdateTags(ctx context.Context, resourc
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *networkProfilesOperations) updateTagsCreateRequest(resourceGroupName string, networkProfileName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles/{networkProfileName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networksecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/networksecuritygroups.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *networkSecurityGroupsOperations) createOrUpdateCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *networkSecurityGroupsOperations) deleteCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *networkSecurityGroupsOperations) getCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +292,7 @@ func (client *networkSecurityGroupsOperations) listCreateRequest(resourceGroupNa
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +352,7 @@ func (client *networkSecurityGroupsOperations) listAllCreateRequest() (*azcore.R
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +408,7 @@ func (client *networkSecurityGroupsOperations) updateTagsCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networksecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/networksecuritygroups.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *networkSecurityGroupsOperations) ResumeCreateOrUpdate(token string
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *networkSecurityGroupsOperations) createOrUpdateCreateRequest(resourceGroupName string, networkSecurityGroupName string, parameters NetworkSecurityGroup) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *networkSecurityGroupsOperations) ResumeDelete(token string) (HTTPP
 
 // deleteCreateRequest creates the Delete request.
 func (client *networkSecurityGroupsOperations) deleteCreateRequest(resourceGroupName string, networkSecurityGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *networkSecurityGroupsOperations) Get(ctx context.Context, resource
 
 // getCreateRequest creates the Get request.
 func (client *networkSecurityGroupsOperations) getCreateRequest(resourceGroupName string, networkSecurityGroupName string, networkSecurityGroupsGetOptions *NetworkSecurityGroupsGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -273,10 +284,14 @@ func (client *networkSecurityGroupsOperations) List(resourceGroupName string) (N
 
 // listCreateRequest creates the List request.
 func (client *networkSecurityGroupsOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -330,9 +345,13 @@ func (client *networkSecurityGroupsOperations) ListAll() (NetworkSecurityGroupLi
 
 // listAllCreateRequest creates the ListAll request.
 func (client *networkSecurityGroupsOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -380,11 +399,15 @@ func (client *networkSecurityGroupsOperations) UpdateTags(ctx context.Context, r
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *networkSecurityGroupsOperations) updateTagsCreateRequest(resourceGroupName string, networkSecurityGroupName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkvirtualappliances.go
+++ b/test/network/2020-03-01/armnetwork/networkvirtualappliances.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *networkVirtualAppliancesOperations) createOrUpdateCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *networkVirtualAppliancesOperations) deleteCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *networkVirtualAppliancesOperations) getCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +291,7 @@ func (client *networkVirtualAppliancesOperations) listCreateRequest() (*azcore.R
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkVirtualAppliances"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +352,7 @@ func (client *networkVirtualAppliancesOperations) listByResourceGroupCreateReque
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +408,7 @@ func (client *networkVirtualAppliancesOperations) updateTagsCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkvirtualappliances.go
+++ b/test/network/2020-03-01/armnetwork/networkvirtualappliances.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *networkVirtualAppliancesOperations) ResumeCreateOrUpdate(token str
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *networkVirtualAppliancesOperations) createOrUpdateCreateRequest(resourceGroupName string, networkVirtualApplianceName string, parameters NetworkVirtualAppliance) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *networkVirtualAppliancesOperations) ResumeDelete(token string) (HT
 
 // deleteCreateRequest creates the Delete request.
 func (client *networkVirtualAppliancesOperations) deleteCreateRequest(resourceGroupName string, networkVirtualApplianceName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *networkVirtualAppliancesOperations) Get(ctx context.Context, resou
 
 // getCreateRequest creates the Get request.
 func (client *networkVirtualAppliancesOperations) getCreateRequest(resourceGroupName string, networkVirtualApplianceName string, networkVirtualAppliancesGetOptions *NetworkVirtualAppliancesGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -273,9 +284,13 @@ func (client *networkVirtualAppliancesOperations) List() (NetworkVirtualApplianc
 
 // listCreateRequest creates the List request.
 func (client *networkVirtualAppliancesOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkVirtualAppliances"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -329,10 +344,14 @@ func (client *networkVirtualAppliancesOperations) ListByResourceGroup(resourceGr
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *networkVirtualAppliancesOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -380,11 +399,15 @@ func (client *networkVirtualAppliancesOperations) UpdateTags(ctx context.Context
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *networkVirtualAppliancesOperations) updateTagsCreateRequest(resourceGroupName string, networkVirtualApplianceName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkwatchers.go
+++ b/test/network/2020-03-01/armnetwork/networkwatchers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -136,7 +137,7 @@ func (client *networkWatchersOperations) checkConnectivityCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +192,7 @@ func (client *networkWatchersOperations) createOrUpdateCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +272,7 @@ func (client *networkWatchersOperations) deleteCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +327,7 @@ func (client *networkWatchersOperations) getCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -406,7 +407,7 @@ func (client *networkWatchersOperations) getAzureReachabilityReportCreateRequest
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -485,7 +486,7 @@ func (client *networkWatchersOperations) getFlowLogStatusCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -564,7 +565,7 @@ func (client *networkWatchersOperations) getNetworkConfigurationDiagnosticCreate
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -643,7 +644,7 @@ func (client *networkWatchersOperations) getNextHopCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -698,7 +699,7 @@ func (client *networkWatchersOperations) getTopologyCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -778,7 +779,7 @@ func (client *networkWatchersOperations) getTroubleshootingCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -857,7 +858,7 @@ func (client *networkWatchersOperations) getTroubleshootingResultCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -936,7 +937,7 @@ func (client *networkWatchersOperations) getVMSecurityRulesCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -990,7 +991,7 @@ func (client *networkWatchersOperations) listCreateRequest(resourceGroupName str
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1044,7 +1045,7 @@ func (client *networkWatchersOperations) listAllCreateRequest() (*azcore.Request
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkWatchers"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1124,7 +1125,7 @@ func (client *networkWatchersOperations) listAvailableProvidersCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1203,7 +1204,7 @@ func (client *networkWatchersOperations) setFlowLogConfigurationCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1258,7 +1259,7 @@ func (client *networkWatchersOperations) updateTagsCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1338,7 +1339,7 @@ func (client *networkWatchersOperations) verifyIPFlowCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/networkwatchers.go
+++ b/test/network/2020-03-01/armnetwork/networkwatchers.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -129,11 +128,15 @@ func (client *networkWatchersOperations) ResumeCheckConnectivity(token string) (
 
 // checkConnectivityCreateRequest creates the CheckConnectivity request.
 func (client *networkWatchersOperations) checkConnectivityCreateRequest(resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectivityCheck"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -180,11 +183,15 @@ func (client *networkWatchersOperations) CreateOrUpdate(ctx context.Context, res
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *networkWatchersOperations) createOrUpdateCreateRequest(resourceGroupName string, networkWatcherName string, parameters NetworkWatcher) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -256,11 +263,15 @@ func (client *networkWatchersOperations) ResumeDelete(token string) (HTTPPoller,
 
 // deleteCreateRequest creates the Delete request.
 func (client *networkWatchersOperations) deleteCreateRequest(resourceGroupName string, networkWatcherName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -307,11 +318,15 @@ func (client *networkWatchersOperations) Get(ctx context.Context, resourceGroupN
 
 // getCreateRequest creates the Get request.
 func (client *networkWatchersOperations) getCreateRequest(resourceGroupName string, networkWatcherName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -383,11 +398,15 @@ func (client *networkWatchersOperations) ResumeGetAzureReachabilityReport(token 
 
 // getAzureReachabilityReportCreateRequest creates the GetAzureReachabilityReport request.
 func (client *networkWatchersOperations) getAzureReachabilityReportCreateRequest(resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/azureReachabilityReport"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -458,11 +477,15 @@ func (client *networkWatchersOperations) ResumeGetFlowLogStatus(token string) (F
 
 // getFlowLogStatusCreateRequest creates the GetFlowLogStatus request.
 func (client *networkWatchersOperations) getFlowLogStatusCreateRequest(resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/queryFlowLogStatus"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -533,11 +556,15 @@ func (client *networkWatchersOperations) ResumeGetNetworkConfigurationDiagnostic
 
 // getNetworkConfigurationDiagnosticCreateRequest creates the GetNetworkConfigurationDiagnostic request.
 func (client *networkWatchersOperations) getNetworkConfigurationDiagnosticCreateRequest(resourceGroupName string, networkWatcherName string, parameters NetworkConfigurationDiagnosticParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/networkConfigurationDiagnostic"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -608,11 +635,15 @@ func (client *networkWatchersOperations) ResumeGetNextHop(token string) (NextHop
 
 // getNextHopCreateRequest creates the GetNextHop request.
 func (client *networkWatchersOperations) getNextHopCreateRequest(resourceGroupName string, networkWatcherName string, parameters NextHopParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/nextHop"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -659,11 +690,15 @@ func (client *networkWatchersOperations) GetTopology(ctx context.Context, resour
 
 // getTopologyCreateRequest creates the GetTopology request.
 func (client *networkWatchersOperations) getTopologyCreateRequest(resourceGroupName string, networkWatcherName string, parameters TopologyParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/topology"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -735,11 +770,15 @@ func (client *networkWatchersOperations) ResumeGetTroubleshooting(token string) 
 
 // getTroubleshootingCreateRequest creates the GetTroubleshooting request.
 func (client *networkWatchersOperations) getTroubleshootingCreateRequest(resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/troubleshoot"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -810,11 +849,15 @@ func (client *networkWatchersOperations) ResumeGetTroubleshootingResult(token st
 
 // getTroubleshootingResultCreateRequest creates the GetTroubleshootingResult request.
 func (client *networkWatchersOperations) getTroubleshootingResultCreateRequest(resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/queryTroubleshootResult"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -885,11 +928,15 @@ func (client *networkWatchersOperations) ResumeGetVMSecurityRules(token string) 
 
 // getVMSecurityRulesCreateRequest creates the GetVMSecurityRules request.
 func (client *networkWatchersOperations) getVMSecurityRulesCreateRequest(resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/securityGroupView"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -936,10 +983,14 @@ func (client *networkWatchersOperations) List(ctx context.Context, resourceGroup
 
 // listCreateRequest creates the List request.
 func (client *networkWatchersOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -987,9 +1038,13 @@ func (client *networkWatchersOperations) ListAll(ctx context.Context) (*NetworkW
 
 // listAllCreateRequest creates the ListAll request.
 func (client *networkWatchersOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkWatchers"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1061,11 +1116,15 @@ func (client *networkWatchersOperations) ResumeListAvailableProviders(token stri
 
 // listAvailableProvidersCreateRequest creates the ListAvailableProviders request.
 func (client *networkWatchersOperations) listAvailableProvidersCreateRequest(resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/availableProvidersList"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1136,11 +1195,15 @@ func (client *networkWatchersOperations) ResumeSetFlowLogConfiguration(token str
 
 // setFlowLogConfigurationCreateRequest creates the SetFlowLogConfiguration request.
 func (client *networkWatchersOperations) setFlowLogConfigurationCreateRequest(resourceGroupName string, networkWatcherName string, parameters FlowLogInformation) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/configureFlowLog"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1187,11 +1250,15 @@ func (client *networkWatchersOperations) UpdateTags(ctx context.Context, resourc
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *networkWatchersOperations) updateTagsCreateRequest(resourceGroupName string, networkWatcherName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1263,11 +1330,15 @@ func (client *networkWatchersOperations) ResumeVerifyIPFlow(token string) (Verif
 
 // verifyIPFlowCreateRequest creates the VerifyIPFlow request.
 func (client *networkWatchersOperations) verifyIPFlowCreateRequest(resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/ipFlowVerify"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/operations.go
+++ b/test/network/2020-03-01/armnetwork/operations.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 )
 
 // Operations contains the methods for the Operations group.
@@ -49,8 +48,12 @@ func (client *operations) List() (OperationListResultPager, error) {
 
 // listCreateRequest creates the List request.
 func (client *operations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/providers/Microsoft.Network/operations"
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/operations.go
+++ b/test/network/2020-03-01/armnetwork/operations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // Operations contains the methods for the Operations group.
@@ -53,7 +54,7 @@ func (client *operations) listCreateRequest() (*azcore.Request, error) {
 		return nil, err
 	}
 	urlPath := "/providers/Microsoft.Network/operations"
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/p2svpngateways.go
+++ b/test/network/2020-03-01/armnetwork/p2svpngateways.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -102,11 +101,15 @@ func (client *p2SVpnGatewaysOperations) ResumeCreateOrUpdate(token string) (P2SV
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *p2SVpnGatewaysOperations) createOrUpdateCreateRequest(resourceGroupName string, gatewayName string, p2SVpnGatewayParameters P2SVpnGateway) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -177,11 +180,15 @@ func (client *p2SVpnGatewaysOperations) ResumeDelete(token string) (HTTPPoller, 
 
 // deleteCreateRequest creates the Delete request.
 func (client *p2SVpnGatewaysOperations) deleteCreateRequest(resourceGroupName string, gatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -252,11 +259,15 @@ func (client *p2SVpnGatewaysOperations) ResumeDisconnectP2SVpnConnections(token 
 
 // disconnectP2SVpnConnectionsCreateRequest creates the DisconnectP2SVpnConnections request.
 func (client *p2SVpnGatewaysOperations) disconnectP2SVpnConnectionsCreateRequest(resourceGroupName string, p2SVpnGatewayName string, request P2SVpnConnectionRequest) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{p2sVpnGatewayName}/disconnectP2sVpnConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{p2sVpnGatewayName}", url.PathEscape(p2SVpnGatewayName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -327,11 +338,15 @@ func (client *p2SVpnGatewaysOperations) ResumeGenerateVpnProfile(token string) (
 
 // generateVpnProfileCreateRequest creates the GenerateVpnProfile request.
 func (client *p2SVpnGatewaysOperations) generateVpnProfileCreateRequest(resourceGroupName string, gatewayName string, parameters P2SVpnProfileParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}/generatevpnprofile"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -378,11 +393,15 @@ func (client *p2SVpnGatewaysOperations) Get(ctx context.Context, resourceGroupNa
 
 // getCreateRequest creates the Get request.
 func (client *p2SVpnGatewaysOperations) getCreateRequest(resourceGroupName string, gatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -454,11 +473,15 @@ func (client *p2SVpnGatewaysOperations) ResumeGetP2SVpnConnectionHealth(token st
 
 // getP2SVpnConnectionHealthCreateRequest creates the GetP2SVpnConnectionHealth request.
 func (client *p2SVpnGatewaysOperations) getP2SVpnConnectionHealthCreateRequest(resourceGroupName string, gatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}/getP2sVpnConnectionHealth"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -529,11 +552,15 @@ func (client *p2SVpnGatewaysOperations) ResumeGetP2SVpnConnectionHealthDetailed(
 
 // getP2SVpnConnectionHealthDetailedCreateRequest creates the GetP2SVpnConnectionHealthDetailed request.
 func (client *p2SVpnGatewaysOperations) getP2SVpnConnectionHealthDetailedCreateRequest(resourceGroupName string, gatewayName string, request P2SVpnConnectionHealthRequest) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}/getP2sVpnConnectionHealthDetailed"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -586,9 +613,13 @@ func (client *p2SVpnGatewaysOperations) List() (ListP2SVpnGatewaysResultPager, e
 
 // listCreateRequest creates the List request.
 func (client *p2SVpnGatewaysOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/p2svpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -642,10 +673,14 @@ func (client *p2SVpnGatewaysOperations) ListByResourceGroup(resourceGroupName st
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *p2SVpnGatewaysOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -693,11 +728,15 @@ func (client *p2SVpnGatewaysOperations) UpdateTags(ctx context.Context, resource
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *p2SVpnGatewaysOperations) updateTagsCreateRequest(resourceGroupName string, gatewayName string, p2SVpnGatewayParameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/p2svpngateways.go
+++ b/test/network/2020-03-01/armnetwork/p2svpngateways.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -109,7 +110,7 @@ func (client *p2SVpnGatewaysOperations) createOrUpdateCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +189,7 @@ func (client *p2SVpnGatewaysOperations) deleteCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +268,7 @@ func (client *p2SVpnGatewaysOperations) disconnectP2SVpnConnectionsCreateRequest
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{p2sVpnGatewayName}", url.PathEscape(p2SVpnGatewayName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -346,7 +347,7 @@ func (client *p2SVpnGatewaysOperations) generateVpnProfileCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +402,7 @@ func (client *p2SVpnGatewaysOperations) getCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -481,7 +482,7 @@ func (client *p2SVpnGatewaysOperations) getP2SVpnConnectionHealthCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +561,7 @@ func (client *p2SVpnGatewaysOperations) getP2SVpnConnectionHealthDetailedCreateR
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -619,7 +620,7 @@ func (client *p2SVpnGatewaysOperations) listCreateRequest() (*azcore.Request, er
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/p2svpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -680,7 +681,7 @@ func (client *p2SVpnGatewaysOperations) listByResourceGroupCreateRequest(resourc
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -736,7 +737,7 @@ func (client *p2SVpnGatewaysOperations) updateTagsCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/packetcaptures.go
+++ b/test/network/2020-03-01/armnetwork/packetcaptures.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -97,7 +98,7 @@ func (client *packetCapturesOperations) createCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{packetCaptureName}", url.PathEscape(packetCaptureName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +178,7 @@ func (client *packetCapturesOperations) deleteCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{packetCaptureName}", url.PathEscape(packetCaptureName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +234,7 @@ func (client *packetCapturesOperations) getCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{packetCaptureName}", url.PathEscape(packetCaptureName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +315,7 @@ func (client *packetCapturesOperations) getStatusCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{packetCaptureName}", url.PathEscape(packetCaptureName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -369,7 +370,7 @@ func (client *packetCapturesOperations) listCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -450,7 +451,7 @@ func (client *packetCapturesOperations) stopCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{packetCaptureName}", url.PathEscape(packetCaptureName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/packetcaptures.go
+++ b/test/network/2020-03-01/armnetwork/packetcaptures.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -89,12 +88,16 @@ func (client *packetCapturesOperations) ResumeCreate(token string) (PacketCaptur
 
 // createCreateRequest creates the Create request.
 func (client *packetCapturesOperations) createCreateRequest(resourceGroupName string, networkWatcherName string, packetCaptureName string, parameters PacketCapture) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{packetCaptureName}", url.PathEscape(packetCaptureName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -165,12 +168,16 @@ func (client *packetCapturesOperations) ResumeDelete(token string) (HTTPPoller, 
 
 // deleteCreateRequest creates the Delete request.
 func (client *packetCapturesOperations) deleteCreateRequest(resourceGroupName string, networkWatcherName string, packetCaptureName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{packetCaptureName}", url.PathEscape(packetCaptureName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -217,12 +224,16 @@ func (client *packetCapturesOperations) Get(ctx context.Context, resourceGroupNa
 
 // getCreateRequest creates the Get request.
 func (client *packetCapturesOperations) getCreateRequest(resourceGroupName string, networkWatcherName string, packetCaptureName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{packetCaptureName}", url.PathEscape(packetCaptureName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -294,12 +305,16 @@ func (client *packetCapturesOperations) ResumeGetStatus(token string) (PacketCap
 
 // getStatusCreateRequest creates the GetStatus request.
 func (client *packetCapturesOperations) getStatusCreateRequest(resourceGroupName string, networkWatcherName string, packetCaptureName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}/queryStatus"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{packetCaptureName}", url.PathEscape(packetCaptureName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -346,11 +361,15 @@ func (client *packetCapturesOperations) List(ctx context.Context, resourceGroupN
 
 // listCreateRequest creates the List request.
 func (client *packetCapturesOperations) listCreateRequest(resourceGroupName string, networkWatcherName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -422,12 +441,16 @@ func (client *packetCapturesOperations) ResumeStop(token string) (HTTPPoller, er
 
 // stopCreateRequest creates the Stop request.
 func (client *packetCapturesOperations) stopCreateRequest(resourceGroupName string, networkWatcherName string, packetCaptureName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}/stop"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
 	urlPath = strings.ReplaceAll(urlPath, "{packetCaptureName}", url.PathEscape(packetCaptureName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/peerexpressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/peerexpressroutecircuitconnections.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -57,7 +58,7 @@ func (client *peerExpressRouteCircuitConnectionsOperations) getCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +121,7 @@ func (client *peerExpressRouteCircuitConnectionsOperations) listCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/peerexpressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/peerexpressroutecircuitconnections.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -48,13 +47,17 @@ func (client *peerExpressRouteCircuitConnectionsOperations) Get(ctx context.Cont
 
 // getCreateRequest creates the Get request.
 func (client *peerExpressRouteCircuitConnectionsOperations) getCreateRequest(resourceGroupName string, circuitName string, peeringName string, connectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/peerConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -108,12 +111,16 @@ func (client *peerExpressRouteCircuitConnectionsOperations) List(resourceGroupNa
 
 // listCreateRequest creates the List request.
 func (client *peerExpressRouteCircuitConnectionsOperations) listCreateRequest(resourceGroupName string, circuitName string, peeringName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/peerConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/privatednszonegroups.go
+++ b/test/network/2020-03-01/armnetwork/privatednszonegroups.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *privateDnsZoneGroupsOperations) createOrUpdateCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateDnsZoneGroupName}", url.PathEscape(privateDnsZoneGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *privateDnsZoneGroupsOperations) deleteCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateDnsZoneGroupName}", url.PathEscape(privateDnsZoneGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *privateDnsZoneGroupsOperations) getCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateDnsZoneGroupName}", url.PathEscape(privateDnsZoneGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *privateDnsZoneGroupsOperations) listCreateRequest(privateEndpointN
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/privatednszonegroups.go
+++ b/test/network/2020-03-01/armnetwork/privatednszonegroups.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *privateDnsZoneGroupsOperations) ResumeCreateOrUpdate(token string)
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *privateDnsZoneGroupsOperations) createOrUpdateCreateRequest(resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, parameters PrivateDNSZoneGroup) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups/{privateDnsZoneGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateDnsZoneGroupName}", url.PathEscape(privateDnsZoneGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *privateDnsZoneGroupsOperations) ResumeDelete(token string) (HTTPPo
 
 // deleteCreateRequest creates the Delete request.
 func (client *privateDnsZoneGroupsOperations) deleteCreateRequest(resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups/{privateDnsZoneGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateDnsZoneGroupName}", url.PathEscape(privateDnsZoneGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *privateDnsZoneGroupsOperations) Get(ctx context.Context, resourceG
 
 // getCreateRequest creates the Get request.
 func (client *privateDnsZoneGroupsOperations) getCreateRequest(resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups/{privateDnsZoneGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateDnsZoneGroupName}", url.PathEscape(privateDnsZoneGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *privateDnsZoneGroupsOperations) List(privateEndpointName string, r
 
 // listCreateRequest creates the List request.
 func (client *privateDnsZoneGroupsOperations) listCreateRequest(privateEndpointName string, resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/privateendpoints.go
+++ b/test/network/2020-03-01/armnetwork/privateendpoints.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -91,7 +92,7 @@ func (client *privateEndpointsOperations) createOrUpdateCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *privateEndpointsOperations) deleteCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +226,7 @@ func (client *privateEndpointsOperations) getCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +290,7 @@ func (client *privateEndpointsOperations) listCreateRequest(resourceGroupName st
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +350,7 @@ func (client *privateEndpointsOperations) listBySubscriptionCreateRequest() (*az
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/privateEndpoints"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/privateendpoints.go
+++ b/test/network/2020-03-01/armnetwork/privateendpoints.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -84,11 +83,15 @@ func (client *privateEndpointsOperations) ResumeCreateOrUpdate(token string) (Pr
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *privateEndpointsOperations) createOrUpdateCreateRequest(resourceGroupName string, privateEndpointName string, parameters PrivateEndpoint) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -159,11 +162,15 @@ func (client *privateEndpointsOperations) ResumeDelete(token string) (HTTPPoller
 
 // deleteCreateRequest creates the Delete request.
 func (client *privateEndpointsOperations) deleteCreateRequest(resourceGroupName string, privateEndpointName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,11 +217,15 @@ func (client *privateEndpointsOperations) Get(ctx context.Context, resourceGroup
 
 // getCreateRequest creates the Get request.
 func (client *privateEndpointsOperations) getCreateRequest(resourceGroupName string, privateEndpointName string, privateEndpointsGetOptions *PrivateEndpointsGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -271,10 +282,14 @@ func (client *privateEndpointsOperations) List(resourceGroupName string) (Privat
 
 // listCreateRequest creates the List request.
 func (client *privateEndpointsOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -328,9 +343,13 @@ func (client *privateEndpointsOperations) ListBySubscription() (PrivateEndpointL
 
 // listBySubscriptionCreateRequest creates the ListBySubscription request.
 func (client *privateEndpointsOperations) listBySubscriptionCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/privateEndpoints"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/privatelinkservices.go
+++ b/test/network/2020-03-01/armnetwork/privatelinkservices.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -106,10 +105,14 @@ func (client *privateLinkServicesOperations) ResumeCheckPrivateLinkServiceVisibi
 
 // checkPrivateLinkServiceVisibilityCreateRequest creates the CheckPrivateLinkServiceVisibility request.
 func (client *privateLinkServicesOperations) checkPrivateLinkServiceVisibilityCreateRequest(location string, parameters CheckPrivateLinkServiceVisibilityRequest) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/checkPrivateLinkServiceVisibility"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -180,11 +183,15 @@ func (client *privateLinkServicesOperations) ResumeCheckPrivateLinkServiceVisibi
 
 // checkPrivateLinkServiceVisibilityByResourceGroupCreateRequest creates the CheckPrivateLinkServiceVisibilityByResourceGroup request.
 func (client *privateLinkServicesOperations) checkPrivateLinkServiceVisibilityByResourceGroupCreateRequest(location string, resourceGroupName string, parameters CheckPrivateLinkServiceVisibilityRequest) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/checkPrivateLinkServiceVisibility"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -255,11 +262,15 @@ func (client *privateLinkServicesOperations) ResumeCreateOrUpdate(token string) 
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *privateLinkServicesOperations) createOrUpdateCreateRequest(resourceGroupName string, serviceName string, parameters PrivateLinkService) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -330,11 +341,15 @@ func (client *privateLinkServicesOperations) ResumeDelete(token string) (HTTPPol
 
 // deleteCreateRequest creates the Delete request.
 func (client *privateLinkServicesOperations) deleteCreateRequest(resourceGroupName string, serviceName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -405,12 +420,16 @@ func (client *privateLinkServicesOperations) ResumeDeletePrivateEndpointConnecti
 
 // deletePrivateEndpointConnectionCreateRequest creates the DeletePrivateEndpointConnection request.
 func (client *privateLinkServicesOperations) deletePrivateEndpointConnectionCreateRequest(resourceGroupName string, serviceName string, peConnectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}/privateEndpointConnections/{peConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{peConnectionName}", url.PathEscape(peConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -457,11 +476,15 @@ func (client *privateLinkServicesOperations) Get(ctx context.Context, resourceGr
 
 // getCreateRequest creates the Get request.
 func (client *privateLinkServicesOperations) getCreateRequest(resourceGroupName string, serviceName string, privateLinkServicesGetOptions *PrivateLinkServicesGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -512,12 +535,16 @@ func (client *privateLinkServicesOperations) GetPrivateEndpointConnection(ctx co
 
 // getPrivateEndpointConnectionCreateRequest creates the GetPrivateEndpointConnection request.
 func (client *privateLinkServicesOperations) getPrivateEndpointConnectionCreateRequest(resourceGroupName string, serviceName string, peConnectionName string, privateLinkServicesGetPrivateEndpointConnectionOptions *PrivateLinkServicesGetPrivateEndpointConnectionOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}/privateEndpointConnections/{peConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{peConnectionName}", url.PathEscape(peConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -574,10 +601,14 @@ func (client *privateLinkServicesOperations) List(resourceGroupName string) (Pri
 
 // listCreateRequest creates the List request.
 func (client *privateLinkServicesOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -631,10 +662,14 @@ func (client *privateLinkServicesOperations) ListAutoApprovedPrivateLinkServices
 
 // listAutoApprovedPrivateLinkServicesCreateRequest creates the ListAutoApprovedPrivateLinkServices request.
 func (client *privateLinkServicesOperations) listAutoApprovedPrivateLinkServicesCreateRequest(location string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/autoApprovedPrivateLinkServices"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -688,11 +723,15 @@ func (client *privateLinkServicesOperations) ListAutoApprovedPrivateLinkServices
 
 // listAutoApprovedPrivateLinkServicesByResourceGroupCreateRequest creates the ListAutoApprovedPrivateLinkServicesByResourceGroup request.
 func (client *privateLinkServicesOperations) listAutoApprovedPrivateLinkServicesByResourceGroupCreateRequest(location string, resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/autoApprovedPrivateLinkServices"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -746,9 +785,13 @@ func (client *privateLinkServicesOperations) ListBySubscription() (PrivateLinkSe
 
 // listBySubscriptionCreateRequest creates the ListBySubscription request.
 func (client *privateLinkServicesOperations) listBySubscriptionCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/privateLinkServices"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -802,11 +845,15 @@ func (client *privateLinkServicesOperations) ListPrivateEndpointConnections(reso
 
 // listPrivateEndpointConnectionsCreateRequest creates the ListPrivateEndpointConnections request.
 func (client *privateLinkServicesOperations) listPrivateEndpointConnectionsCreateRequest(resourceGroupName string, serviceName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}/privateEndpointConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -854,12 +901,16 @@ func (client *privateLinkServicesOperations) UpdatePrivateEndpointConnection(ctx
 
 // updatePrivateEndpointConnectionCreateRequest creates the UpdatePrivateEndpointConnection request.
 func (client *privateLinkServicesOperations) updatePrivateEndpointConnectionCreateRequest(resourceGroupName string, serviceName string, peConnectionName string, parameters PrivateEndpointConnection) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}/privateEndpointConnections/{peConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{peConnectionName}", url.PathEscape(peConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/privatelinkservices.go
+++ b/test/network/2020-03-01/armnetwork/privatelinkservices.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -112,7 +113,7 @@ func (client *privateLinkServicesOperations) checkPrivateLinkServiceVisibilityCr
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/checkPrivateLinkServiceVisibility"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +192,7 @@ func (client *privateLinkServicesOperations) checkPrivateLinkServiceVisibilityBy
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +271,7 @@ func (client *privateLinkServicesOperations) createOrUpdateCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +350,7 @@ func (client *privateLinkServicesOperations) deleteCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -429,7 +430,7 @@ func (client *privateLinkServicesOperations) deletePrivateEndpointConnectionCrea
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{peConnectionName}", url.PathEscape(peConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -484,7 +485,7 @@ func (client *privateLinkServicesOperations) getCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -544,7 +545,7 @@ func (client *privateLinkServicesOperations) getPrivateEndpointConnectionCreateR
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{peConnectionName}", url.PathEscape(peConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -608,7 +609,7 @@ func (client *privateLinkServicesOperations) listCreateRequest(resourceGroupName
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -669,7 +670,7 @@ func (client *privateLinkServicesOperations) listAutoApprovedPrivateLinkServices
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/autoApprovedPrivateLinkServices"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -731,7 +732,7 @@ func (client *privateLinkServicesOperations) listAutoApprovedPrivateLinkServices
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -791,7 +792,7 @@ func (client *privateLinkServicesOperations) listBySubscriptionCreateRequest() (
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/privateLinkServices"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -853,7 +854,7 @@ func (client *privateLinkServicesOperations) listPrivateEndpointConnectionsCreat
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -910,7 +911,7 @@ func (client *privateLinkServicesOperations) updatePrivateEndpointConnectionCrea
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
 	urlPath = strings.ReplaceAll(urlPath, "{peConnectionName}", url.PathEscape(peConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/publicipaddresses.go
+++ b/test/network/2020-03-01/armnetwork/publicipaddresses.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -92,11 +91,15 @@ func (client *publicIPAddressesOperations) ResumeCreateOrUpdate(token string) (P
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *publicIPAddressesOperations) createOrUpdateCreateRequest(resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -167,11 +170,15 @@ func (client *publicIPAddressesOperations) ResumeDelete(token string) (HTTPPolle
 
 // deleteCreateRequest creates the Delete request.
 func (client *publicIPAddressesOperations) deleteCreateRequest(resourceGroupName string, publicIPAddressName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -218,11 +225,15 @@ func (client *publicIPAddressesOperations) Get(ctx context.Context, resourceGrou
 
 // getCreateRequest creates the Get request.
 func (client *publicIPAddressesOperations) getCreateRequest(resourceGroupName string, publicIPAddressName string, publicIPAddressesGetOptions *PublicIPAddressesGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -273,6 +284,10 @@ func (client *publicIPAddressesOperations) GetVirtualMachineScaleSetPublicIPAddr
 
 // getVirtualMachineScaleSetPublicIPAddressCreateRequest creates the GetVirtualMachineScaleSetPublicIPAddress request.
 func (client *publicIPAddressesOperations) getVirtualMachineScaleSetPublicIPAddressCreateRequest(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, publicIPAddressName string, publicIPAddressesGetVirtualMachineScaleSetPublicIpaddressOptions *PublicIPAddressesGetVirtualMachineScaleSetPublicIPAddressOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}/ipconfigurations/{ipConfigurationName}/publicipaddresses/{publicIpAddressName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
@@ -281,7 +296,7 @@ func (client *publicIPAddressesOperations) getVirtualMachineScaleSetPublicIPAddr
 	urlPath = strings.ReplaceAll(urlPath, "{ipConfigurationName}", url.PathEscape(ipConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -338,10 +353,14 @@ func (client *publicIPAddressesOperations) List(resourceGroupName string) (Publi
 
 // listCreateRequest creates the List request.
 func (client *publicIPAddressesOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -395,9 +414,13 @@ func (client *publicIPAddressesOperations) ListAll() (PublicIPAddressListResultP
 
 // listAllCreateRequest creates the ListAll request.
 func (client *publicIPAddressesOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/publicIPAddresses"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -451,11 +474,15 @@ func (client *publicIPAddressesOperations) ListVirtualMachineScaleSetPublicIPAdd
 
 // listVirtualMachineScaleSetPublicIPAddressesCreateRequest creates the ListVirtualMachineScaleSetPublicIPAddresses request.
 func (client *publicIPAddressesOperations) listVirtualMachineScaleSetPublicIPAddressesCreateRequest(resourceGroupName string, virtualMachineScaleSetName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/publicipaddresses"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -509,6 +536,10 @@ func (client *publicIPAddressesOperations) ListVirtualMachineScaleSetVMPublicIPa
 
 // listVirtualMachineScaleSetVMPublicIpaddressesCreateRequest creates the ListVirtualMachineScaleSetVMPublicIPaddresses request.
 func (client *publicIPAddressesOperations) listVirtualMachineScaleSetVMPublicIpaddressesCreateRequest(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}/ipconfigurations/{ipConfigurationName}/publicipaddresses"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
@@ -516,7 +547,7 @@ func (client *publicIPAddressesOperations) listVirtualMachineScaleSetVMPublicIpa
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipConfigurationName}", url.PathEscape(ipConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -564,11 +595,15 @@ func (client *publicIPAddressesOperations) UpdateTags(ctx context.Context, resou
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *publicIPAddressesOperations) updateTagsCreateRequest(resourceGroupName string, publicIPAddressName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/publicipaddresses.go
+++ b/test/network/2020-03-01/armnetwork/publicipaddresses.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -99,7 +100,7 @@ func (client *publicIPAddressesOperations) createOrUpdateCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +179,7 @@ func (client *publicIPAddressesOperations) deleteCreateRequest(resourceGroupName
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +234,7 @@ func (client *publicIPAddressesOperations) getCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +297,7 @@ func (client *publicIPAddressesOperations) getVirtualMachineScaleSetPublicIPAddr
 	urlPath = strings.ReplaceAll(urlPath, "{ipConfigurationName}", url.PathEscape(ipConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +361,7 @@ func (client *publicIPAddressesOperations) listCreateRequest(resourceGroupName s
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -420,7 +421,7 @@ func (client *publicIPAddressesOperations) listAllCreateRequest() (*azcore.Reque
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/publicIPAddresses"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -482,7 +483,7 @@ func (client *publicIPAddressesOperations) listVirtualMachineScaleSetPublicIPAdd
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -547,7 +548,7 @@ func (client *publicIPAddressesOperations) listVirtualMachineScaleSetVMPublicIpa
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipConfigurationName}", url.PathEscape(ipConfigurationName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -603,7 +604,7 @@ func (client *publicIPAddressesOperations) updateTagsCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/publicipprefixes.go
+++ b/test/network/2020-03-01/armnetwork/publicipprefixes.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *publicIPPrefixesOperations) ResumeCreateOrUpdate(token string) (Pu
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *publicIPPrefixesOperations) createOrUpdateCreateRequest(resourceGroupName string, publicIPPrefixName string, parameters PublicIPPrefix) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIpPrefixName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *publicIPPrefixesOperations) ResumeDelete(token string) (HTTPPoller
 
 // deleteCreateRequest creates the Delete request.
 func (client *publicIPPrefixesOperations) deleteCreateRequest(resourceGroupName string, publicIPPrefixName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIpPrefixName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *publicIPPrefixesOperations) Get(ctx context.Context, resourceGroup
 
 // getCreateRequest creates the Get request.
 func (client *publicIPPrefixesOperations) getCreateRequest(resourceGroupName string, publicIPPrefixName string, publicIPPrefixesGetOptions *PublicIPPrefixesGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIpPrefixName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -273,10 +284,14 @@ func (client *publicIPPrefixesOperations) List(resourceGroupName string) (Public
 
 // listCreateRequest creates the List request.
 func (client *publicIPPrefixesOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -330,9 +345,13 @@ func (client *publicIPPrefixesOperations) ListAll() (PublicIPPrefixListResultPag
 
 // listAllCreateRequest creates the ListAll request.
 func (client *publicIPPrefixesOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/publicIPPrefixes"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -380,11 +399,15 @@ func (client *publicIPPrefixesOperations) UpdateTags(ctx context.Context, resour
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *publicIPPrefixesOperations) updateTagsCreateRequest(resourceGroupName string, publicIPPrefixName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIpPrefixName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/publicipprefixes.go
+++ b/test/network/2020-03-01/armnetwork/publicipprefixes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *publicIPPrefixesOperations) createOrUpdateCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *publicIPPrefixesOperations) deleteCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *publicIPPrefixesOperations) getCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +292,7 @@ func (client *publicIPPrefixesOperations) listCreateRequest(resourceGroupName st
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +352,7 @@ func (client *publicIPPrefixesOperations) listAllCreateRequest() (*azcore.Reques
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/publicIPPrefixes"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +408,7 @@ func (client *publicIPPrefixesOperations) updateTagsCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/resourcenavigationlinks.go
+++ b/test/network/2020-03-01/armnetwork/resourcenavigationlinks.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -45,12 +44,16 @@ func (client *resourceNavigationLinksOperations) List(ctx context.Context, resou
 
 // listCreateRequest creates the List request.
 func (client *resourceNavigationLinksOperations) listCreateRequest(resourceGroupName string, virtualNetworkName string, subnetName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/ResourceNavigationLinks"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/resourcenavigationlinks.go
+++ b/test/network/2020-03-01/armnetwork/resourcenavigationlinks.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -53,7 +54,7 @@ func (client *resourceNavigationLinksOperations) listCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/routefilterrules.go
+++ b/test/network/2020-03-01/armnetwork/routefilterrules.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *routeFilterRulesOperations) ResumeCreateOrUpdate(token string) (Ro
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *routeFilterRulesOperations) createOrUpdateCreateRequest(resourceGroupName string, routeFilterName string, ruleName string, routeFilterRuleParameters RouteFilterRule) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}/routeFilterRules/{ruleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleName}", url.PathEscape(ruleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *routeFilterRulesOperations) ResumeDelete(token string) (HTTPPoller
 
 // deleteCreateRequest creates the Delete request.
 func (client *routeFilterRulesOperations) deleteCreateRequest(resourceGroupName string, routeFilterName string, ruleName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}/routeFilterRules/{ruleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleName}", url.PathEscape(ruleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *routeFilterRulesOperations) Get(ctx context.Context, resourceGroup
 
 // getCreateRequest creates the Get request.
 func (client *routeFilterRulesOperations) getCreateRequest(resourceGroupName string, routeFilterName string, ruleName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}/routeFilterRules/{ruleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleName}", url.PathEscape(ruleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *routeFilterRulesOperations) ListByRouteFilter(resourceGroupName st
 
 // listByRouteFilterCreateRequest creates the ListByRouteFilter request.
 func (client *routeFilterRulesOperations) listByRouteFilterCreateRequest(resourceGroupName string, routeFilterName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}/routeFilterRules"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/routefilterrules.go
+++ b/test/network/2020-03-01/armnetwork/routefilterrules.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *routeFilterRulesOperations) createOrUpdateCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleName}", url.PathEscape(ruleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *routeFilterRulesOperations) deleteCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleName}", url.PathEscape(ruleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *routeFilterRulesOperations) getCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{ruleName}", url.PathEscape(ruleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *routeFilterRulesOperations) listByRouteFilterCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/routefilters.go
+++ b/test/network/2020-03-01/armnetwork/routefilters.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *routeFiltersOperations) createOrUpdateCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *routeFiltersOperations) deleteCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *routeFiltersOperations) getCreateRequest(resourceGroupName string,
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +291,7 @@ func (client *routeFiltersOperations) listCreateRequest() (*azcore.Request, erro
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/routeFilters"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +352,7 @@ func (client *routeFiltersOperations) listByResourceGroupCreateRequest(resourceG
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +408,7 @@ func (client *routeFiltersOperations) updateTagsCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/routefilters.go
+++ b/test/network/2020-03-01/armnetwork/routefilters.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *routeFiltersOperations) ResumeCreateOrUpdate(token string) (RouteF
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *routeFiltersOperations) createOrUpdateCreateRequest(resourceGroupName string, routeFilterName string, routeFilterParameters RouteFilter) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *routeFiltersOperations) ResumeDelete(token string) (HTTPPoller, er
 
 // deleteCreateRequest creates the Delete request.
 func (client *routeFiltersOperations) deleteCreateRequest(resourceGroupName string, routeFilterName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *routeFiltersOperations) Get(ctx context.Context, resourceGroupName
 
 // getCreateRequest creates the Get request.
 func (client *routeFiltersOperations) getCreateRequest(resourceGroupName string, routeFilterName string, routeFiltersGetOptions *RouteFiltersGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -273,9 +284,13 @@ func (client *routeFiltersOperations) List() (RouteFilterListResultPager, error)
 
 // listCreateRequest creates the List request.
 func (client *routeFiltersOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/routeFilters"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -329,10 +344,14 @@ func (client *routeFiltersOperations) ListByResourceGroup(resourceGroupName stri
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *routeFiltersOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -380,11 +399,15 @@ func (client *routeFiltersOperations) UpdateTags(ctx context.Context, resourceGr
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *routeFiltersOperations) updateTagsCreateRequest(resourceGroupName string, routeFilterName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/routes.go
+++ b/test/network/2020-03-01/armnetwork/routes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *routesOperations) createOrUpdateCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeName}", url.PathEscape(routeName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *routesOperations) deleteCreateRequest(resourceGroupName string, ro
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeName}", url.PathEscape(routeName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *routesOperations) getCreateRequest(resourceGroupName string, route
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeName}", url.PathEscape(routeName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *routesOperations) listCreateRequest(resourceGroupName string, rout
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/routes.go
+++ b/test/network/2020-03-01/armnetwork/routes.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *routesOperations) ResumeCreateOrUpdate(token string) (RoutePoller,
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *routesOperations) createOrUpdateCreateRequest(resourceGroupName string, routeTableName string, routeName string, routeParameters Route) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}/routes/{routeName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeName}", url.PathEscape(routeName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *routesOperations) ResumeDelete(token string) (HTTPPoller, error) {
 
 // deleteCreateRequest creates the Delete request.
 func (client *routesOperations) deleteCreateRequest(resourceGroupName string, routeTableName string, routeName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}/routes/{routeName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeName}", url.PathEscape(routeName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *routesOperations) Get(ctx context.Context, resourceGroupName strin
 
 // getCreateRequest creates the Get request.
 func (client *routesOperations) getCreateRequest(resourceGroupName string, routeTableName string, routeName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}/routes/{routeName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeName}", url.PathEscape(routeName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *routesOperations) List(resourceGroupName string, routeTableName st
 
 // listCreateRequest creates the List request.
 func (client *routesOperations) listCreateRequest(resourceGroupName string, routeTableName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}/routes"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/routetables.go
+++ b/test/network/2020-03-01/armnetwork/routetables.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *routeTablesOperations) ResumeCreateOrUpdate(token string) (RouteTa
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *routeTablesOperations) createOrUpdateCreateRequest(resourceGroupName string, routeTableName string, parameters RouteTable) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *routeTablesOperations) ResumeDelete(token string) (HTTPPoller, err
 
 // deleteCreateRequest creates the Delete request.
 func (client *routeTablesOperations) deleteCreateRequest(resourceGroupName string, routeTableName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *routeTablesOperations) Get(ctx context.Context, resourceGroupName 
 
 // getCreateRequest creates the Get request.
 func (client *routeTablesOperations) getCreateRequest(resourceGroupName string, routeTableName string, routeTablesGetOptions *RouteTablesGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -273,10 +284,14 @@ func (client *routeTablesOperations) List(resourceGroupName string) (RouteTableL
 
 // listCreateRequest creates the List request.
 func (client *routeTablesOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -330,9 +345,13 @@ func (client *routeTablesOperations) ListAll() (RouteTableListResultPager, error
 
 // listAllCreateRequest creates the ListAll request.
 func (client *routeTablesOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/routeTables"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -380,11 +399,15 @@ func (client *routeTablesOperations) UpdateTags(ctx context.Context, resourceGro
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *routeTablesOperations) updateTagsCreateRequest(resourceGroupName string, routeTableName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/routetables.go
+++ b/test/network/2020-03-01/armnetwork/routetables.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *routeTablesOperations) createOrUpdateCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *routeTablesOperations) deleteCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *routeTablesOperations) getCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +292,7 @@ func (client *routeTablesOperations) listCreateRequest(resourceGroupName string)
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +352,7 @@ func (client *routeTablesOperations) listAllCreateRequest() (*azcore.Request, er
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/routeTables"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +408,7 @@ func (client *routeTablesOperations) updateTagsCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/securitypartnerproviders.go
+++ b/test/network/2020-03-01/armnetwork/securitypartnerproviders.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *securityPartnerProvidersOperations) createOrUpdateCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *securityPartnerProvidersOperations) deleteCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *securityPartnerProvidersOperations) getCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +288,7 @@ func (client *securityPartnerProvidersOperations) listCreateRequest() (*azcore.R
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/securityPartnerProviders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +349,7 @@ func (client *securityPartnerProvidersOperations) listByResourceGroupCreateReque
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +405,7 @@ func (client *securityPartnerProvidersOperations) updateTagsCreateRequest(resour
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/securitypartnerproviders.go
+++ b/test/network/2020-03-01/armnetwork/securitypartnerproviders.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *securityPartnerProvidersOperations) ResumeCreateOrUpdate(token str
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *securityPartnerProvidersOperations) createOrUpdateCreateRequest(resourceGroupName string, securityPartnerProviderName string, parameters SecurityPartnerProvider) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders/{securityPartnerProviderName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *securityPartnerProvidersOperations) ResumeDelete(token string) (HT
 
 // deleteCreateRequest creates the Delete request.
 func (client *securityPartnerProvidersOperations) deleteCreateRequest(resourceGroupName string, securityPartnerProviderName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders/{securityPartnerProviderName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *securityPartnerProvidersOperations) Get(ctx context.Context, resou
 
 // getCreateRequest creates the Get request.
 func (client *securityPartnerProvidersOperations) getCreateRequest(resourceGroupName string, securityPartnerProviderName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders/{securityPartnerProviderName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -270,9 +281,13 @@ func (client *securityPartnerProvidersOperations) List() (SecurityPartnerProvide
 
 // listCreateRequest creates the List request.
 func (client *securityPartnerProvidersOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/securityPartnerProviders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -326,10 +341,14 @@ func (client *securityPartnerProvidersOperations) ListByResourceGroup(resourceGr
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *securityPartnerProvidersOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -377,11 +396,15 @@ func (client *securityPartnerProvidersOperations) UpdateTags(ctx context.Context
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *securityPartnerProvidersOperations) updateTagsCreateRequest(resourceGroupName string, securityPartnerProviderName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders/{securityPartnerProviderName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/securityrules.go
+++ b/test/network/2020-03-01/armnetwork/securityrules.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *securityRulesOperations) createOrUpdateCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityRuleName}", url.PathEscape(securityRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *securityRulesOperations) deleteCreateRequest(resourceGroupName str
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityRuleName}", url.PathEscape(securityRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *securityRulesOperations) getCreateRequest(resourceGroupName string
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityRuleName}", url.PathEscape(securityRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *securityRulesOperations) listCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/securityrules.go
+++ b/test/network/2020-03-01/armnetwork/securityrules.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *securityRulesOperations) ResumeCreateOrUpdate(token string) (Secur
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *securityRulesOperations) createOrUpdateCreateRequest(resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules/{securityRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityRuleName}", url.PathEscape(securityRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *securityRulesOperations) ResumeDelete(token string) (HTTPPoller, e
 
 // deleteCreateRequest creates the Delete request.
 func (client *securityRulesOperations) deleteCreateRequest(resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules/{securityRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityRuleName}", url.PathEscape(securityRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *securityRulesOperations) Get(ctx context.Context, resourceGroupNam
 
 // getCreateRequest creates the Get request.
 func (client *securityRulesOperations) getCreateRequest(resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules/{securityRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityRuleName}", url.PathEscape(securityRuleName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *securityRulesOperations) List(resourceGroupName string, networkSec
 
 // listCreateRequest creates the List request.
 func (client *securityRulesOperations) listCreateRequest(resourceGroupName string, networkSecurityGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/serviceassociationlinks.go
+++ b/test/network/2020-03-01/armnetwork/serviceassociationlinks.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -53,7 +54,7 @@ func (client *serviceAssociationLinksOperations) listCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/serviceassociationlinks.go
+++ b/test/network/2020-03-01/armnetwork/serviceassociationlinks.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -45,12 +44,16 @@ func (client *serviceAssociationLinksOperations) List(ctx context.Context, resou
 
 // listCreateRequest creates the List request.
 func (client *serviceAssociationLinksOperations) listCreateRequest(resourceGroupName string, virtualNetworkName string, subnetName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/ServiceAssociationLinks"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/serviceendpointpolicies.go
+++ b/test/network/2020-03-01/armnetwork/serviceendpointpolicies.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *serviceEndpointPoliciesOperations) createOrUpdateCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *serviceEndpointPoliciesOperations) deleteCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *serviceEndpointPoliciesOperations) getCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +291,7 @@ func (client *serviceEndpointPoliciesOperations) listCreateRequest() (*azcore.Re
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ServiceEndpointPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +352,7 @@ func (client *serviceEndpointPoliciesOperations) listByResourceGroupCreateReques
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +408,7 @@ func (client *serviceEndpointPoliciesOperations) updateTagsCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/serviceendpointpolicies.go
+++ b/test/network/2020-03-01/armnetwork/serviceendpointpolicies.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *serviceEndpointPoliciesOperations) ResumeCreateOrUpdate(token stri
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *serviceEndpointPoliciesOperations) createOrUpdateCreateRequest(resourceGroupName string, serviceEndpointPolicyName string, parameters ServiceEndpointPolicy) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *serviceEndpointPoliciesOperations) ResumeDelete(token string) (HTT
 
 // deleteCreateRequest creates the Delete request.
 func (client *serviceEndpointPoliciesOperations) deleteCreateRequest(resourceGroupName string, serviceEndpointPolicyName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *serviceEndpointPoliciesOperations) Get(ctx context.Context, resour
 
 // getCreateRequest creates the Get request.
 func (client *serviceEndpointPoliciesOperations) getCreateRequest(resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPoliciesGetOptions *ServiceEndpointPoliciesGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -273,9 +284,13 @@ func (client *serviceEndpointPoliciesOperations) List() (ServiceEndpointPolicyLi
 
 // listCreateRequest creates the List request.
 func (client *serviceEndpointPoliciesOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ServiceEndpointPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -329,10 +344,14 @@ func (client *serviceEndpointPoliciesOperations) ListByResourceGroup(resourceGro
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *serviceEndpointPoliciesOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -380,11 +399,15 @@ func (client *serviceEndpointPoliciesOperations) UpdateTags(ctx context.Context,
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *serviceEndpointPoliciesOperations) updateTagsCreateRequest(resourceGroupName string, serviceEndpointPolicyName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/serviceendpointpolicydefinitions.go
+++ b/test/network/2020-03-01/armnetwork/serviceendpointpolicydefinitions.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *serviceEndpointPolicyDefinitionsOperations) ResumeCreateOrUpdate(t
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *serviceEndpointPolicyDefinitionsOperations) createOrUpdateCreateRequest(resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, serviceEndpointPolicyDefinitions ServiceEndpointPolicyDefinition) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}/serviceEndpointPolicyDefinitions/{serviceEndpointPolicyDefinitionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyDefinitionName}", url.PathEscape(serviceEndpointPolicyDefinitionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *serviceEndpointPolicyDefinitionsOperations) ResumeDelete(token str
 
 // deleteCreateRequest creates the Delete request.
 func (client *serviceEndpointPolicyDefinitionsOperations) deleteCreateRequest(resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}/serviceEndpointPolicyDefinitions/{serviceEndpointPolicyDefinitionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyDefinitionName}", url.PathEscape(serviceEndpointPolicyDefinitionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *serviceEndpointPolicyDefinitionsOperations) Get(ctx context.Contex
 
 // getCreateRequest creates the Get request.
 func (client *serviceEndpointPolicyDefinitionsOperations) getCreateRequest(resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}/serviceEndpointPolicyDefinitions/{serviceEndpointPolicyDefinitionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyDefinitionName}", url.PathEscape(serviceEndpointPolicyDefinitionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *serviceEndpointPolicyDefinitionsOperations) ListByResourceGroup(re
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *serviceEndpointPolicyDefinitionsOperations) listByResourceGroupCreateRequest(resourceGroupName string, serviceEndpointPolicyName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}/serviceEndpointPolicyDefinitions"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/serviceendpointpolicydefinitions.go
+++ b/test/network/2020-03-01/armnetwork/serviceendpointpolicydefinitions.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *serviceEndpointPolicyDefinitionsOperations) createOrUpdateCreateRe
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyDefinitionName}", url.PathEscape(serviceEndpointPolicyDefinitionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *serviceEndpointPolicyDefinitionsOperations) deleteCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyDefinitionName}", url.PathEscape(serviceEndpointPolicyDefinitionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *serviceEndpointPolicyDefinitionsOperations) getCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyDefinitionName}", url.PathEscape(serviceEndpointPolicyDefinitionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *serviceEndpointPolicyDefinitionsOperations) listByResourceGroupCre
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/servicetags.go
+++ b/test/network/2020-03-01/armnetwork/servicetags.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -45,10 +44,14 @@ func (client *serviceTagsOperations) List(ctx context.Context, location string) 
 
 // listCreateRequest creates the List request.
 func (client *serviceTagsOperations) listCreateRequest(location string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/serviceTags"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/servicetags.go
+++ b/test/network/2020-03-01/armnetwork/servicetags.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -51,7 +52,7 @@ func (client *serviceTagsOperations) listCreateRequest(location string) (*azcore
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/serviceTags"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/subnets.go
+++ b/test/network/2020-03-01/armnetwork/subnets.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -90,12 +89,16 @@ func (client *subnetsOperations) ResumeCreateOrUpdate(token string) (SubnetPolle
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *subnetsOperations) createOrUpdateCreateRequest(resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -166,12 +169,16 @@ func (client *subnetsOperations) ResumeDelete(token string) (HTTPPoller, error) 
 
 // deleteCreateRequest creates the Delete request.
 func (client *subnetsOperations) deleteCreateRequest(resourceGroupName string, virtualNetworkName string, subnetName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -218,12 +225,16 @@ func (client *subnetsOperations) Get(ctx context.Context, resourceGroupName stri
 
 // getCreateRequest creates the Get request.
 func (client *subnetsOperations) getCreateRequest(resourceGroupName string, virtualNetworkName string, subnetName string, subnetsGetOptions *SubnetsGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -280,11 +291,15 @@ func (client *subnetsOperations) List(resourceGroupName string, virtualNetworkNa
 
 // listCreateRequest creates the List request.
 func (client *subnetsOperations) listCreateRequest(resourceGroupName string, virtualNetworkName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -356,12 +371,16 @@ func (client *subnetsOperations) ResumePrepareNetworkPolicies(token string) (HTT
 
 // prepareNetworkPoliciesCreateRequest creates the PrepareNetworkPolicies request.
 func (client *subnetsOperations) prepareNetworkPoliciesCreateRequest(resourceGroupName string, virtualNetworkName string, subnetName string, prepareNetworkPoliciesRequestParameters PrepareNetworkPoliciesRequest) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/PrepareNetworkPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -432,12 +451,16 @@ func (client *subnetsOperations) ResumeUnprepareNetworkPolicies(token string) (H
 
 // unprepareNetworkPoliciesCreateRequest creates the UnprepareNetworkPolicies request.
 func (client *subnetsOperations) unprepareNetworkPoliciesCreateRequest(resourceGroupName string, virtualNetworkName string, subnetName string, unprepareNetworkPoliciesRequestParameters UnprepareNetworkPoliciesRequest) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/UnprepareNetworkPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/subnets.go
+++ b/test/network/2020-03-01/armnetwork/subnets.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -98,7 +99,7 @@ func (client *subnetsOperations) createOrUpdateCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +179,7 @@ func (client *subnetsOperations) deleteCreateRequest(resourceGroupName string, v
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +235,7 @@ func (client *subnetsOperations) getCreateRequest(resourceGroupName string, virt
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +300,7 @@ func (client *subnetsOperations) listCreateRequest(resourceGroupName string, vir
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +381,7 @@ func (client *subnetsOperations) prepareNetworkPoliciesCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -460,7 +461,7 @@ func (client *subnetsOperations) unprepareNetworkPoliciesCreateRequest(resourceG
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subnetName}", url.PathEscape(subnetName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/usages.go
+++ b/test/network/2020-03-01/armnetwork/usages.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -51,10 +50,14 @@ func (client *usagesOperations) List(location string) (UsagesListResultPager, er
 
 // listCreateRequest creates the List request.
 func (client *usagesOperations) listCreateRequest(location string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/usages"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/usages.go
+++ b/test/network/2020-03-01/armnetwork/usages.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -57,7 +58,7 @@ func (client *usagesOperations) listCreateRequest(location string) (*azcore.Requ
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/usages"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualhubroutetablev2s.go
+++ b/test/network/2020-03-01/armnetwork/virtualhubroutetablev2s.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *virtualHubRouteTableV2SOperations) ResumeCreateOrUpdate(token stri
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *virtualHubRouteTableV2SOperations) createOrUpdateCreateRequest(resourceGroupName string, virtualHubName string, routeTableName string, virtualHubRouteTableV2Parameters VirtualHubRouteTableV2) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeTables/{routeTableName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *virtualHubRouteTableV2SOperations) ResumeDelete(token string) (HTT
 
 // deleteCreateRequest creates the Delete request.
 func (client *virtualHubRouteTableV2SOperations) deleteCreateRequest(resourceGroupName string, virtualHubName string, routeTableName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeTables/{routeTableName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *virtualHubRouteTableV2SOperations) Get(ctx context.Context, resour
 
 // getCreateRequest creates the Get request.
 func (client *virtualHubRouteTableV2SOperations) getCreateRequest(resourceGroupName string, virtualHubName string, routeTableName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeTables/{routeTableName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *virtualHubRouteTableV2SOperations) List(resourceGroupName string, 
 
 // listCreateRequest creates the List request.
 func (client *virtualHubRouteTableV2SOperations) listCreateRequest(resourceGroupName string, virtualHubName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeTables"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualhubroutetablev2s.go
+++ b/test/network/2020-03-01/armnetwork/virtualhubroutetablev2s.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *virtualHubRouteTableV2SOperations) createOrUpdateCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *virtualHubRouteTableV2SOperations) deleteCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *virtualHubRouteTableV2SOperations) getCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *virtualHubRouteTableV2SOperations) listCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualhubs.go
+++ b/test/network/2020-03-01/armnetwork/virtualhubs.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *virtualHubsOperations) ResumeCreateOrUpdate(token string) (Virtual
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *virtualHubsOperations) createOrUpdateCreateRequest(resourceGroupName string, virtualHubName string, virtualHubParameters VirtualHub) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *virtualHubsOperations) ResumeDelete(token string) (HTTPPoller, err
 
 // deleteCreateRequest creates the Delete request.
 func (client *virtualHubsOperations) deleteCreateRequest(resourceGroupName string, virtualHubName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *virtualHubsOperations) Get(ctx context.Context, resourceGroupName 
 
 // getCreateRequest creates the Get request.
 func (client *virtualHubsOperations) getCreateRequest(resourceGroupName string, virtualHubName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -270,9 +281,13 @@ func (client *virtualHubsOperations) List() (ListVirtualHubsResultPager, error) 
 
 // listCreateRequest creates the List request.
 func (client *virtualHubsOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualHubs"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -326,10 +341,14 @@ func (client *virtualHubsOperations) ListByResourceGroup(resourceGroupName strin
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *virtualHubsOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -377,11 +396,15 @@ func (client *virtualHubsOperations) UpdateTags(ctx context.Context, resourceGro
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *virtualHubsOperations) updateTagsCreateRequest(resourceGroupName string, virtualHubName string, virtualHubParameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualhubs.go
+++ b/test/network/2020-03-01/armnetwork/virtualhubs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *virtualHubsOperations) createOrUpdateCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *virtualHubsOperations) deleteCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *virtualHubsOperations) getCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +288,7 @@ func (client *virtualHubsOperations) listCreateRequest() (*azcore.Request, error
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualHubs"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +349,7 @@ func (client *virtualHubsOperations) listByResourceGroupCreateRequest(resourceGr
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +405,7 @@ func (client *virtualHubsOperations) updateTagsCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualnetworkgatewayconnections.go
+++ b/test/network/2020-03-01/armnetwork/virtualnetworkgatewayconnections.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -111,7 +112,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) createOrUpdateCreateRe
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +191,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) deleteCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +246,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) getCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +302,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) getSharedKeyCreateRequ
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -362,7 +363,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) listCreateRequest(reso
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -442,7 +443,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) resetSharedKeyCreateRe
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -521,7 +522,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) setSharedKeyCreateRequ
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -600,7 +601,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) startPacketCaptureCrea
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -682,7 +683,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) stopPacketCaptureCreat
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -761,7 +762,7 @@ func (client *virtualNetworkGatewayConnectionsOperations) updateTagsCreateReques
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualnetworkgatewayconnections.go
+++ b/test/network/2020-03-01/armnetwork/virtualnetworkgatewayconnections.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -104,11 +103,15 @@ func (client *virtualNetworkGatewayConnectionsOperations) ResumeCreateOrUpdate(t
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *virtualNetworkGatewayConnectionsOperations) createOrUpdateCreateRequest(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -179,11 +182,15 @@ func (client *virtualNetworkGatewayConnectionsOperations) ResumeDelete(token str
 
 // deleteCreateRequest creates the Delete request.
 func (client *virtualNetworkGatewayConnectionsOperations) deleteCreateRequest(resourceGroupName string, virtualNetworkGatewayConnectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -230,11 +237,15 @@ func (client *virtualNetworkGatewayConnectionsOperations) Get(ctx context.Contex
 
 // getCreateRequest creates the Get request.
 func (client *virtualNetworkGatewayConnectionsOperations) getCreateRequest(resourceGroupName string, virtualNetworkGatewayConnectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -282,11 +293,15 @@ func (client *virtualNetworkGatewayConnectionsOperations) GetSharedKey(ctx conte
 
 // getSharedKeyCreateRequest creates the GetSharedKey request.
 func (client *virtualNetworkGatewayConnectionsOperations) getSharedKeyCreateRequest(resourceGroupName string, virtualNetworkGatewayConnectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -340,10 +355,14 @@ func (client *virtualNetworkGatewayConnectionsOperations) List(resourceGroupName
 
 // listCreateRequest creates the List request.
 func (client *virtualNetworkGatewayConnectionsOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -415,11 +434,15 @@ func (client *virtualNetworkGatewayConnectionsOperations) ResumeResetSharedKey(t
 
 // resetSharedKeyCreateRequest creates the ResetSharedKey request.
 func (client *virtualNetworkGatewayConnectionsOperations) resetSharedKeyCreateRequest(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey/reset"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -490,11 +513,15 @@ func (client *virtualNetworkGatewayConnectionsOperations) ResumeSetSharedKey(tok
 
 // setSharedKeyCreateRequest creates the SetSharedKey request.
 func (client *virtualNetworkGatewayConnectionsOperations) setSharedKeyCreateRequest(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -565,11 +592,15 @@ func (client *virtualNetworkGatewayConnectionsOperations) ResumeStartPacketCaptu
 
 // startPacketCaptureCreateRequest creates the StartPacketCapture request.
 func (client *virtualNetworkGatewayConnectionsOperations) startPacketCaptureCreateRequest(resourceGroupName string, virtualNetworkGatewayConnectionName string, virtualNetworkGatewayConnectionsStartPacketCaptureOptions *VirtualNetworkGatewayConnectionsStartPacketCaptureOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/startPacketCapture"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -643,11 +674,15 @@ func (client *virtualNetworkGatewayConnectionsOperations) ResumeStopPacketCaptur
 
 // stopPacketCaptureCreateRequest creates the StopPacketCapture request.
 func (client *virtualNetworkGatewayConnectionsOperations) stopPacketCaptureCreateRequest(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnPacketCaptureStopParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/stopPacketCapture"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -718,11 +753,15 @@ func (client *virtualNetworkGatewayConnectionsOperations) ResumeUpdateTags(token
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *virtualNetworkGatewayConnectionsOperations) updateTagsCreateRequest(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/virtualnetworkgateways.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -155,7 +156,7 @@ func (client *virtualNetworkGatewaysOperations) createOrUpdateCreateRequest(reso
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +235,7 @@ func (client *virtualNetworkGatewaysOperations) deleteCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -313,7 +314,7 @@ func (client *virtualNetworkGatewaysOperations) disconnectVirtualNetworkGatewayV
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -392,7 +393,7 @@ func (client *virtualNetworkGatewaysOperations) generateVpnProfileCreateRequest(
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +472,7 @@ func (client *virtualNetworkGatewaysOperations) generatevpnclientpackageCreateRe
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -526,7 +527,7 @@ func (client *virtualNetworkGatewaysOperations) getCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -606,7 +607,7 @@ func (client *virtualNetworkGatewaysOperations) getAdvertisedRoutesCreateRequest
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -686,7 +687,7 @@ func (client *virtualNetworkGatewaysOperations) getBgpPeerStatusCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -768,7 +769,7 @@ func (client *virtualNetworkGatewaysOperations) getLearnedRoutesCreateRequest(re
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -847,7 +848,7 @@ func (client *virtualNetworkGatewaysOperations) getVpnProfilePackageUrlCreateReq
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -926,7 +927,7 @@ func (client *virtualNetworkGatewaysOperations) getVpnclientConnectionHealthCrea
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1005,7 +1006,7 @@ func (client *virtualNetworkGatewaysOperations) getVpnclientIPsecParametersCreat
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1065,7 +1066,7 @@ func (client *virtualNetworkGatewaysOperations) listCreateRequest(resourceGroupN
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1127,7 +1128,7 @@ func (client *virtualNetworkGatewaysOperations) listConnectionsCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1207,7 +1208,7 @@ func (client *virtualNetworkGatewaysOperations) resetCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1289,7 +1290,7 @@ func (client *virtualNetworkGatewaysOperations) resetVpnClientSharedKeyCreateReq
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1368,7 +1369,7 @@ func (client *virtualNetworkGatewaysOperations) setVpnclientIPsecParametersCreat
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1447,7 +1448,7 @@ func (client *virtualNetworkGatewaysOperations) startPacketCaptureCreateRequest(
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1529,7 +1530,7 @@ func (client *virtualNetworkGatewaysOperations) stopPacketCaptureCreateRequest(r
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1584,7 +1585,7 @@ func (client *virtualNetworkGatewaysOperations) supportedVpnDevicesCreateRequest
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1664,7 +1665,7 @@ func (client *virtualNetworkGatewaysOperations) updateTagsCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1719,7 +1720,7 @@ func (client *virtualNetworkGatewaysOperations) vpnDeviceConfigurationScriptCrea
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/virtualnetworkgateways.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -148,11 +147,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeCreateOrUpdate(token strin
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *virtualNetworkGatewaysOperations) createOrUpdateCreateRequest(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -223,11 +226,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeDelete(token string) (HTTP
 
 // deleteCreateRequest creates the Delete request.
 func (client *virtualNetworkGatewaysOperations) deleteCreateRequest(resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -298,11 +305,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeDisconnectVirtualNetworkGa
 
 // disconnectVirtualNetworkGatewayVpnConnectionsCreateRequest creates the DisconnectVirtualNetworkGatewayVpnConnections request.
 func (client *virtualNetworkGatewaysOperations) disconnectVirtualNetworkGatewayVpnConnectionsCreateRequest(resourceGroupName string, virtualNetworkGatewayName string, request P2SVpnConnectionRequest) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/disconnectVirtualNetworkGatewayVpnConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -373,11 +384,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeGenerateVpnProfile(token s
 
 // generateVpnProfileCreateRequest creates the GenerateVpnProfile request.
 func (client *virtualNetworkGatewaysOperations) generateVpnProfileCreateRequest(resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/generatevpnprofile"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -448,11 +463,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeGeneratevpnclientpackage(t
 
 // generatevpnclientpackageCreateRequest creates the Generatevpnclientpackage request.
 func (client *virtualNetworkGatewaysOperations) generatevpnclientpackageCreateRequest(resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/generatevpnclientpackage"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -499,11 +518,15 @@ func (client *virtualNetworkGatewaysOperations) Get(ctx context.Context, resourc
 
 // getCreateRequest creates the Get request.
 func (client *virtualNetworkGatewaysOperations) getCreateRequest(resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -575,11 +598,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeGetAdvertisedRoutes(token 
 
 // getAdvertisedRoutesCreateRequest creates the GetAdvertisedRoutes request.
 func (client *virtualNetworkGatewaysOperations) getAdvertisedRoutesCreateRequest(resourceGroupName string, virtualNetworkGatewayName string, peer string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getAdvertisedRoutes"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -651,11 +678,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeGetBgpPeerStatus(token str
 
 // getBgpPeerStatusCreateRequest creates the GetBgpPeerStatus request.
 func (client *virtualNetworkGatewaysOperations) getBgpPeerStatusCreateRequest(resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysGetBgpPeerStatusOptions *VirtualNetworkGatewaysGetBgpPeerStatusOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getBgpPeerStatus"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -729,11 +760,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeGetLearnedRoutes(token str
 
 // getLearnedRoutesCreateRequest creates the GetLearnedRoutes request.
 func (client *virtualNetworkGatewaysOperations) getLearnedRoutesCreateRequest(resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getLearnedRoutes"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -804,11 +839,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeGetVpnProfilePackageURL(to
 
 // getVpnProfilePackageUrlCreateRequest creates the GetVpnProfilePackageURL request.
 func (client *virtualNetworkGatewaysOperations) getVpnProfilePackageUrlCreateRequest(resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getvpnprofilepackageurl"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -879,11 +918,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeGetVpnclientConnectionHeal
 
 // getVpnclientConnectionHealthCreateRequest creates the GetVpnclientConnectionHealth request.
 func (client *virtualNetworkGatewaysOperations) getVpnclientConnectionHealthCreateRequest(resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getVpnClientConnectionHealth"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -954,11 +997,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeGetVpnclientIPsecParameter
 
 // getVpnclientIPsecParametersCreateRequest creates the GetVpnclientIPsecParameters request.
 func (client *virtualNetworkGatewaysOperations) getVpnclientIPsecParametersCreateRequest(resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getvpnclientipsecparameters"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1011,10 +1058,14 @@ func (client *virtualNetworkGatewaysOperations) List(resourceGroupName string) (
 
 // listCreateRequest creates the List request.
 func (client *virtualNetworkGatewaysOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1068,11 +1119,15 @@ func (client *virtualNetworkGatewaysOperations) ListConnections(resourceGroupNam
 
 // listConnectionsCreateRequest creates the ListConnections request.
 func (client *virtualNetworkGatewaysOperations) listConnectionsCreateRequest(resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/connections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1144,11 +1199,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeReset(token string) (Virtu
 
 // resetCreateRequest creates the Reset request.
 func (client *virtualNetworkGatewaysOperations) resetCreateRequest(resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysResetOptions *VirtualNetworkGatewaysResetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/reset"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1222,11 +1281,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeResetVpnClientSharedKey(to
 
 // resetVpnClientSharedKeyCreateRequest creates the ResetVpnClientSharedKey request.
 func (client *virtualNetworkGatewaysOperations) resetVpnClientSharedKeyCreateRequest(resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/resetvpnclientsharedkey"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1297,11 +1360,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeSetVpnclientIPsecParameter
 
 // setVpnclientIPsecParametersCreateRequest creates the SetVpnclientIPsecParameters request.
 func (client *virtualNetworkGatewaysOperations) setVpnclientIPsecParametersCreateRequest(resourceGroupName string, virtualNetworkGatewayName string, vpnclientIpsecParams VpnClientIPsecParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/setvpnclientipsecparameters"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1372,11 +1439,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeStartPacketCapture(token s
 
 // startPacketCaptureCreateRequest creates the StartPacketCapture request.
 func (client *virtualNetworkGatewaysOperations) startPacketCaptureCreateRequest(resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysStartPacketCaptureOptions *VirtualNetworkGatewaysStartPacketCaptureOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/startPacketCapture"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1450,11 +1521,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeStopPacketCapture(token st
 
 // stopPacketCaptureCreateRequest creates the StopPacketCapture request.
 func (client *virtualNetworkGatewaysOperations) stopPacketCaptureCreateRequest(resourceGroupName string, virtualNetworkGatewayName string, parameters VpnPacketCaptureStopParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/stopPacketCapture"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1501,11 +1576,15 @@ func (client *virtualNetworkGatewaysOperations) SupportedVpnDevices(ctx context.
 
 // supportedVpnDevicesCreateRequest creates the SupportedVpnDevices request.
 func (client *virtualNetworkGatewaysOperations) supportedVpnDevicesCreateRequest(resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/supportedvpndevices"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1577,11 +1656,15 @@ func (client *virtualNetworkGatewaysOperations) ResumeUpdateTags(token string) (
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *virtualNetworkGatewaysOperations) updateTagsCreateRequest(resourceGroupName string, virtualNetworkGatewayName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1628,11 +1711,15 @@ func (client *virtualNetworkGatewaysOperations) VpnDeviceConfigurationScript(ctx
 
 // vpnDeviceConfigurationScriptCreateRequest creates the VpnDeviceConfigurationScript request.
 func (client *virtualNetworkGatewaysOperations) vpnDeviceConfigurationScriptCreateRequest(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnDeviceScriptParameters) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/vpndeviceconfigurationscript"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualnetworkpeerings.go
+++ b/test/network/2020-03-01/armnetwork/virtualnetworkpeerings.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *virtualNetworkPeeringsOperations) createOrUpdateCreateRequest(reso
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkPeeringName}", url.PathEscape(virtualNetworkPeeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *virtualNetworkPeeringsOperations) deleteCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkPeeringName}", url.PathEscape(virtualNetworkPeeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *virtualNetworkPeeringsOperations) getCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkPeeringName}", url.PathEscape(virtualNetworkPeeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *virtualNetworkPeeringsOperations) listCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualnetworkpeerings.go
+++ b/test/network/2020-03-01/armnetwork/virtualnetworkpeerings.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *virtualNetworkPeeringsOperations) ResumeCreateOrUpdate(token strin
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *virtualNetworkPeeringsOperations) createOrUpdateCreateRequest(resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, virtualNetworkPeeringParameters VirtualNetworkPeering) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings/{virtualNetworkPeeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkPeeringName}", url.PathEscape(virtualNetworkPeeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *virtualNetworkPeeringsOperations) ResumeDelete(token string) (HTTP
 
 // deleteCreateRequest creates the Delete request.
 func (client *virtualNetworkPeeringsOperations) deleteCreateRequest(resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings/{virtualNetworkPeeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkPeeringName}", url.PathEscape(virtualNetworkPeeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *virtualNetworkPeeringsOperations) Get(ctx context.Context, resourc
 
 // getCreateRequest creates the Get request.
 func (client *virtualNetworkPeeringsOperations) getCreateRequest(resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings/{virtualNetworkPeeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkPeeringName}", url.PathEscape(virtualNetworkPeeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *virtualNetworkPeeringsOperations) List(resourceGroupName string, v
 
 // listCreateRequest creates the List request.
 func (client *virtualNetworkPeeringsOperations) listCreateRequest(resourceGroupName string, virtualNetworkName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualnetworks.go
+++ b/test/network/2020-03-01/armnetwork/virtualnetworks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -73,7 +74,7 @@ func (client *virtualNetworksOperations) checkIPAddressAvailabilityCreateRequest
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +155,7 @@ func (client *virtualNetworksOperations) createOrUpdateCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +234,7 @@ func (client *virtualNetworksOperations) deleteCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *virtualNetworksOperations) getCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +353,7 @@ func (client *virtualNetworksOperations) listCreateRequest(resourceGroupName str
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -412,7 +413,7 @@ func (client *virtualNetworksOperations) listAllCreateRequest() (*azcore.Request
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworks"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -474,7 +475,7 @@ func (client *virtualNetworksOperations) listUsageCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -530,7 +531,7 @@ func (client *virtualNetworksOperations) updateTagsCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualnetworks.go
+++ b/test/network/2020-03-01/armnetwork/virtualnetworks.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -66,11 +65,15 @@ func (client *virtualNetworksOperations) CheckIPAddressAvailability(ctx context.
 
 // checkIPAddressAvailabilityCreateRequest creates the CheckIPAddressAvailability request.
 func (client *virtualNetworksOperations) checkIPAddressAvailabilityCreateRequest(resourceGroupName string, virtualNetworkName string, ipAddress string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/CheckIPAddressAvailability"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -143,11 +146,15 @@ func (client *virtualNetworksOperations) ResumeCreateOrUpdate(token string) (Vir
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *virtualNetworksOperations) createOrUpdateCreateRequest(resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -218,11 +225,15 @@ func (client *virtualNetworksOperations) ResumeDelete(token string) (HTTPPoller,
 
 // deleteCreateRequest creates the Delete request.
 func (client *virtualNetworksOperations) deleteCreateRequest(resourceGroupName string, virtualNetworkName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *virtualNetworksOperations) Get(ctx context.Context, resourceGroupN
 
 // getCreateRequest creates the Get request.
 func (client *virtualNetworksOperations) getCreateRequest(resourceGroupName string, virtualNetworkName string, virtualNetworksGetOptions *VirtualNetworksGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -330,10 +345,14 @@ func (client *virtualNetworksOperations) List(resourceGroupName string) (Virtual
 
 // listCreateRequest creates the List request.
 func (client *virtualNetworksOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -387,9 +406,13 @@ func (client *virtualNetworksOperations) ListAll() (VirtualNetworkListResultPage
 
 // listAllCreateRequest creates the ListAll request.
 func (client *virtualNetworksOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworks"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -443,11 +466,15 @@ func (client *virtualNetworksOperations) ListUsage(resourceGroupName string, vir
 
 // listUsageCreateRequest creates the ListUsage request.
 func (client *virtualNetworksOperations) listUsageCreateRequest(resourceGroupName string, virtualNetworkName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/usages"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -495,11 +522,15 @@ func (client *virtualNetworksOperations) UpdateTags(ctx context.Context, resourc
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *virtualNetworksOperations) updateTagsCreateRequest(resourceGroupName string, virtualNetworkName string, parameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualnetworktaps.go
+++ b/test/network/2020-03-01/armnetwork/virtualnetworktaps.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *virtualNetworkTapsOperations) createOrUpdateCreateRequest(resource
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *virtualNetworkTapsOperations) deleteCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *virtualNetworkTapsOperations) getCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +288,7 @@ func (client *virtualNetworkTapsOperations) listAllCreateRequest() (*azcore.Requ
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworkTaps"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +349,7 @@ func (client *virtualNetworkTapsOperations) listByResourceGroupCreateRequest(res
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +405,7 @@ func (client *virtualNetworkTapsOperations) updateTagsCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualnetworktaps.go
+++ b/test/network/2020-03-01/armnetwork/virtualnetworktaps.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *virtualNetworkTapsOperations) ResumeCreateOrUpdate(token string) (
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *virtualNetworkTapsOperations) createOrUpdateCreateRequest(resourceGroupName string, tapName string, parameters VirtualNetworkTap) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps/{tapName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *virtualNetworkTapsOperations) ResumeDelete(token string) (HTTPPoll
 
 // deleteCreateRequest creates the Delete request.
 func (client *virtualNetworkTapsOperations) deleteCreateRequest(resourceGroupName string, tapName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps/{tapName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *virtualNetworkTapsOperations) Get(ctx context.Context, resourceGro
 
 // getCreateRequest creates the Get request.
 func (client *virtualNetworkTapsOperations) getCreateRequest(resourceGroupName string, tapName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps/{tapName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -270,9 +281,13 @@ func (client *virtualNetworkTapsOperations) ListAll() (VirtualNetworkTapListResu
 
 // listAllCreateRequest creates the ListAll request.
 func (client *virtualNetworkTapsOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworkTaps"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -326,10 +341,14 @@ func (client *virtualNetworkTapsOperations) ListByResourceGroup(resourceGroupNam
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *virtualNetworkTapsOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -377,11 +396,15 @@ func (client *virtualNetworkTapsOperations) UpdateTags(ctx context.Context, reso
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *virtualNetworkTapsOperations) updateTagsCreateRequest(resourceGroupName string, tapName string, tapParameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps/{tapName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualrouterpeerings.go
+++ b/test/network/2020-03-01/armnetwork/virtualrouterpeerings.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *virtualRouterPeeringsOperations) createOrUpdateCreateRequest(resou
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *virtualRouterPeeringsOperations) deleteCreateRequest(resourceGroup
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *virtualRouterPeeringsOperations) getCreateRequest(resourceGroupNam
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *virtualRouterPeeringsOperations) listCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualrouterpeerings.go
+++ b/test/network/2020-03-01/armnetwork/virtualrouterpeerings.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *virtualRouterPeeringsOperations) ResumeCreateOrUpdate(token string
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *virtualRouterPeeringsOperations) createOrUpdateCreateRequest(resourceGroupName string, virtualRouterName string, peeringName string, parameters VirtualRouterPeering) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *virtualRouterPeeringsOperations) ResumeDelete(token string) (HTTPP
 
 // deleteCreateRequest creates the Delete request.
 func (client *virtualRouterPeeringsOperations) deleteCreateRequest(resourceGroupName string, virtualRouterName string, peeringName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *virtualRouterPeeringsOperations) Get(ctx context.Context, resource
 
 // getCreateRequest creates the Get request.
 func (client *virtualRouterPeeringsOperations) getCreateRequest(resourceGroupName string, virtualRouterName string, peeringName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{peeringName}", url.PathEscape(peeringName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *virtualRouterPeeringsOperations) List(resourceGroupName string, vi
 
 // listCreateRequest creates the List request.
 func (client *virtualRouterPeeringsOperations) listCreateRequest(resourceGroupName string, virtualRouterName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}/peerings"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualrouters.go
+++ b/test/network/2020-03-01/armnetwork/virtualrouters.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -84,11 +83,15 @@ func (client *virtualRoutersOperations) ResumeCreateOrUpdate(token string) (Virt
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *virtualRoutersOperations) createOrUpdateCreateRequest(resourceGroupName string, virtualRouterName string, parameters VirtualRouter) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -159,11 +162,15 @@ func (client *virtualRoutersOperations) ResumeDelete(token string) (HTTPPoller, 
 
 // deleteCreateRequest creates the Delete request.
 func (client *virtualRoutersOperations) deleteCreateRequest(resourceGroupName string, virtualRouterName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,11 +217,15 @@ func (client *virtualRoutersOperations) Get(ctx context.Context, resourceGroupNa
 
 // getCreateRequest creates the Get request.
 func (client *virtualRoutersOperations) getCreateRequest(resourceGroupName string, virtualRouterName string, virtualRoutersGetOptions *VirtualRoutersGetOptions) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -271,9 +282,13 @@ func (client *virtualRoutersOperations) List() (VirtualRouterListResultPager, er
 
 // listCreateRequest creates the List request.
 func (client *virtualRoutersOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualRouters"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -327,10 +342,14 @@ func (client *virtualRoutersOperations) ListByResourceGroup(resourceGroupName st
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *virtualRoutersOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualrouters.go
+++ b/test/network/2020-03-01/armnetwork/virtualrouters.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -91,7 +92,7 @@ func (client *virtualRoutersOperations) createOrUpdateCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *virtualRoutersOperations) deleteCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +226,7 @@ func (client *virtualRoutersOperations) getCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *virtualRoutersOperations) listCreateRequest() (*azcore.Request, er
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualRouters"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +350,7 @@ func (client *virtualRoutersOperations) listByResourceGroupCreateRequest(resourc
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualwans.go
+++ b/test/network/2020-03-01/armnetwork/virtualwans.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *virtualWansOperations) createOrUpdateCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWanName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *virtualWansOperations) deleteCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWanName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *virtualWansOperations) getCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWanName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +288,7 @@ func (client *virtualWansOperations) listCreateRequest() (*azcore.Request, error
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualWans"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +349,7 @@ func (client *virtualWansOperations) listByResourceGroupCreateRequest(resourceGr
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +405,7 @@ func (client *virtualWansOperations) updateTagsCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWanName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/virtualwans.go
+++ b/test/network/2020-03-01/armnetwork/virtualwans.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *virtualWansOperations) ResumeCreateOrUpdate(token string) (Virtual
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *virtualWansOperations) createOrUpdateCreateRequest(resourceGroupName string, virtualWanName string, wanParameters VirtualWan) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{VirtualWANName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWanName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *virtualWansOperations) ResumeDelete(token string) (HTTPPoller, err
 
 // deleteCreateRequest creates the Delete request.
 func (client *virtualWansOperations) deleteCreateRequest(resourceGroupName string, virtualWanName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{VirtualWANName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWanName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *virtualWansOperations) Get(ctx context.Context, resourceGroupName 
 
 // getCreateRequest creates the Get request.
 func (client *virtualWansOperations) getCreateRequest(resourceGroupName string, virtualWanName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{VirtualWANName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWanName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -270,9 +281,13 @@ func (client *virtualWansOperations) List() (ListVirtualWaNsResultPager, error) 
 
 // listCreateRequest creates the List request.
 func (client *virtualWansOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualWans"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -326,10 +341,14 @@ func (client *virtualWansOperations) ListByResourceGroup(resourceGroupName strin
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *virtualWansOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -377,11 +396,15 @@ func (client *virtualWansOperations) UpdateTags(ctx context.Context, resourceGro
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *virtualWansOperations) updateTagsCreateRequest(resourceGroupName string, virtualWanName string, wanParameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{VirtualWANName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWanName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnconnections.go
+++ b/test/network/2020-03-01/armnetwork/vpnconnections.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -82,12 +81,16 @@ func (client *vpnConnectionsOperations) ResumeCreateOrUpdate(token string) (VpnC
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *vpnConnectionsOperations) createOrUpdateCreateRequest(resourceGroupName string, gatewayName string, connectionName string, vpnConnectionParameters VpnConnection) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +161,16 @@ func (client *vpnConnectionsOperations) ResumeDelete(token string) (HTTPPoller, 
 
 // deleteCreateRequest creates the Delete request.
 func (client *vpnConnectionsOperations) deleteCreateRequest(resourceGroupName string, gatewayName string, connectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -210,12 +217,16 @@ func (client *vpnConnectionsOperations) Get(ctx context.Context, resourceGroupNa
 
 // getCreateRequest creates the Get request.
 func (client *vpnConnectionsOperations) getCreateRequest(resourceGroupName string, gatewayName string, connectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +280,15 @@ func (client *vpnConnectionsOperations) ListByVpnGateway(resourceGroupName strin
 
 // listByVpnGatewayCreateRequest creates the ListByVpnGateway request.
 func (client *vpnConnectionsOperations) listByVpnGatewayCreateRequest(resourceGroupName string, gatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnconnections.go
+++ b/test/network/2020-03-01/armnetwork/vpnconnections.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -90,7 +91,7 @@ func (client *vpnConnectionsOperations) createOrUpdateCreateRequest(resourceGrou
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func (client *vpnConnectionsOperations) deleteCreateRequest(resourceGroupName st
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +227,7 @@ func (client *vpnConnectionsOperations) getCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (client *vpnConnectionsOperations) listByVpnGatewayCreateRequest(resourceGr
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpngateways.go
+++ b/test/network/2020-03-01/armnetwork/vpngateways.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -90,11 +89,15 @@ func (client *vpnGatewaysOperations) ResumeCreateOrUpdate(token string) (VpnGate
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *vpnGatewaysOperations) createOrUpdateCreateRequest(resourceGroupName string, gatewayName string, vpnGatewayParameters VpnGateway) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -165,11 +168,15 @@ func (client *vpnGatewaysOperations) ResumeDelete(token string) (HTTPPoller, err
 
 // deleteCreateRequest creates the Delete request.
 func (client *vpnGatewaysOperations) deleteCreateRequest(resourceGroupName string, gatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -216,11 +223,15 @@ func (client *vpnGatewaysOperations) Get(ctx context.Context, resourceGroupName 
 
 // getCreateRequest creates the Get request.
 func (client *vpnGatewaysOperations) getCreateRequest(resourceGroupName string, gatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -274,9 +285,13 @@ func (client *vpnGatewaysOperations) List() (ListVpnGatewaysResultPager, error) 
 
 // listCreateRequest creates the List request.
 func (client *vpnGatewaysOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -330,10 +345,14 @@ func (client *vpnGatewaysOperations) ListByResourceGroup(resourceGroupName strin
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *vpnGatewaysOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -405,11 +424,15 @@ func (client *vpnGatewaysOperations) ResumeReset(token string) (VpnGatewayPoller
 
 // resetCreateRequest creates the Reset request.
 func (client *vpnGatewaysOperations) resetCreateRequest(resourceGroupName string, gatewayName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/reset"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -456,11 +479,15 @@ func (client *vpnGatewaysOperations) UpdateTags(ctx context.Context, resourceGro
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *vpnGatewaysOperations) updateTagsCreateRequest(resourceGroupName string, gatewayName string, vpnGatewayParameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpngateways.go
+++ b/test/network/2020-03-01/armnetwork/vpngateways.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -97,7 +98,7 @@ func (client *vpnGatewaysOperations) createOrUpdateCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +177,7 @@ func (client *vpnGatewaysOperations) deleteCreateRequest(resourceGroupName strin
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +232,7 @@ func (client *vpnGatewaysOperations) getCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +292,7 @@ func (client *vpnGatewaysOperations) listCreateRequest() (*azcore.Request, error
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +353,7 @@ func (client *vpnGatewaysOperations) listByResourceGroupCreateRequest(resourceGr
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -432,7 +433,7 @@ func (client *vpnGatewaysOperations) resetCreateRequest(resourceGroupName string
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -487,7 +488,7 @@ func (client *vpnGatewaysOperations) updateTagsCreateRequest(resourceGroupName s
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnlinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/vpnlinkconnections.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -51,12 +50,16 @@ func (client *vpnLinkConnectionsOperations) ListByVpnConnection(resourceGroupNam
 
 // listByVpnConnectionCreateRequest creates the ListByVpnConnection request.
 func (client *vpnLinkConnectionsOperations) listByVpnConnectionCreateRequest(resourceGroupName string, gatewayName string, connectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}/vpnLinkConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnlinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/vpnlinkconnections.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -59,7 +60,7 @@ func (client *vpnLinkConnectionsOperations) listByVpnConnectionCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnserverconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/vpnserverconfigurations.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *vpnServerConfigurationsOperations) ResumeCreateOrUpdate(token stri
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *vpnServerConfigurationsOperations) createOrUpdateCreateRequest(resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters VpnServerConfiguration) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *vpnServerConfigurationsOperations) ResumeDelete(token string) (HTT
 
 // deleteCreateRequest creates the Delete request.
 func (client *vpnServerConfigurationsOperations) deleteCreateRequest(resourceGroupName string, vpnServerConfigurationName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *vpnServerConfigurationsOperations) Get(ctx context.Context, resour
 
 // getCreateRequest creates the Get request.
 func (client *vpnServerConfigurationsOperations) getCreateRequest(resourceGroupName string, vpnServerConfigurationName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -270,9 +281,13 @@ func (client *vpnServerConfigurationsOperations) List() (ListVpnServerConfigurat
 
 // listCreateRequest creates the List request.
 func (client *vpnServerConfigurationsOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnServerConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -326,10 +341,14 @@ func (client *vpnServerConfigurationsOperations) ListByResourceGroup(resourceGro
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *vpnServerConfigurationsOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -377,11 +396,15 @@ func (client *vpnServerConfigurationsOperations) UpdateTags(ctx context.Context,
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *vpnServerConfigurationsOperations) updateTagsCreateRequest(resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnserverconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/vpnserverconfigurations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *vpnServerConfigurationsOperations) createOrUpdateCreateRequest(res
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *vpnServerConfigurationsOperations) deleteCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *vpnServerConfigurationsOperations) getCreateRequest(resourceGroupN
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +288,7 @@ func (client *vpnServerConfigurationsOperations) listCreateRequest() (*azcore.Re
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnServerConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +349,7 @@ func (client *vpnServerConfigurationsOperations) listByResourceGroupCreateReques
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +405,7 @@ func (client *vpnServerConfigurationsOperations) updateTagsCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnserverconfigurationsassociatedwithvirtualwan.go
+++ b/test/network/2020-03-01/armnetwork/vpnserverconfigurationsassociatedwithvirtualwan.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -73,11 +72,15 @@ func (client *vpnServerConfigurationsAssociatedWithVirtualWanOperations) ResumeL
 
 // listCreateRequest creates the List request.
 func (client *vpnServerConfigurationsAssociatedWithVirtualWanOperations) listCreateRequest(resourceGroupName string, virtualWanName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/vpnServerConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWanName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnserverconfigurationsassociatedwithvirtualwan.go
+++ b/test/network/2020-03-01/armnetwork/vpnserverconfigurationsassociatedwithvirtualwan.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -80,7 +81,7 @@ func (client *vpnServerConfigurationsAssociatedWithVirtualWanOperations) listCre
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWanName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnsitelinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/vpnsitelinkconnections.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -45,13 +44,17 @@ func (client *vpnSiteLinkConnectionsOperations) Get(ctx context.Context, resourc
 
 // getCreateRequest creates the Get request.
 func (client *vpnSiteLinkConnectionsOperations) getCreateRequest(resourceGroupName string, gatewayName string, connectionName string, linkConnectionName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}/vpnLinkConnections/{linkConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{linkConnectionName}", url.PathEscape(linkConnectionName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnsitelinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/vpnsitelinkconnections.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -54,7 +55,7 @@ func (client *vpnSiteLinkConnectionsOperations) getCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
 	urlPath = strings.ReplaceAll(urlPath, "{linkConnectionName}", url.PathEscape(linkConnectionName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnsitelinks.go
+++ b/test/network/2020-03-01/armnetwork/vpnsitelinks.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -48,12 +47,16 @@ func (client *vpnSiteLinksOperations) Get(ctx context.Context, resourceGroupName
 
 // getCreateRequest creates the Get request.
 func (client *vpnSiteLinksOperations) getCreateRequest(resourceGroupName string, vpnSiteName string, vpnSiteLinkName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}/vpnSiteLinks/{vpnSiteLinkName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteLinkName}", url.PathEscape(vpnSiteLinkName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -107,11 +110,15 @@ func (client *vpnSiteLinksOperations) ListByVpnSite(resourceGroupName string, vp
 
 // listByVpnSiteCreateRequest creates the ListByVpnSite request.
 func (client *vpnSiteLinksOperations) listByVpnSiteCreateRequest(resourceGroupName string, vpnSiteName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}/vpnSiteLinks"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnsitelinks.go
+++ b/test/network/2020-03-01/armnetwork/vpnsitelinks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -56,7 +57,7 @@ func (client *vpnSiteLinksOperations) getCreateRequest(resourceGroupName string,
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteLinkName}", url.PathEscape(vpnSiteLinkName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func (client *vpnSiteLinksOperations) listByVpnSiteCreateRequest(resourceGroupNa
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnsites.go
+++ b/test/network/2020-03-01/armnetwork/vpnsites.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -93,7 +94,7 @@ func (client *vpnSitesOperations) createOrUpdateCreateRequest(resourceGroupName 
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (client *vpnSitesOperations) deleteCreateRequest(resourceGroupName string, 
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func (client *vpnSitesOperations) getCreateRequest(resourceGroupName string, vpn
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +288,7 @@ func (client *vpnSitesOperations) listCreateRequest() (*azcore.Request, error) {
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnSites"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +349,7 @@ func (client *vpnSitesOperations) listByResourceGroupCreateRequest(resourceGroup
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +405,7 @@ func (client *vpnSitesOperations) updateTagsCreateRequest(resourceGroupName stri
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnsites.go
+++ b/test/network/2020-03-01/armnetwork/vpnsites.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -86,11 +85,15 @@ func (client *vpnSitesOperations) ResumeCreateOrUpdate(token string) (VpnSitePol
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *vpnSitesOperations) createOrUpdateCreateRequest(resourceGroupName string, vpnSiteName string, vpnSiteParameters VpnSite) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +164,15 @@ func (client *vpnSitesOperations) ResumeDelete(token string) (HTTPPoller, error)
 
 // deleteCreateRequest creates the Delete request.
 func (client *vpnSitesOperations) deleteCreateRequest(resourceGroupName string, vpnSiteName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +219,15 @@ func (client *vpnSitesOperations) Get(ctx context.Context, resourceGroupName str
 
 // getCreateRequest creates the Get request.
 func (client *vpnSitesOperations) getCreateRequest(resourceGroupName string, vpnSiteName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -270,9 +281,13 @@ func (client *vpnSitesOperations) List() (ListVpnSitesResultPager, error) {
 
 // listCreateRequest creates the List request.
 func (client *vpnSitesOperations) listCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnSites"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -326,10 +341,14 @@ func (client *vpnSitesOperations) ListByResourceGroup(resourceGroupName string) 
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
 func (client *vpnSitesOperations) listByResourceGroupCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -377,11 +396,15 @@ func (client *vpnSitesOperations) UpdateTags(ctx context.Context, resourceGroupN
 
 // updateTagsCreateRequest creates the UpdateTags request.
 func (client *vpnSitesOperations) updateTagsCreateRequest(resourceGroupName string, vpnSiteName string, vpnSiteParameters TagsObject) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnsitesconfiguration.go
+++ b/test/network/2020-03-01/armnetwork/vpnsitesconfiguration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -80,7 +81,7 @@ func (client *vpnSitesConfigurationOperations) downloadCreateRequest(resourceGro
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWanName))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/vpnsitesconfiguration.go
+++ b/test/network/2020-03-01/armnetwork/vpnsitesconfiguration.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -73,11 +72,15 @@ func (client *vpnSitesConfigurationOperations) ResumeDownload(token string) (HTT
 
 // downloadCreateRequest creates the Download request.
 func (client *vpnSitesConfigurationOperations) downloadCreateRequest(resourceGroupName string, virtualWanName string, request GetVpnSitesConfigurationRequest) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/vpnConfiguration"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWanName))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/webapplicationfirewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/webapplicationfirewallpolicies.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -65,7 +66,7 @@ func (client *webApplicationFirewallPoliciesOperations) createOrUpdateCreateRequ
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{policyName}", url.PathEscape(policyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +146,7 @@ func (client *webApplicationFirewallPoliciesOperations) deleteCreateRequest(reso
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{policyName}", url.PathEscape(policyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +201,7 @@ func (client *webApplicationFirewallPoliciesOperations) getCreateRequest(resourc
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{policyName}", url.PathEscape(policyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +262,7 @@ func (client *webApplicationFirewallPoliciesOperations) listCreateRequest(resour
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +322,7 @@ func (client *webApplicationFirewallPoliciesOperations) listAllCreateRequest() (
 	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err = u.Parse(urlPath)
+	u, err = u.Parse(path.Join(u.Path, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/webapplicationfirewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/webapplicationfirewallpolicies.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"time"
 )
@@ -58,11 +57,15 @@ func (client *webApplicationFirewallPoliciesOperations) CreateOrUpdate(ctx conte
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *webApplicationFirewallPoliciesOperations) createOrUpdateCreateRequest(resourceGroupName string, policyName string, parameters WebApplicationFirewallPolicy) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/{policyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{policyName}", url.PathEscape(policyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -134,11 +137,15 @@ func (client *webApplicationFirewallPoliciesOperations) ResumeDelete(token strin
 
 // deleteCreateRequest creates the Delete request.
 func (client *webApplicationFirewallPoliciesOperations) deleteCreateRequest(resourceGroupName string, policyName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/{policyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{policyName}", url.PathEscape(policyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -185,11 +192,15 @@ func (client *webApplicationFirewallPoliciesOperations) Get(ctx context.Context,
 
 // getCreateRequest creates the Get request.
 func (client *webApplicationFirewallPoliciesOperations) getCreateRequest(resourceGroupName string, policyName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/{policyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{policyName}", url.PathEscape(policyName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -243,10 +254,14 @@ func (client *webApplicationFirewallPoliciesOperations) List(resourceGroupName s
 
 // listCreateRequest creates the List request.
 func (client *webApplicationFirewallPoliciesOperations) listCreateRequest(resourceGroupName string) (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -300,9 +315,13 @@ func (client *webApplicationFirewallPoliciesOperations) ListAll() (WebApplicatio
 
 // listAllCreateRequest creates the ListAll request.
 func (client *webApplicationFirewallPoliciesOperations) listAllCreateRequest() (*azcore.Request, error) {
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	u, err := client.u.Parse(path.Join(client.u.Path, urlPath))
+	u, err = u.Parse(urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
@@ -49,8 +49,10 @@ func (client *appendBlobOperations) AppendBlock(ctx context.Context, contentLeng
 
 // appendBlockCreateRequest creates the AppendBlock request.
 func (client *appendBlobOperations) appendBlockCreateRequest(contentLength int64, body azcore.ReadSeekCloser, appendBlobAppendBlockOptions *AppendBlobAppendBlockOptions, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "appendblock")
 	if appendBlobAppendBlockOptions != nil && appendBlobAppendBlockOptions.Timeout != nil {
@@ -203,8 +205,10 @@ func (client *appendBlobOperations) AppendBlockFromURL(ctx context.Context, sour
 
 // appendBlockFromUrlCreateRequest creates the AppendBlockFromURL request.
 func (client *appendBlobOperations) appendBlockFromUrlCreateRequest(sourceUrl url.URL, contentLength int64, appendBlobAppendBlockFromUrlOptions *AppendBlobAppendBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "appendblock")
 	if appendBlobAppendBlockFromUrlOptions != nil && appendBlobAppendBlockFromUrlOptions.Timeout != nil {
@@ -373,8 +377,10 @@ func (client *appendBlobOperations) Create(ctx context.Context, contentLength in
 
 // createCreateRequest creates the Create request.
 func (client *appendBlobOperations) createCreateRequest(contentLength int64, appendBlobCreateOptions *AppendBlobCreateOptions, blobHttpHeaders *BlobHttpHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if appendBlobCreateOptions != nil && appendBlobCreateOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*appendBlobCreateOptions.Timeout), 10))

--- a/test/storage/2019-07-07/azblob/zz_generated_blob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blob.go
@@ -84,8 +84,10 @@ func (client *blobOperations) AbortCopyFromURL(ctx context.Context, copyId strin
 
 // abortCopyFromUrlCreateRequest creates the AbortCopyFromURL request.
 func (client *blobOperations) abortCopyFromUrlCreateRequest(copyId string, blobAbortCopyFromUrlOptions *BlobAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "copy")
 	query.Set("copyid", copyId)
@@ -158,8 +160,10 @@ func (client *blobOperations) AcquireLease(ctx context.Context, blobAcquireLease
 
 // acquireLeaseCreateRequest creates the AcquireLease request.
 func (client *blobOperations) acquireLeaseCreateRequest(blobAcquireLeaseOptions *BlobAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "lease")
 	if blobAcquireLeaseOptions != nil && blobAcquireLeaseOptions.Timeout != nil {
@@ -259,8 +263,10 @@ func (client *blobOperations) BreakLease(ctx context.Context, blobBreakLeaseOpti
 
 // breakLeaseCreateRequest creates the BreakLease request.
 func (client *blobOperations) breakLeaseCreateRequest(blobBreakLeaseOptions *BlobBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "lease")
 	if blobBreakLeaseOptions != nil && blobBreakLeaseOptions.Timeout != nil {
@@ -362,8 +368,10 @@ func (client *blobOperations) ChangeLease(ctx context.Context, leaseId string, p
 
 // changeLeaseCreateRequest creates the ChangeLease request.
 func (client *blobOperations) changeLeaseCreateRequest(leaseId string, proposedLeaseId string, blobChangeLeaseOptions *BlobChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "lease")
 	if blobChangeLeaseOptions != nil && blobChangeLeaseOptions.Timeout != nil {
@@ -459,8 +467,10 @@ func (client *blobOperations) CopyFromURL(ctx context.Context, copySource url.UR
 
 // copyFromUrlCreateRequest creates the CopyFromURL request.
 func (client *blobOperations) copyFromUrlCreateRequest(copySource url.URL, blobCopyFromUrlOptions *BlobCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if blobCopyFromUrlOptions != nil && blobCopyFromUrlOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*blobCopyFromUrlOptions.Timeout), 10))
@@ -597,8 +607,10 @@ func (client *blobOperations) CreateSnapshot(ctx context.Context, blobCreateSnap
 
 // createSnapshotCreateRequest creates the CreateSnapshot request.
 func (client *blobOperations) createSnapshotCreateRequest(blobCreateSnapshotOptions *BlobCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "snapshot")
 	if blobCreateSnapshotOptions != nil && blobCreateSnapshotOptions.Timeout != nil {
@@ -715,8 +727,10 @@ func (client *blobOperations) Delete(ctx context.Context, blobDeleteOptions *Blo
 
 // deleteCreateRequest creates the Delete request.
 func (client *blobOperations) deleteCreateRequest(blobDeleteOptions *BlobDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if blobDeleteOptions != nil && blobDeleteOptions.Snapshot != nil {
 		query.Set("snapshot", *blobDeleteOptions.Snapshot)
@@ -804,8 +818,10 @@ func (client *blobOperations) Download(ctx context.Context, blobDownloadOptions 
 
 // downloadCreateRequest creates the Download request.
 func (client *blobOperations) downloadCreateRequest(blobDownloadOptions *BlobDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if blobDownloadOptions != nil && blobDownloadOptions.Snapshot != nil {
 		query.Set("snapshot", *blobDownloadOptions.Snapshot)
@@ -1030,8 +1046,10 @@ func (client *blobOperations) GetAccessControl(ctx context.Context, blobGetAcces
 
 // getAccessControlCreateRequest creates the GetAccessControl request.
 func (client *blobOperations) getAccessControlCreateRequest(blobGetAccessControlOptions *BlobGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("action", "getAccessControl")
 	if blobGetAccessControlOptions != nil && blobGetAccessControlOptions.Timeout != nil {
@@ -1136,8 +1154,10 @@ func (client *blobOperations) GetAccountInfo(ctx context.Context) (*BlobGetAccou
 
 // getAccountInfoCreateRequest creates the GetAccountInfo request.
 func (client *blobOperations) getAccountInfoCreateRequest() (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("restype", "account")
 	query.Set("comp", "properties")
@@ -1206,8 +1226,10 @@ func (client *blobOperations) GetProperties(ctx context.Context, blobGetProperti
 
 // getPropertiesCreateRequest creates the GetProperties request.
 func (client *blobOperations) getPropertiesCreateRequest(blobGetPropertiesOptions *BlobGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if blobGetPropertiesOptions != nil && blobGetPropertiesOptions.Snapshot != nil {
 		query.Set("snapshot", *blobGetPropertiesOptions.Snapshot)
@@ -1442,8 +1464,10 @@ func (client *blobOperations) ReleaseLease(ctx context.Context, leaseId string, 
 
 // releaseLeaseCreateRequest creates the ReleaseLease request.
 func (client *blobOperations) releaseLeaseCreateRequest(leaseId string, blobReleaseLeaseOptions *BlobReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "lease")
 	if blobReleaseLeaseOptions != nil && blobReleaseLeaseOptions.Timeout != nil {
@@ -1535,8 +1559,10 @@ func (client *blobOperations) Rename(ctx context.Context, renameSource string, b
 
 // renameCreateRequest creates the Rename request.
 func (client *blobOperations) renameCreateRequest(renameSource string, blobRenameOptions *BlobRenameOptions, directoryHttpHeaders *DirectoryHttpHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if blobRenameOptions != nil && blobRenameOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*blobRenameOptions.Timeout), 10))
@@ -1678,8 +1704,10 @@ func (client *blobOperations) RenewLease(ctx context.Context, leaseId string, bl
 
 // renewLeaseCreateRequest creates the RenewLease request.
 func (client *blobOperations) renewLeaseCreateRequest(leaseId string, blobRenewLeaseOptions *BlobRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "lease")
 	if blobRenewLeaseOptions != nil && blobRenewLeaseOptions.Timeout != nil {
@@ -1774,8 +1802,10 @@ func (client *blobOperations) SetAccessControl(ctx context.Context, blobSetAcces
 
 // setAccessControlCreateRequest creates the SetAccessControl request.
 func (client *blobOperations) setAccessControlCreateRequest(blobSetAccessControlOptions *BlobSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("action", "setAccessControl")
 	if blobSetAccessControlOptions != nil && blobSetAccessControlOptions.Timeout != nil {
@@ -1877,8 +1907,10 @@ func (client *blobOperations) SetHTTPHeaders(ctx context.Context, blobSetHttpHea
 
 // setHttpHeadersCreateRequest creates the SetHTTPHeaders request.
 func (client *blobOperations) setHttpHeadersCreateRequest(blobSetHttpHeadersOptions *BlobSetHTTPHeadersOptions, blobHttpHeaders *BlobHttpHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "properties")
 	if blobSetHttpHeadersOptions != nil && blobSetHttpHeadersOptions.Timeout != nil {
@@ -1996,8 +2028,10 @@ func (client *blobOperations) SetMetadata(ctx context.Context, blobSetMetadataOp
 
 // setMetadataCreateRequest creates the SetMetadata request.
 func (client *blobOperations) setMetadataCreateRequest(blobSetMetadataOptions *BlobSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "metadata")
 	if blobSetMetadataOptions != nil && blobSetMetadataOptions.Timeout != nil {
@@ -2117,8 +2151,10 @@ func (client *blobOperations) SetTier(ctx context.Context, tier AccessTier, blob
 
 // setTierCreateRequest creates the SetTier request.
 func (client *blobOperations) setTierCreateRequest(tier AccessTier, blobSetTierOptions *BlobSetTierOptions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "tier")
 	if blobSetTierOptions != nil && blobSetTierOptions.Timeout != nil {
@@ -2186,8 +2222,10 @@ func (client *blobOperations) StartCopyFromURL(ctx context.Context, copySource u
 
 // startCopyFromUrlCreateRequest creates the StartCopyFromURL request.
 func (client *blobOperations) startCopyFromUrlCreateRequest(copySource url.URL, blobStartCopyFromUrlOptions *BlobStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if blobStartCopyFromUrlOptions != nil && blobStartCopyFromUrlOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*blobStartCopyFromUrlOptions.Timeout), 10))
@@ -2309,8 +2347,10 @@ func (client *blobOperations) Undelete(ctx context.Context, blobUndeleteOptions 
 
 // undeleteCreateRequest creates the Undelete request.
 func (client *blobOperations) undeleteCreateRequest(blobUndeleteOptions *BlobUndeleteOptions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "undelete")
 	if blobUndeleteOptions != nil && blobUndeleteOptions.Timeout != nil {

--- a/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
@@ -53,8 +53,10 @@ func (client *blockBlobOperations) CommitBlockList(ctx context.Context, blocks B
 
 // commitBlockListCreateRequest creates the CommitBlockList request.
 func (client *blockBlobOperations) commitBlockListCreateRequest(blocks BlockLookupList, blockBlobCommitBlockListOptions *BlockBlobCommitBlockListOptions, blobHttpHeaders *BlobHttpHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "blocklist")
 	if blockBlobCommitBlockListOptions != nil && blockBlobCommitBlockListOptions.Timeout != nil {
@@ -215,8 +217,10 @@ func (client *blockBlobOperations) GetBlockList(ctx context.Context, listType Bl
 
 // getBlockListCreateRequest creates the GetBlockList request.
 func (client *blockBlobOperations) getBlockListCreateRequest(listType BlockListType, blockBlobGetBlockListOptions *BlockBlobGetBlockListOptions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "blocklist")
 	if blockBlobGetBlockListOptions != nil && blockBlobGetBlockListOptions.Snapshot != nil {
@@ -311,8 +315,10 @@ func (client *blockBlobOperations) StageBlock(ctx context.Context, blockId strin
 
 // stageBlockCreateRequest creates the StageBlock request.
 func (client *blockBlobOperations) stageBlockCreateRequest(blockId string, contentLength int64, body azcore.ReadSeekCloser, blockBlobStageBlockOptions *BlockBlobStageBlockOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "block")
 	query.Set("blockid", blockId)
@@ -427,8 +433,10 @@ func (client *blockBlobOperations) StageBlockFromURL(ctx context.Context, blockI
 
 // stageBlockFromUrlCreateRequest creates the StageBlockFromURL request.
 func (client *blockBlobOperations) stageBlockFromUrlCreateRequest(blockId string, contentLength int64, sourceUrl url.URL, blockBlobStageBlockFromUrlOptions *BlockBlobStageBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "block")
 	query.Set("blockid", blockId)
@@ -559,8 +567,10 @@ func (client *blockBlobOperations) Upload(ctx context.Context, contentLength int
 
 // uploadCreateRequest creates the Upload request.
 func (client *blockBlobOperations) uploadCreateRequest(contentLength int64, body azcore.ReadSeekCloser, blockBlobUploadOptions *BlockBlobUploadOptions, blobHttpHeaders *BlobHttpHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if blockBlobUploadOptions != nil && blockBlobUploadOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*blockBlobUploadOptions.Timeout), 10))

--- a/test/storage/2019-07-07/azblob/zz_generated_client.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_client.go
@@ -8,7 +8,6 @@ package azblob
 import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/url"
 )
 
 const scope = "https://storage.azure.com/.default"
@@ -45,12 +44,12 @@ func (c *clientOptions) telemetryOptions() azcore.TelemetryOptions {
 }
 
 type client struct {
-	u *url.URL
+	u string
 	p azcore.Pipeline
 }
 
 // newClient creates an instance of the client type with the specified endpoint.
-func newClient(endpoint string, cred azcore.Credential, options *clientOptions) (*client, error) {
+func newClient(endpoint string, cred azcore.Credential, options *clientOptions) *client {
 	if options == nil {
 		o := defaultClientOptions()
 		options = &o
@@ -65,15 +64,8 @@ func newClient(endpoint string, cred azcore.Credential, options *clientOptions) 
 }
 
 // newClientWithPipeline creates an instance of the client type with the specified endpoint and pipeline.
-func newClientWithPipeline(endpoint string, p azcore.Pipeline) (*client, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme detected in endpoint %s", endpoint)
-	}
-	return &client{u: u, p: p}, nil
+func newClientWithPipeline(endpoint string, p azcore.Pipeline) *client {
+	return &client{u: endpoint, p: p}
 }
 
 // ServiceOperations returns the ServiceOperations associated with this client.

--- a/test/storage/2019-07-07/azblob/zz_generated_container.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_container.go
@@ -73,8 +73,10 @@ func (client *containerOperations) AcquireLease(ctx context.Context, containerAc
 
 // acquireLeaseCreateRequest creates the AcquireLease request.
 func (client *containerOperations) acquireLeaseCreateRequest(containerAcquireLeaseOptions *ContainerAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "lease")
 	query.Set("restype", "container")
@@ -169,8 +171,10 @@ func (client *containerOperations) BreakLease(ctx context.Context, containerBrea
 
 // breakLeaseCreateRequest creates the BreakLease request.
 func (client *containerOperations) breakLeaseCreateRequest(containerBreakLeaseOptions *ContainerBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "lease")
 	query.Set("restype", "container")
@@ -267,8 +271,10 @@ func (client *containerOperations) ChangeLease(ctx context.Context, leaseId stri
 
 // changeLeaseCreateRequest creates the ChangeLease request.
 func (client *containerOperations) changeLeaseCreateRequest(leaseId string, proposedLeaseId string, containerChangeLeaseOptions *ContainerChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "lease")
 	query.Set("restype", "container")
@@ -359,8 +365,10 @@ func (client *containerOperations) Create(ctx context.Context, containerCreateOp
 
 // createCreateRequest creates the Create request.
 func (client *containerOperations) createCreateRequest(containerCreateOptions *ContainerCreateOptions, containerCpkScopeInfo *ContainerCpkScopeInfo) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("restype", "container")
 	if containerCreateOptions != nil && containerCreateOptions.Timeout != nil {
@@ -452,8 +460,10 @@ func (client *containerOperations) Delete(ctx context.Context, containerDeleteOp
 
 // deleteCreateRequest creates the Delete request.
 func (client *containerOperations) deleteCreateRequest(containerDeleteOptions *ContainerDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("restype", "container")
 	if containerDeleteOptions != nil && containerDeleteOptions.Timeout != nil {
@@ -530,8 +540,10 @@ func (client *containerOperations) GetAccessPolicy(ctx context.Context, containe
 
 // getAccessPolicyCreateRequest creates the GetAccessPolicy request.
 func (client *containerOperations) getAccessPolicyCreateRequest(containerGetAccessPolicyOptions *ContainerGetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("restype", "container")
 	query.Set("comp", "acl")
@@ -616,8 +628,10 @@ func (client *containerOperations) GetAccountInfo(ctx context.Context) (*Contain
 
 // getAccountInfoCreateRequest creates the GetAccountInfo request.
 func (client *containerOperations) getAccountInfoCreateRequest() (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("restype", "account")
 	query.Set("comp", "properties")
@@ -686,8 +700,10 @@ func (client *containerOperations) GetProperties(ctx context.Context, containerG
 
 // getPropertiesCreateRequest creates the GetProperties request.
 func (client *containerOperations) getPropertiesCreateRequest(containerGetPropertiesOptions *ContainerGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("restype", "container")
 	if containerGetPropertiesOptions != nil && containerGetPropertiesOptions.Timeout != nil {
@@ -813,8 +829,10 @@ func (client *containerOperations) ListBlobFlatSegment(containerListBlobFlatSegm
 
 // listBlobFlatSegmentCreateRequest creates the ListBlobFlatSegment request.
 func (client *containerOperations) listBlobFlatSegmentCreateRequest(containerListBlobFlatSegmentOptions *ContainerListBlobFlatSegmentOptions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("restype", "container")
 	query.Set("comp", "list")
@@ -904,8 +922,10 @@ func (client *containerOperations) ListBlobHierarchySegment(delimiter string, co
 
 // listBlobHierarchySegmentCreateRequest creates the ListBlobHierarchySegment request.
 func (client *containerOperations) listBlobHierarchySegmentCreateRequest(delimiter string, containerListBlobHierarchySegmentOptions *ContainerListBlobHierarchySegmentOptions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("restype", "container")
 	query.Set("comp", "list")
@@ -990,8 +1010,10 @@ func (client *containerOperations) ReleaseLease(ctx context.Context, leaseId str
 
 // releaseLeaseCreateRequest creates the ReleaseLease request.
 func (client *containerOperations) releaseLeaseCreateRequest(leaseId string, containerReleaseLeaseOptions *ContainerReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "lease")
 	query.Set("restype", "container")
@@ -1078,8 +1100,10 @@ func (client *containerOperations) RenewLease(ctx context.Context, leaseId strin
 
 // renewLeaseCreateRequest creates the RenewLease request.
 func (client *containerOperations) renewLeaseCreateRequest(leaseId string, containerRenewLeaseOptions *ContainerRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "lease")
 	query.Set("restype", "container")
@@ -1169,8 +1193,10 @@ func (client *containerOperations) SetAccessPolicy(ctx context.Context, containe
 
 // setAccessPolicyCreateRequest creates the SetAccessPolicy request.
 func (client *containerOperations) setAccessPolicyCreateRequest(containerSetAccessPolicyOptions *ContainerSetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("restype", "container")
 	query.Set("comp", "acl")
@@ -1268,8 +1294,10 @@ func (client *containerOperations) SetMetadata(ctx context.Context, containerSet
 
 // setMetadataCreateRequest creates the SetMetadata request.
 func (client *containerOperations) setMetadataCreateRequest(containerSetMetadataOptions *ContainerSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("restype", "container")
 	query.Set("comp", "metadata")

--- a/test/storage/2019-07-07/azblob/zz_generated_directory.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_directory.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 )
@@ -52,8 +53,10 @@ func (client *directoryOperations) Create(ctx context.Context, directoryCreateOp
 
 // createCreateRequest creates the Create request.
 func (client *directoryOperations) createCreateRequest(directoryCreateOptions *DirectoryCreateOptions, directoryHttpHeaders *DirectoryHttpHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("resource", "directory")
 	if directoryCreateOptions != nil && directoryCreateOptions.Timeout != nil {
@@ -177,8 +180,10 @@ func (client *directoryOperations) Delete(ctx context.Context, recursiveDirector
 
 // deleteCreateRequest creates the Delete request.
 func (client *directoryOperations) deleteCreateRequest(recursiveDirectoryDelete bool, directoryDeleteOptions *DirectoryDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if directoryDeleteOptions != nil && directoryDeleteOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*directoryDeleteOptions.Timeout), 10))
@@ -267,8 +272,10 @@ func (client *directoryOperations) GetAccessControl(ctx context.Context, directo
 
 // getAccessControlCreateRequest creates the GetAccessControl request.
 func (client *directoryOperations) getAccessControlCreateRequest(directoryGetAccessControlOptions *DirectoryGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("action", "getAccessControl")
 	if directoryGetAccessControlOptions != nil && directoryGetAccessControlOptions.Timeout != nil {
@@ -373,8 +380,10 @@ func (client *directoryOperations) Rename(ctx context.Context, renameSource stri
 
 // renameCreateRequest creates the Rename request.
 func (client *directoryOperations) renameCreateRequest(renameSource string, directoryRenameOptions *DirectoryRenameOptions, directoryHttpHeaders *DirectoryHttpHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if directoryRenameOptions != nil && directoryRenameOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*directoryRenameOptions.Timeout), 10))
@@ -522,8 +531,10 @@ func (client *directoryOperations) SetAccessControl(ctx context.Context, directo
 
 // setAccessControlCreateRequest creates the SetAccessControl request.
 func (client *directoryOperations) setAccessControlCreateRequest(directorySetAccessControlOptions *DirectorySetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("action", "setAccessControl")
 	if directorySetAccessControlOptions != nil && directorySetAccessControlOptions.Timeout != nil {

--- a/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
@@ -61,8 +61,10 @@ func (client *pageBlobOperations) ClearPages(ctx context.Context, contentLength 
 
 // clearPagesCreateRequest creates the ClearPages request.
 func (client *pageBlobOperations) clearPagesCreateRequest(contentLength int64, pageBlobClearPagesOptions *PageBlobClearPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "page")
 	if pageBlobClearPagesOptions != nil && pageBlobClearPagesOptions.Timeout != nil {
@@ -199,8 +201,10 @@ func (client *pageBlobOperations) CopyIncremental(ctx context.Context, copySourc
 
 // copyIncrementalCreateRequest creates the CopyIncremental request.
 func (client *pageBlobOperations) copyIncrementalCreateRequest(copySource url.URL, pageBlobCopyIncrementalOptions *PageBlobCopyIncrementalOptions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "incrementalcopy")
 	if pageBlobCopyIncrementalOptions != nil && pageBlobCopyIncrementalOptions.Timeout != nil {
@@ -297,8 +301,10 @@ func (client *pageBlobOperations) Create(ctx context.Context, contentLength int6
 
 // createCreateRequest creates the Create request.
 func (client *pageBlobOperations) createCreateRequest(contentLength int64, blobContentLength int64, pageBlobCreateOptions *PageBlobCreateOptions, blobHttpHeaders *BlobHttpHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	if pageBlobCreateOptions != nil && pageBlobCreateOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*pageBlobCreateOptions.Timeout), 10))
@@ -451,8 +457,10 @@ func (client *pageBlobOperations) GetPageRanges(ctx context.Context, pageBlobGet
 
 // getPageRangesCreateRequest creates the GetPageRanges request.
 func (client *pageBlobOperations) getPageRangesCreateRequest(pageBlobGetPageRangesOptions *PageBlobGetPageRangesOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "pagelist")
 	if pageBlobGetPageRangesOptions != nil && pageBlobGetPageRangesOptions.Snapshot != nil {
@@ -558,8 +566,10 @@ func (client *pageBlobOperations) GetPageRangesDiff(ctx context.Context, pageBlo
 
 // getPageRangesDiffCreateRequest creates the GetPageRangesDiff request.
 func (client *pageBlobOperations) getPageRangesDiffCreateRequest(pageBlobGetPageRangesDiffOptions *PageBlobGetPageRangesDiffOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "pagelist")
 	if pageBlobGetPageRangesDiffOptions != nil && pageBlobGetPageRangesDiffOptions.Snapshot != nil {
@@ -671,8 +681,10 @@ func (client *pageBlobOperations) Resize(ctx context.Context, blobContentLength 
 
 // resizeCreateRequest creates the Resize request.
 func (client *pageBlobOperations) resizeCreateRequest(blobContentLength int64, pageBlobResizeOptions *PageBlobResizeOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "properties")
 	if pageBlobResizeOptions != nil && pageBlobResizeOptions.Timeout != nil {
@@ -782,8 +794,10 @@ func (client *pageBlobOperations) UpdateSequenceNumber(ctx context.Context, sequ
 
 // updateSequenceNumberCreateRequest creates the UpdateSequenceNumber request.
 func (client *pageBlobOperations) updateSequenceNumberCreateRequest(sequenceNumberAction SequenceNumberActionType, pageBlobUpdateSequenceNumberOptions *PageBlobUpdateSequenceNumberOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "properties")
 	if pageBlobUpdateSequenceNumberOptions != nil && pageBlobUpdateSequenceNumberOptions.Timeout != nil {
@@ -887,8 +901,10 @@ func (client *pageBlobOperations) UploadPages(ctx context.Context, contentLength
 
 // uploadPagesCreateRequest creates the UploadPages request.
 func (client *pageBlobOperations) uploadPagesCreateRequest(contentLength int64, body azcore.ReadSeekCloser, pageBlobUploadPagesOptions *PageBlobUploadPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "page")
 	if pageBlobUploadPagesOptions != nil && pageBlobUploadPagesOptions.Timeout != nil {
@@ -1044,8 +1060,10 @@ func (client *pageBlobOperations) UploadPagesFromURL(ctx context.Context, source
 
 // uploadPagesFromUrlCreateRequest creates the UploadPagesFromURL request.
 func (client *pageBlobOperations) uploadPagesFromUrlCreateRequest(sourceUrl url.URL, sourceRange string, contentLength int64, rangeParameter string, pageBlobUploadPagesFromUrlOptions *PageBlobUploadPagesFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "page")
 	if pageBlobUploadPagesFromUrlOptions != nil && pageBlobUploadPagesFromUrlOptions.Timeout != nil {

--- a/test/storage/2019-07-07/azblob/zz_generated_service.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_service.go
@@ -57,8 +57,10 @@ func (client *serviceOperations) GetAccountInfo(ctx context.Context) (*ServiceGe
 
 // getAccountInfoCreateRequest creates the GetAccountInfo request.
 func (client *serviceOperations) getAccountInfoCreateRequest() (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("restype", "account")
 	query.Set("comp", "properties")
@@ -127,8 +129,10 @@ func (client *serviceOperations) GetProperties(ctx context.Context, serviceGetPr
 
 // getPropertiesCreateRequest creates the GetProperties request.
 func (client *serviceOperations) getPropertiesCreateRequest(serviceGetPropertiesOptions *ServiceGetPropertiesOptions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("restype", "service")
 	query.Set("comp", "properties")
@@ -190,8 +194,10 @@ func (client *serviceOperations) GetStatistics(ctx context.Context, serviceGetSt
 
 // getStatisticsCreateRequest creates the GetStatistics request.
 func (client *serviceOperations) getStatisticsCreateRequest(serviceGetStatisticsOptions *ServiceGetStatisticsOptions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("restype", "service")
 	query.Set("comp", "stats")
@@ -260,8 +266,10 @@ func (client *serviceOperations) GetUserDelegationKey(ctx context.Context, keyIn
 
 // getUserDelegationKeyCreateRequest creates the GetUserDelegationKey request.
 func (client *serviceOperations) getUserDelegationKeyCreateRequest(keyInfo KeyInfo, serviceGetUserDelegationKeyOptions *ServiceGetUserDelegationKeyOptions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("restype", "service")
 	query.Set("comp", "userdelegationkey")
@@ -336,8 +344,10 @@ func (client *serviceOperations) ListContainersSegment(serviceListContainersSegm
 
 // listContainersSegmentCreateRequest creates the ListContainersSegment request.
 func (client *serviceOperations) listContainersSegmentCreateRequest(serviceListContainersSegmentOptions *ServiceListContainersSegmentOptions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "list")
 	if serviceListContainersSegmentOptions != nil && serviceListContainersSegmentOptions.Prefix != nil {
@@ -407,8 +417,10 @@ func (client *serviceOperations) SetProperties(ctx context.Context, storageServi
 
 // setPropertiesCreateRequest creates the SetProperties request.
 func (client *serviceOperations) setPropertiesCreateRequest(storageServiceProperties StorageServiceProperties, serviceSetPropertiesOptions *ServiceSetPropertiesOptions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("restype", "service")
 	query.Set("comp", "properties")
@@ -470,8 +482,10 @@ func (client *serviceOperations) SubmitBatch(ctx context.Context, contentLength 
 
 // submitBatchCreateRequest creates the SubmitBatch request.
 func (client *serviceOperations) submitBatchCreateRequest(contentLength int64, multipartContentType string, body azcore.ReadSeekCloser, serviceSubmitBatchOptions *ServiceSubmitBatchOptions) (*azcore.Request, error) {
-	copy := *client.u
-	u := &copy
+	u, err := url.Parse(client.u)
+	if err != nil {
+		return nil, err
+	}
 	query := u.Query()
 	query.Set("comp", "batch")
 	if serviceSubmitBatchOptions != nil && serviceSubmitBatchOptions.Timeout != nil {


### PR DESCRIPTION
Moved parsing out of the constructor, into the API call.
Fixed an issue with imports not getting added to client.go files.