### PR TITLE
Support discriminated types with additional properties

### DIFF
--- a/test/autorest/complexgroup/polymorphism_test.go
+++ b/test/autorest/complexgroup/polymorphism_test.go
@@ -75,6 +75,18 @@ func TestPolymorphismGetComplicated(t *testing.T) {
 	}
 	helpers.DeepEqualOrFatal(t, salmon, &complexgroup.SmartSalmon{
 		Salmon: expectedSalmon,
+		AdditionalProperties: &map[string]interface{}{
+			"additionalProperty1": float64(1),
+			"additionalProperty2": false,
+			"additionalProperty3": "hello",
+			"additionalProperty4": map[string]interface{}{
+				"a": float64(1),
+				"b": float64(2),
+			},
+			"additionalProperty5": []interface{}{
+				float64(1), float64(3),
+			},
+		},
 	})
 	helpers.DeepEqualOrFatal(t, result.Salmon.GetSalmon(), &expectedSalmon)
 	helpers.DeepEqualOrFatal(t, result.Salmon.GetFish(), &expectedFish)
@@ -268,7 +280,72 @@ func TestPolymorphismGetValid(t *testing.T) {
 
 // PutComplicated - Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
 func TestPolymorphismPutComplicated(t *testing.T) {
-	t.Skip("additional properties NYI")
+	goblinBday := time.Date(2015, time.August, 8, 0, 0, 0, 0, time.UTC)
+	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
+	sharkBday := time.Date(2012, time.January, 5, 1, 0, 0, 0, time.UTC)
+	client := complexgroup.NewDefaultClient(nil).PolymorphismOperations()
+	result, err := client.PutComplicated(context.Background(), &complexgroup.SmartSalmon{
+		Salmon: complexgroup.Salmon{
+			Fish: complexgroup.Fish{
+				Fishtype: to.StringPtr("smart_salmon"),
+				Length:   to.Float32Ptr(1),
+				Siblings: &[]complexgroup.FishClassification{
+					&complexgroup.Shark{
+						Fish: complexgroup.Fish{
+							Fishtype: to.StringPtr("shark"),
+							Length:   to.Float32Ptr(20),
+							Species:  to.StringPtr("predator")},
+						Age:      to.Int32Ptr(6),
+						Birthday: &sharkBday,
+					},
+					&complexgroup.Sawshark{
+						Shark: complexgroup.Shark{
+							Fish: complexgroup.Fish{
+								Fishtype: to.StringPtr("sawshark"),
+								Length:   to.Float32Ptr(10),
+								Species:  to.StringPtr("dangerous"),
+							},
+							Age:      to.Int32Ptr(105),
+							Birthday: &sawBday,
+						},
+						Picture: &[]byte{255, 255, 255, 255, 254},
+					},
+					&complexgroup.Goblinshark{
+						Shark: complexgroup.Shark{
+							Fish: complexgroup.Fish{
+								Fishtype: to.StringPtr("goblin"),
+								Length:   to.Float32Ptr(30),
+								Species:  to.StringPtr("scary"),
+							},
+							Age:      to.Int32Ptr(1),
+							Birthday: &goblinBday,
+						},
+						Color:   complexgroup.GoblinSharkColor("pinkish-gray").ToPtr(),
+						Jawsize: to.Int32Ptr(5),
+					},
+				},
+				Species: to.StringPtr("king"),
+			},
+			Iswild:   to.BoolPtr(true),
+			Location: to.StringPtr("alaska"),
+		},
+		AdditionalProperties: &map[string]interface{}{
+			"additionalProperty1": float64(1),
+			"additionalProperty2": false,
+			"additionalProperty3": "hello",
+			"additionalProperty4": map[string]interface{}{
+				"a": float64(1),
+				"b": float64(2),
+			},
+			"additionalProperty5": []interface{}{
+				float64(1), float64(3),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
 // PutMissingDiscriminator - Put complex types that are polymorphic, omitting the discriminator

--- a/test/autorest/generated/complexgroup/models.go
+++ b/test/autorest/generated/complexgroup/models.go
@@ -225,23 +225,7 @@ func (d *DotFish) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "fish.type":
-			if val != nil {
-				err = json.Unmarshal(*val, &d.FishType)
-			}
-		case "species":
-			if val != nil {
-				err = json.Unmarshal(*val, &d.Species)
-			}
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return d.unmarshalInternal(rawMsg)
 }
 
 func (d DotFish) marshalInternal(discValue string) map[string]interface{} {
@@ -252,6 +236,28 @@ func (d DotFish) marshalInternal(discValue string) map[string]interface{} {
 		objectMap["species"] = d.Species
 	}
 	return objectMap
+}
+
+func (d *DotFish) unmarshalInternal(rawMsg map[string]*json.RawMessage) error {
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "fish.type":
+			if val != nil {
+				err = json.Unmarshal(*val, &d.FishType)
+			}
+			delete(rawMsg, key)
+		case "species":
+			if val != nil {
+				err = json.Unmarshal(*val, &d.Species)
+			}
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type DotFishMarket struct {
@@ -274,18 +280,22 @@ func (d *DotFishMarket) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				d.Fishes, err = unmarshalDotFishClassificationArray(*val)
 			}
+			delete(rawMsg, key)
 		case "salmons":
 			if val != nil {
 				err = json.Unmarshal(*val, &d.Salmons)
 			}
+			delete(rawMsg, key)
 		case "sampleFish":
 			if val != nil {
 				d.SampleFish, err = unmarshalDotFishClassification(*val)
 			}
+			delete(rawMsg, key)
 		case "sampleSalmon":
 			if val != nil {
 				err = json.Unmarshal(*val, &d.SampleSalmon)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
@@ -351,16 +361,18 @@ func (d *DotSalmon) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &d.Iswild)
 			}
+			delete(rawMsg, key)
 		case "location":
 			if val != nil {
 				err = json.Unmarshal(*val, &d.Location)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return json.Unmarshal(data, &d.DotFish)
+	return d.DotFish.unmarshalInternal(rawMsg)
 }
 
 type DoubleWrapper struct {
@@ -429,31 +441,7 @@ func (f *Fish) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "fishtype":
-			if val != nil {
-				err = json.Unmarshal(*val, &f.Fishtype)
-			}
-		case "length":
-			if val != nil {
-				err = json.Unmarshal(*val, &f.Length)
-			}
-		case "siblings":
-			if val != nil {
-				f.Siblings, err = unmarshalFishClassificationArray(*val)
-			}
-		case "species":
-			if val != nil {
-				err = json.Unmarshal(*val, &f.Species)
-			}
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return f.unmarshalInternal(rawMsg)
 }
 
 func (f Fish) marshalInternal(discValue string) map[string]interface{} {
@@ -470,6 +458,38 @@ func (f Fish) marshalInternal(discValue string) map[string]interface{} {
 		objectMap["species"] = f.Species
 	}
 	return objectMap
+}
+
+func (f *Fish) unmarshalInternal(rawMsg map[string]*json.RawMessage) error {
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "fishtype":
+			if val != nil {
+				err = json.Unmarshal(*val, &f.Fishtype)
+			}
+			delete(rawMsg, key)
+		case "length":
+			if val != nil {
+				err = json.Unmarshal(*val, &f.Length)
+			}
+			delete(rawMsg, key)
+		case "siblings":
+			if val != nil {
+				f.Siblings, err = unmarshalFishClassificationArray(*val)
+			}
+			delete(rawMsg, key)
+		case "species":
+			if val != nil {
+				err = json.Unmarshal(*val, &f.Species)
+			}
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // FishResponse is the response envelope for operations that return a Fish type.
@@ -535,16 +555,18 @@ func (g *Goblinshark) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &g.Color)
 			}
+			delete(rawMsg, key)
 		case "jawsize":
 			if val != nil {
 				err = json.Unmarshal(*val, &g.Jawsize)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return json.Unmarshal(data, &g.Shark)
+	return g.Shark.unmarshalInternal(rawMsg)
 }
 
 type IntWrapper struct {
@@ -597,27 +619,7 @@ func (m *MyBaseType) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "helper":
-			if val != nil {
-				err = json.Unmarshal(*val, &m.Helper)
-			}
-		case "kind":
-			if val != nil {
-				err = json.Unmarshal(*val, &m.Kind)
-			}
-		case "propB1":
-			if val != nil {
-				err = json.Unmarshal(*val, &m.PropB1)
-			}
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return m.unmarshalInternal(rawMsg)
 }
 
 func (m MyBaseType) marshalInternal(discValue MyKind) map[string]interface{} {
@@ -631,6 +633,33 @@ func (m MyBaseType) marshalInternal(discValue MyKind) map[string]interface{} {
 		objectMap["propB1"] = m.PropB1
 	}
 	return objectMap
+}
+
+func (m *MyBaseType) unmarshalInternal(rawMsg map[string]*json.RawMessage) error {
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "helper":
+			if val != nil {
+				err = json.Unmarshal(*val, &m.Helper)
+			}
+			delete(rawMsg, key)
+		case "kind":
+			if val != nil {
+				err = json.Unmarshal(*val, &m.Kind)
+			}
+			delete(rawMsg, key)
+		case "propB1":
+			if val != nil {
+				err = json.Unmarshal(*val, &m.PropB1)
+			}
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // MyBaseTypeResponse is the response envelope for operations that return a MyBaseType type.
@@ -678,12 +707,13 @@ func (m *MyDerivedType) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &m.PropD1)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return json.Unmarshal(data, &m.MyBaseType)
+	return m.MyBaseType.unmarshalInternal(rawMsg)
 }
 
 type Pet struct {
@@ -720,13 +750,7 @@ func (s *Salmon) GetSalmon() *Salmon { return s }
 
 // MarshalJSON implements the json.Marshaller interface for type Salmon.
 func (s Salmon) MarshalJSON() ([]byte, error) {
-	objectMap := s.Fish.marshalInternal("salmon")
-	if s.Iswild != nil {
-		objectMap["iswild"] = s.Iswild
-	}
-	if s.Location != nil {
-		objectMap["location"] = s.Location
-	}
+	objectMap := s.marshalInternal("salmon")
 	return json.Marshal(objectMap)
 }
 
@@ -736,23 +760,7 @@ func (s *Salmon) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "iswild":
-			if val != nil {
-				err = json.Unmarshal(*val, &s.Iswild)
-			}
-		case "location":
-			if val != nil {
-				err = json.Unmarshal(*val, &s.Location)
-			}
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return json.Unmarshal(data, &s.Fish)
+	return s.unmarshalInternal(rawMsg)
 }
 
 func (s Salmon) marshalInternal(discValue string) map[string]interface{} {
@@ -764,6 +772,28 @@ func (s Salmon) marshalInternal(discValue string) map[string]interface{} {
 		objectMap["location"] = s.Location
 	}
 	return objectMap
+}
+
+func (s *Salmon) unmarshalInternal(rawMsg map[string]*json.RawMessage) error {
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "iswild":
+			if val != nil {
+				err = json.Unmarshal(*val, &s.Iswild)
+			}
+			delete(rawMsg, key)
+		case "location":
+			if val != nil {
+				err = json.Unmarshal(*val, &s.Location)
+			}
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return s.Fish.unmarshalInternal(rawMsg)
 }
 
 // SalmonResponse is the response envelope for operations that return a Salmon type.
@@ -810,12 +840,13 @@ func (s *Sawshark) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &s.Picture)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return json.Unmarshal(data, &s.Shark)
+	return s.Shark.unmarshalInternal(rawMsg)
 }
 
 // SharkClassification provides polymorphic access to related types.
@@ -835,13 +866,7 @@ func (s *Shark) GetShark() *Shark { return s }
 
 // MarshalJSON implements the json.Marshaller interface for type Shark.
 func (s Shark) MarshalJSON() ([]byte, error) {
-	objectMap := s.Fish.marshalInternal("shark")
-	if s.Age != nil {
-		objectMap["age"] = s.Age
-	}
-	if s.Birthday != nil {
-		objectMap["birthday"] = (*timeRFC3339)(s.Birthday)
-	}
+	objectMap := s.marshalInternal("shark")
 	return json.Marshal(objectMap)
 }
 
@@ -851,25 +876,7 @@ func (s *Shark) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "age":
-			if val != nil {
-				err = json.Unmarshal(*val, &s.Age)
-			}
-		case "birthday":
-			if val != nil {
-				var aux timeRFC3339
-				err = json.Unmarshal(*val, &aux)
-				s.Birthday = (*time.Time)(&aux)
-			}
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return json.Unmarshal(data, &s.Fish)
+	return s.unmarshalInternal(rawMsg)
 }
 
 func (s Shark) marshalInternal(discValue string) map[string]interface{} {
@@ -881,6 +888,30 @@ func (s Shark) marshalInternal(discValue string) map[string]interface{} {
 		objectMap["birthday"] = (*timeRFC3339)(s.Birthday)
 	}
 	return objectMap
+}
+
+func (s *Shark) unmarshalInternal(rawMsg map[string]*json.RawMessage) error {
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "age":
+			if val != nil {
+				err = json.Unmarshal(*val, &s.Age)
+			}
+			delete(rawMsg, key)
+		case "birthday":
+			if val != nil {
+				var aux timeRFC3339
+				err = json.Unmarshal(*val, &aux)
+				s.Birthday = (*time.Time)(&aux)
+			}
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return s.Fish.unmarshalInternal(rawMsg)
 }
 
 type Siamese struct {
@@ -908,6 +939,11 @@ func (s SmartSalmon) MarshalJSON() ([]byte, error) {
 	if s.CollegeDegree != nil {
 		objectMap["college_degree"] = s.CollegeDegree
 	}
+	if s.AdditionalProperties != nil {
+		for key, val := range *s.AdditionalProperties {
+			objectMap[key] = val
+		}
+	}
 	return json.Marshal(objectMap)
 }
 
@@ -920,16 +956,40 @@ func (s *SmartSalmon) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "AdditionalProperties":
+			if val != nil {
+				err = json.Unmarshal(*val, &s.AdditionalProperties)
+			}
+			delete(rawMsg, key)
 		case "college_degree":
 			if val != nil {
 				err = json.Unmarshal(*val, &s.CollegeDegree)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return json.Unmarshal(data, &s.Salmon)
+	if err := s.Salmon.unmarshalInternal(rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		if s.AdditionalProperties == nil {
+			s.AdditionalProperties = &map[string]interface{}{}
+		}
+		if val != nil {
+			var aux interface{}
+			err = json.Unmarshal(*val, &aux)
+			(*s.AdditionalProperties)[key] = aux
+		}
+		delete(rawMsg, key)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type StringWrapper struct {

--- a/test/autorest/generated/errorsgroup/models.go
+++ b/test/autorest/generated/errorsgroup/models.go
@@ -33,16 +33,34 @@ func (a *AnimalNotFound) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &a.Name)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return json.Unmarshal(data, &a.NotFoundErrorBase)
+	return a.NotFoundErrorBase.unmarshalInternal(rawMsg)
 }
 
 type BaseError struct {
 	SomeBaseProp *string `json:"someBaseProp,omitempty"`
+}
+
+func (b *BaseError) unmarshalInternal(rawMsg map[string]*json.RawMessage) error {
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "someBaseProp":
+			if val != nil {
+				err = json.Unmarshal(*val, &b.SomeBaseProp)
+			}
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type LinkNotFound struct {
@@ -63,12 +81,13 @@ func (l *LinkNotFound) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &l.WhatSubAddress)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return json.Unmarshal(data, &l.NotFoundErrorBase)
+	return l.NotFoundErrorBase.unmarshalInternal(rawMsg)
 }
 
 // NotFoundErrorBaseClassification provides polymorphic access to related types.
@@ -107,6 +126,10 @@ func (n *NotFoundErrorBase) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
+	return n.unmarshalInternal(rawMsg)
+}
+
+func (n *NotFoundErrorBase) unmarshalInternal(rawMsg map[string]*json.RawMessage) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
@@ -114,16 +137,18 @@ func (n *NotFoundErrorBase) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &n.Reason)
 			}
