### PR TITLE
Support header collections in responses

### DIFF
--- a/src/autorest-configuration.md
+++ b/src/autorest-configuration.md
@@ -10,7 +10,7 @@ AutoRest needs the below config to pick this up as a plug-in - see https://githu
 
 ``` yaml !isLoaded('@autorest/remodeler') 
 use-extension:
-  "@autorest/modelerfour" : "4.15.407" 
+  "@autorest/modelerfour" : "4.15.419" 
 
 # will use highest 4.0.x 
 ```

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -463,6 +463,14 @@ function processOperationResponses(session: Session<CodeModel>) {
         const httpResponse = <HttpResponse>resp.protocol.http;
         for (const header of values(httpResponse.headers)) {
           header.schema.language.go!.name = schemaTypeToGoType(session.model, header.schema, false);
+          // check if this is a header collection
+          if (header.extensions?.['x-ms-header-collection-prefix']) {
+            // key is always string, use the specified type for the value
+            const ds = new DictionarySchema(`map[string]${header.schema.language.go!.name}`, '', header.schema);
+            ds.language.go = ds.language.default;
+            ds.language.go!.headerCollectionPrefix = header.extensions['x-ms-header-collection-prefix'];
+            header.schema = ds;
+          }
         }
         filtered.push(resp);
       }

--- a/test/autorest/additionalpropsgroup/zz_generated_pets.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_pets.go
@@ -67,6 +67,7 @@ func (client *PetsClient) CreateApInPropertiesCreateRequest(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(createParameters)
 }
 
@@ -112,6 +113,7 @@ func (client *PetsClient) CreateApInPropertiesWithApstringCreateRequest(ctx cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(createParameters)
 }
 
@@ -157,6 +159,7 @@ func (client *PetsClient) CreateApObjectCreateRequest(ctx context.Context, creat
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(createParameters)
 }
 
@@ -202,6 +205,7 @@ func (client *PetsClient) CreateApStringCreateRequest(ctx context.Context, creat
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(createParameters)
 }
 
@@ -247,6 +251,7 @@ func (client *PetsClient) CreateApTrueCreateRequest(ctx context.Context, createP
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(createParameters)
 }
 
@@ -292,6 +297,7 @@ func (client *PetsClient) CreateCatApTrueCreateRequest(ctx context.Context, crea
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(createParameters)
 }
 