+			delete(rawMsg, key)
 		case "whatNotFound":
 			if val != nil {
 				err = json.Unmarshal(*val, &n.WhatNotFound)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return json.Unmarshal(data, &n.BaseError)
+	return n.BaseError.unmarshalInternal(rawMsg)
 }
 
 type Pet struct {
@@ -173,6 +198,10 @@ func (p *PetActionError) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
+	return p.unmarshalInternal(rawMsg)
+}
+
+func (p *PetActionError) unmarshalInternal(rawMsg map[string]*json.RawMessage) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
@@ -180,10 +209,12 @@ func (p *PetActionError) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &p.ErrorMessage)
 			}
+			delete(rawMsg, key)
 		case "errorType":
 			if val != nil {
 				err = json.Unmarshal(*val, &p.ErrorType)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
@@ -219,12 +250,13 @@ func (p *PetHungryOrThirstyError) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &p.HungryOrThirsty)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return json.Unmarshal(data, &p.PetSadError)
+	return p.PetSadError.unmarshalInternal(rawMsg)
 }
 
 // PetResponse is the response envelope for operations that return a Pet type.
@@ -256,6 +288,10 @@ func (p *PetSadError) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
+	return p.unmarshalInternal(rawMsg)
+}
+
+func (p *PetSadError) unmarshalInternal(rawMsg map[string]*json.RawMessage) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
@@ -263,10 +299,11 @@ func (p *PetSadError) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &p.Reason)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return json.Unmarshal(data, &p.PetActionError)
+	return p.PetActionError.unmarshalInternal(rawMsg)
 }

--- a/test/network/2020-03-01/armnetwork/models.go
+++ b/test/network/2020-03-01/armnetwork/models.go
@@ -1251,32 +1251,38 @@ func (a *ApplicationRuleCondition) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &a.DestinationAddresses)
 			}
+			delete(rawMsg, key)
 		case "fqdnTags":
 			if val != nil {
 				err = json.Unmarshal(*val, &a.FqdnTags)
 			}
+			delete(rawMsg, key)
 		case "protocols":
 			if val != nil {
 				err = json.Unmarshal(*val, &a.Protocols)
 			}
+			delete(rawMsg, key)
 		case "sourceAddresses":
 			if val != nil {
 				err = json.Unmarshal(*val, &a.SourceAddresses)
 			}
+			delete(rawMsg, key)
 		case "sourceIpGroups":
 			if val != nil {
 				err = json.Unmarshal(*val, &a.SourceIPGroups)
 			}
+			delete(rawMsg, key)
 		case "targetFqdns":
 			if val != nil {
 				err = json.Unmarshal(*val, &a.TargetFqdns)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return json.Unmarshal(data, &a.FirewallPolicyRuleCondition)
+	return a.FirewallPolicyRuleCondition.unmarshalInternal(rawMsg)
 }
 
 // An application security group in a resource group.