--- a/test/autorest/arraygroup/zz_generated_array.go
+++ b/test/autorest/arraygroup/zz_generated_array.go
@@ -194,6 +194,7 @@ func (client *ArrayClient) GetArrayEmptyCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -239,6 +240,7 @@ func (client *ArrayClient) GetArrayItemEmptyCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -284,6 +286,7 @@ func (client *ArrayClient) GetArrayItemNullCreateRequest(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -329,6 +332,7 @@ func (client *ArrayClient) GetArrayNullCreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -374,6 +378,7 @@ func (client *ArrayClient) GetArrayValidCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -419,6 +424,7 @@ func (client *ArrayClient) GetBase64URLCreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -464,6 +470,7 @@ func (client *ArrayClient) GetBooleanInvalidNullCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -509,6 +516,7 @@ func (client *ArrayClient) GetBooleanInvalidStringCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -554,6 +562,7 @@ func (client *ArrayClient) GetBooleanTfftCreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -599,6 +608,7 @@ func (client *ArrayClient) GetByteInvalidNullCreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -644,6 +654,7 @@ func (client *ArrayClient) GetByteValidCreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -689,6 +700,7 @@ func (client *ArrayClient) GetComplexEmptyCreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -734,6 +746,7 @@ func (client *ArrayClient) GetComplexItemEmptyCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -779,6 +792,7 @@ func (client *ArrayClient) GetComplexItemNullCreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -824,6 +838,7 @@ func (client *ArrayClient) GetComplexNullCreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -869,6 +884,7 @@ func (client *ArrayClient) GetComplexValidCreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -914,6 +930,7 @@ func (client *ArrayClient) GetDateInvalidCharsCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -959,6 +976,7 @@ func (client *ArrayClient) GetDateInvalidNullCreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1004,6 +1022,7 @@ func (client *ArrayClient) GetDateTimeInvalidCharsCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1056,6 +1075,7 @@ func (client *ArrayClient) GetDateTimeInvalidNullCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1108,6 +1128,7 @@ func (client *ArrayClient) GetDateTimeRFC1123ValidCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1160,6 +1181,7 @@ func (client *ArrayClient) GetDateTimeValidCreateRequest(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1212,6 +1234,7 @@ func (client *ArrayClient) GetDateValidCreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1257,6 +1280,7 @@ func (client *ArrayClient) GetDictionaryEmptyCreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1302,6 +1326,7 @@ func (client *ArrayClient) GetDictionaryItemEmptyCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1347,6 +1372,7 @@ func (client *ArrayClient) GetDictionaryItemNullCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1392,6 +1418,7 @@ func (client *ArrayClient) GetDictionaryNullCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1437,6 +1464,7 @@ func (client *ArrayClient) GetDictionaryValidCreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1482,6 +1510,7 @@ func (client *ArrayClient) GetDoubleInvalidNullCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1527,6 +1556,7 @@ func (client *ArrayClient) GetDoubleInvalidStringCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1572,6 +1602,7 @@ func (client *ArrayClient) GetDoubleValidCreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1617,6 +1648,7 @@ func (client *ArrayClient) GetDurationValidCreateRequest(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1662,6 +1694,7 @@ func (client *ArrayClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.R
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1707,6 +1740,7 @@ func (client *ArrayClient) GetEnumValidCreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1752,6 +1786,7 @@ func (client *ArrayClient) GetFloatInvalidNullCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1797,6 +1832,7 @@ func (client *ArrayClient) GetFloatInvalidStringCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1842,6 +1878,7 @@ func (client *ArrayClient) GetFloatValidCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1887,6 +1924,7 @@ func (client *ArrayClient) GetIntInvalidNullCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1932,6 +1970,7 @@ func (client *ArrayClient) GetIntInvalidStringCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1977,6 +2016,7 @@ func (client *ArrayClient) GetIntegerValidCreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2022,6 +2062,7 @@ func (client *ArrayClient) GetInvalidCreateRequest(ctx context.Context) (*azcore
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2067,6 +2108,7 @@ func (client *ArrayClient) GetLongInvalidNullCreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2112,6 +2154,7 @@ func (client *ArrayClient) GetLongInvalidStringCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2157,6 +2200,7 @@ func (client *ArrayClient) GetLongValidCreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2202,6 +2246,7 @@ func (client *ArrayClient) GetNullCreateRequest(ctx context.Context) (*azcore.Re
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2247,6 +2292,7 @@ func (client *ArrayClient) GetStringEnumValidCreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2292,6 +2338,7 @@ func (client *ArrayClient) GetStringValidCreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2337,6 +2384,7 @@ func (client *ArrayClient) GetStringWithInvalidCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2382,6 +2430,7 @@ func (client *ArrayClient) GetStringWithNullCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2427,6 +2476,7 @@ func (client *ArrayClient) GetUUIDInvalidCharsCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2472,6 +2522,7 @@ func (client *ArrayClient) GetUUIDValidCreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2517,6 +2568,7 @@ func (client *ArrayClient) PutArrayValidCreateRequest(ctx context.Context, array
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2561,6 +2613,7 @@ func (client *ArrayClient) PutBooleanTfftCreateRequest(ctx context.Context, arra
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2605,6 +2658,7 @@ func (client *ArrayClient) PutByteValidCreateRequest(ctx context.Context, arrayB
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2649,6 +2703,7 @@ func (client *ArrayClient) PutComplexValidCreateRequest(ctx context.Context, arr
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2693,6 +2748,7 @@ func (client *ArrayClient) PutDateTimeRFC1123ValidCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	aux := make([]timeRFC1123, len(arrayBody), len(arrayBody))
 	for i := 0; i < len(arrayBody); i++ {
 		aux[i] = timeRFC1123(arrayBody[i])
@@ -2741,6 +2797,7 @@ func (client *ArrayClient) PutDateTimeValidCreateRequest(ctx context.Context, ar
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2785,6 +2842,7 @@ func (client *ArrayClient) PutDateValidCreateRequest(ctx context.Context, arrayB
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2829,6 +2887,7 @@ func (client *ArrayClient) PutDictionaryValidCreateRequest(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2873,6 +2932,7 @@ func (client *ArrayClient) PutDoubleValidCreateRequest(ctx context.Context, arra
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2917,6 +2977,7 @@ func (client *ArrayClient) PutDurationValidCreateRequest(ctx context.Context, ar
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2961,6 +3022,7 @@ func (client *ArrayClient) PutEmptyCreateRequest(ctx context.Context, arrayBody 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -3005,6 +3067,7 @@ func (client *ArrayClient) PutEnumValidCreateRequest(ctx context.Context, arrayB
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -3049,6 +3112,7 @@ func (client *ArrayClient) PutFloatValidCreateRequest(ctx context.Context, array
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -3093,6 +3157,7 @@ func (client *ArrayClient) PutIntegerValidCreateRequest(ctx context.Context, arr
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -3137,6 +3202,7 @@ func (client *ArrayClient) PutLongValidCreateRequest(ctx context.Context, arrayB
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -3181,6 +3247,7 @@ func (client *ArrayClient) PutStringEnumValidCreateRequest(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -3225,6 +3292,7 @@ func (client *ArrayClient) PutStringValidCreateRequest(ctx context.Context, arra
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -3269,6 +3337,7 @@ func (client *ArrayClient) PutUUIDValidCreateRequest(ctx context.Context, arrayB
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 

--- a/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
+++ b/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
@@ -62,6 +62,7 @@ func (client *AutoRestReportServiceForAzureClient) GetReportCreateRequest(ctx co
 		query.Set("qualifier", *autoRestReportServiceForAzureGetReportOptions.Qualifier)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault.go
@@ -66,6 +66,7 @@ func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValidCreateRequ
 	query := req.URL.Query()
 	query.Set("api-version", "2015-07-01-preview")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -113,6 +114,7 @@ func (client *APIVersionDefaultClient) GetMethodGlobalValidCreateRequest(ctx con
 	query := req.URL.Query()
 	query.Set("api-version", "2015-07-01-preview")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -160,6 +162,7 @@ func (client *APIVersionDefaultClient) GetPathGlobalValidCreateRequest(ctx conte
 	query := req.URL.Query()
 	query.Set("api-version", "2015-07-01-preview")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -207,6 +210,7 @@ func (client *APIVersionDefaultClient) GetSwaggerGlobalValidCreateRequest(ctx co
 	query := req.URL.Query()
 	query.Set("api-version", "2015-07-01-preview")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal.go
@@ -68,6 +68,7 @@ func (client *APIVersionLocalClient) GetMethodLocalNullCreateRequest(ctx context
 		query.Set("api-version", *apiVersionLocalGetMethodLocalNullOptions.ApiVersion)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -115,6 +116,7 @@ func (client *APIVersionLocalClient) GetMethodLocalValidCreateRequest(ctx contex
 	query := req.URL.Query()
 	query.Set("api-version", "2.0")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -162,6 +164,7 @@ func (client *APIVersionLocalClient) GetPathLocalValidCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2.0")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -209,6 +212,7 @@ func (client *APIVersionLocalClient) GetSwaggerLocalValidCreateRequest(ctx conte
 	query := req.URL.Query()
 	query.Set("api-version", "2.0")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/azurespecialsgroup/zz_generated_header.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_header.go
@@ -62,6 +62,7 @@ func (client *HeaderClient) CustomNamedRequestIDCreateRequest(ctx context.Contex
 		return nil, err
 	}
 	req.Header.Set("foo-client-request-id", fooClientRequestId)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -111,6 +112,7 @@ func (client *HeaderClient) CustomNamedRequestIDHeadCreateRequest(ctx context.Co
 		return nil, err
 	}
 	req.Header.Set("foo-client-request-id", fooClientRequestId)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -160,6 +162,7 @@ func (client *HeaderClient) CustomNamedRequestIDParamGroupingCreateRequest(ctx c
 		return nil, err
 	}
 	req.Header.Set("foo-client-request-id", headerCustomNamedRequestIdParamGroupingParameters.FooClientRequestId)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/azurespecialsgroup/zz_generated_odata.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_odata.go
@@ -69,6 +69,7 @@ func (client *OdataClient) GetWithFilterCreateRequest(ctx context.Context, odata
 		query.Set("$orderby", *odataGetWithFilterOptions.Orderby)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding.go
@@ -71,6 +71,7 @@ func (client *SkipURLEncodingClient) GetMethodPathValidCreateRequest(ctx context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -120,6 +121,7 @@ func (client *SkipURLEncodingClient) GetMethodQueryNullCreateRequest(ctx context
 		unencodedParams = append(unencodedParams, "q1="+*skipUrlEncodingGetMethodQueryNullOptions.Q1)
 	}
 	req.URL.RawQuery = strings.Join(unencodedParams, "&")
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -167,6 +169,7 @@ func (client *SkipURLEncodingClient) GetMethodQueryValidCreateRequest(ctx contex
 	unencodedParams := []string{}
 	unencodedParams = append(unencodedParams, "q1="+q1)
 	req.URL.RawQuery = strings.Join(unencodedParams, "&")
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -214,6 +217,7 @@ func (client *SkipURLEncodingClient) GetPathQueryValidCreateRequest(ctx context.
 	unencodedParams := []string{}
 	unencodedParams = append(unencodedParams, "q1="+q1)
 	req.URL.RawQuery = strings.Join(unencodedParams, "&")
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -259,6 +263,7 @@ func (client *SkipURLEncodingClient) GetPathValidCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -304,6 +309,7 @@ func (client *SkipURLEncodingClient) GetSwaggerPathValidCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -351,6 +357,7 @@ func (client *SkipURLEncodingClient) GetSwaggerQueryValidCreateRequest(ctx conte
 	unencodedParams := []string{}
 	unencodedParams = append(unencodedParams, "q1="+"value1&q2=value2&q3=value3")
 	req.URL.RawQuery = strings.Join(unencodedParams, "&")
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials.go
@@ -72,6 +72,7 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValidC
 	query := req.URL.Query()
 	query.Set("api-version", "2015-07-01-preview")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -117,6 +118,7 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNullCreateRequest
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -162,6 +164,7 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalValidCreateReques
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -207,6 +210,7 @@ func (client *SubscriptionInCredentialsClient) PostPathGlobalValidCreateRequest(
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -252,6 +256,7 @@ func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValidCreateReque
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod.go
@@ -66,6 +66,7 @@ func (client *SubscriptionInMethodClient) PostMethodLocalNullCreateRequest(ctx c
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -111,6 +112,7 @@ func (client *SubscriptionInMethodClient) PostMethodLocalValidCreateRequest(ctx 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -156,6 +158,7 @@ func (client *SubscriptionInMethodClient) PostPathLocalValidCreateRequest(ctx co
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -201,6 +204,7 @@ func (client *SubscriptionInMethodClient) PostSwaggerLocalValidCreateRequest(ctx
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid.go
@@ -110,6 +110,7 @@ func (client *XMSClientRequestIDClient) ParamGetCreateRequest(ctx context.Contex
 		return nil, err
 	}
 	req.Header.Set("x-ms-client-request-id", xMSClientRequestId)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/booleangroup/zz_generated_bool.go
+++ b/test/autorest/booleangroup/zz_generated_bool.go
@@ -67,6 +67,7 @@ func (client *BoolClient) GetFalseCreateRequest(ctx context.Context) (*azcore.Re
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -112,6 +113,7 @@ func (client *BoolClient) GetInvalidCreateRequest(ctx context.Context) (*azcore.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -157,6 +159,7 @@ func (client *BoolClient) GetNullCreateRequest(ctx context.Context) (*azcore.Req
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -202,6 +205,7 @@ func (client *BoolClient) GetTrueCreateRequest(ctx context.Context) (*azcore.Req
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -247,6 +251,7 @@ func (client *BoolClient) PutFalseCreateRequest(ctx context.Context) (*azcore.Re
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(false)
 }
 
@@ -291,6 +296,7 @@ func (client *BoolClient) PutTrueCreateRequest(ctx context.Context) (*azcore.Req
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 

--- a/test/autorest/bytegroup/zz_generated_byte.go
+++ b/test/autorest/bytegroup/zz_generated_byte.go
@@ -65,6 +65,7 @@ func (client *ByteClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.Re
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -110,6 +111,7 @@ func (client *ByteClient) GetInvalidCreateRequest(ctx context.Context) (*azcore.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -155,6 +157,7 @@ func (client *ByteClient) GetNonASCIICreateRequest(ctx context.Context) (*azcore
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -200,6 +203,7 @@ func (client *ByteClient) GetNullCreateRequest(ctx context.Context) (*azcore.Req
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -245,6 +249,7 @@ func (client *ByteClient) PutNonASCIICreateRequest(ctx context.Context, byteBody
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsByteArray(byteBody, azcore.Base64StdFormat)
 }
 

--- a/test/autorest/complexgroup/zz_generated_array.go
+++ b/test/autorest/complexgroup/zz_generated_array.go
@@ -65,6 +65,7 @@ func (client *ArrayClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.R
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -110,6 +111,7 @@ func (client *ArrayClient) GetNotProvidedCreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -155,6 +157,7 @@ func (client *ArrayClient) GetValidCreateRequest(ctx context.Context) (*azcore.R
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -200,6 +203,7 @@ func (client *ArrayClient) PutEmptyCreateRequest(ctx context.Context, complexBod
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 
@@ -244,6 +248,7 @@ func (client *ArrayClient) PutValidCreateRequest(ctx context.Context, complexBod
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 

--- a/test/autorest/complexgroup/zz_generated_basic.go
+++ b/test/autorest/complexgroup/zz_generated_basic.go
@@ -67,6 +67,7 @@ func (client *BasicClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.R
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -112,6 +113,7 @@ func (client *BasicClient) GetInvalidCreateRequest(ctx context.Context) (*azcore
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -157,6 +159,7 @@ func (client *BasicClient) GetNotProvidedCreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -202,6 +205,7 @@ func (client *BasicClient) GetNullCreateRequest(ctx context.Context) (*azcore.Re
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -247,6 +251,7 @@ func (client *BasicClient) GetValidCreateRequest(ctx context.Context) (*azcore.R
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -295,6 +300,7 @@ func (client *BasicClient) PutValidCreateRequest(ctx context.Context, complexBod
 	query := req.URL.Query()
 	query.Set("api-version", "2016-02-29")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 

--- a/test/autorest/complexgroup/zz_generated_dictionary.go
+++ b/test/autorest/complexgroup/zz_generated_dictionary.go
@@ -67,6 +67,7 @@ func (client *DictionaryClient) GetEmptyCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -112,6 +113,7 @@ func (client *DictionaryClient) GetNotProvidedCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -157,6 +159,7 @@ func (client *DictionaryClient) GetNullCreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -202,6 +205,7 @@ func (client *DictionaryClient) GetValidCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -247,6 +251,7 @@ func (client *DictionaryClient) PutEmptyCreateRequest(ctx context.Context, compl
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 
@@ -291,6 +296,7 @@ func (client *DictionaryClient) PutValidCreateRequest(ctx context.Context, compl
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 

--- a/test/autorest/complexgroup/zz_generated_flattencomplex.go
+++ b/test/autorest/complexgroup/zz_generated_flattencomplex.go
@@ -58,6 +58,7 @@ func (client *FlattencomplexClient) GetValidCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/complexgroup/zz_generated_inheritance.go
+++ b/test/autorest/complexgroup/zz_generated_inheritance.go
@@ -59,6 +59,7 @@ func (client *InheritanceClient) GetValidCreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -104,6 +105,7 @@ func (client *InheritanceClient) PutValidCreateRequest(ctx context.Context, comp
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 

--- a/test/autorest/complexgroup/zz_generated_polymorphicrecursive.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphicrecursive.go
@@ -59,6 +59,7 @@ func (client *PolymorphicrecursiveClient) GetValidCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -104,6 +105,7 @@ func (client *PolymorphicrecursiveClient) PutValidCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 

--- a/test/autorest/complexgroup/zz_generated_polymorphism.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphism.go
@@ -73,6 +73,7 @@ func (client *PolymorphismClient) GetComplicatedCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -118,6 +119,7 @@ func (client *PolymorphismClient) GetComposedWithDiscriminatorCreateRequest(ctx 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -163,6 +165,7 @@ func (client *PolymorphismClient) GetComposedWithoutDiscriminatorCreateRequest(c
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -208,6 +211,7 @@ func (client *PolymorphismClient) GetDotSyntaxCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -253,6 +257,7 @@ func (client *PolymorphismClient) GetValidCreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -298,6 +303,7 @@ func (client *PolymorphismClient) PutComplicatedCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 
@@ -342,6 +348,7 @@ func (client *PolymorphismClient) PutMissingDiscriminatorCreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 
@@ -387,6 +394,7 @@ func (client *PolymorphismClient) PutValidCreateRequest(ctx context.Context, com
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 
@@ -431,6 +439,7 @@ func (client *PolymorphismClient) PutValidMissingRequiredCreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 

--- a/test/autorest/complexgroup/zz_generated_primitive.go
+++ b/test/autorest/complexgroup/zz_generated_primitive.go
@@ -99,6 +99,7 @@ func (client *PrimitiveClient) GetBoolCreateRequest(ctx context.Context) (*azcor
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -144,6 +145,7 @@ func (client *PrimitiveClient) GetByteCreateRequest(ctx context.Context) (*azcor
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -189,6 +191,7 @@ func (client *PrimitiveClient) GetDateCreateRequest(ctx context.Context) (*azcor
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -234,6 +237,7 @@ func (client *PrimitiveClient) GetDateTimeCreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -279,6 +283,7 @@ func (client *PrimitiveClient) GetDateTimeRFC1123CreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -324,6 +329,7 @@ func (client *PrimitiveClient) GetDoubleCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -369,6 +375,7 @@ func (client *PrimitiveClient) GetDurationCreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -414,6 +421,7 @@ func (client *PrimitiveClient) GetFloatCreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -459,6 +467,7 @@ func (client *PrimitiveClient) GetIntCreateRequest(ctx context.Context) (*azcore
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -504,6 +513,7 @@ func (client *PrimitiveClient) GetLongCreateRequest(ctx context.Context) (*azcor
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -549,6 +559,7 @@ func (client *PrimitiveClient) GetStringCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -594,6 +605,7 @@ func (client *PrimitiveClient) PutBoolCreateRequest(ctx context.Context, complex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 
@@ -638,6 +650,7 @@ func (client *PrimitiveClient) PutByteCreateRequest(ctx context.Context, complex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 
@@ -682,6 +695,7 @@ func (client *PrimitiveClient) PutDateCreateRequest(ctx context.Context, complex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 
@@ -726,6 +740,7 @@ func (client *PrimitiveClient) PutDateTimeCreateRequest(ctx context.Context, com
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 
@@ -770,6 +785,7 @@ func (client *PrimitiveClient) PutDateTimeRFC1123CreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 
@@ -814,6 +830,7 @@ func (client *PrimitiveClient) PutDoubleCreateRequest(ctx context.Context, compl
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 
@@ -858,6 +875,7 @@ func (client *PrimitiveClient) PutDurationCreateRequest(ctx context.Context, com
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 
@@ -902,6 +920,7 @@ func (client *PrimitiveClient) PutFloatCreateRequest(ctx context.Context, comple
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 
@@ -946,6 +965,7 @@ func (client *PrimitiveClient) PutIntCreateRequest(ctx context.Context, complexB
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 
@@ -990,6 +1010,7 @@ func (client *PrimitiveClient) PutLongCreateRequest(ctx context.Context, complex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 
@@ -1034,6 +1055,7 @@ func (client *PrimitiveClient) PutStringCreateRequest(ctx context.Context, compl
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 

--- a/test/autorest/complexgroup/zz_generated_readonlyproperty.go
+++ b/test/autorest/complexgroup/zz_generated_readonlyproperty.go
@@ -59,6 +59,7 @@ func (client *ReadonlypropertyClient) GetValidCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -104,6 +105,7 @@ func (client *ReadonlypropertyClient) PutValidCreateRequest(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(complexBody)
 }
 

--- a/test/autorest/complexmodelgroup/zz_generated_complexmodelclient.go
+++ b/test/autorest/complexmodelgroup/zz_generated_complexmodelclient.go
@@ -68,6 +68,7 @@ func (client *ComplexModelClient) CreateCreateRequest(ctx context.Context, subsc
 	query := req.URL.Query()
 	query.Set("api-version", "2014-04-01-preview")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
@@ -118,6 +119,7 @@ func (client *ComplexModelClient) ListCreateRequest(ctx context.Context, resourc
 	query := req.URL.Query()
 	query.Set("api-version", "2014-04-01-preview")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -168,6 +170,7 @@ func (client *ComplexModelClient) UpdateCreateRequest(ctx context.Context, subsc
 	query := req.URL.Query()
 	query.Set("api-version", "2014-04-01-preview")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 

--- a/test/autorest/custombaseurlgroup/zz_generated_paths.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_paths.go
@@ -61,6 +61,7 @@ func (client *PathsClient) GetEmptyCreateRequest(ctx context.Context, accountNam
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/datetimegroup/zz_generated_datetime.go
+++ b/test/autorest/datetimegroup/zz_generated_datetime.go
@@ -100,6 +100,7 @@ func (client *DatetimeClient) GetInvalidCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -146,6 +147,7 @@ func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTimeCreateRe
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -192,6 +194,7 @@ func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTimeCreateRequest(ctx
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -238,6 +241,7 @@ func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTimeCreateRe
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -284,6 +288,7 @@ func (client *DatetimeClient) GetLocalNoOffsetMinDateTimeCreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -330,6 +335,7 @@ func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTimeCreateRe
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -376,6 +382,7 @@ func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTimeCreateRequest(ctx
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -422,6 +429,7 @@ func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTimeCreateRe
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -468,6 +476,7 @@ func (client *DatetimeClient) GetNullCreateRequest(ctx context.Context) (*azcore
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -514,6 +523,7 @@ func (client *DatetimeClient) GetOverflowCreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -560,6 +570,7 @@ func (client *DatetimeClient) GetUTCLowercaseMaxDateTimeCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -606,6 +617,7 @@ func (client *DatetimeClient) GetUTCMinDateTimeCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -652,6 +664,7 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTimeCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -698,6 +711,7 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7DigitsCreateRequest(ctx
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -744,6 +758,7 @@ func (client *DatetimeClient) GetUnderflowCreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -790,6 +805,7 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTimeCreateRequest(ctx
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(datetimeBody)
 }
 
@@ -834,6 +850,7 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTimeCreateRequest(ctx
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(datetimeBody)
 }
 
@@ -878,6 +895,7 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTimeCreateRequest(ctx
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(datetimeBody)
 }
 
@@ -922,6 +940,7 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTimeCreateRequest(ctx
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(datetimeBody)
 }
 
@@ -966,6 +985,7 @@ func (client *DatetimeClient) PutUTCMaxDateTimeCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(datetimeBody)
 }
 
@@ -1010,6 +1030,7 @@ func (client *DatetimeClient) PutUTCMaxDateTime7DigitsCreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(datetimeBody)
 }
 
@@ -1054,6 +1075,7 @@ func (client *DatetimeClient) PutUTCMinDateTimeCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(datetimeBody)
 }
 

--- a/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123.go
@@ -74,6 +74,7 @@ func (client *Datetimerfc1123Client) GetInvalidCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -120,6 +121,7 @@ func (client *Datetimerfc1123Client) GetNullCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -166,6 +168,7 @@ func (client *Datetimerfc1123Client) GetOverflowCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -212,6 +215,7 @@ func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTimeCreateRequest(ctx
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -258,6 +262,7 @@ func (client *Datetimerfc1123Client) GetUTCMinDateTimeCreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -304,6 +309,7 @@ func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTimeCreateRequest(ctx
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -350,6 +356,7 @@ func (client *Datetimerfc1123Client) GetUnderflowCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -396,6 +403,7 @@ func (client *Datetimerfc1123Client) PutUTCMaxDateTimeCreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	aux := timeRFC1123(datetimeBody)
 	return req, req.MarshalAsJSON(aux)
 }
@@ -441,6 +449,7 @@ func (client *Datetimerfc1123Client) PutUTCMinDateTimeCreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	aux := timeRFC1123(datetimeBody)
 	return req, req.MarshalAsJSON(aux)
 }

--- a/test/autorest/dictionarygroup/zz_generated_dictionary.go
+++ b/test/autorest/dictionarygroup/zz_generated_dictionary.go
@@ -186,6 +186,7 @@ func (client *DictionaryClient) GetArrayEmptyCreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -231,6 +232,7 @@ func (client *DictionaryClient) GetArrayItemEmptyCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -276,6 +278,7 @@ func (client *DictionaryClient) GetArrayItemNullCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -321,6 +324,7 @@ func (client *DictionaryClient) GetArrayNullCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -366,6 +370,7 @@ func (client *DictionaryClient) GetArrayValidCreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -411,6 +416,7 @@ func (client *DictionaryClient) GetBase64URLCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -456,6 +462,7 @@ func (client *DictionaryClient) GetBooleanInvalidNullCreateRequest(ctx context.C
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -501,6 +508,7 @@ func (client *DictionaryClient) GetBooleanInvalidStringCreateRequest(ctx context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -546,6 +554,7 @@ func (client *DictionaryClient) GetBooleanTfftCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -591,6 +600,7 @@ func (client *DictionaryClient) GetByteInvalidNullCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -636,6 +646,7 @@ func (client *DictionaryClient) GetByteValidCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -681,6 +692,7 @@ func (client *DictionaryClient) GetComplexEmptyCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -726,6 +738,7 @@ func (client *DictionaryClient) GetComplexItemEmptyCreateRequest(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -771,6 +784,7 @@ func (client *DictionaryClient) GetComplexItemNullCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -816,6 +830,7 @@ func (client *DictionaryClient) GetComplexNullCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -861,6 +876,7 @@ func (client *DictionaryClient) GetComplexValidCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -906,6 +922,7 @@ func (client *DictionaryClient) GetDateInvalidCharsCreateRequest(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -951,6 +968,7 @@ func (client *DictionaryClient) GetDateInvalidNullCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -996,6 +1014,7 @@ func (client *DictionaryClient) GetDateTimeInvalidCharsCreateRequest(ctx context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1048,6 +1067,7 @@ func (client *DictionaryClient) GetDateTimeInvalidNullCreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1100,6 +1120,7 @@ func (client *DictionaryClient) GetDateTimeRFC1123ValidCreateRequest(ctx context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1152,6 +1173,7 @@ func (client *DictionaryClient) GetDateTimeValidCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1204,6 +1226,7 @@ func (client *DictionaryClient) GetDateValidCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1249,6 +1272,7 @@ func (client *DictionaryClient) GetDictionaryEmptyCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1294,6 +1318,7 @@ func (client *DictionaryClient) GetDictionaryItemEmptyCreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1339,6 +1364,7 @@ func (client *DictionaryClient) GetDictionaryItemNullCreateRequest(ctx context.C
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1384,6 +1410,7 @@ func (client *DictionaryClient) GetDictionaryNullCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1429,6 +1456,7 @@ func (client *DictionaryClient) GetDictionaryValidCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1474,6 +1502,7 @@ func (client *DictionaryClient) GetDoubleInvalidNullCreateRequest(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1519,6 +1548,7 @@ func (client *DictionaryClient) GetDoubleInvalidStringCreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1564,6 +1594,7 @@ func (client *DictionaryClient) GetDoubleValidCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1609,6 +1640,7 @@ func (client *DictionaryClient) GetDurationValidCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1654,6 +1686,7 @@ func (client *DictionaryClient) GetEmptyCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1699,6 +1732,7 @@ func (client *DictionaryClient) GetEmptyStringKeyCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1744,6 +1778,7 @@ func (client *DictionaryClient) GetFloatInvalidNullCreateRequest(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1789,6 +1824,7 @@ func (client *DictionaryClient) GetFloatInvalidStringCreateRequest(ctx context.C
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1834,6 +1870,7 @@ func (client *DictionaryClient) GetFloatValidCreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1879,6 +1916,7 @@ func (client *DictionaryClient) GetIntInvalidNullCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1924,6 +1962,7 @@ func (client *DictionaryClient) GetIntInvalidStringCreateRequest(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1969,6 +2008,7 @@ func (client *DictionaryClient) GetIntegerValidCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2014,6 +2054,7 @@ func (client *DictionaryClient) GetInvalidCreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2059,6 +2100,7 @@ func (client *DictionaryClient) GetLongInvalidNullCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2104,6 +2146,7 @@ func (client *DictionaryClient) GetLongInvalidStringCreateRequest(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2149,6 +2192,7 @@ func (client *DictionaryClient) GetLongValidCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2194,6 +2238,7 @@ func (client *DictionaryClient) GetNullCreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2239,6 +2284,7 @@ func (client *DictionaryClient) GetNullKeyCreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2284,6 +2330,7 @@ func (client *DictionaryClient) GetNullValueCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2329,6 +2376,7 @@ func (client *DictionaryClient) GetStringValidCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2374,6 +2422,7 @@ func (client *DictionaryClient) GetStringWithInvalidCreateRequest(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2419,6 +2468,7 @@ func (client *DictionaryClient) GetStringWithNullCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -2464,6 +2514,7 @@ func (client *DictionaryClient) PutArrayValidCreateRequest(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2508,6 +2559,7 @@ func (client *DictionaryClient) PutBooleanTfftCreateRequest(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2552,6 +2604,7 @@ func (client *DictionaryClient) PutByteValidCreateRequest(ctx context.Context, a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2596,6 +2649,7 @@ func (client *DictionaryClient) PutComplexValidCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2640,6 +2694,7 @@ func (client *DictionaryClient) PutDateTimeRFC1123ValidCreateRequest(ctx context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	aux := map[string]timeRFC1123{}
 	for k, v := range arrayBody {
 		aux[k] = timeRFC1123(v)
@@ -2688,6 +2743,7 @@ func (client *DictionaryClient) PutDateTimeValidCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	aux := map[string]timeRFC3339{}
 	for k, v := range arrayBody {
 		aux[k] = timeRFC3339(v)
@@ -2736,6 +2792,7 @@ func (client *DictionaryClient) PutDateValidCreateRequest(ctx context.Context, a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2780,6 +2837,7 @@ func (client *DictionaryClient) PutDictionaryValidCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2824,6 +2882,7 @@ func (client *DictionaryClient) PutDoubleValidCreateRequest(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2868,6 +2927,7 @@ func (client *DictionaryClient) PutDurationValidCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2912,6 +2972,7 @@ func (client *DictionaryClient) PutEmptyCreateRequest(ctx context.Context, array
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -2956,6 +3017,7 @@ func (client *DictionaryClient) PutFloatValidCreateRequest(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -3000,6 +3062,7 @@ func (client *DictionaryClient) PutIntegerValidCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -3044,6 +3107,7 @@ func (client *DictionaryClient) PutLongValidCreateRequest(ctx context.Context, a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
@@ -3088,6 +3152,7 @@ func (client *DictionaryClient) PutStringValidCreateRequest(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(arrayBody)
 }
 

--- a/test/autorest/durationgroup/zz_generated_duration.go
+++ b/test/autorest/durationgroup/zz_generated_duration.go
@@ -63,6 +63,7 @@ func (client *DurationClient) GetInvalidCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -108,6 +109,7 @@ func (client *DurationClient) GetNullCreateRequest(ctx context.Context) (*azcore
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -153,6 +155,7 @@ func (client *DurationClient) GetPositiveDurationCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -198,6 +201,7 @@ func (client *DurationClient) PutPositiveDurationCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(durationBody)
 }
 

--- a/test/autorest/errorsgroup/zz_generated_pet.go
+++ b/test/autorest/errorsgroup/zz_generated_pet.go
@@ -65,6 +65,7 @@ func (client *PetClient) DoSomethingCreateRequest(ctx context.Context, whatActio
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -120,6 +121,7 @@ func (client *PetClient) GetPetByIDCreateRequest(ctx context.Context, petId stri
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/extenumsgroup/zz_generated_pet.go
+++ b/test/autorest/extenumsgroup/zz_generated_pet.go
@@ -64,6 +64,7 @@ func (client *PetClient) AddPetCreateRequest(ctx context.Context, petAddPetOptio
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if petAddPetOptions != nil {
 		return req, req.MarshalAsJSON(petAddPetOptions.PetParam)
 	}
@@ -116,6 +117,7 @@ func (client *PetClient) GetByPetIDCreateRequest(ctx context.Context, petId stri
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/filegroup/zz_generated_files.go
+++ b/test/autorest/filegroup/zz_generated_files.go
@@ -62,6 +62,7 @@ func (client *FilesClient) GetEmptyFileCreateRequest(ctx context.Context) (*azco
 		return nil, err
 	}
 	req.SkipBodyDownload()
+	req.Header.Set("Accept", "image/png, application/json")
 	return req, nil
 }
 
@@ -107,6 +108,7 @@ func (client *FilesClient) GetFileCreateRequest(ctx context.Context) (*azcore.Re
 		return nil, err
 	}
 	req.SkipBodyDownload()
+	req.Header.Set("Accept", "image/png, application/json")
 	return req, nil
 }
 
@@ -152,6 +154,7 @@ func (client *FilesClient) GetFileLargeCreateRequest(ctx context.Context) (*azco
 		return nil, err
 	}
 	req.SkipBodyDownload()
+	req.Header.Set("Accept", "image/png, application/json")
 	return req, nil
 }
 

--- a/test/autorest/headergroup/zz_generated_header.go
+++ b/test/autorest/headergroup/zz_generated_header.go
@@ -116,6 +116,7 @@ func (client *HeaderClient) CustomRequestIDCreateRequest(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -162,6 +163,7 @@ func (client *HeaderClient) ParamBoolCreateRequest(ctx context.Context, scenario
 	}
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", strconv.FormatBool(value))
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -208,6 +210,7 @@ func (client *HeaderClient) ParamByteCreateRequest(ctx context.Context, scenario
 	}
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", base64.StdEncoding.EncodeToString(value))
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -254,6 +257,7 @@ func (client *HeaderClient) ParamDateCreateRequest(ctx context.Context, scenario
 	}
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", value.Format("2006-01-02"))
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -300,6 +304,7 @@ func (client *HeaderClient) ParamDatetimeCreateRequest(ctx context.Context, scen
 	}
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", value.Format(time.RFC3339Nano))
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -348,6 +353,7 @@ func (client *HeaderClient) ParamDatetimeRFC1123CreateRequest(ctx context.Contex
 	if headerParamDatetimeRfc1123Options != nil && headerParamDatetimeRfc1123Options.Value != nil {
 		req.Header.Set("value", headerParamDatetimeRfc1123Options.Value.Format(time.RFC1123))
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -394,6 +400,7 @@ func (client *HeaderClient) ParamDoubleCreateRequest(ctx context.Context, scenar
 	}
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", strconv.FormatFloat(value, 'f', -1, 64))
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -440,6 +447,7 @@ func (client *HeaderClient) ParamDurationCreateRequest(ctx context.Context, scen
 	}
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", value)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -488,6 +496,7 @@ func (client *HeaderClient) ParamEnumCreateRequest(ctx context.Context, scenario
 	if headerParamEnumOptions != nil && headerParamEnumOptions.Value != nil {
 		req.Header.Set("value", string(*headerParamEnumOptions.Value))
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -533,6 +542,7 @@ func (client *HeaderClient) ParamExistingKeyCreateRequest(ctx context.Context, u
 		return nil, err
 	}
 	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -579,6 +589,7 @@ func (client *HeaderClient) ParamFloatCreateRequest(ctx context.Context, scenari
 	}
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", strconv.FormatFloat(float64(value), 'f', -1, 32))
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -625,6 +636,7 @@ func (client *HeaderClient) ParamIntegerCreateRequest(ctx context.Context, scena
 	}
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", strconv.FormatInt(int64(value), 10))
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -671,6 +683,7 @@ func (client *HeaderClient) ParamLongCreateRequest(ctx context.Context, scenario
 	}
 	req.Header.Set("scenario", scenario)
 	req.Header.Set("value", strconv.FormatInt(value, 10))
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -716,6 +729,7 @@ func (client *HeaderClient) ParamProtectedKeyCreateRequest(ctx context.Context, 
 		return nil, err
 	}
 	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -764,6 +778,7 @@ func (client *HeaderClient) ParamStringCreateRequest(ctx context.Context, scenar
 	if headerParamStringOptions != nil && headerParamStringOptions.Value != nil {
 		req.Header.Set("value", *headerParamStringOptions.Value)
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -809,6 +824,7 @@ func (client *HeaderClient) ResponseBoolCreateRequest(ctx context.Context, scena
 		return nil, err
 	}
 	req.Header.Set("scenario", scenario)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -862,6 +878,7 @@ func (client *HeaderClient) ResponseByteCreateRequest(ctx context.Context, scena
 		return nil, err
 	}
 	req.Header.Set("scenario", scenario)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -915,6 +932,7 @@ func (client *HeaderClient) ResponseDateCreateRequest(ctx context.Context, scena
 		return nil, err
 	}
 	req.Header.Set("scenario", scenario)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -968,6 +986,7 @@ func (client *HeaderClient) ResponseDatetimeCreateRequest(ctx context.Context, s
 		return nil, err
 	}
 	req.Header.Set("scenario", scenario)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1021,6 +1040,7 @@ func (client *HeaderClient) ResponseDatetimeRFC1123CreateRequest(ctx context.Con
 		return nil, err
 	}
 	req.Header.Set("scenario", scenario)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1074,6 +1094,7 @@ func (client *HeaderClient) ResponseDoubleCreateRequest(ctx context.Context, sce
 		return nil, err
 	}
 	req.Header.Set("scenario", scenario)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1127,6 +1148,7 @@ func (client *HeaderClient) ResponseDurationCreateRequest(ctx context.Context, s
 		return nil, err
 	}
 	req.Header.Set("scenario", scenario)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1176,6 +1198,7 @@ func (client *HeaderClient) ResponseEnumCreateRequest(ctx context.Context, scena
 		return nil, err
 	}
 	req.Header.Set("scenario", scenario)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1224,6 +1247,7 @@ func (client *HeaderClient) ResponseExistingKeyCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1273,6 +1297,7 @@ func (client *HeaderClient) ResponseFloatCreateRequest(ctx context.Context, scen
 		return nil, err
 	}
 	req.Header.Set("scenario", scenario)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1327,6 +1352,7 @@ func (client *HeaderClient) ResponseIntegerCreateRequest(ctx context.Context, sc
 		return nil, err
 	}
 	req.Header.Set("scenario", scenario)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1381,6 +1407,7 @@ func (client *HeaderClient) ResponseLongCreateRequest(ctx context.Context, scena
 		return nil, err
 	}
 	req.Header.Set("scenario", scenario)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1433,6 +1460,7 @@ func (client *HeaderClient) ResponseProtectedKeyCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1482,6 +1510,7 @@ func (client *HeaderClient) ResponseStringCreateRequest(ctx context.Context, sce
 		return nil, err
 	}
 	req.Header.Set("scenario", scenario)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure.go
@@ -107,6 +107,7 @@ func (client *HTTPClientFailureClient) Delete400CreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -148,6 +149,7 @@ func (client *HTTPClientFailureClient) Delete407CreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -189,6 +191,7 @@ func (client *HTTPClientFailureClient) Delete417CreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -230,6 +233,7 @@ func (client *HTTPClientFailureClient) Get400CreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -271,6 +275,7 @@ func (client *HTTPClientFailureClient) Get402CreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -312,6 +317,7 @@ func (client *HTTPClientFailureClient) Get403CreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -353,6 +359,7 @@ func (client *HTTPClientFailureClient) Get411CreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -394,6 +401,7 @@ func (client *HTTPClientFailureClient) Get412CreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -435,6 +443,7 @@ func (client *HTTPClientFailureClient) Get416CreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -476,6 +485,7 @@ func (client *HTTPClientFailureClient) Head400CreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -517,6 +527,7 @@ func (client *HTTPClientFailureClient) Head401CreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -558,6 +569,7 @@ func (client *HTTPClientFailureClient) Head410CreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -599,6 +611,7 @@ func (client *HTTPClientFailureClient) Head429CreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -640,6 +653,7 @@ func (client *HTTPClientFailureClient) Options400CreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -681,6 +695,7 @@ func (client *HTTPClientFailureClient) Options403CreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -722,6 +737,7 @@ func (client *HTTPClientFailureClient) Options412CreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -763,6 +779,7 @@ func (client *HTTPClientFailureClient) Patch400CreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -804,6 +821,7 @@ func (client *HTTPClientFailureClient) Patch405CreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -845,6 +863,7 @@ func (client *HTTPClientFailureClient) Patch414CreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -886,6 +905,7 @@ func (client *HTTPClientFailureClient) Post400CreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -927,6 +947,7 @@ func (client *HTTPClientFailureClient) Post406CreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -968,6 +989,7 @@ func (client *HTTPClientFailureClient) Post415CreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -1009,6 +1031,7 @@ func (client *HTTPClientFailureClient) Put400CreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -1050,6 +1073,7 @@ func (client *HTTPClientFailureClient) Put404CreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -1091,6 +1115,7 @@ func (client *HTTPClientFailureClient) Put409CreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -1132,6 +1157,7 @@ func (client *HTTPClientFailureClient) Put413CreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure.go
@@ -64,6 +64,7 @@ func (client *HTTPFailureClient) GetEmptyErrorCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -109,6 +110,7 @@ func (client *HTTPFailureClient) GetNoModelEmptyCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -157,6 +159,7 @@ func (client *HTTPFailureClient) GetNoModelErrorCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
@@ -88,6 +88,7 @@ func (client *HTTPRedirectsClient) Delete307CreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -133,6 +134,7 @@ func (client *HTTPRedirectsClient) Get300CreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -189,6 +191,7 @@ func (client *HTTPRedirectsClient) Get301CreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -233,6 +236,7 @@ func (client *HTTPRedirectsClient) Get302CreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +281,7 @@ func (client *HTTPRedirectsClient) Get307CreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -321,6 +326,7 @@ func (client *HTTPRedirectsClient) Head300CreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -369,6 +375,7 @@ func (client *HTTPRedirectsClient) Head301CreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -413,6 +420,7 @@ func (client *HTTPRedirectsClient) Head302CreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -457,6 +465,7 @@ func (client *HTTPRedirectsClient) Head307CreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -501,6 +510,7 @@ func (client *HTTPRedirectsClient) Options307CreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -545,6 +555,7 @@ func (client *HTTPRedirectsClient) Patch302CreateRequest(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -593,6 +604,7 @@ func (client *HTTPRedirectsClient) Patch307CreateRequest(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -637,6 +649,7 @@ func (client *HTTPRedirectsClient) Post303CreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -685,6 +698,7 @@ func (client *HTTPRedirectsClient) Post307CreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -729,6 +743,7 @@ func (client *HTTPRedirectsClient) Put301CreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -777,6 +792,7 @@ func (client *HTTPRedirectsClient) Put307CreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpretry.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpretry.go
@@ -73,6 +73,7 @@ func (client *HTTPRetryClient) Delete503CreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -117,6 +118,7 @@ func (client *HTTPRetryClient) Get502CreateRequest(ctx context.Context) (*azcore
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -161,6 +163,7 @@ func (client *HTTPRetryClient) Head408CreateRequest(ctx context.Context) (*azcor
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -205,6 +208,7 @@ func (client *HTTPRetryClient) Options502CreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -250,6 +254,7 @@ func (client *HTTPRetryClient) Patch500CreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -294,6 +299,7 @@ func (client *HTTPRetryClient) Patch504CreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -338,6 +344,7 @@ func (client *HTTPRetryClient) Post503CreateRequest(ctx context.Context) (*azcor
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -382,6 +389,7 @@ func (client *HTTPRetryClient) Put500CreateRequest(ctx context.Context) (*azcore
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -426,6 +434,7 @@ func (client *HTTPRetryClient) Put504CreateRequest(ctx context.Context) (*azcore
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure.go
@@ -63,6 +63,7 @@ func (client *HTTPServerFailureClient) Delete505CreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -104,6 +105,7 @@ func (client *HTTPServerFailureClient) Get501CreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -145,6 +147,7 @@ func (client *HTTPServerFailureClient) Head501CreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -186,6 +189,7 @@ func (client *HTTPServerFailureClient) Post505CreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess.go
@@ -93,6 +93,7 @@ func (client *HTTPSuccessClient) Delete200CreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -137,6 +138,7 @@ func (client *HTTPSuccessClient) Delete202CreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -181,6 +183,7 @@ func (client *HTTPSuccessClient) Delete204CreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -225,6 +228,7 @@ func (client *HTTPSuccessClient) Get200CreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -270,6 +274,7 @@ func (client *HTTPSuccessClient) Head200CreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -314,6 +319,7 @@ func (client *HTTPSuccessClient) Head204CreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -358,6 +364,7 @@ func (client *HTTPSuccessClient) Head404CreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -402,6 +409,7 @@ func (client *HTTPSuccessClient) Options200CreateRequest(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -447,6 +455,7 @@ func (client *HTTPSuccessClient) Patch200CreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -491,6 +500,7 @@ func (client *HTTPSuccessClient) Patch202CreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -535,6 +545,7 @@ func (client *HTTPSuccessClient) Patch204CreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -579,6 +590,7 @@ func (client *HTTPSuccessClient) Post200CreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -623,6 +635,7 @@ func (client *HTTPSuccessClient) Post201CreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -667,6 +680,7 @@ func (client *HTTPSuccessClient) Post202CreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -711,6 +725,7 @@ func (client *HTTPSuccessClient) Post204CreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -755,6 +770,7 @@ func (client *HTTPSuccessClient) Put200CreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -799,6 +815,7 @@ func (client *HTTPSuccessClient) Put201CreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -843,6 +860,7 @@ func (client *HTTPSuccessClient) Put202CreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 
@@ -887,6 +905,7 @@ func (client *HTTPSuccessClient) Put204CreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(true)
 }
 

--- a/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses.go
@@ -134,6 +134,7 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError200ValidCr
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -185,6 +186,7 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError201ValidCr
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -236,6 +238,7 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError400ValidCr
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -286,6 +289,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200Valid
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -331,6 +335,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201Inval
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -376,6 +381,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202NoneC
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -421,6 +427,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204Valid
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -466,6 +473,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400Valid
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -511,6 +519,7 @@ func (client *MultipleResponsesClient) Get200ModelA200InvalidCreateRequest(ctx c
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -559,6 +568,7 @@ func (client *MultipleResponsesClient) Get200ModelA200NoneCreateRequest(ctx cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -607,6 +617,7 @@ func (client *MultipleResponsesClient) Get200ModelA200ValidCreateRequest(ctx con
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -656,6 +667,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -710,6 +722,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -764,6 +777,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -818,6 +832,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -871,6 +886,7 @@ func (client *MultipleResponsesClient) Get200ModelA202ValidCreateRequest(ctx con
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -919,6 +935,7 @@ func (client *MultipleResponsesClient) Get200ModelA400InvalidCreateRequest(ctx c
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -967,6 +984,7 @@ func (client *MultipleResponsesClient) Get200ModelA400NoneCreateRequest(ctx cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1015,6 +1033,7 @@ func (client *MultipleResponsesClient) Get200ModelA400ValidCreateRequest(ctx con
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1063,6 +1082,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError202NoneCreat
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1107,6 +1127,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError204NoneCreat
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1151,6 +1172,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError400ValidCrea
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1383,6 +1405,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA200NoneCreateRequest(ctx 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1431,6 +1454,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA200ValidCreateRequest(ctx
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1479,6 +1503,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA400NoneCreateRequest(ctx 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1523,6 +1548,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA400ValidCreateRequest(ctx
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/integergroup/zz_generated_int.go
+++ b/test/autorest/integergroup/zz_generated_int.go
@@ -84,6 +84,7 @@ func (client *IntClient) GetInvalidCreateRequest(ctx context.Context) (*azcore.R
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -129,6 +130,7 @@ func (client *IntClient) GetInvalidUnixTimeCreateRequest(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -175,6 +177,7 @@ func (client *IntClient) GetNullCreateRequest(ctx context.Context) (*azcore.Requ
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -220,6 +223,7 @@ func (client *IntClient) GetNullUnixTimeCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -266,6 +270,7 @@ func (client *IntClient) GetOverflowInt32CreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -311,6 +316,7 @@ func (client *IntClient) GetOverflowInt64CreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -356,6 +362,7 @@ func (client *IntClient) GetUnderflowInt32CreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -401,6 +408,7 @@ func (client *IntClient) GetUnderflowInt64CreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -446,6 +454,7 @@ func (client *IntClient) GetUnixTimeCreateRequest(ctx context.Context) (*azcore.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -492,6 +501,7 @@ func (client *IntClient) PutMax32CreateRequest(ctx context.Context, intBody int3
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(intBody)
 }
 
@@ -536,6 +546,7 @@ func (client *IntClient) PutMax64CreateRequest(ctx context.Context, intBody int6
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(intBody)
 }
 
@@ -580,6 +591,7 @@ func (client *IntClient) PutMin32CreateRequest(ctx context.Context, intBody int3
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(intBody)
 }
 
@@ -624,6 +636,7 @@ func (client *IntClient) PutMin64CreateRequest(ctx context.Context, intBody int6
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(intBody)
 }
 
@@ -668,6 +681,7 @@ func (client *IntClient) PutUnixTimeDateCreateRequest(ctx context.Context, intBo
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	aux := timeUnix(intBody)
 	return req, req.MarshalAsJSON(aux)
 }

--- a/test/autorest/lrogroup/zz_generated_lroretrys.go
+++ b/test/autorest/lrogroup/zz_generated_lroretrys.go
@@ -109,6 +109,7 @@ func (client *LroRetrysClient) Delete202Retry200CreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -177,6 +178,7 @@ func (client *LroRetrysClient) DeleteAsyncRelativeRetrySucceededCreateRequest(ct
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -245,6 +247,7 @@ func (client *LroRetrysClient) DeleteProvisioning202Accepted200SucceededCreateRe
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -313,6 +316,7 @@ func (client *LroRetrysClient) Post202Retry200CreateRequest(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lroRetrysPost202Retry200Options != nil {
 		return req, req.MarshalAsJSON(lroRetrysPost202Retry200Options.Product)
 	}
@@ -384,6 +388,7 @@ func (client *LroRetrysClient) PostAsyncRelativeRetrySucceededCreateRequest(ctx 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lroRetrysPostAsyncRelativeRetrySucceededOptions != nil {
 		return req, req.MarshalAsJSON(lroRetrysPostAsyncRelativeRetrySucceededOptions.Product)
 	}
@@ -455,6 +460,7 @@ func (client *LroRetrysClient) Put201CreatingSucceeded200CreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lroRetrysPut201CreatingSucceeded200Options != nil {
 		return req, req.MarshalAsJSON(lroRetrysPut201CreatingSucceeded200Options.Product)
 	}
@@ -526,6 +532,7 @@ func (client *LroRetrysClient) PutAsyncRelativeRetrySucceededCreateRequest(ctx c
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lroRetrysPutAsyncRelativeRetrySucceededOptions != nil {
 		return req, req.MarshalAsJSON(lroRetrysPutAsyncRelativeRetrySucceededOptions.Product)
 	}

--- a/test/autorest/lrogroup/zz_generated_lros.go
+++ b/test/autorest/lrogroup/zz_generated_lros.go
@@ -245,6 +245,7 @@ func (client *LrOSClient) Delete202NoRetry204CreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -313,6 +314,7 @@ func (client *LrOSClient) Delete202Retry200CreateRequest(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -381,6 +383,7 @@ func (client *LrOSClient) Delete204SucceededCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -449,6 +452,7 @@ func (client *LrOSClient) DeleteAsyncNoHeaderInRetryCreateRequest(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -517,6 +521,7 @@ func (client *LrOSClient) DeleteAsyncNoRetrySucceededCreateRequest(ctx context.C
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -585,6 +590,7 @@ func (client *LrOSClient) DeleteAsyncRetryFailedCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -653,6 +659,7 @@ func (client *LrOSClient) DeleteAsyncRetrySucceededCreateRequest(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -721,6 +728,7 @@ func (client *LrOSClient) DeleteAsyncRetrycanceledCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -789,6 +797,7 @@ func (client *LrOSClient) DeleteNoHeaderInRetryCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -857,6 +866,7 @@ func (client *LrOSClient) DeleteProvisioning202Accepted200SucceededCreateRequest
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -925,6 +935,7 @@ func (client *LrOSClient) DeleteProvisioning202DeletingFailed200CreateRequest(ct
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -993,6 +1004,7 @@ func (client *LrOSClient) DeleteProvisioning202Deletingcanceled200CreateRequest(
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1061,6 +1073,7 @@ func (client *LrOSClient) Post200WithPayloadCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1129,6 +1142,7 @@ func (client *LrOSClient) Post202ListCreateRequest(ctx context.Context) (*azcore
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1197,6 +1211,7 @@ func (client *LrOSClient) Post202NoRetry204CreateRequest(ctx context.Context, lr
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPost202NoRetry204Options != nil {
 		return req, req.MarshalAsJSON(lrOSPost202NoRetry204Options.Product)
 	}
@@ -1268,6 +1283,7 @@ func (client *LrOSClient) Post202Retry200CreateRequest(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPost202Retry200Options != nil {
 		return req, req.MarshalAsJSON(lrOSPost202Retry200Options.Product)
 	}
@@ -1339,6 +1355,7 @@ func (client *LrOSClient) PostAsyncNoRetrySucceededCreateRequest(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPostAsyncNoRetrySucceededOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPostAsyncNoRetrySucceededOptions.Product)
 	}
@@ -1410,6 +1427,7 @@ func (client *LrOSClient) PostAsyncRetryFailedCreateRequest(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPostAsyncRetryFailedOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPostAsyncRetryFailedOptions.Product)
 	}
@@ -1481,6 +1499,7 @@ func (client *LrOSClient) PostAsyncRetrySucceededCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPostAsyncRetrySucceededOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPostAsyncRetrySucceededOptions.Product)
 	}
@@ -1552,6 +1571,7 @@ func (client *LrOSClient) PostAsyncRetrycanceledCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPostAsyncRetrycanceledOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPostAsyncRetrycanceledOptions.Product)
 	}
@@ -1623,6 +1643,7 @@ func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetCreateRequest(ctx 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1691,6 +1712,7 @@ func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetDefaultCreateReque
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1759,6 +1781,7 @@ func (client *LrOSClient) PostDoubleHeadersFinalLocationGetCreateRequest(ctx con
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1827,6 +1850,7 @@ func (client *LrOSClient) Put200Acceptedcanceled200CreateRequest(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPut200Acceptedcanceled200Options != nil {
 		return req, req.MarshalAsJSON(lrOSPut200Acceptedcanceled200Options.Product)
 	}
@@ -1898,6 +1922,7 @@ func (client *LrOSClient) Put200SucceededCreateRequest(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPut200SucceededOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPut200SucceededOptions.Product)
 	}
@@ -1969,6 +1994,7 @@ func (client *LrOSClient) Put200SucceededNoStateCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPut200SucceededNoStateOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPut200SucceededNoStateOptions.Product)
 	}
@@ -2040,6 +2066,7 @@ func (client *LrOSClient) Put200UpdatingSucceeded204CreateRequest(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPut200UpdatingSucceeded204Options != nil {
 		return req, req.MarshalAsJSON(lrOSPut200UpdatingSucceeded204Options.Product)
 	}
@@ -2111,6 +2138,7 @@ func (client *LrOSClient) Put201CreatingFailed200CreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPut201CreatingFailed200Options != nil {
 		return req, req.MarshalAsJSON(lrOSPut201CreatingFailed200Options.Product)
 	}
@@ -2182,6 +2210,7 @@ func (client *LrOSClient) Put201CreatingSucceeded200CreateRequest(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPut201CreatingSucceeded200Options != nil {
 		return req, req.MarshalAsJSON(lrOSPut201CreatingSucceeded200Options.Product)
 	}
@@ -2253,6 +2282,7 @@ func (client *LrOSClient) Put201SucceededCreateRequest(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPut201SucceededOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPut201SucceededOptions.Product)
 	}
@@ -2324,6 +2354,7 @@ func (client *LrOSClient) Put202Retry200CreateRequest(ctx context.Context, lrOSP
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPut202Retry200Options != nil {
 		return req, req.MarshalAsJSON(lrOSPut202Retry200Options.Product)
 	}
@@ -2395,6 +2426,7 @@ func (client *LrOSClient) PutAsyncNoHeaderInRetryCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPutAsyncNoHeaderInRetryOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPutAsyncNoHeaderInRetryOptions.Product)
 	}
@@ -2466,6 +2498,7 @@ func (client *LrOSClient) PutAsyncNoRetrySucceededCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPutAsyncNoRetrySucceededOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPutAsyncNoRetrySucceededOptions.Product)
 	}
@@ -2537,6 +2570,7 @@ func (client *LrOSClient) PutAsyncNoRetrycanceledCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPutAsyncNoRetrycanceledOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPutAsyncNoRetrycanceledOptions.Product)
 	}
@@ -2608,6 +2642,7 @@ func (client *LrOSClient) PutAsyncNonResourceCreateRequest(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPutAsyncNonResourceOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPutAsyncNonResourceOptions.Sku)
 	}
@@ -2679,6 +2714,7 @@ func (client *LrOSClient) PutAsyncRetryFailedCreateRequest(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPutAsyncRetryFailedOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPutAsyncRetryFailedOptions.Product)
 	}
@@ -2750,6 +2786,7 @@ func (client *LrOSClient) PutAsyncRetrySucceededCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPutAsyncRetrySucceededOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPutAsyncRetrySucceededOptions.Product)
 	}
@@ -2821,6 +2858,7 @@ func (client *LrOSClient) PutAsyncSubResourceCreateRequest(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPutAsyncSubResourceOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPutAsyncSubResourceOptions.Product)
 	}
@@ -2892,6 +2930,7 @@ func (client *LrOSClient) PutNoHeaderInRetryCreateRequest(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPutNoHeaderInRetryOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPutNoHeaderInRetryOptions.Product)
 	}
@@ -2963,6 +3002,7 @@ func (client *LrOSClient) PutNonResourceCreateRequest(ctx context.Context, lrOSP
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPutNonResourceOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPutNonResourceOptions.Sku)
 	}
@@ -3034,6 +3074,7 @@ func (client *LrOSClient) PutSubResourceCreateRequest(ctx context.Context, lrOSP
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSPutSubResourceOptions != nil {
 		return req, req.MarshalAsJSON(lrOSPutSubResourceOptions.Product)
 	}

--- a/test/autorest/lrogroup/zz_generated_lrosads.go
+++ b/test/autorest/lrogroup/zz_generated_lrosads.go
@@ -185,6 +185,7 @@ func (client *LrosaDsClient) Delete202NonRetry400CreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -253,6 +254,7 @@ func (client *LrosaDsClient) Delete202RetryInvalidHeaderCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -321,6 +323,7 @@ func (client *LrosaDsClient) Delete204SucceededCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -389,6 +392,7 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetry400CreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -457,6 +461,7 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidHeaderCreateRequest(
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -525,6 +530,7 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidJSONPollingCreateReq
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -593,6 +599,7 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryNoStatusCreateRequest(ctx c
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -661,6 +668,7 @@ func (client *LrosaDsClient) DeleteNonRetry400CreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -729,6 +737,7 @@ func (client *LrosaDsClient) Post202NoLocationCreateRequest(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPost202NoLocationOptions != nil {
 		return req, req.MarshalAsJSON(lrosaDsPost202NoLocationOptions.Product)
 	}
@@ -800,6 +809,7 @@ func (client *LrosaDsClient) Post202NonRetry400CreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPost202NonRetry400Options != nil {
 		return req, req.MarshalAsJSON(lrosaDsPost202NonRetry400Options.Product)
 	}
@@ -871,6 +881,7 @@ func (client *LrosaDsClient) Post202RetryInvalidHeaderCreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPost202RetryInvalidHeaderOptions != nil {
 		return req, req.MarshalAsJSON(lrosaDsPost202RetryInvalidHeaderOptions.Product)
 	}
@@ -942,6 +953,7 @@ func (client *LrosaDsClient) PostAsyncRelativeRetry400CreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPostAsyncRelativeRetry400Options != nil {
 		return req, req.MarshalAsJSON(lrosaDsPostAsyncRelativeRetry400Options.Product)
 	}
@@ -1013,6 +1025,7 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidHeaderCreateRequest(ct
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPostAsyncRelativeRetryInvalidHeaderOptions != nil {
 		return req, req.MarshalAsJSON(lrosaDsPostAsyncRelativeRetryInvalidHeaderOptions.Product)
 	}
@@ -1084,6 +1097,7 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidJSONPollingCreateReque
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPostAsyncRelativeRetryInvalidJsonPollingOptions != nil {
 		return req, req.MarshalAsJSON(lrosaDsPostAsyncRelativeRetryInvalidJsonPollingOptions.Product)
 	}
@@ -1155,6 +1169,7 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryNoPayloadCreateRequest(ctx co
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPostAsyncRelativeRetryNoPayloadOptions != nil {
 		return req, req.MarshalAsJSON(lrosaDsPostAsyncRelativeRetryNoPayloadOptions.Product)
 	}
@@ -1226,6 +1241,7 @@ func (client *LrosaDsClient) PostNonRetry400CreateRequest(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPostNonRetry400Options != nil {
 		return req, req.MarshalAsJSON(lrosaDsPostNonRetry400Options.Product)
 	}
@@ -1297,6 +1313,7 @@ func (client *LrosaDsClient) Put200InvalidJSONCreateRequest(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPut200InvalidJsonOptions != nil {
 		return req, req.MarshalAsJSON(lrosaDsPut200InvalidJsonOptions.Product)
 	}
@@ -1368,6 +1385,7 @@ func (client *LrosaDsClient) PutAsyncRelativeRetry400CreateRequest(ctx context.C
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPutAsyncRelativeRetry400Options != nil {
 		return req, req.MarshalAsJSON(lrosaDsPutAsyncRelativeRetry400Options.Product)
 	}
@@ -1439,6 +1457,7 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidHeaderCreateRequest(ctx
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPutAsyncRelativeRetryInvalidHeaderOptions != nil {
 		return req, req.MarshalAsJSON(lrosaDsPutAsyncRelativeRetryInvalidHeaderOptions.Product)
 	}
@@ -1510,6 +1529,7 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidJSONPollingCreateReques
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPutAsyncRelativeRetryInvalidJsonPollingOptions != nil {
 		return req, req.MarshalAsJSON(lrosaDsPutAsyncRelativeRetryInvalidJsonPollingOptions.Product)
 	}
@@ -1581,6 +1601,7 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusCreateRequest(ctx cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPutAsyncRelativeRetryNoStatusOptions != nil {
 		return req, req.MarshalAsJSON(lrosaDsPutAsyncRelativeRetryNoStatusOptions.Product)
 	}
@@ -1652,6 +1673,7 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusPayloadCreateRequest(c
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions != nil {
 		return req, req.MarshalAsJSON(lrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions.Product)
 	}
@@ -1723,6 +1745,7 @@ func (client *LrosaDsClient) PutError201NoProvisioningStatePayloadCreateRequest(
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPutError201NoProvisioningStatePayloadOptions != nil {
 		return req, req.MarshalAsJSON(lrosaDsPutError201NoProvisioningStatePayloadOptions.Product)
 	}
@@ -1794,6 +1817,7 @@ func (client *LrosaDsClient) PutNonRetry201Creating400CreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPutNonRetry201Creating400Options != nil {
 		return req, req.MarshalAsJSON(lrosaDsPutNonRetry201Creating400Options.Product)
 	}
@@ -1865,6 +1889,7 @@ func (client *LrosaDsClient) PutNonRetry201Creating400InvalidJSONCreateRequest(c
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPutNonRetry201Creating400InvalidJsonOptions != nil {
 		return req, req.MarshalAsJSON(lrosaDsPutNonRetry201Creating400InvalidJsonOptions.Product)
 	}
@@ -1936,6 +1961,7 @@ func (client *LrosaDsClient) PutNonRetry400CreateRequest(ctx context.Context, lr
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrosaDsPutNonRetry400Options != nil {
 		return req, req.MarshalAsJSON(lrosaDsPutNonRetry400Options.Product)
 	}

--- a/test/autorest/lrogroup/zz_generated_lroscustomheader.go
+++ b/test/autorest/lrogroup/zz_generated_lroscustomheader.go
@@ -97,6 +97,7 @@ func (client *LrOSCustomHeaderClient) Post202Retry200CreateRequest(ctx context.C
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSCustomHeaderPost202Retry200Options != nil {
 		return req, req.MarshalAsJSON(lrOSCustomHeaderPost202Retry200Options.Product)
 	}
@@ -168,6 +169,7 @@ func (client *LrOSCustomHeaderClient) PostAsyncRetrySucceededCreateRequest(ctx c
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSCustomHeaderPostAsyncRetrySucceededOptions != nil {
 		return req, req.MarshalAsJSON(lrOSCustomHeaderPostAsyncRetrySucceededOptions.Product)
 	}
@@ -239,6 +241,7 @@ func (client *LrOSCustomHeaderClient) Put201CreatingSucceeded200CreateRequest(ct
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSCustomHeaderPut201CreatingSucceeded200Options != nil {
 		return req, req.MarshalAsJSON(lrOSCustomHeaderPut201CreatingSucceeded200Options.Product)
 	}
@@ -310,6 +313,7 @@ func (client *LrOSCustomHeaderClient) PutAsyncRetrySucceededCreateRequest(ctx co
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if lrOSCustomHeaderPutAsyncRetrySucceededOptions != nil {
 		return req, req.MarshalAsJSON(lrOSCustomHeaderPutAsyncRetrySucceededOptions.Product)
 	}

--- a/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient.go
+++ b/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient.go
@@ -78,6 +78,7 @@ func (client *MultipleInheritanceServiceClient) GetCatCreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -123,6 +124,7 @@ func (client *MultipleInheritanceServiceClient) GetFelineCreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -168,6 +170,7 @@ func (client *MultipleInheritanceServiceClient) GetHorseCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -213,6 +216,7 @@ func (client *MultipleInheritanceServiceClient) GetKittenCreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -258,6 +262,7 @@ func (client *MultipleInheritanceServiceClient) GetPetCreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -303,6 +308,7 @@ func (client *MultipleInheritanceServiceClient) PutCatCreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(cat)
 }
 
@@ -351,6 +357,7 @@ func (client *MultipleInheritanceServiceClient) PutFelineCreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(feline)
 }
 
@@ -399,6 +406,7 @@ func (client *MultipleInheritanceServiceClient) PutHorseCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(horse)
 }
 
@@ -447,6 +455,7 @@ func (client *MultipleInheritanceServiceClient) PutKittenCreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(kitten)
 }
 
@@ -495,6 +504,7 @@ func (client *MultipleInheritanceServiceClient) PutPetCreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(pet)
 }
 

--- a/test/autorest/morecustombaseurigroup/zz_generated_paths.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_paths.go
@@ -71,6 +71,7 @@ func (client *PathsClient) GetEmptyCreateRequest(ctx context.Context, vault stri
 		query.Set("keyVersion", *pathsGetEmptyOptions.KeyVersion)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/nonstringenumgroup/zz_generated_float.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_float.go
@@ -62,6 +62,7 @@ func (client *FloatClient) GetCreateRequest(ctx context.Context) (*azcore.Reques
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -110,6 +111,7 @@ func (client *FloatClient) PutCreateRequest(ctx context.Context, floatPutOptions
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if floatPutOptions != nil {
 		return req, req.MarshalAsJSON(floatPutOptions.Input)
 	}

--- a/test/autorest/nonstringenumgroup/zz_generated_int.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_int.go
@@ -62,6 +62,7 @@ func (client *IntClient) GetCreateRequest(ctx context.Context) (*azcore.Request,
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -110,6 +111,7 @@ func (client *IntClient) PutCreateRequest(ctx context.Context, intPutOptions *In
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if intPutOptions != nil {
 		return req, req.MarshalAsJSON(intPutOptions.Input)
 	}

--- a/test/autorest/numbergroup/zz_generated_number.go
+++ b/test/autorest/numbergroup/zz_generated_number.go
@@ -103,6 +103,7 @@ func (client *NumberClient) GetBigDecimalCreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -148,6 +149,7 @@ func (client *NumberClient) GetBigDecimalNegativeDecimalCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -193,6 +195,7 @@ func (client *NumberClient) GetBigDecimalPositiveDecimalCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -238,6 +241,7 @@ func (client *NumberClient) GetBigDoubleCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -283,6 +287,7 @@ func (client *NumberClient) GetBigDoubleNegativeDecimalCreateRequest(ctx context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -328,6 +333,7 @@ func (client *NumberClient) GetBigDoublePositiveDecimalCreateRequest(ctx context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -373,6 +379,7 @@ func (client *NumberClient) GetBigFloatCreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -418,6 +425,7 @@ func (client *NumberClient) GetInvalidDecimalCreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -463,6 +471,7 @@ func (client *NumberClient) GetInvalidDoubleCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -508,6 +517,7 @@ func (client *NumberClient) GetInvalidFloatCreateRequest(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -553,6 +563,7 @@ func (client *NumberClient) GetNullCreateRequest(ctx context.Context) (*azcore.R
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -598,6 +609,7 @@ func (client *NumberClient) GetSmallDecimalCreateRequest(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -643,6 +655,7 @@ func (client *NumberClient) GetSmallDoubleCreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -688,6 +701,7 @@ func (client *NumberClient) GetSmallFloatCreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -733,6 +747,7 @@ func (client *NumberClient) PutBigDecimalCreateRequest(ctx context.Context, numb
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(numberBody)
 }
 
@@ -777,6 +792,7 @@ func (client *NumberClient) PutBigDecimalNegativeDecimalCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(-99999999.99)
 }
 
@@ -821,6 +837,7 @@ func (client *NumberClient) PutBigDecimalPositiveDecimalCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(99999999.99)
 }
 
@@ -865,6 +882,7 @@ func (client *NumberClient) PutBigDoubleCreateRequest(ctx context.Context, numbe
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(numberBody)
 }
 
@@ -909,6 +927,7 @@ func (client *NumberClient) PutBigDoubleNegativeDecimalCreateRequest(ctx context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(-99999999.99)
 }
 
@@ -953,6 +972,7 @@ func (client *NumberClient) PutBigDoublePositiveDecimalCreateRequest(ctx context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(99999999.99)
 }
 
@@ -997,6 +1017,7 @@ func (client *NumberClient) PutBigFloatCreateRequest(ctx context.Context, number
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(numberBody)
 }
 
@@ -1041,6 +1062,7 @@ func (client *NumberClient) PutSmallDecimalCreateRequest(ctx context.Context, nu
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(numberBody)
 }
 
@@ -1085,6 +1107,7 @@ func (client *NumberClient) PutSmallDoubleCreateRequest(ctx context.Context, num
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(numberBody)
 }
 
@@ -1129,6 +1152,7 @@ func (client *NumberClient) PutSmallFloatCreateRequest(ctx context.Context, numb
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(numberBody)
 }
 

--- a/test/autorest/optionalgroup/zz_generated_explicit.go
+++ b/test/autorest/optionalgroup/zz_generated_explicit.go
@@ -104,6 +104,7 @@ func (client *ExplicitClient) PostOptionalArrayHeaderCreateRequest(ctx context.C
 	if explicitPostOptionalArrayHeaderOptions != nil && explicitPostOptionalArrayHeaderOptions.HeaderParameter != nil {
 		req.Header.Set("headerParameter", strings.Join(*explicitPostOptionalArrayHeaderOptions.HeaderParameter, ","))
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -148,6 +149,7 @@ func (client *ExplicitClient) PostOptionalArrayParameterCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if explicitPostOptionalArrayParameterOptions != nil {
 		return req, req.MarshalAsJSON(explicitPostOptionalArrayParameterOptions.BodyParameter)
 	}
@@ -195,6 +197,7 @@ func (client *ExplicitClient) PostOptionalArrayPropertyCreateRequest(ctx context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if explicitPostOptionalArrayPropertyOptions != nil {
 		return req, req.MarshalAsJSON(explicitPostOptionalArrayPropertyOptions.BodyParameter)
 	}
@@ -242,6 +245,7 @@ func (client *ExplicitClient) PostOptionalClassParameterCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if explicitPostOptionalClassParameterOptions != nil {
 		return req, req.MarshalAsJSON(explicitPostOptionalClassParameterOptions.BodyParameter)
 	}
@@ -289,6 +293,7 @@ func (client *ExplicitClient) PostOptionalClassPropertyCreateRequest(ctx context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if explicitPostOptionalClassPropertyOptions != nil {
 		return req, req.MarshalAsJSON(explicitPostOptionalClassPropertyOptions.BodyParameter)
 	}
@@ -339,6 +344,7 @@ func (client *ExplicitClient) PostOptionalIntegerHeaderCreateRequest(ctx context
 	if explicitPostOptionalIntegerHeaderOptions != nil && explicitPostOptionalIntegerHeaderOptions.HeaderParameter != nil {
 		req.Header.Set("headerParameter", strconv.FormatInt(int64(*explicitPostOptionalIntegerHeaderOptions.HeaderParameter), 10))
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -383,6 +389,7 @@ func (client *ExplicitClient) PostOptionalIntegerParameterCreateRequest(ctx cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if explicitPostOptionalIntegerParameterOptions != nil {
 		return req, req.MarshalAsJSON(explicitPostOptionalIntegerParameterOptions.BodyParameter)
 	}
@@ -430,6 +437,7 @@ func (client *ExplicitClient) PostOptionalIntegerPropertyCreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if explicitPostOptionalIntegerPropertyOptions != nil {
 		return req, req.MarshalAsJSON(explicitPostOptionalIntegerPropertyOptions.BodyParameter)
 	}
@@ -480,6 +488,7 @@ func (client *ExplicitClient) PostOptionalStringHeaderCreateRequest(ctx context.
 	if explicitPostOptionalStringHeaderOptions != nil && explicitPostOptionalStringHeaderOptions.BodyParameter != nil {
 		req.Header.Set("bodyParameter", *explicitPostOptionalStringHeaderOptions.BodyParameter)
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -524,6 +533,7 @@ func (client *ExplicitClient) PostOptionalStringParameterCreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if explicitPostOptionalStringParameterOptions != nil {
 		return req, req.MarshalAsJSON(explicitPostOptionalStringParameterOptions.BodyParameter)
 	}
@@ -571,6 +581,7 @@ func (client *ExplicitClient) PostOptionalStringPropertyCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if explicitPostOptionalStringPropertyOptions != nil {
 		return req, req.MarshalAsJSON(explicitPostOptionalStringPropertyOptions.BodyParameter)
 	}
@@ -619,6 +630,7 @@ func (client *ExplicitClient) PostRequiredArrayHeaderCreateRequest(ctx context.C
 		return nil, err
 	}
 	req.Header.Set("headerParameter", strings.Join(headerParameter, ","))
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -663,6 +675,7 @@ func (client *ExplicitClient) PostRequiredArrayParameterCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
@@ -707,6 +720,7 @@ func (client *ExplicitClient) PostRequiredArrayPropertyCreateRequest(ctx context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
@@ -751,6 +765,7 @@ func (client *ExplicitClient) PostRequiredClassParameterCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
@@ -795,6 +810,7 @@ func (client *ExplicitClient) PostRequiredClassPropertyCreateRequest(ctx context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
@@ -840,6 +856,7 @@ func (client *ExplicitClient) PostRequiredIntegerHeaderCreateRequest(ctx context
 		return nil, err
 	}
 	req.Header.Set("headerParameter", strconv.FormatInt(int64(headerParameter), 10))
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -884,6 +901,7 @@ func (client *ExplicitClient) PostRequiredIntegerParameterCreateRequest(ctx cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
@@ -928,6 +946,7 @@ func (client *ExplicitClient) PostRequiredIntegerPropertyCreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
@@ -973,6 +992,7 @@ func (client *ExplicitClient) PostRequiredStringHeaderCreateRequest(ctx context.
 		return nil, err
 	}
 	req.Header.Set("headerParameter", headerParameter)
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1017,6 +1037,7 @@ func (client *ExplicitClient) PostRequiredStringParameterCreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
@@ -1061,6 +1082,7 @@ func (client *ExplicitClient) PostRequiredStringPropertyCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 

--- a/test/autorest/optionalgroup/zz_generated_implicit.go
+++ b/test/autorest/optionalgroup/zz_generated_implicit.go
@@ -80,6 +80,7 @@ func (client *ImplicitClient) GetOptionalGlobalQueryCreateRequest(ctx context.Co
 		query.Set("optional-global-query", strconv.FormatInt(int64(*client.optionalGlobalQuery), 10))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -125,6 +126,7 @@ func (client *ImplicitClient) GetRequiredGlobalPathCreateRequest(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -172,6 +174,7 @@ func (client *ImplicitClient) GetRequiredGlobalQueryCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("required-global-query", client.requiredGlobalQuery)
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -217,6 +220,7 @@ func (client *ImplicitClient) GetRequiredPathCreateRequest(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -261,6 +265,7 @@ func (client *ImplicitClient) PutOptionalBodyCreateRequest(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if implicitPutOptionalBodyOptions != nil {
 		return req, req.MarshalAsJSON(implicitPutOptionalBodyOptions.BodyParameter)
 	}
@@ -311,6 +316,7 @@ func (client *ImplicitClient) PutOptionalHeaderCreateRequest(ctx context.Context
 	if implicitPutOptionalHeaderOptions != nil && implicitPutOptionalHeaderOptions.QueryParameter != nil {
 		req.Header.Set("queryParameter", *implicitPutOptionalHeaderOptions.QueryParameter)
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -360,6 +366,7 @@ func (client *ImplicitClient) PutOptionalQueryCreateRequest(ctx context.Context,
 		query.Set("queryParameter", *implicitPutOptionalQueryOptions.QueryParameter)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/paginggroup/zz_generated_paging.go
+++ b/test/autorest/paginggroup/zz_generated_paging.go
@@ -103,6 +103,7 @@ func (client *PagingClient) GetMultiplePagesCreateRequest(ctx context.Context, p
 	if pagingGetMultiplePagesOptions != nil && pagingGetMultiplePagesOptions.Timeout != nil {
 		req.Header.Set("timeout", strconv.FormatInt(int64(*pagingGetMultiplePagesOptions.Timeout), 10))
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -148,6 +149,7 @@ func (client *PagingClient) GetMultiplePagesFailureCreateRequest(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -193,6 +195,7 @@ func (client *PagingClient) GetMultiplePagesFailureURICreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -242,6 +245,7 @@ func (client *PagingClient) GetMultiplePagesFragmentNextLinkCreateRequest(ctx co
 	query := req.URL.Query()
 	query.Set("api_version", apiVersion)
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -291,6 +295,7 @@ func (client *PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkCreateRe
 	query := req.URL.Query()
 	query.Set("api_version", customParameterGroup.ApiVersion)
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -373,6 +378,7 @@ func (client *PagingClient) GetMultiplePagesLroCreateRequest(ctx context.Context
 	if pagingGetMultiplePagesLroOptions != nil && pagingGetMultiplePagesLroOptions.Timeout != nil {
 		req.Header.Set("timeout", strconv.FormatInt(int64(*pagingGetMultiplePagesLroOptions.Timeout), 10))
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -426,6 +432,7 @@ func (client *PagingClient) GetMultiplePagesRetryFirstCreateRequest(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -471,6 +478,7 @@ func (client *PagingClient) GetMultiplePagesRetrySecondCreateRequest(ctx context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -526,6 +534,7 @@ func (client *PagingClient) GetMultiplePagesWithOffsetCreateRequest(ctx context.
 	if pagingGetMultiplePagesWithOffsetOptions.Timeout != nil {
 		req.Header.Set("timeout", strconv.FormatInt(int64(*pagingGetMultiplePagesWithOffsetOptions.Timeout), 10))
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -571,6 +580,7 @@ func (client *PagingClient) GetNoItemNamePagesCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -619,6 +629,7 @@ func (client *PagingClient) GetNullNextLinkNamePagesCreateRequest(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -673,6 +684,7 @@ func (client *PagingClient) GetOdataMultiplePagesCreateRequest(ctx context.Conte
 	if pagingGetOdataMultiplePagesOptions != nil && pagingGetOdataMultiplePagesOptions.Timeout != nil {
 		req.Header.Set("timeout", strconv.FormatInt(int64(*pagingGetOdataMultiplePagesOptions.Timeout), 10))
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -718,6 +730,7 @@ func (client *PagingClient) GetPagingModelWithItemNameWithXmsClientNameCreateReq
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -763,6 +776,7 @@ func (client *PagingClient) GetSinglePagesCreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -808,6 +822,7 @@ func (client *PagingClient) GetSinglePagesFailureCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -857,6 +872,7 @@ func (client *PagingClient) GetWithQueryParamsCreateRequest(ctx context.Context,
 	query.Set("requiredQueryParameter", strconv.FormatInt(int64(requiredQueryParameter), 10))
 	query.Set("queryConstant", "true")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -893,6 +909,7 @@ func (client *PagingClient) NextFragmentCreateRequest(ctx context.Context, apiVe
 	query := req.URL.Query()
 	query.Set("api_version", apiVersion)
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -929,6 +946,7 @@ func (client *PagingClient) NextFragmentWithGroupingCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api_version", customParameterGroup.ApiVersion)
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -963,6 +981,7 @@ func (client *PagingClient) NextOperationWithQueryParamsCreateRequest(ctx contex
 	query := req.URL.Query()
 	query.Set("queryConstant", "true")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/paramgroupinggroup/zz_generated_parametergrouping.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_parametergrouping.go
@@ -80,6 +80,7 @@ func (client *ParameterGroupingClient) PostMultiParamGroupsCreateRequest(ctx con
 	if parameterGroupingPostMultiParamGroupsSecondParamGroup != nil && parameterGroupingPostMultiParamGroupsSecondParamGroup.HeaderTwo != nil {
 		req.Header.Set("header-two", *parameterGroupingPostMultiParamGroupsSecondParamGroup.HeaderTwo)
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -132,6 +133,7 @@ func (client *ParameterGroupingClient) PostOptionalCreateRequest(ctx context.Con
 	if parameterGroupingPostOptionalParameters != nil && parameterGroupingPostOptionalParameters.CustomHeader != nil {
 		req.Header.Set("customHeader", *parameterGroupingPostOptionalParameters.CustomHeader)
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -185,6 +187,7 @@ func (client *ParameterGroupingClient) PostRequiredCreateRequest(ctx context.Con
 	if parameterGroupingPostRequiredParameters.CustomHeader != nil {
 		req.Header.Set("customHeader", *parameterGroupingPostRequiredParameters.CustomHeader)
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameterGroupingPostRequiredParameters.Body)
 }
 
@@ -237,6 +240,7 @@ func (client *ParameterGroupingClient) PostSharedParameterGroupObjectCreateReque
 	if firstParameterGroup != nil && firstParameterGroup.HeaderOne != nil {
 		req.Header.Set("header-one", *firstParameterGroup.HeaderOne)
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/reportgroup/zz_generated_autorestreportservice.go
+++ b/test/autorest/reportgroup/zz_generated_autorestreportservice.go
@@ -64,6 +64,7 @@ func (client *AutoRestReportServiceClient) GetOptionalReportCreateRequest(ctx co
 		query.Set("qualifier", *autoRestReportServiceGetOptionalReportOptions.Qualifier)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -114,6 +115,7 @@ func (client *AutoRestReportServiceClient) GetReportCreateRequest(ctx context.Co
 		query.Set("qualifier", *autoRestReportServiceGetReportOptions.Qualifier)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/stringgroup/zz_generated_enum.go
+++ b/test/autorest/stringgroup/zz_generated_enum.go
@@ -67,6 +67,7 @@ func (client *EnumClient) GetNotExpandableCreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -112,6 +113,7 @@ func (client *EnumClient) GetReferencedCreateRequest(ctx context.Context) (*azco
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -157,6 +159,7 @@ func (client *EnumClient) GetReferencedConstantCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -202,6 +205,7 @@ func (client *EnumClient) PutNotExpandableCreateRequest(ctx context.Context, str
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(stringBody)
 }
 
@@ -246,6 +250,7 @@ func (client *EnumClient) PutReferencedCreateRequest(ctx context.Context, enumSt
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(enumStringBody)
 }
 
@@ -290,6 +295,7 @@ func (client *EnumClient) PutReferencedConstantCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(enumStringBody)
 }
 

--- a/test/autorest/stringgroup/zz_generated_string.go
+++ b/test/autorest/stringgroup/zz_generated_string.go
@@ -81,6 +81,7 @@ func (client *StringClient) GetBase64EncodedCreateRequest(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -126,6 +127,7 @@ func (client *StringClient) GetBase64URLEncodedCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -171,6 +173,7 @@ func (client *StringClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -216,6 +219,7 @@ func (client *StringClient) GetMBCSCreateRequest(ctx context.Context) (*azcore.R
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -261,6 +265,7 @@ func (client *StringClient) GetNotProvidedCreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -306,6 +311,7 @@ func (client *StringClient) GetNullCreateRequest(ctx context.Context) (*azcore.R
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -351,6 +357,7 @@ func (client *StringClient) GetNullBase64URLEncodedCreateRequest(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -396,6 +403,7 @@ func (client *StringClient) GetWhitespaceCreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -441,6 +449,7 @@ func (client *StringClient) PutBase64URLEncodedCreateRequest(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsByteArray(stringBody, azcore.Base64URLFormat)
 }
 
@@ -485,6 +494,7 @@ func (client *StringClient) PutEmptyCreateRequest(ctx context.Context) (*azcore.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON("")
 }
 
@@ -529,6 +539,7 @@ func (client *StringClient) PutMBCSCreateRequest(ctx context.Context) (*azcore.R
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON("啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€")
 }
 
@@ -573,6 +584,7 @@ func (client *StringClient) PutNullCreateRequest(ctx context.Context, stringPutN
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if stringPutNullOptions != nil {
 		return req, req.MarshalAsJSON(stringPutNullOptions.StringBody)
 	}
@@ -620,6 +632,7 @@ func (client *StringClient) PutWhitespaceCreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON("    Now is the time for all good men to come to the aid of their country    ")
 }
 

--- a/test/autorest/urlgroup/zz_generated_pathitems.go
+++ b/test/autorest/urlgroup/zz_generated_pathitems.go
@@ -81,6 +81,7 @@ func (client *PathItemsClient) GetAllWithValuesCreateRequest(ctx context.Context
 		query.Set("localStringQuery", *pathItemsGetAllWithValuesOptions.LocalStringQuery)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -139,6 +140,7 @@ func (client *PathItemsClient) GetGlobalAndLocalQueryNullCreateRequest(ctx conte
 		query.Set("localStringQuery", *pathItemsGetGlobalAndLocalQueryNullOptions.LocalStringQuery)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -197,6 +199,7 @@ func (client *PathItemsClient) GetGlobalQueryNullCreateRequest(ctx context.Conte
 		query.Set("localStringQuery", *pathItemsGetGlobalQueryNullOptions.LocalStringQuery)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -255,6 +258,7 @@ func (client *PathItemsClient) GetLocalPathItemQueryNullCreateRequest(ctx contex
 		query.Set("localStringQuery", *pathItemsGetLocalPathItemQueryNullOptions.LocalStringQuery)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/urlgroup/zz_generated_paths.go
+++ b/test/autorest/urlgroup/zz_generated_paths.go
@@ -114,6 +114,7 @@ func (client *PathsClient) ArrayCSVInPathCreateRequest(ctx context.Context, arra
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -159,6 +160,7 @@ func (client *PathsClient) Base64URLCreateRequest(ctx context.Context, base64Url
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -204,6 +206,7 @@ func (client *PathsClient) ByteEmptyCreateRequest(ctx context.Context) (*azcore.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -249,6 +252,7 @@ func (client *PathsClient) ByteMultiByteCreateRequest(ctx context.Context, byteP
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -294,6 +298,7 @@ func (client *PathsClient) ByteNullCreateRequest(ctx context.Context, bytePath [
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -339,6 +344,7 @@ func (client *PathsClient) DateNullCreateRequest(ctx context.Context, datePath t
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -384,6 +390,7 @@ func (client *PathsClient) DateTimeNullCreateRequest(ctx context.Context, dateTi
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -429,6 +436,7 @@ func (client *PathsClient) DateTimeValidCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -474,6 +482,7 @@ func (client *PathsClient) DateValidCreateRequest(ctx context.Context) (*azcore.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -519,6 +528,7 @@ func (client *PathsClient) DoubleDecimalNegativeCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -564,6 +574,7 @@ func (client *PathsClient) DoubleDecimalPositiveCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -609,6 +620,7 @@ func (client *PathsClient) EnumNullCreateRequest(ctx context.Context, enumPath U
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -654,6 +666,7 @@ func (client *PathsClient) EnumValidCreateRequest(ctx context.Context, enumPath 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -699,6 +712,7 @@ func (client *PathsClient) FloatScientificNegativeCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -744,6 +758,7 @@ func (client *PathsClient) FloatScientificPositiveCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -789,6 +804,7 @@ func (client *PathsClient) GetBooleanFalseCreateRequest(ctx context.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -834,6 +850,7 @@ func (client *PathsClient) GetBooleanTrueCreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -879,6 +896,7 @@ func (client *PathsClient) GetIntNegativeOneMillionCreateRequest(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -924,6 +942,7 @@ func (client *PathsClient) GetIntOneMillionCreateRequest(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -969,6 +988,7 @@ func (client *PathsClient) GetNegativeTenBillionCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1014,6 +1034,7 @@ func (client *PathsClient) GetTenBillionCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1059,6 +1080,7 @@ func (client *PathsClient) StringEmptyCreateRequest(ctx context.Context) (*azcor
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1104,6 +1126,7 @@ func (client *PathsClient) StringNullCreateRequest(ctx context.Context, stringPa
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1149,6 +1172,7 @@ func (client *PathsClient) StringURLEncodedCreateRequest(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1194,6 +1218,7 @@ func (client *PathsClient) StringURLNonEncodedCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1239,6 +1264,7 @@ func (client *PathsClient) StringUnicodeCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1284,6 +1310,7 @@ func (client *PathsClient) UnixTimeURLCreateRequest(ctx context.Context, unixTim
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/urlgroup/zz_generated_queries.go
+++ b/test/autorest/urlgroup/zz_generated_queries.go
@@ -134,6 +134,7 @@ func (client *QueriesClient) ArrayStringCSVEmptyCreateRequest(ctx context.Contex
 		query.Set("arrayQuery", strings.Join(*queriesArrayStringCsvEmptyOptions.ArrayQuery, ","))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -183,6 +184,7 @@ func (client *QueriesClient) ArrayStringCSVNullCreateRequest(ctx context.Context
 		query.Set("arrayQuery", strings.Join(*queriesArrayStringCsvNullOptions.ArrayQuery, ","))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -232,6 +234,7 @@ func (client *QueriesClient) ArrayStringCSVValidCreateRequest(ctx context.Contex
 		query.Set("arrayQuery", strings.Join(*queriesArrayStringCsvValidOptions.ArrayQuery, ","))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -281,6 +284,7 @@ func (client *QueriesClient) ArrayStringNoCollectionFormatEmptyCreateRequest(ctx
 		query.Set("arrayQuery", strings.Join(*queriesArrayStringNoCollectionFormatEmptyOptions.ArrayQuery, ","))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -330,6 +334,7 @@ func (client *QueriesClient) ArrayStringPipesValidCreateRequest(ctx context.Cont
 		query.Set("arrayQuery", strings.Join(*queriesArrayStringPipesValidOptions.ArrayQuery, "|"))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -379,6 +384,7 @@ func (client *QueriesClient) ArrayStringSsvValidCreateRequest(ctx context.Contex
 		query.Set("arrayQuery", strings.Join(*queriesArrayStringSsvValidOptions.ArrayQuery, " "))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -428,6 +434,7 @@ func (client *QueriesClient) ArrayStringTsvValidCreateRequest(ctx context.Contex
 		query.Set("arrayQuery", strings.Join(*queriesArrayStringTsvValidOptions.ArrayQuery, "\t"))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -475,6 +482,7 @@ func (client *QueriesClient) ByteEmptyCreateRequest(ctx context.Context) (*azcor
 	query := req.URL.Query()
 	query.Set("byteQuery", "")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -524,6 +532,7 @@ func (client *QueriesClient) ByteMultiByteCreateRequest(ctx context.Context, que
 		query.Set("byteQuery", base64.StdEncoding.EncodeToString(*queriesByteMultiByteOptions.ByteQuery))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -573,6 +582,7 @@ func (client *QueriesClient) ByteNullCreateRequest(ctx context.Context, queriesB
 		query.Set("byteQuery", base64.StdEncoding.EncodeToString(*queriesByteNullOptions.ByteQuery))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -622,6 +632,7 @@ func (client *QueriesClient) DateNullCreateRequest(ctx context.Context, queriesD
 		query.Set("dateQuery", queriesDateNullOptions.DateQuery.Format("2006-01-02"))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -671,6 +682,7 @@ func (client *QueriesClient) DateTimeNullCreateRequest(ctx context.Context, quer
 		query.Set("dateTimeQuery", queriesDateTimeNullOptions.DateTimeQuery.Format(time.RFC3339Nano))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -718,6 +730,7 @@ func (client *QueriesClient) DateTimeValidCreateRequest(ctx context.Context) (*a
 	query := req.URL.Query()
 	query.Set("dateTimeQuery", "2012-01-01T01:01:01Z")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -765,6 +778,7 @@ func (client *QueriesClient) DateValidCreateRequest(ctx context.Context) (*azcor
 	query := req.URL.Query()
 	query.Set("dateQuery", "2012-01-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -812,6 +826,7 @@ func (client *QueriesClient) DoubleDecimalNegativeCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("doubleQuery", "-9999999.999")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -859,6 +874,7 @@ func (client *QueriesClient) DoubleDecimalPositiveCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("doubleQuery", "9999999.999")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -908,6 +924,7 @@ func (client *QueriesClient) DoubleNullCreateRequest(ctx context.Context, querie
 		query.Set("doubleQuery", strconv.FormatFloat(*queriesDoubleNullOptions.DoubleQuery, 'f', -1, 64))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -957,6 +974,7 @@ func (client *QueriesClient) EnumNullCreateRequest(ctx context.Context, queriesE
 		query.Set("enumQuery", string(*queriesEnumNullOptions.EnumQuery))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1006,6 +1024,7 @@ func (client *QueriesClient) EnumValidCreateRequest(ctx context.Context, queries
 		query.Set("enumQuery", string(*queriesEnumValidOptions.EnumQuery))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1055,6 +1074,7 @@ func (client *QueriesClient) FloatNullCreateRequest(ctx context.Context, queries
 		query.Set("floatQuery", strconv.FormatFloat(float64(*queriesFloatNullOptions.FloatQuery), 'f', -1, 32))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1102,6 +1122,7 @@ func (client *QueriesClient) FloatScientificNegativeCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("floatQuery", "-1.034e-20")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1149,6 +1170,7 @@ func (client *QueriesClient) FloatScientificPositiveCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("floatQuery", "103400000000000000000")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1196,6 +1218,7 @@ func (client *QueriesClient) GetBooleanFalseCreateRequest(ctx context.Context) (
 	query := req.URL.Query()
 	query.Set("boolQuery", "false")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1245,6 +1268,7 @@ func (client *QueriesClient) GetBooleanNullCreateRequest(ctx context.Context, qu
 		query.Set("boolQuery", strconv.FormatBool(*queriesGetBooleanNullOptions.BoolQuery))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1292,6 +1316,7 @@ func (client *QueriesClient) GetBooleanTrueCreateRequest(ctx context.Context) (*
 	query := req.URL.Query()
 	query.Set("boolQuery", "true")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1339,6 +1364,7 @@ func (client *QueriesClient) GetIntNegativeOneMillionCreateRequest(ctx context.C
 	query := req.URL.Query()
 	query.Set("intQuery", "-1000000")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1388,6 +1414,7 @@ func (client *QueriesClient) GetIntNullCreateRequest(ctx context.Context, querie
 		query.Set("intQuery", strconv.FormatInt(int64(*queriesGetIntNullOptions.IntQuery), 10))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1435,6 +1462,7 @@ func (client *QueriesClient) GetIntOneMillionCreateRequest(ctx context.Context) 
 	query := req.URL.Query()
 	query.Set("intQuery", "1000000")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1484,6 +1512,7 @@ func (client *QueriesClient) GetLongNullCreateRequest(ctx context.Context, queri
 		query.Set("longQuery", strconv.FormatInt(*queriesGetLongNullOptions.LongQuery, 10))
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1531,6 +1560,7 @@ func (client *QueriesClient) GetNegativeTenBillionCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("longQuery", "-10000000000")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1578,6 +1608,7 @@ func (client *QueriesClient) GetTenBillionCreateRequest(ctx context.Context) (*a
 	query := req.URL.Query()
 	query.Set("longQuery", "10000000000")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1625,6 +1656,7 @@ func (client *QueriesClient) StringEmptyCreateRequest(ctx context.Context) (*azc
 	query := req.URL.Query()
 	query.Set("stringQuery", "")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1674,6 +1706,7 @@ func (client *QueriesClient) StringNullCreateRequest(ctx context.Context, querie
 		query.Set("stringQuery", *queriesStringNullOptions.StringQuery)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1721,6 +1754,7 @@ func (client *QueriesClient) StringURLEncodedCreateRequest(ctx context.Context) 
 	query := req.URL.Query()
 	query.Set("stringQuery", "begin!*'();:@ &=+$,/?#[]end")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1768,6 +1802,7 @@ func (client *QueriesClient) StringUnicodeCreateRequest(ctx context.Context) (*a
 	query := req.URL.Query()
 	query.Set("stringQuery", "啊齄丂狛狜隣郎隣兀﨩")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/urlmultigroup/zz_generated_queries.go
+++ b/test/autorest/urlmultigroup/zz_generated_queries.go
@@ -68,6 +68,7 @@ func (client *QueriesClient) ArrayStringMultiEmptyCreateRequest(ctx context.Cont
 		}
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -119,6 +120,7 @@ func (client *QueriesClient) ArrayStringMultiNullCreateRequest(ctx context.Conte
 		}
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -170,6 +172,7 @@ func (client *QueriesClient) ArrayStringMultiValidCreateRequest(ctx context.Cont
 		}
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/validationgroup/zz_generated_autorestvalidationtest.go
+++ b/test/autorest/validationgroup/zz_generated_autorestvalidationtest.go
@@ -115,6 +115,7 @@ func (client *AutoRestValidationTestClient) PostWithConstantInBodyCreateRequest(
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	if autoRestValidationTestPostWithConstantInBodyOptions != nil {
 		return req, req.MarshalAsJSON(autoRestValidationTestPostWithConstantInBodyOptions.Body)
 	}
@@ -172,6 +173,7 @@ func (client *AutoRestValidationTestClient) ValidationOfBodyCreateRequest(ctx co
 	query := req.URL.Query()
 	query.Set("apiVersion", "1.0.0")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	if autoRestValidationTestValidationOfBodyOptions != nil {
 		return req, req.MarshalAsJSON(autoRestValidationTestValidationOfBodyOptions.Body)
 	}
@@ -226,6 +228,7 @@ func (client *AutoRestValidationTestClient) ValidationOfMethodParametersCreateRe
 	query := req.URL.Query()
 	query.Set("apiVersion", "1.0.0")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/autorest/xmlgroup/zz_generated_xml.go
+++ b/test/autorest/xmlgroup/zz_generated_xml.go
@@ -123,6 +123,7 @@ func (client *XMLClient) GetACLsCreateRequest(ctx context.Context) (*azcore.Requ
 	query.Set("comp", "acl")
 	query.Set("restype", "container")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -171,6 +172,7 @@ func (client *XMLClient) GetComplexTypeRefNoMetaCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -219,6 +221,7 @@ func (client *XMLClient) GetComplexTypeRefWithMetaCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -267,6 +270,7 @@ func (client *XMLClient) GetEmptyChildElementCreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -315,6 +319,7 @@ func (client *XMLClient) GetEmptyListCreateRequest(ctx context.Context) (*azcore
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -363,6 +368,7 @@ func (client *XMLClient) GetEmptyRootListCreateRequest(ctx context.Context) (*az
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -411,6 +417,7 @@ func (client *XMLClient) GetEmptyWrappedListsCreateRequest(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -510,6 +517,7 @@ func (client *XMLClient) GetRootListCreateRequest(ctx context.Context) (*azcore.
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -558,6 +566,7 @@ func (client *XMLClient) GetRootListSingleItemCreateRequest(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -610,6 +619,7 @@ func (client *XMLClient) GetServicePropertiesCreateRequest(ctx context.Context) 
 	query.Set("comp", "properties")
 	query.Set("restype", "service")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -658,6 +668,7 @@ func (client *XMLClient) GetSimpleCreateRequest(ctx context.Context) (*azcore.Re
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -703,6 +714,7 @@ func (client *XMLClient) GetWrappedListsCreateRequest(ctx context.Context) (*azc
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -751,6 +763,7 @@ func (client *XMLClient) GetXMSTextCreateRequest(ctx context.Context) (*azcore.R
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -846,6 +859,7 @@ func (client *XMLClient) JSONOutputCreateRequest(ctx context.Context) (*azcore.R
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -898,6 +912,7 @@ func (client *XMLClient) ListBlobsCreateRequest(ctx context.Context) (*azcore.Re
 	query.Set("comp", "list")
 	query.Set("restype", "container")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -949,6 +964,7 @@ func (client *XMLClient) ListContainersCreateRequest(ctx context.Context) (*azco
 	query := req.URL.Query()
 	query.Set("comp", "list")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -1491,6 +1507,7 @@ func (client *XMLClient) PutSimpleCreateRequest(ctx context.Context, slideshow S
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, req.MarshalAsXML(slideshow)
 }
 
@@ -1535,6 +1552,7 @@ func (client *XMLClient) PutWrappedListsCreateRequest(ctx context.Context, wrapp
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, req.MarshalAsXML(wrappedLists)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
@@ -139,6 +139,7 @@ func (client *ApplicationGatewaysClient) BackendHealthCreateRequest(ctx context.
 		query.Set("$expand", *applicationGatewaysBackendHealthOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -216,6 +217,7 @@ func (client *ApplicationGatewaysClient) BackendHealthOnDemandCreateRequest(ctx 
 		query.Set("$expand", *applicationGatewaysBackendHealthOnDemandOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(probeRequest)
 }
 
@@ -290,6 +292,7 @@ func (client *ApplicationGatewaysClient) CreateOrUpdateCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -364,6 +367,7 @@ func (client *ApplicationGatewaysClient) DeleteCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -414,6 +418,7 @@ func (client *ApplicationGatewaysClient) GetCreateRequest(ctx context.Context, r
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -464,6 +469,7 @@ func (client *ApplicationGatewaysClient) GetSslPredefinedPolicyCreateRequest(ctx
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -511,6 +517,7 @@ func (client *ApplicationGatewaysClient) ListCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -557,6 +564,7 @@ func (client *ApplicationGatewaysClient) ListAllCreateRequest(ctx context.Contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -606,6 +614,7 @@ func (client *ApplicationGatewaysClient) ListAvailableRequestHeadersCreateReques
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -655,6 +664,7 @@ func (client *ApplicationGatewaysClient) ListAvailableResponseHeadersCreateReque
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -704,6 +714,7 @@ func (client *ApplicationGatewaysClient) ListAvailableServerVariablesCreateReque
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -753,6 +764,7 @@ func (client *ApplicationGatewaysClient) ListAvailableSslOptionsCreateRequest(ct
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -799,6 +811,7 @@ func (client *ApplicationGatewaysClient) ListAvailableSslPredefinedPoliciesCreat
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -848,6 +861,7 @@ func (client *ApplicationGatewaysClient) ListAvailableWafRuleSetsCreateRequest(c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -923,6 +937,7 @@ func (client *ApplicationGatewaysClient) StartCreateRequest(ctx context.Context,
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -997,6 +1012,7 @@ func (client *ApplicationGatewaysClient) StopCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1047,6 +1063,7 @@ func (client *ApplicationGatewaysClient) UpdateTagsCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups.go
@@ -106,6 +106,7 @@ func (client *ApplicationSecurityGroupsClient) CreateOrUpdateCreateRequest(ctx c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -180,6 +181,7 @@ func (client *ApplicationSecurityGroupsClient) DeleteCreateRequest(ctx context.C
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -230,6 +232,7 @@ func (client *ApplicationSecurityGroupsClient) GetCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *ApplicationSecurityGroupsClient) ListCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -323,6 +327,7 @@ func (client *ApplicationSecurityGroupsClient) ListAllCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -374,6 +379,7 @@ func (client *ApplicationSecurityGroupsClient) UpdateTagsCreateRequest(ctx conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations.go
@@ -62,6 +62,7 @@ func (client *AvailableDelegationsClient) ListCreateRequest(ctx context.Context,
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices.go
@@ -62,6 +62,7 @@ func (client *AvailableEndpointServicesClient) ListCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes.go
@@ -64,6 +64,7 @@ func (client *AvailablePrivateEndpointTypesClient) ListCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -112,6 +113,7 @@ func (client *AvailablePrivateEndpointTypesClient) ListByResourceGroupCreateRequ
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations.go
@@ -63,6 +63,7 @@ func (client *AvailableResourceGroupDelegationsClient) ListCreateRequest(ctx con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases.go
@@ -64,6 +64,7 @@ func (client *AvailableServiceAliasesClient) ListCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -112,6 +113,7 @@ func (client *AvailableServiceAliasesClient) ListByResourceGroupCreateRequest(ct
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags.go
@@ -61,6 +61,7 @@ func (client *AzureFirewallFqdnTagsClient) ListAllCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls.go
@@ -108,6 +108,7 @@ func (client *AzureFirewallsClient) CreateOrUpdateCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -182,6 +183,7 @@ func (client *AzureFirewallsClient) DeleteCreateRequest(ctx context.Context, res
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -232,6 +234,7 @@ func (client *AzureFirewallsClient) GetCreateRequest(ctx context.Context, resour
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -279,6 +282,7 @@ func (client *AzureFirewallsClient) ListCreateRequest(ctx context.Context, resou
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -325,6 +329,7 @@ func (client *AzureFirewallsClient) ListAllCreateRequest(ctx context.Context) (*
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -400,6 +405,7 @@ func (client *AzureFirewallsClient) UpdateTagsCreateRequest(ctx context.Context,
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts.go
@@ -104,6 +104,7 @@ func (client *BastionHostsClient) CreateOrUpdateCreateRequest(ctx context.Contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -178,6 +179,7 @@ func (client *BastionHostsClient) DeleteCreateRequest(ctx context.Context, resou
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -228,6 +230,7 @@ func (client *BastionHostsClient) GetCreateRequest(ctx context.Context, resource
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -274,6 +277,7 @@ func (client *BastionHostsClient) ListCreateRequest(ctx context.Context) (*azcor
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -321,6 +325,7 @@ func (client *BastionHostsClient) ListByResourceGroupCreateRequest(ctx context.C
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities.go
@@ -61,6 +61,7 @@ func (client *BgpServiceCommunitiesClient) ListCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors.go
@@ -117,6 +117,7 @@ func (client *ConnectionMonitorsClient) CreateOrUpdateCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -192,6 +193,7 @@ func (client *ConnectionMonitorsClient) DeleteCreateRequest(ctx context.Context,
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -243,6 +245,7 @@ func (client *ConnectionMonitorsClient) GetCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -294,6 +297,7 @@ func (client *ConnectionMonitorsClient) ListCreateRequest(ctx context.Context, r
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -370,6 +374,7 @@ func (client *ConnectionMonitorsClient) QueryCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -445,6 +450,7 @@ func (client *ConnectionMonitorsClient) StartCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -520,6 +526,7 @@ func (client *ConnectionMonitorsClient) StopCreateRequest(ctx context.Context, r
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -571,6 +578,7 @@ func (client *ConnectionMonitorsClient) UpdateTagsCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies.go
@@ -102,6 +102,7 @@ func (client *DdosCustomPoliciesClient) CreateOrUpdateCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -176,6 +177,7 @@ func (client *DdosCustomPoliciesClient) DeleteCreateRequest(ctx context.Context,
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -226,6 +228,7 @@ func (client *DdosCustomPoliciesClient) GetCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *DdosCustomPoliciesClient) UpdateTagsCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans.go
@@ -106,6 +106,7 @@ func (client *DdosProtectionPlansClient) CreateOrUpdateCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -180,6 +181,7 @@ func (client *DdosProtectionPlansClient) DeleteCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -230,6 +232,7 @@ func (client *DdosProtectionPlansClient) GetCreateRequest(ctx context.Context, r
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -276,6 +279,7 @@ func (client *DdosProtectionPlansClient) ListCreateRequest(ctx context.Context) 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -323,6 +327,7 @@ func (client *DdosProtectionPlansClient) ListByResourceGroupCreateRequest(ctx co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -374,6 +379,7 @@ func (client *DdosProtectionPlansClient) UpdateTagsCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules.go
@@ -69,6 +69,7 @@ func (client *DefaultSecurityRulesClient) GetCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -117,6 +118,7 @@ func (client *DefaultSecurityRulesClient) ListCreateRequest(ctx context.Context,
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations.go
@@ -103,6 +103,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) CreateOrUpdateCreateReque
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(authorizationParameters)
 }
 
@@ -178,6 +179,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) DeleteCreateRequest(ctx c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) GetCreateRequest(ctx cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) ListCreateRequest(ctx con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections.go
@@ -104,6 +104,7 @@ func (client *ExpressRouteCircuitConnectionsClient) CreateOrUpdateCreateRequest(
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(expressRouteCircuitConnectionParameters)
 }
 
@@ -180,6 +181,7 @@ func (client *ExpressRouteCircuitConnectionsClient) DeleteCreateRequest(ctx cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -232,6 +234,7 @@ func (client *ExpressRouteCircuitConnectionsClient) GetCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -281,6 +284,7 @@ func (client *ExpressRouteCircuitConnectionsClient) ListCreateRequest(ctx contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings.go
@@ -103,6 +103,7 @@ func (client *ExpressRouteCircuitPeeringsClient) CreateOrUpdateCreateRequest(ctx
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(peeringParameters)
 }
 
@@ -178,6 +179,7 @@ func (client *ExpressRouteCircuitPeeringsClient) DeleteCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *ExpressRouteCircuitPeeringsClient) GetCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *ExpressRouteCircuitPeeringsClient) ListCreateRequest(ctx context.C
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits.go
@@ -122,6 +122,7 @@ func (client *ExpressRouteCircuitsClient) CreateOrUpdateCreateRequest(ctx contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -196,6 +197,7 @@ func (client *ExpressRouteCircuitsClient) DeleteCreateRequest(ctx context.Contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -246,6 +248,7 @@ func (client *ExpressRouteCircuitsClient) GetCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -298,6 +301,7 @@ func (client *ExpressRouteCircuitsClient) GetPeeringStatsCreateRequest(ctx conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -349,6 +353,7 @@ func (client *ExpressRouteCircuitsClient) GetStatsCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -396,6 +401,7 @@ func (client *ExpressRouteCircuitsClient) ListCreateRequest(ctx context.Context,
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -442,6 +448,7 @@ func (client *ExpressRouteCircuitsClient) ListAllCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -519,6 +526,7 @@ func (client *ExpressRouteCircuitsClient) ListArpTableCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -595,6 +603,7 @@ func (client *ExpressRouteCircuitsClient) ListRoutesTableCreateRequest(ctx conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -671,6 +680,7 @@ func (client *ExpressRouteCircuitsClient) ListRoutesTableSummaryCreateRequest(ct
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -721,6 +731,7 @@ func (client *ExpressRouteCircuitsClient) UpdateTagsCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections.go
@@ -103,6 +103,7 @@ func (client *ExpressRouteConnectionsClient) CreateOrUpdateCreateRequest(ctx con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(putExpressRouteConnectionParameters)
 }
 
@@ -178,6 +179,7 @@ func (client *ExpressRouteConnectionsClient) DeleteCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *ExpressRouteConnectionsClient) GetCreateRequest(ctx context.Contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -280,6 +283,7 @@ func (client *ExpressRouteConnectionsClient) ListCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings.go
@@ -103,6 +103,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) CreateOrUpdateCreateReq
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(peeringParameters)
 }
 
@@ -178,6 +179,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) DeleteCreateRequest(ctx
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) GetCreateRequest(ctx co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) ListCreateRequest(ctx c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections.go
@@ -114,6 +114,7 @@ func (client *ExpressRouteCrossConnectionsClient) CreateOrUpdateCreateRequest(ct
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -164,6 +165,7 @@ func (client *ExpressRouteCrossConnectionsClient) GetCreateRequest(ctx context.C
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -210,6 +212,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -287,6 +290,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListArpTableCreateRequest(ctx 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -333,6 +337,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListByResourceGroupCreateReque
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -410,6 +415,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableCreateRequest(c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -486,6 +492,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableSummaryCreateRe
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -536,6 +543,7 @@ func (client *ExpressRouteCrossConnectionsClient) UpdateTagsCreateRequest(ctx co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(crossConnectionParameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways.go
@@ -104,6 +104,7 @@ func (client *ExpressRouteGatewaysClient) CreateOrUpdateCreateRequest(ctx contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(putExpressRouteGatewayParameters)
 }
 
@@ -178,6 +179,7 @@ func (client *ExpressRouteGatewaysClient) DeleteCreateRequest(ctx context.Contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -228,6 +230,7 @@ func (client *ExpressRouteGatewaysClient) GetCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -278,6 +281,7 @@ func (client *ExpressRouteGatewaysClient) ListByResourceGroupCreateRequest(ctx c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -327,6 +331,7 @@ func (client *ExpressRouteGatewaysClient) ListBySubscriptionCreateRequest(ctx co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks.go
@@ -69,6 +69,7 @@ func (client *ExpressRouteLinksClient) GetCreateRequest(ctx context.Context, res
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -117,6 +118,7 @@ func (client *ExpressRouteLinksClient) ListCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports.go
@@ -106,6 +106,7 @@ func (client *ExpressRoutePortsClient) CreateOrUpdateCreateRequest(ctx context.C
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -180,6 +181,7 @@ func (client *ExpressRoutePortsClient) DeleteCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -230,6 +232,7 @@ func (client *ExpressRoutePortsClient) GetCreateRequest(ctx context.Context, res
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -276,6 +279,7 @@ func (client *ExpressRoutePortsClient) ListCreateRequest(ctx context.Context) (*
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -323,6 +327,7 @@ func (client *ExpressRoutePortsClient) ListByResourceGroupCreateRequest(ctx cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -374,6 +379,7 @@ func (client *ExpressRoutePortsClient) UpdateTagsCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations.go
@@ -67,6 +67,7 @@ func (client *ExpressRoutePortsLocationsClient) GetCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -113,6 +114,7 @@ func (client *ExpressRoutePortsLocationsClient) ListCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders.go
@@ -61,6 +61,7 @@ func (client *ExpressRouteServiceProvidersClient) ListCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies.go
@@ -104,6 +104,7 @@ func (client *FirewallPoliciesClient) CreateOrUpdateCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -178,6 +179,7 @@ func (client *FirewallPoliciesClient) DeleteCreateRequest(ctx context.Context, r
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -231,6 +233,7 @@ func (client *FirewallPoliciesClient) GetCreateRequest(ctx context.Context, reso
 		query.Set("$expand", *firewallPoliciesGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -278,6 +281,7 @@ func (client *FirewallPoliciesClient) ListCreateRequest(ctx context.Context, res
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -324,6 +328,7 @@ func (client *FirewallPoliciesClient) ListAllCreateRequest(ctx context.Context) 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups.go
@@ -103,6 +103,7 @@ func (client *FirewallPolicyRuleGroupsClient) CreateOrUpdateCreateRequest(ctx co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -178,6 +179,7 @@ func (client *FirewallPolicyRuleGroupsClient) DeleteCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *FirewallPolicyRuleGroupsClient) GetCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *FirewallPolicyRuleGroupsClient) ListCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_flowlogs.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_flowlogs.go
@@ -103,6 +103,7 @@ func (client *FlowLogsClient) CreateOrUpdateCreateRequest(ctx context.Context, r
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -178,6 +179,7 @@ func (client *FlowLogsClient) DeleteCreateRequest(ctx context.Context, resourceG
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *FlowLogsClient) GetCreateRequest(ctx context.Context, resourceGrou
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *FlowLogsClient) ListCreateRequest(ctx context.Context, resourceGro
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections.go
@@ -69,6 +69,7 @@ func (client *HubVirtualNetworkConnectionsClient) GetCreateRequest(ctx context.C
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -117,6 +118,7 @@ func (client *HubVirtualNetworkConnectionsClient) ListCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules.go
@@ -103,6 +103,7 @@ func (client *InboundNatRulesClient) CreateOrUpdateCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(inboundNatRuleParameters)
 }
 
@@ -178,6 +179,7 @@ func (client *InboundNatRulesClient) DeleteCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -232,6 +234,7 @@ func (client *InboundNatRulesClient) GetCreateRequest(ctx context.Context, resou
 		query.Set("$expand", *inboundNatRulesGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -280,6 +283,7 @@ func (client *InboundNatRulesClient) ListCreateRequest(ctx context.Context, reso
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipallocations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipallocations.go
@@ -106,6 +106,7 @@ func (client *IPAllocationsClient) CreateOrUpdateCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -180,6 +181,7 @@ func (client *IPAllocationsClient) DeleteCreateRequest(ctx context.Context, reso
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -233,6 +235,7 @@ func (client *IPAllocationsClient) GetCreateRequest(ctx context.Context, resourc
 		query.Set("$expand", *ipAllocationsGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -279,6 +282,7 @@ func (client *IPAllocationsClient) ListCreateRequest(ctx context.Context) (*azco
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -326,6 +330,7 @@ func (client *IPAllocationsClient) ListByResourceGroupCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -377,6 +382,7 @@ func (client *IPAllocationsClient) UpdateTagsCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipgroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipgroups.go
@@ -106,6 +106,7 @@ func (client *IPGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, r
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -180,6 +181,7 @@ func (client *IPGroupsClient) DeleteCreateRequest(ctx context.Context, resourceG
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -233,6 +235,7 @@ func (client *IPGroupsClient) GetCreateRequest(ctx context.Context, resourceGrou
 		query.Set("$expand", *ipGroupsGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -279,6 +282,7 @@ func (client *IPGroupsClient) ListCreateRequest(ctx context.Context) (*azcore.Re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -326,6 +330,7 @@ func (client *IPGroupsClient) ListByResourceGroupCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -377,6 +382,7 @@ func (client *IPGroupsClient) UpdateGroupsCreateRequest(ctx context.Context, res
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools.go
@@ -69,6 +69,7 @@ func (client *LoadBalancerBackendAddressPoolsClient) GetCreateRequest(ctx contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -117,6 +118,7 @@ func (client *LoadBalancerBackendAddressPoolsClient) ListCreateRequest(ctx conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations.go
@@ -69,6 +69,7 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) GetCreateRequest(ctx c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -117,6 +118,7 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) ListCreateRequest(ctx 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules.go
@@ -69,6 +69,7 @@ func (client *LoadBalancerLoadBalancingRulesClient) GetCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -117,6 +118,7 @@ func (client *LoadBalancerLoadBalancingRulesClient) ListCreateRequest(ctx contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces.go
@@ -63,6 +63,7 @@ func (client *LoadBalancerNetworkInterfacesClient) ListCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules.go
@@ -69,6 +69,7 @@ func (client *LoadBalancerOutboundRulesClient) GetCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -117,6 +118,7 @@ func (client *LoadBalancerOutboundRulesClient) ListCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes.go
@@ -69,6 +69,7 @@ func (client *LoadBalancerProbesClient) GetCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -117,6 +118,7 @@ func (client *LoadBalancerProbesClient) ListCreateRequest(ctx context.Context, r
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers.go
@@ -106,6 +106,7 @@ func (client *LoadBalancersClient) CreateOrUpdateCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -180,6 +181,7 @@ func (client *LoadBalancersClient) DeleteCreateRequest(ctx context.Context, reso
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -233,6 +235,7 @@ func (client *LoadBalancersClient) GetCreateRequest(ctx context.Context, resourc
 		query.Set("$expand", *loadBalancersGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -280,6 +283,7 @@ func (client *LoadBalancersClient) ListCreateRequest(ctx context.Context, resour
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -326,6 +330,7 @@ func (client *LoadBalancersClient) ListAllCreateRequest(ctx context.Context) (*a
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -377,6 +382,7 @@ func (client *LoadBalancersClient) UpdateTagsCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways.go
@@ -104,6 +104,7 @@ func (client *LocalNetworkGatewaysClient) CreateOrUpdateCreateRequest(ctx contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -178,6 +179,7 @@ func (client *LocalNetworkGatewaysClient) DeleteCreateRequest(ctx context.Contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -228,6 +230,7 @@ func (client *LocalNetworkGatewaysClient) GetCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -275,6 +278,7 @@ func (client *LocalNetworkGatewaysClient) ListCreateRequest(ctx context.Context,
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -326,6 +330,7 @@ func (client *LocalNetworkGatewaysClient) UpdateTagsCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_natgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_natgateways.go
@@ -106,6 +106,7 @@ func (client *NatGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -180,6 +181,7 @@ func (client *NatGatewaysClient) DeleteCreateRequest(ctx context.Context, resour
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -233,6 +235,7 @@ func (client *NatGatewaysClient) GetCreateRequest(ctx context.Context, resourceG
 		query.Set("$expand", *natGatewaysGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -280,6 +283,7 @@ func (client *NatGatewaysClient) ListCreateRequest(ctx context.Context, resource
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -326,6 +330,7 @@ func (client *NatGatewaysClient) ListAllCreateRequest(ctx context.Context) (*azc
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -377,6 +382,7 @@ func (client *NatGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations.go
@@ -69,6 +69,7 @@ func (client *NetworkInterfaceIPConfigurationsClient) GetCreateRequest(ctx conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -117,6 +118,7 @@ func (client *NetworkInterfaceIPConfigurationsClient) ListCreateRequest(ctx cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers.go
@@ -63,6 +63,7 @@ func (client *NetworkInterfaceLoadBalancersClient) ListCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces.go
@@ -124,6 +124,7 @@ func (client *NetworkInterfacesClient) CreateOrUpdateCreateRequest(ctx context.C
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -198,6 +199,7 @@ func (client *NetworkInterfacesClient) DeleteCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -251,6 +253,7 @@ func (client *NetworkInterfacesClient) GetCreateRequest(ctx context.Context, res
 		query.Set("$expand", *networkInterfacesGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -326,6 +329,7 @@ func (client *NetworkInterfacesClient) GetEffectiveRouteTableCreateRequest(ctx c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -382,6 +386,7 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfigurationC
 		query.Set("$expand", *networkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -438,6 +443,7 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterface
 		query.Set("$expand", *networkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -485,6 +491,7 @@ func (client *NetworkInterfacesClient) ListCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -531,6 +538,7 @@ func (client *NetworkInterfacesClient) ListAllCreateRequest(ctx context.Context)
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -606,6 +614,7 @@ func (client *NetworkInterfacesClient) ListEffectiveNetworkSecurityGroupsCreateR
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -658,6 +667,7 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfiguration
 		query.Set("$expand", *networkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -706,6 +716,7 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfac
 	query := req.URL.Query()
 	query.Set("api-version", "2018-10-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -755,6 +766,7 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterf
 	query := req.URL.Query()
 	query.Set("api-version", "2018-10-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -806,6 +818,7 @@ func (client *NetworkInterfacesClient) UpdateTagsCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations.go
@@ -103,6 +103,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) CreateOrUpdateCreateReque
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(tapConfigurationParameters)
 }
 
@@ -178,6 +179,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) DeleteCreateRequest(ctx c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) GetCreateRequest(ctx cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) ListCreateRequest(ctx con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient.go
@@ -90,6 +90,7 @@ func (client *NetworkManagementClient) CheckDNSNameAvailabilityCreateRequest(ctx
 	query.Set("domainNameLabel", domainNameLabel)
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -165,6 +166,7 @@ func (client *NetworkManagementClient) DeleteBastionShareableLinkCreateRequest(c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(bslRequest)
 }
 
@@ -212,6 +214,7 @@ func (client *NetworkManagementClient) DisconnectActiveSessionsCreateRequest(ctx
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(sessionIds)
 }
 
@@ -287,6 +290,7 @@ func (client *NetworkManagementClient) Generatevirtualwanvpnserverconfigurationv
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(vpnClientParams)
 }
 
@@ -362,6 +366,7 @@ func (client *NetworkManagementClient) GetActiveSessionsCreateRequest(ctx contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -418,6 +423,7 @@ func (client *NetworkManagementClient) GetBastionShareableLinkCreateRequest(ctx 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(bslRequest)
 }
 
@@ -494,6 +500,7 @@ func (client *NetworkManagementClient) PutBastionShareableLinkCreateRequest(ctx 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(bslRequest)
 }
 
@@ -553,6 +560,7 @@ func (client *NetworkManagementClient) SupportedSecurityProvidersCreateRequest(c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles.go
@@ -80,6 +80,7 @@ func (client *NetworkProfilesClient) CreateOrUpdateCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -155,6 +156,7 @@ func (client *NetworkProfilesClient) DeleteCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -208,6 +210,7 @@ func (client *NetworkProfilesClient) GetCreateRequest(ctx context.Context, resou
 		query.Set("$expand", *networkProfilesGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -255,6 +258,7 @@ func (client *NetworkProfilesClient) ListCreateRequest(ctx context.Context, reso
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -301,6 +305,7 @@ func (client *NetworkProfilesClient) ListAllCreateRequest(ctx context.Context) (
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -352,6 +357,7 @@ func (client *NetworkProfilesClient) UpdateTagsCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups.go
@@ -106,6 +106,7 @@ func (client *NetworkSecurityGroupsClient) CreateOrUpdateCreateRequest(ctx conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -180,6 +181,7 @@ func (client *NetworkSecurityGroupsClient) DeleteCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -233,6 +235,7 @@ func (client *NetworkSecurityGroupsClient) GetCreateRequest(ctx context.Context,
 		query.Set("$expand", *networkSecurityGroupsGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -280,6 +283,7 @@ func (client *NetworkSecurityGroupsClient) ListCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -326,6 +330,7 @@ func (client *NetworkSecurityGroupsClient) ListAllCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -377,6 +382,7 @@ func (client *NetworkSecurityGroupsClient) UpdateTagsCreateRequest(ctx context.C
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances.go
@@ -106,6 +106,7 @@ func (client *NetworkVirtualAppliancesClient) CreateOrUpdateCreateRequest(ctx co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -180,6 +181,7 @@ func (client *NetworkVirtualAppliancesClient) DeleteCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -233,6 +235,7 @@ func (client *NetworkVirtualAppliancesClient) GetCreateRequest(ctx context.Conte
 		query.Set("$expand", *networkVirtualAppliancesGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -279,6 +282,7 @@ func (client *NetworkVirtualAppliancesClient) ListCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -326,6 +330,7 @@ func (client *NetworkVirtualAppliancesClient) ListByResourceGroupCreateRequest(c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -377,6 +382,7 @@ func (client *NetworkVirtualAppliancesClient) UpdateTagsCreateRequest(ctx contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers.go
@@ -150,6 +150,7 @@ func (client *NetworkWatchersClient) CheckConnectivityCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -200,6 +201,7 @@ func (client *NetworkWatchersClient) CreateOrUpdateCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -275,6 +277,7 @@ func (client *NetworkWatchersClient) DeleteCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -325,6 +328,7 @@ func (client *NetworkWatchersClient) GetCreateRequest(ctx context.Context, resou
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -400,6 +404,7 @@ func (client *NetworkWatchersClient) GetAzureReachabilityReportCreateRequest(ctx
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -474,6 +479,7 @@ func (client *NetworkWatchersClient) GetFlowLogStatusCreateRequest(ctx context.C
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -548,6 +554,7 @@ func (client *NetworkWatchersClient) GetNetworkConfigurationDiagnosticCreateRequ
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -622,6 +629,7 @@ func (client *NetworkWatchersClient) GetNextHopCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -672,6 +680,7 @@ func (client *NetworkWatchersClient) GetTopologyCreateRequest(ctx context.Contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -747,6 +756,7 @@ func (client *NetworkWatchersClient) GetTroubleshootingCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -821,6 +831,7 @@ func (client *NetworkWatchersClient) GetTroubleshootingResultCreateRequest(ctx c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -895,6 +906,7 @@ func (client *NetworkWatchersClient) GetVMSecurityRulesCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -944,6 +956,7 @@ func (client *NetworkWatchersClient) ListCreateRequest(ctx context.Context, reso
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -993,6 +1006,7 @@ func (client *NetworkWatchersClient) ListAllCreateRequest(ctx context.Context) (
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1068,6 +1082,7 @@ func (client *NetworkWatchersClient) ListAvailableProvidersCreateRequest(ctx con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -1142,6 +1157,7 @@ func (client *NetworkWatchersClient) SetFlowLogConfigurationCreateRequest(ctx co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -1192,6 +1208,7 @@ func (client *NetworkWatchersClient) UpdateTagsCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -1267,6 +1284,7 @@ func (client *NetworkWatchersClient) VerifyIPFlowCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_operations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_operations.go
@@ -57,6 +57,7 @@ func (client *OperationsClient) ListCreateRequest(ctx context.Context) (*azcore.
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways.go
@@ -122,6 +122,7 @@ func (client *P2SVpnGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(p2SVpnGatewayParameters)
 }
 
@@ -196,6 +197,7 @@ func (client *P2SVpnGatewaysClient) DeleteCreateRequest(ctx context.Context, res
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -270,6 +272,7 @@ func (client *P2SVpnGatewaysClient) DisconnectP2SVpnConnectionsCreateRequest(ctx
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(request)
 }
 
@@ -344,6 +347,7 @@ func (client *P2SVpnGatewaysClient) GenerateVpnProfileCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -394,6 +398,7 @@ func (client *P2SVpnGatewaysClient) GetCreateRequest(ctx context.Context, resour
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -469,6 +474,7 @@ func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthCreateRequest(ctx c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -543,6 +549,7 @@ func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthDetailedCreateReque
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(request)
 }
 
@@ -588,6 +595,7 @@ func (client *P2SVpnGatewaysClient) ListCreateRequest(ctx context.Context) (*azc
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -635,6 +643,7 @@ func (client *P2SVpnGatewaysClient) ListByResourceGroupCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -686,6 +695,7 @@ func (client *P2SVpnGatewaysClient) UpdateTagsCreateRequest(ctx context.Context,
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(p2SVpnGatewayParameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures.go
@@ -111,6 +111,7 @@ func (client *PacketCapturesClient) CreateCreateRequest(ctx context.Context, res
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -186,6 +187,7 @@ func (client *PacketCapturesClient) DeleteCreateRequest(ctx context.Context, res
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -237,6 +239,7 @@ func (client *PacketCapturesClient) GetCreateRequest(ctx context.Context, resour
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -313,6 +316,7 @@ func (client *PacketCapturesClient) GetStatusCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -363,6 +367,7 @@ func (client *PacketCapturesClient) ListCreateRequest(ctx context.Context, resou
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -439,6 +444,7 @@ func (client *PacketCapturesClient) StopCreateRequest(ctx context.Context, resou
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections.go
@@ -70,6 +70,7 @@ func (client *PeerExpressRouteCircuitConnectionsClient) GetCreateRequest(ctx con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -119,6 +120,7 @@ func (client *PeerExpressRouteCircuitConnectionsClient) ListCreateRequest(ctx co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups.go
@@ -103,6 +103,7 @@ func (client *PrivateDNSZoneGroupsClient) CreateOrUpdateCreateRequest(ctx contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -178,6 +179,7 @@ func (client *PrivateDNSZoneGroupsClient) DeleteCreateRequest(ctx context.Contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *PrivateDNSZoneGroupsClient) GetCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *PrivateDNSZoneGroupsClient) ListCreateRequest(ctx context.Context,
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints.go
@@ -104,6 +104,7 @@ func (client *PrivateEndpointsClient) CreateOrUpdateCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -178,6 +179,7 @@ func (client *PrivateEndpointsClient) DeleteCreateRequest(ctx context.Context, r
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -231,6 +233,7 @@ func (client *PrivateEndpointsClient) GetCreateRequest(ctx context.Context, reso
 		query.Set("$expand", *privateEndpointsGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -278,6 +281,7 @@ func (client *PrivateEndpointsClient) ListCreateRequest(ctx context.Context, res
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -324,6 +328,7 @@ func (client *PrivateEndpointsClient) ListBySubscriptionCreateRequest(ctx contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices.go
@@ -125,6 +125,7 @@ func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityCreate
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -199,6 +200,7 @@ func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityByReso
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -273,6 +275,7 @@ func (client *PrivateLinkServicesClient) CreateOrUpdateCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -347,6 +350,7 @@ func (client *PrivateLinkServicesClient) DeleteCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -422,6 +426,7 @@ func (client *PrivateLinkServicesClient) DeletePrivateEndpointConnectionCreateRe
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -475,6 +480,7 @@ func (client *PrivateLinkServicesClient) GetCreateRequest(ctx context.Context, r
 		query.Set("$expand", *privateLinkServicesGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -530,6 +536,7 @@ func (client *PrivateLinkServicesClient) GetPrivateEndpointConnectionCreateReque
 		query.Set("$expand", *privateLinkServicesGetPrivateEndpointConnectionOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -577,6 +584,7 @@ func (client *PrivateLinkServicesClient) ListCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -624,6 +632,7 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesCrea
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -672,6 +681,7 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesByRe
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -718,6 +728,7 @@ func (client *PrivateLinkServicesClient) ListBySubscriptionCreateRequest(ctx con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -766,6 +777,7 @@ func (client *PrivateLinkServicesClient) ListPrivateEndpointConnectionsCreateReq
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -818,6 +830,7 @@ func (client *PrivateLinkServicesClient) UpdatePrivateEndpointConnectionCreateRe
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses.go
@@ -112,6 +112,7 @@ func (client *PublicIPAddressesClient) CreateOrUpdateCreateRequest(ctx context.C
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -186,6 +187,7 @@ func (client *PublicIPAddressesClient) DeleteCreateRequest(ctx context.Context, 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -239,6 +241,7 @@ func (client *PublicIPAddressesClient) GetCreateRequest(ctx context.Context, res
 		query.Set("$expand", *publicIPAddressesGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -297,6 +300,7 @@ func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddressC
 		query.Set("$expand", *publicIPAddressesGetVirtualMachineScaleSetPublicIpaddressOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -344,6 +348,7 @@ func (client *PublicIPAddressesClient) ListCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -390,6 +395,7 @@ func (client *PublicIPAddressesClient) ListAllCreateRequest(ctx context.Context)
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -438,6 +444,7 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetPublicIPAddress
 	query := req.URL.Query()
 	query.Set("api-version", "2018-10-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -489,6 +496,7 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetVMPublicIPaddre
 	query := req.URL.Query()
 	query.Set("api-version", "2018-10-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -540,6 +548,7 @@ func (client *PublicIPAddressesClient) UpdateTagsCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes.go
@@ -106,6 +106,7 @@ func (client *PublicIPPrefixesClient) CreateOrUpdateCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -180,6 +181,7 @@ func (client *PublicIPPrefixesClient) DeleteCreateRequest(ctx context.Context, r
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -233,6 +235,7 @@ func (client *PublicIPPrefixesClient) GetCreateRequest(ctx context.Context, reso
 		query.Set("$expand", *publicIPPrefixesGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -280,6 +283,7 @@ func (client *PublicIPPrefixesClient) ListCreateRequest(ctx context.Context, res
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -326,6 +330,7 @@ func (client *PublicIPPrefixesClient) ListAllCreateRequest(ctx context.Context) 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -377,6 +382,7 @@ func (client *PublicIPPrefixesClient) UpdateTagsCreateRequest(ctx context.Contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks.go
@@ -67,6 +67,7 @@ func (client *ResourceNavigationLinksClient) ListCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules.go
@@ -103,6 +103,7 @@ func (client *RouteFilterRulesClient) CreateOrUpdateCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(routeFilterRuleParameters)
 }
 
@@ -178,6 +179,7 @@ func (client *RouteFilterRulesClient) DeleteCreateRequest(ctx context.Context, r
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *RouteFilterRulesClient) GetCreateRequest(ctx context.Context, reso
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *RouteFilterRulesClient) ListByRouteFilterCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilters.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilters.go
@@ -106,6 +106,7 @@ func (client *RouteFiltersClient) CreateOrUpdateCreateRequest(ctx context.Contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(routeFilterParameters)
 }
 
@@ -180,6 +181,7 @@ func (client *RouteFiltersClient) DeleteCreateRequest(ctx context.Context, resou
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -233,6 +235,7 @@ func (client *RouteFiltersClient) GetCreateRequest(ctx context.Context, resource
 		query.Set("$expand", *routeFiltersGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -279,6 +282,7 @@ func (client *RouteFiltersClient) ListCreateRequest(ctx context.Context) (*azcor
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -326,6 +330,7 @@ func (client *RouteFiltersClient) ListByResourceGroupCreateRequest(ctx context.C
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -377,6 +382,7 @@ func (client *RouteFiltersClient) UpdateTagsCreateRequest(ctx context.Context, r
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_routes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routes.go
@@ -103,6 +103,7 @@ func (client *RoutesClient) CreateOrUpdateCreateRequest(ctx context.Context, res
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(routeParameters)
 }
 
@@ -178,6 +179,7 @@ func (client *RoutesClient) DeleteCreateRequest(ctx context.Context, resourceGro
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *RoutesClient) GetCreateRequest(ctx context.Context, resourceGroupN
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *RoutesClient) ListCreateRequest(ctx context.Context, resourceGroup
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_routetables.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routetables.go
@@ -106,6 +106,7 @@ func (client *RouteTablesClient) CreateOrUpdateCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -180,6 +181,7 @@ func (client *RouteTablesClient) DeleteCreateRequest(ctx context.Context, resour
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -233,6 +235,7 @@ func (client *RouteTablesClient) GetCreateRequest(ctx context.Context, resourceG
 		query.Set("$expand", *routeTablesGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -280,6 +283,7 @@ func (client *RouteTablesClient) ListCreateRequest(ctx context.Context, resource
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -326,6 +330,7 @@ func (client *RouteTablesClient) ListAllCreateRequest(ctx context.Context) (*azc
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -377,6 +382,7 @@ func (client *RouteTablesClient) UpdateTagsCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders.go
@@ -106,6 +106,7 @@ func (client *SecurityPartnerProvidersClient) CreateOrUpdateCreateRequest(ctx co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -180,6 +181,7 @@ func (client *SecurityPartnerProvidersClient) DeleteCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -230,6 +232,7 @@ func (client *SecurityPartnerProvidersClient) GetCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -276,6 +279,7 @@ func (client *SecurityPartnerProvidersClient) ListCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -323,6 +327,7 @@ func (client *SecurityPartnerProvidersClient) ListByResourceGroupCreateRequest(c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -374,6 +379,7 @@ func (client *SecurityPartnerProvidersClient) UpdateTagsCreateRequest(ctx contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_securityrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securityrules.go
@@ -103,6 +103,7 @@ func (client *SecurityRulesClient) CreateOrUpdateCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(securityRuleParameters)
 }
 
@@ -178,6 +179,7 @@ func (client *SecurityRulesClient) DeleteCreateRequest(ctx context.Context, reso
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *SecurityRulesClient) GetCreateRequest(ctx context.Context, resourc
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *SecurityRulesClient) ListCreateRequest(ctx context.Context, resour
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks.go
@@ -67,6 +67,7 @@ func (client *ServiceAssociationLinksClient) ListCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies.go
@@ -106,6 +106,7 @@ func (client *ServiceEndpointPoliciesClient) CreateOrUpdateCreateRequest(ctx con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -180,6 +181,7 @@ func (client *ServiceEndpointPoliciesClient) DeleteCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -233,6 +235,7 @@ func (client *ServiceEndpointPoliciesClient) GetCreateRequest(ctx context.Contex
 		query.Set("$expand", *serviceEndpointPoliciesGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -279,6 +282,7 @@ func (client *ServiceEndpointPoliciesClient) ListCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -326,6 +330,7 @@ func (client *ServiceEndpointPoliciesClient) ListByResourceGroupCreateRequest(ct
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -377,6 +382,7 @@ func (client *ServiceEndpointPoliciesClient) UpdateTagsCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions.go
@@ -103,6 +103,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) CreateOrUpdateCreateReques
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(serviceEndpointPolicyDefinitions)
 }
 
@@ -178,6 +179,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) DeleteCreateRequest(ctx co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) GetCreateRequest(ctx conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) ListByResourceGroupCreateR
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_servicetags.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_servicetags.go
@@ -65,6 +65,7 @@ func (client *ServiceTagsClient) ListCreateRequest(ctx context.Context, location
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_subnets.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_subnets.go
@@ -111,6 +111,7 @@ func (client *SubnetsClient) CreateOrUpdateCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(subnetParameters)
 }
 
@@ -186,6 +187,7 @@ func (client *SubnetsClient) DeleteCreateRequest(ctx context.Context, resourceGr
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -240,6 +242,7 @@ func (client *SubnetsClient) GetCreateRequest(ctx context.Context, resourceGroup
 		query.Set("$expand", *subnetsGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -288,6 +291,7 @@ func (client *SubnetsClient) ListCreateRequest(ctx context.Context, resourceGrou
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -364,6 +368,7 @@ func (client *SubnetsClient) PrepareNetworkPoliciesCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(prepareNetworkPoliciesRequestParameters)
 }
 
@@ -439,6 +444,7 @@ func (client *SubnetsClient) UnprepareNetworkPoliciesCreateRequest(ctx context.C
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(unprepareNetworkPoliciesRequestParameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_usages.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_usages.go
@@ -62,6 +62,7 @@ func (client *UsagesClient) ListCreateRequest(ctx context.Context, location stri
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s.go
@@ -103,6 +103,7 @@ func (client *VirtualHubRouteTableV2SClient) CreateOrUpdateCreateRequest(ctx con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(virtualHubRouteTableV2Parameters)
 }
 
@@ -178,6 +179,7 @@ func (client *VirtualHubRouteTableV2SClient) DeleteCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *VirtualHubRouteTableV2SClient) GetCreateRequest(ctx context.Contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *VirtualHubRouteTableV2SClient) ListCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs.go
@@ -106,6 +106,7 @@ func (client *VirtualHubsClient) CreateOrUpdateCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(virtualHubParameters)
 }
 
@@ -180,6 +181,7 @@ func (client *VirtualHubsClient) DeleteCreateRequest(ctx context.Context, resour
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -230,6 +232,7 @@ func (client *VirtualHubsClient) GetCreateRequest(ctx context.Context, resourceG
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -276,6 +279,7 @@ func (client *VirtualHubsClient) ListCreateRequest(ctx context.Context) (*azcore
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -323,6 +327,7 @@ func (client *VirtualHubsClient) ListByResourceGroupCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -374,6 +379,7 @@ func (client *VirtualHubsClient) UpdateTagsCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(virtualHubParameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
@@ -124,6 +124,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) CreateOrUpdateCreateReques
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -198,6 +199,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) DeleteCreateRequest(ctx co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -248,6 +250,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) GetCreateRequest(ctx conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -299,6 +302,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKeyCreateRequest(
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -346,6 +350,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) ListCreateRequest(ctx cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -421,6 +426,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) ResetSharedKeyCreateReques
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -495,6 +501,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) SetSharedKeyCreateRequest(
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -569,6 +576,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) StartPacketCaptureCreateRe
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	if virtualNetworkGatewayConnectionsStartPacketCaptureOptions != nil {
 		return req, req.MarshalAsJSON(virtualNetworkGatewayConnectionsStartPacketCaptureOptions.Parameters)
 	}
@@ -646,6 +654,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) StopPacketCaptureCreateReq
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -720,6 +729,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) UpdateTagsCreateRequest(ct
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
@@ -168,6 +168,7 @@ func (client *VirtualNetworkGatewaysClient) CreateOrUpdateCreateRequest(ctx cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -242,6 +243,7 @@ func (client *VirtualNetworkGatewaysClient) DeleteCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -316,6 +318,7 @@ func (client *VirtualNetworkGatewaysClient) DisconnectVirtualNetworkGatewayVpnCo
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(request)
 }
 
@@ -390,6 +393,7 @@ func (client *VirtualNetworkGatewaysClient) GenerateVpnProfileCreateRequest(ctx 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -464,6 +468,7 @@ func (client *VirtualNetworkGatewaysClient) GeneratevpnclientpackageCreateReques
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -514,6 +519,7 @@ func (client *VirtualNetworkGatewaysClient) GetCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -590,6 +596,7 @@ func (client *VirtualNetworkGatewaysClient) GetAdvertisedRoutesCreateRequest(ctx
 	query.Set("peer", peer)
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -667,6 +674,7 @@ func (client *VirtualNetworkGatewaysClient) GetBgpPeerStatusCreateRequest(ctx co
 	}
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -741,6 +749,7 @@ func (client *VirtualNetworkGatewaysClient) GetLearnedRoutesCreateRequest(ctx co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -815,6 +824,7 @@ func (client *VirtualNetworkGatewaysClient) GetVpnProfilePackageURLCreateRequest
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -889,6 +899,7 @@ func (client *VirtualNetworkGatewaysClient) GetVpnclientConnectionHealthCreateRe
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -963,6 +974,7 @@ func (client *VirtualNetworkGatewaysClient) GetVpnclientIPsecParametersCreateReq
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1009,6 +1021,7 @@ func (client *VirtualNetworkGatewaysClient) ListCreateRequest(ctx context.Contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1057,6 +1070,7 @@ func (client *VirtualNetworkGatewaysClient) ListConnectionsCreateRequest(ctx con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1135,6 +1149,7 @@ func (client *VirtualNetworkGatewaysClient) ResetCreateRequest(ctx context.Conte
 	}
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1209,6 +1224,7 @@ func (client *VirtualNetworkGatewaysClient) ResetVpnClientSharedKeyCreateRequest
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1283,6 +1299,7 @@ func (client *VirtualNetworkGatewaysClient) SetVpnclientIPsecParametersCreateReq
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(vpnclientIpsecParams)
 }
 
@@ -1357,6 +1374,7 @@ func (client *VirtualNetworkGatewaysClient) StartPacketCaptureCreateRequest(ctx 
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	if virtualNetworkGatewaysStartPacketCaptureOptions != nil {
 		return req, req.MarshalAsJSON(virtualNetworkGatewaysStartPacketCaptureOptions.Parameters)
 	}
@@ -1434,6 +1452,7 @@ func (client *VirtualNetworkGatewaysClient) StopPacketCaptureCreateRequest(ctx c
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -1484,6 +1503,7 @@ func (client *VirtualNetworkGatewaysClient) SupportedVpnDevicesCreateRequest(ctx
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -1559,6 +1579,7 @@ func (client *VirtualNetworkGatewaysClient) UpdateTagsCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -1609,6 +1630,7 @@ func (client *VirtualNetworkGatewaysClient) VpnDeviceConfigurationScriptCreateRe
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings.go
@@ -103,6 +103,7 @@ func (client *VirtualNetworkPeeringsClient) CreateOrUpdateCreateRequest(ctx cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(virtualNetworkPeeringParameters)
 }
 
@@ -178,6 +179,7 @@ func (client *VirtualNetworkPeeringsClient) DeleteCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *VirtualNetworkPeeringsClient) GetCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *VirtualNetworkPeeringsClient) ListCreateRequest(ctx context.Contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks.go
@@ -87,6 +87,7 @@ func (client *VirtualNetworksClient) CheckIPAddressAvailabilityCreateRequest(ctx
 	query.Set("ipAddress", ipAddress)
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -162,6 +163,7 @@ func (client *VirtualNetworksClient) CreateOrUpdateCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -236,6 +238,7 @@ func (client *VirtualNetworksClient) DeleteCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -289,6 +292,7 @@ func (client *VirtualNetworksClient) GetCreateRequest(ctx context.Context, resou
 		query.Set("$expand", *virtualNetworksGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -336,6 +340,7 @@ func (client *VirtualNetworksClient) ListCreateRequest(ctx context.Context, reso
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -382,6 +387,7 @@ func (client *VirtualNetworksClient) ListAllCreateRequest(ctx context.Context) (
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -430,6 +436,7 @@ func (client *VirtualNetworksClient) ListUsageCreateRequest(ctx context.Context,
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -481,6 +488,7 @@ func (client *VirtualNetworksClient) UpdateTagsCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps.go
@@ -106,6 +106,7 @@ func (client *VirtualNetworkTapsClient) CreateOrUpdateCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -180,6 +181,7 @@ func (client *VirtualNetworkTapsClient) DeleteCreateRequest(ctx context.Context,
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -230,6 +232,7 @@ func (client *VirtualNetworkTapsClient) GetCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -276,6 +279,7 @@ func (client *VirtualNetworkTapsClient) ListAllCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -323,6 +327,7 @@ func (client *VirtualNetworkTapsClient) ListByResourceGroupCreateRequest(ctx con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -374,6 +379,7 @@ func (client *VirtualNetworkTapsClient) UpdateTagsCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(tapParameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings.go
@@ -103,6 +103,7 @@ func (client *VirtualRouterPeeringsClient) CreateOrUpdateCreateRequest(ctx conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -178,6 +179,7 @@ func (client *VirtualRouterPeeringsClient) DeleteCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *VirtualRouterPeeringsClient) GetCreateRequest(ctx context.Context,
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *VirtualRouterPeeringsClient) ListCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters.go
@@ -104,6 +104,7 @@ func (client *VirtualRoutersClient) CreateOrUpdateCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -178,6 +179,7 @@ func (client *VirtualRoutersClient) DeleteCreateRequest(ctx context.Context, res
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -231,6 +233,7 @@ func (client *VirtualRoutersClient) GetCreateRequest(ctx context.Context, resour
 		query.Set("$expand", *virtualRoutersGetOptions.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *VirtualRoutersClient) ListCreateRequest(ctx context.Context) (*azc
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -324,6 +328,7 @@ func (client *VirtualRoutersClient) ListByResourceGroupCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualwans.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualwans.go
@@ -106,6 +106,7 @@ func (client *VirtualWansClient) CreateOrUpdateCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(wanParameters)
 }
 
@@ -180,6 +181,7 @@ func (client *VirtualWansClient) DeleteCreateRequest(ctx context.Context, resour
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -230,6 +232,7 @@ func (client *VirtualWansClient) GetCreateRequest(ctx context.Context, resourceG
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -276,6 +279,7 @@ func (client *VirtualWansClient) ListCreateRequest(ctx context.Context) (*azcore
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -323,6 +327,7 @@ func (client *VirtualWansClient) ListByResourceGroupCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -374,6 +379,7 @@ func (client *VirtualWansClient) UpdateTagsCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(wanParameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections.go
@@ -103,6 +103,7 @@ func (client *VpnConnectionsClient) CreateOrUpdateCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(vpnConnectionParameters)
 }
 
@@ -178,6 +179,7 @@ func (client *VpnConnectionsClient) DeleteCreateRequest(ctx context.Context, res
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -229,6 +231,7 @@ func (client *VpnConnectionsClient) GetCreateRequest(ctx context.Context, resour
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -277,6 +280,7 @@ func (client *VpnConnectionsClient) ListByVpnGatewayCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpngateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpngateways.go
@@ -110,6 +110,7 @@ func (client *VpnGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(vpnGatewayParameters)
 }
 
@@ -184,6 +185,7 @@ func (client *VpnGatewaysClient) DeleteCreateRequest(ctx context.Context, resour
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -234,6 +236,7 @@ func (client *VpnGatewaysClient) GetCreateRequest(ctx context.Context, resourceG
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -280,6 +283,7 @@ func (client *VpnGatewaysClient) ListCreateRequest(ctx context.Context) (*azcore
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -327,6 +331,7 @@ func (client *VpnGatewaysClient) ListByResourceGroupCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -402,6 +407,7 @@ func (client *VpnGatewaysClient) ResetCreateRequest(ctx context.Context, resourc
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -452,6 +458,7 @@ func (client *VpnGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(vpnGatewayParameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections.go
@@ -64,6 +64,7 @@ func (client *VpnLinkConnectionsClient) ListByVpnConnectionCreateRequest(ctx con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations.go
@@ -106,6 +106,7 @@ func (client *VpnServerConfigurationsClient) CreateOrUpdateCreateRequest(ctx con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(vpnServerConfigurationParameters)
 }
 
@@ -180,6 +181,7 @@ func (client *VpnServerConfigurationsClient) DeleteCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -230,6 +232,7 @@ func (client *VpnServerConfigurationsClient) GetCreateRequest(ctx context.Contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -276,6 +279,7 @@ func (client *VpnServerConfigurationsClient) ListCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -323,6 +327,7 @@ func (client *VpnServerConfigurationsClient) ListByResourceGroupCreateRequest(ct
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -374,6 +379,7 @@ func (client *VpnServerConfigurationsClient) UpdateTagsCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(vpnServerConfigurationParameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan.go
@@ -94,6 +94,7 @@ func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) ListCreateR
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections.go
@@ -68,6 +68,7 @@ func (client *VpnSiteLinkConnectionsClient) GetCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks.go
@@ -69,6 +69,7 @@ func (client *VpnSiteLinksClient) GetCreateRequest(ctx context.Context, resource
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -117,6 +118,7 @@ func (client *VpnSiteLinksClient) ListByVpnSiteCreateRequest(ctx context.Context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsites.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsites.go
@@ -106,6 +106,7 @@ func (client *VpnSitesClient) CreateOrUpdateCreateRequest(ctx context.Context, r
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(vpnSiteParameters)
 }
 
@@ -180,6 +181,7 @@ func (client *VpnSitesClient) DeleteCreateRequest(ctx context.Context, resourceG
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -230,6 +232,7 @@ func (client *VpnSitesClient) GetCreateRequest(ctx context.Context, resourceGrou
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -276,6 +279,7 @@ func (client *VpnSitesClient) ListCreateRequest(ctx context.Context) (*azcore.Re
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -323,6 +327,7 @@ func (client *VpnSitesClient) ListByResourceGroupCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -374,6 +379,7 @@ func (client *VpnSitesClient) UpdateTagsCreateRequest(ctx context.Context, resou
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(vpnSiteParameters)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration.go
@@ -94,6 +94,7 @@ func (client *VpnSitesConfigurationClient) DownloadCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(request)
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies.go
@@ -78,6 +78,7 @@ func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdateCreateRequest(
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
 }
 
@@ -153,6 +154,7 @@ func (client *WebApplicationFirewallPoliciesClient) DeleteCreateRequest(ctx cont
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -203,6 +205,7 @@ func (client *WebApplicationFirewallPoliciesClient) GetCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -250,6 +253,7 @@ func (client *WebApplicationFirewallPoliciesClient) ListCreateRequest(ctx contex
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 
@@ -296,6 +300,7 @@ func (client *WebApplicationFirewallPoliciesClient) ListAllCreateRequest(ctx con
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
 	return req, nil
 }
 

--- a/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
@@ -111,6 +111,7 @@ func (client *appendBlobClient) AppendBlockCreateRequest(ctx context.Context, co
 	if appendBlobAppendBlockOptions != nil && appendBlobAppendBlockOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *appendBlobAppendBlockOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, req.SetBody(body, "application/octet-stream")
 }
 
@@ -285,6 +286,7 @@ func (client *appendBlobClient) AppendBlockFromURLCreateRequest(ctx context.Cont
 	if appendBlobAppendBlockFromUrlOptions != nil && appendBlobAppendBlockFromUrlOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *appendBlobAppendBlockFromUrlOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -448,6 +450,7 @@ func (client *appendBlobClient) CreateCreateRequest(ctx context.Context, content
 	if appendBlobCreateOptions != nil && appendBlobCreateOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *appendBlobCreateOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 

--- a/test/storage/2019-07-07/azblob/zz_generated_blob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blob.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -114,6 +115,7 @@ func (client *blobClient) AbortCopyFromURLCreateRequest(ctx context.Context, cop
 	if blobAbortCopyFromUrlOptions != nil && blobAbortCopyFromUrlOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blobAbortCopyFromUrlOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -203,6 +205,7 @@ func (client *blobClient) AcquireLeaseCreateRequest(ctx context.Context, blobAcq
 	if blobAcquireLeaseOptions != nil && blobAcquireLeaseOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blobAcquireLeaseOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -302,6 +305,7 @@ func (client *blobClient) BreakLeaseCreateRequest(ctx context.Context, blobBreak
 	if blobBreakLeaseOptions != nil && blobBreakLeaseOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blobBreakLeaseOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -405,6 +409,7 @@ func (client *blobClient) ChangeLeaseCreateRequest(ctx context.Context, leaseId 
 	if blobChangeLeaseOptions != nil && blobChangeLeaseOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blobChangeLeaseOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -527,6 +532,7 @@ func (client *blobClient) CopyFromURLCreateRequest(ctx context.Context, copySour
 	if blobCopyFromUrlOptions != nil && blobCopyFromUrlOptions.SourceContentMd5 != nil {
 		req.Header.Set("x-ms-source-content-md5", base64.StdEncoding.EncodeToString(*blobCopyFromUrlOptions.SourceContentMd5))
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -656,6 +662,7 @@ func (client *blobClient) CreateSnapshotCreateRequest(ctx context.Context, blobC
 	if blobCreateSnapshotOptions != nil && blobCreateSnapshotOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blobCreateSnapshotOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -766,6 +773,7 @@ func (client *blobClient) DeleteCreateRequest(ctx context.Context, blobDeleteOpt
 	if blobDeleteOptions != nil && blobDeleteOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blobDeleteOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -869,6 +877,7 @@ func (client *blobClient) DownloadCreateRequest(ctx context.Context, blobDownloa
 	if blobDownloadOptions != nil && blobDownloadOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blobDownloadOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -885,8 +894,13 @@ func (client *blobClient) DownloadHandleResponse(resp *azcore.Response) (*BlobDo
 		}
 		result.LastModified = &lastModified
 	}
-	if val := resp.Header.Get("x-ms-meta"); val != "" {
-		result.Metadata = &val
+	for hh := range resp.Header {
+		if strings.HasPrefix(hh, "x-ms-meta-") {
+			if result.Metadata == nil {
+				result.Metadata = &map[string]string{}
+			}
+			(*result.Metadata)[hh[len("x-ms-meta-"):]] = resp.Header.Get(hh)
+		}
 	}
 	if val := resp.Header.Get("Content-Length"); val != "" {
 		contentLength, err := strconv.ParseInt(val, 10, 64)
@@ -1081,6 +1095,7 @@ func (client *blobClient) GetAccessControlCreateRequest(ctx context.Context, blo
 		req.Header.Set("x-ms-client-request-id", *blobGetAccessControlOptions.RequestId)
 	}
 	req.Header.Set("x-ms-version", "2019-07-07")
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -1165,6 +1180,7 @@ func (client *blobClient) GetAccountInfoCreateRequest(ctx context.Context) (*azc
 	query.Set("comp", "properties")
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("x-ms-version", "2019-07-07")
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -1264,6 +1280,7 @@ func (client *blobClient) GetPropertiesCreateRequest(ctx context.Context, blobGe
 	if blobGetPropertiesOptions != nil && blobGetPropertiesOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blobGetPropertiesOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -1287,8 +1304,13 @@ func (client *blobClient) GetPropertiesHandleResponse(resp *azcore.Response) (*B
 		}
 		result.CreationTime = &creationTime
 	}
-	if val := resp.Header.Get("x-ms-meta"); val != "" {
-		result.Metadata = &val
+	for hh := range resp.Header {
+		if strings.HasPrefix(hh, "x-ms-meta-") {
+			if result.Metadata == nil {
+				result.Metadata = &map[string]string{}
+			}
+			(*result.Metadata)[hh[len("x-ms-meta-"):]] = resp.Header.Get(hh)
+		}
 	}
 	if val := resp.Header.Get("x-ms-blob-type"); val != "" {
 		result.BlobType = (*BlobType)(&val)
@@ -1492,6 +1514,7 @@ func (client *blobClient) ReleaseLeaseCreateRequest(ctx context.Context, leaseId
 	if blobReleaseLeaseOptions != nil && blobReleaseLeaseOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blobReleaseLeaseOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -1629,6 +1652,7 @@ func (client *blobClient) RenameCreateRequest(ctx context.Context, renameSource 
 	if blobRenameOptions != nil && blobRenameOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blobRenameOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -1730,6 +1754,7 @@ func (client *blobClient) RenewLeaseCreateRequest(ctx context.Context, leaseId s
 	if blobRenewLeaseOptions != nil && blobRenewLeaseOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blobRenewLeaseOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -1840,6 +1865,7 @@ func (client *blobClient) SetAccessControlCreateRequest(ctx context.Context, blo
 		req.Header.Set("x-ms-client-request-id", *blobSetAccessControlOptions.RequestId)
 	}
 	req.Header.Set("x-ms-version", "2019-07-07")
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -1950,6 +1976,7 @@ func (client *blobClient) SetHTTPHeadersCreateRequest(ctx context.Context, blobS
 	if blobSetHttpHeadersOptions != nil && blobSetHttpHeadersOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blobSetHttpHeadersOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -2066,6 +2093,7 @@ func (client *blobClient) SetMetadataCreateRequest(ctx context.Context, blobSetM
 	if blobSetMetadataOptions != nil && blobSetMetadataOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blobSetMetadataOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -2166,6 +2194,7 @@ func (client *blobClient) SetTierCreateRequest(ctx context.Context, tier AccessT
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseId != nil {
 		req.Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -2267,6 +2296,7 @@ func (client *blobClient) StartCopyFromURLCreateRequest(ctx context.Context, cop
 	if blobStartCopyFromUrlOptions != nil && blobStartCopyFromUrlOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blobStartCopyFromUrlOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -2353,6 +2383,7 @@ func (client *blobClient) UndeleteCreateRequest(ctx context.Context, blobUndelet
 	if blobUndeleteOptions != nil && blobUndeleteOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blobUndeleteOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 

--- a/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
@@ -134,6 +134,7 @@ func (client *blockBlobClient) CommitBlockListCreateRequest(ctx context.Context,
 	if blockBlobCommitBlockListOptions != nil && blockBlobCommitBlockListOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blockBlobCommitBlockListOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, req.MarshalAsXML(blocks)
 }
 
@@ -248,6 +249,7 @@ func (client *blockBlobClient) GetBlockListCreateRequest(ctx context.Context, li
 	if blockBlobGetBlockListOptions != nil && blockBlobGetBlockListOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blockBlobGetBlockListOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -358,6 +360,7 @@ func (client *blockBlobClient) StageBlockCreateRequest(ctx context.Context, bloc
 	if blockBlobStageBlockOptions != nil && blockBlobStageBlockOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blockBlobStageBlockOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, req.SetBody(body, "application/octet-stream")
 }
 
@@ -491,6 +494,7 @@ func (client *blockBlobClient) StageBlockFromURLCreateRequest(ctx context.Contex
 	if blockBlobStageBlockFromUrlOptions != nil && blockBlobStageBlockFromUrlOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blockBlobStageBlockFromUrlOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -642,6 +646,7 @@ func (client *blockBlobClient) UploadCreateRequest(ctx context.Context, contentL
 	if blockBlobUploadOptions != nil && blockBlobUploadOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *blockBlobUploadOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, req.SetBody(body, "application/octet-stream")
 }
 

--- a/test/storage/2019-07-07/azblob/zz_generated_container.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_container.go
@@ -111,6 +111,7 @@ func (client *containerClient) AcquireLeaseCreateRequest(ctx context.Context, co
 	if containerAcquireLeaseOptions != nil && containerAcquireLeaseOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *containerAcquireLeaseOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -205,6 +206,7 @@ func (client *containerClient) BreakLeaseCreateRequest(ctx context.Context, cont
 	if containerBreakLeaseOptions != nil && containerBreakLeaseOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *containerBreakLeaseOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -303,6 +305,7 @@ func (client *containerClient) ChangeLeaseCreateRequest(ctx context.Context, lea
 	if containerChangeLeaseOptions != nil && containerChangeLeaseOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *containerChangeLeaseOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -400,6 +403,7 @@ func (client *containerClient) CreateCreateRequest(ctx context.Context, containe
 	if containerCpkScopeInfo != nil && containerCpkScopeInfo.PreventEncryptionScopeOverride != nil {
 		req.Header.Set("x-ms-deny-encryption-scope-override", strconv.FormatBool(*containerCpkScopeInfo.PreventEncryptionScopeOverride))
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -489,6 +493,7 @@ func (client *containerClient) DeleteCreateRequest(ctx context.Context, containe
 	if containerDeleteOptions != nil && containerDeleteOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *containerDeleteOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -563,6 +568,7 @@ func (client *containerClient) GetAccessPolicyCreateRequest(ctx context.Context,
 	if containerGetAccessPolicyOptions != nil && containerGetAccessPolicyOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *containerGetAccessPolicyOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -641,6 +647,7 @@ func (client *containerClient) GetAccountInfoCreateRequest(ctx context.Context) 
 	query.Set("comp", "properties")
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("x-ms-version", "2019-07-07")
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -720,6 +727,7 @@ func (client *containerClient) GetPropertiesCreateRequest(ctx context.Context, c
 	if containerGetPropertiesOptions != nil && containerGetPropertiesOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *containerGetPropertiesOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -729,8 +737,13 @@ func (client *containerClient) GetPropertiesHandleResponse(resp *azcore.Response
 		return nil, client.GetPropertiesHandleError(resp)
 	}
 	result := ContainerGetPropertiesResponse{RawResponse: resp.Response}
-	if val := resp.Header.Get("x-ms-meta"); val != "" {
-		result.Metadata = &val
+	for hh := range resp.Header {
+		if strings.HasPrefix(hh, "x-ms-meta-") {
+			if result.Metadata == nil {
+				result.Metadata = &map[string]string{}
+			}
+			(*result.Metadata)[hh[len("x-ms-meta-"):]] = resp.Header.Get(hh)
+		}
 	}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -849,6 +862,7 @@ func (client *containerClient) ListBlobFlatSegmentCreateRequest(ctx context.Cont
 	if containerListBlobFlatSegmentOptions != nil && containerListBlobFlatSegmentOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *containerListBlobFlatSegmentOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -933,6 +947,7 @@ func (client *containerClient) ListBlobHierarchySegmentCreateRequest(ctx context
 	if containerListBlobHierarchySegmentOptions != nil && containerListBlobHierarchySegmentOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *containerListBlobHierarchySegmentOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -1015,6 +1030,7 @@ func (client *containerClient) ReleaseLeaseCreateRequest(ctx context.Context, le
 	if containerReleaseLeaseOptions != nil && containerReleaseLeaseOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *containerReleaseLeaseOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -1104,6 +1120,7 @@ func (client *containerClient) RenewLeaseCreateRequest(ctx context.Context, leas
 	if containerRenewLeaseOptions != nil && containerRenewLeaseOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *containerRenewLeaseOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -1200,6 +1217,7 @@ func (client *containerClient) SetAccessPolicyCreateRequest(ctx context.Context,
 	if containerSetAccessPolicyOptions != nil && containerSetAccessPolicyOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *containerSetAccessPolicyOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	type wrapper struct {
 		XMLName      xml.Name            `xml:"SignedIdentifiers"`
 		ContainerAcl *[]SignedIDentifier `xml:"SignedIdentifier"`
@@ -1299,6 +1317,7 @@ func (client *containerClient) SetMetadataCreateRequest(ctx context.Context, con
 	if containerSetMetadataOptions != nil && containerSetMetadataOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *containerSetMetadataOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 

--- a/test/storage/2019-07-07/azblob/zz_generated_directory.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_directory.go
@@ -116,6 +116,7 @@ func (client *directoryClient) CreateCreateRequest(ctx context.Context, director
 	if directoryCreateOptions != nil && directoryCreateOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *directoryCreateOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -221,6 +222,7 @@ func (client *directoryClient) DeleteCreateRequest(ctx context.Context, recursiv
 	if directoryDeleteOptions != nil && directoryDeleteOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *directoryDeleteOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -312,6 +314,7 @@ func (client *directoryClient) GetAccessControlCreateRequest(ctx context.Context
 		req.Header.Set("x-ms-client-request-id", *directoryGetAccessControlOptions.RequestId)
 	}
 	req.Header.Set("x-ms-version", "2019-07-07")
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -461,6 +464,7 @@ func (client *directoryClient) RenameCreateRequest(ctx context.Context, renameSo
 	if directoryRenameOptions != nil && directoryRenameOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *directoryRenameOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -578,6 +582,7 @@ func (client *directoryClient) SetAccessControlCreateRequest(ctx context.Context
 		req.Header.Set("x-ms-client-request-id", *directorySetAccessControlOptions.RequestId)
 	}
 	req.Header.Set("x-ms-version", "2019-07-07")
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 

--- a/test/storage/2019-07-07/azblob/zz_generated_models.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_models.go
@@ -644,7 +644,7 @@ type BlobDownloadResponse struct {
 	LeaseStatus *LeaseStatusType
 
 	// Metadata contains the information returned from the x-ms-meta header response.
-	Metadata *string
+	Metadata *map[string]string
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -851,7 +851,7 @@ type BlobGetPropertiesResponse struct {
 	LeaseStatus *LeaseStatusType
 
 	// Metadata contains the information returned from the x-ms-meta header response.
-	Metadata *string
+	Metadata *map[string]string
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -1930,7 +1930,7 @@ type ContainerGetPropertiesResponse struct {
 	LeaseStatus *LeaseStatusType
 
 	// Metadata contains the information returned from the x-ms-meta header response.
-	Metadata *string
+	Metadata *map[string]string
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response

--- a/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
@@ -124,6 +124,7 @@ func (client *pageBlobClient) ClearPagesCreateRequest(ctx context.Context, conte
 	if pageBlobClearPagesOptions != nil && pageBlobClearPagesOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *pageBlobClearPagesOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -238,6 +239,7 @@ func (client *pageBlobClient) CopyIncrementalCreateRequest(ctx context.Context, 
 	if pageBlobCopyIncrementalOptions != nil && pageBlobCopyIncrementalOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *pageBlobCopyIncrementalOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -379,6 +381,7 @@ func (client *pageBlobClient) CreateCreateRequest(ctx context.Context, contentLe
 	if pageBlobCreateOptions != nil && pageBlobCreateOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *pageBlobCreateOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -500,6 +503,7 @@ func (client *pageBlobClient) GetPageRangesCreateRequest(ctx context.Context, pa
 	if pageBlobGetPageRangesOptions != nil && pageBlobGetPageRangesOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *pageBlobGetPageRangesOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -614,6 +618,7 @@ func (client *pageBlobClient) GetPageRangesDiffCreateRequest(ctx context.Context
 	if pageBlobGetPageRangesDiffOptions != nil && pageBlobGetPageRangesDiffOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *pageBlobGetPageRangesDiffOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -726,6 +731,7 @@ func (client *pageBlobClient) ResizeCreateRequest(ctx context.Context, blobConte
 	if pageBlobResizeOptions != nil && pageBlobResizeOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *pageBlobResizeOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -832,6 +838,7 @@ func (client *pageBlobClient) UpdateSequenceNumberCreateRequest(ctx context.Cont
 	if pageBlobUpdateSequenceNumberOptions != nil && pageBlobUpdateSequenceNumberOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *pageBlobUpdateSequenceNumberOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -963,6 +970,7 @@ func (client *pageBlobClient) UploadPagesCreateRequest(ctx context.Context, cont
 	if pageBlobUploadPagesOptions != nil && pageBlobUploadPagesOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *pageBlobUploadPagesOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, req.SetBody(body, "application/octet-stream")
 }
 
@@ -1133,6 +1141,7 @@ func (client *pageBlobClient) UploadPagesFromURLCreateRequest(ctx context.Contex
 	if pageBlobUploadPagesFromUrlOptions != nil && pageBlobUploadPagesFromUrlOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *pageBlobUploadPagesFromUrlOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 

--- a/test/storage/2019-07-07/azblob/zz_generated_service.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_service.go
@@ -75,6 +75,7 @@ func (client *serviceClient) GetAccountInfoCreateRequest(ctx context.Context) (*
 	query.Set("comp", "properties")
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("x-ms-version", "2019-07-07")
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -152,6 +153,7 @@ func (client *serviceClient) GetPropertiesCreateRequest(ctx context.Context, ser
 	if serviceGetPropertiesOptions != nil && serviceGetPropertiesOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *serviceGetPropertiesOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -216,6 +218,7 @@ func (client *serviceClient) GetStatisticsCreateRequest(ctx context.Context, ser
 	if serviceGetStatisticsOptions != nil && serviceGetStatisticsOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *serviceGetStatisticsOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -287,6 +290,7 @@ func (client *serviceClient) GetUserDelegationKeyCreateRequest(ctx context.Conte
 	if serviceGetUserDelegationKeyOptions != nil && serviceGetUserDelegationKeyOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *serviceGetUserDelegationKeyOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, req.MarshalAsXML(keyInfo)
 }
 
@@ -363,6 +367,7 @@ func (client *serviceClient) ListContainersSegmentCreateRequest(ctx context.Cont
 	if serviceListContainersSegmentOptions != nil && serviceListContainersSegmentOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *serviceListContainersSegmentOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, nil
 }
 
@@ -427,6 +432,7 @@ func (client *serviceClient) SetPropertiesCreateRequest(ctx context.Context, sto
 	if serviceSetPropertiesOptions != nil && serviceSetPropertiesOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *serviceSetPropertiesOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, req.MarshalAsXML(storageServiceProperties)
 }
 
@@ -493,6 +499,7 @@ func (client *serviceClient) SubmitBatchCreateRequest(ctx context.Context, conte
 	if serviceSubmitBatchOptions != nil && serviceSubmitBatchOptions.RequestId != nil {
 		req.Header.Set("x-ms-client-request-id", *serviceSubmitBatchOptions.RequestId)
 	}
+	req.Header.Set("Accept", "application/xml")
 	return req, req.MarshalAsXML(body)
 }
 


### PR DESCRIPTION
Add support for x-ms-header-collection-prefix on header response types.
This required updating M4 to properly support which also introduced the
header 'Accept' which specifies the content type.