@@ -5016,16 +5022,18 @@ func (f *FirewallPolicyFilterRule) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &f.Action)
 			}
+			delete(rawMsg, key)
 		case "ruleConditions":
 			if val != nil {
 				f.RuleConditions, err = unmarshalFirewallPolicyRuleConditionClassificationArray(*val)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return json.Unmarshal(data, &f.FirewallPolicyRule)
+	return f.FirewallPolicyRule.unmarshalInternal(rawMsg)
 }
 
 // Properties of the FirewallPolicyFilterRuleAction.
@@ -5099,24 +5107,28 @@ func (f *FirewallPolicyNatRule) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &f.Action)
 			}
+			delete(rawMsg, key)
 		case "ruleCondition":
 			if val != nil {
 				f.RuleCondition, err = unmarshalFirewallPolicyRuleConditionClassification(*val)
 			}
+			delete(rawMsg, key)
 		case "translatedAddress":
 			if val != nil {
 				err = json.Unmarshal(*val, &f.TranslatedAddress)
 			}
+			delete(rawMsg, key)
 		case "translatedPort":
 			if val != nil {
 				err = json.Unmarshal(*val, &f.TranslatedPort)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return json.Unmarshal(data, &f.FirewallPolicyRule)
+	return f.FirewallPolicyRule.unmarshalInternal(rawMsg)
 }
 
 // Properties of the FirewallPolicyNatRuleAction.
@@ -5193,27 +5205,7 @@ func (f *FirewallPolicyRule) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "name":
-			if val != nil {
-				err = json.Unmarshal(*val, &f.Name)
-			}
-		case "priority":
-			if val != nil {
-				err = json.Unmarshal(*val, &f.Priority)
-			}
-		case "ruleType":
-			if val != nil {
-				err = json.Unmarshal(*val, &f.RuleType)
-			}
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return f.unmarshalInternal(rawMsg)
 }
 
 func (f FirewallPolicyRule) marshalInternal(discValue FirewallPolicyRuleType) map[string]interface{} {
@@ -5227,6 +5219,33 @@ func (f FirewallPolicyRule) marshalInternal(discValue FirewallPolicyRuleType) ma
 	f.RuleType = &discValue
 	objectMap["ruleType"] = f.RuleType
 	return objectMap
+}
+
+func (f *FirewallPolicyRule) unmarshalInternal(rawMsg map[string]*json.RawMessage) error {
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "name":
+			if val != nil {
+				err = json.Unmarshal(*val, &f.Name)
+			}
+			delete(rawMsg, key)
+		case "priority":
+			if val != nil {
+				err = json.Unmarshal(*val, &f.Priority)
+			}
+			delete(rawMsg, key)
+		case "ruleType":
+			if val != nil {
+				err = json.Unmarshal(*val, &f.RuleType)
+			}
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // FirewallPolicyRuleConditionClassification provides polymorphic access to related types.
@@ -5257,27 +5276,7 @@ func (f *FirewallPolicyRuleCondition) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return err
 	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "description":
-			if val != nil {
-				err = json.Unmarshal(*val, &f.Description)
-			}
-		case "name":
-			if val != nil {
-				err = json.Unmarshal(*val, &f.Name)
-			}
-		case "ruleConditionType":
-			if val != nil {
-				err = json.Unmarshal(*val, &f.RuleConditionType)
-			}
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return f.unmarshalInternal(rawMsg)
 }
 
 func (f FirewallPolicyRuleCondition) marshalInternal(discValue FirewallPolicyRuleConditionType) map[string]interface{} {
@@ -5291,6 +5290,33 @@ func (f FirewallPolicyRuleCondition) marshalInternal(discValue FirewallPolicyRul
 	f.RuleConditionType = &discValue
 	objectMap["ruleConditionType"] = f.RuleConditionType
 	return objectMap
+}
+
+func (f *FirewallPolicyRuleCondition) unmarshalInternal(rawMsg map[string]*json.RawMessage) error {
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "description":
+			if val != nil {
+				err = json.Unmarshal(*val, &f.Description)
+			}
+			delete(rawMsg, key)
+		case "name":
+			if val != nil {
+				err = json.Unmarshal(*val, &f.Name)
+			}
+			delete(rawMsg, key)
+		case "ruleConditionType":
+			if val != nil {
+				err = json.Unmarshal(*val, &f.RuleConditionType)
+			}
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Properties of the application rule protocol.
@@ -5375,14 +5401,17 @@ func (f *FirewallPolicyRuleGroupProperties) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &f.Priority)
 			}
+			delete(rawMsg, key)
 		case "provisioningState":
 			if val != nil {
 				err = json.Unmarshal(*val, &f.ProvisioningState)
 			}
+			delete(rawMsg, key)
 		case "rules":
 			if val != nil {
 				f.Rules, err = unmarshalFirewallPolicyRuleClassificationArray(*val)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
@@ -7046,28 +7075,33 @@ func (n *NatRuleCondition) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &n.DestinationAddresses)
 			}
+			delete(rawMsg, key)
 		case "destinationPorts":
 			if val != nil {
 				err = json.Unmarshal(*val, &n.DestinationPorts)
 			}
+			delete(rawMsg, key)
 		case "ipProtocols":
 			if val != nil {
 				err = json.Unmarshal(*val, &n.IPProtocols)
 			}
+			delete(rawMsg, key)
 		case "sourceAddresses":
 			if val != nil {
 				err = json.Unmarshal(*val, &n.SourceAddresses)
 			}
+			delete(rawMsg, key)
 		case "sourceIpGroups":
 			if val != nil {
 				err = json.Unmarshal(*val, &n.SourceIPGroups)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return json.Unmarshal(data, &n.FirewallPolicyRuleCondition)
+	return n.FirewallPolicyRuleCondition.unmarshalInternal(rawMsg)
 }
 
 // Parameters to get network configuration diagnostic.
@@ -7602,32 +7636,38 @@ func (n *NetworkRuleCondition) UnmarshalJSON(data []byte) error {
 			if val != nil {
 				err = json.Unmarshal(*val, &n.DestinationAddresses)
 			}
+			delete(rawMsg, key)
 		case "destinationIpGroups":
 			if val != nil {
 				err = json.Unmarshal(*val, &n.DestinationIPGroups)
 			}
+			delete(rawMsg, key)
 		case "destinationPorts":
 			if val != nil {
 				err = json.Unmarshal(*val, &n.DestinationPorts)
 			}
+			delete(rawMsg, key)
 		case "ipProtocols":
 			if val != nil {
 				err = json.Unmarshal(*val, &n.IPProtocols)
 			}
+			delete(rawMsg, key)
 		case "sourceAddresses":
 			if val != nil {
 				err = json.Unmarshal(*val, &n.SourceAddresses)
 			}
+			delete(rawMsg, key)
 		case "sourceIpGroups":
 			if val != nil {
 				err = json.Unmarshal(*val, &n.SourceIPGroups)
 			}
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return json.Unmarshal(data, &n.FirewallPolicyRuleCondition)
+	return n.FirewallPolicyRuleCondition.unmarshalInternal(rawMsg)
 }
 
 // NetworkSecurityGroup resource.


### PR DESCRIPTION
Due to current bifurcated codegen of discriminated types and
non-discriminated types, support for additional properties wasn't added
to the discriminated types bucket.

To support this, the unmarshalling had to be changed to unmarshal known
fields first, starting at the child.  Once all known fields have been
consumed, any remaining fields are unmarshalled into additionl
properties.