### PR TITLE
Call error handler outside of response handler

### DIFF
--- a/src/generator/arm_pollers.ts
+++ b/src/generator/arm_pollers.ts
@@ -24,6 +24,7 @@ function generatePagerReturnInstance(op: Operation, imports: ImportManager): str
   text += `\treturn &${camelCase(op.language.go!.pageableType.name)}{\n`;
   text += `\t\tpipeline: p.pipeline,\n`;
   text += `\t\tresp: resp,\n`;
+  text += '\t\terrorer: p.errHandler,\n';
   text += `\t\tresponder: p.respHandler,\n`;
   const pager = <PagerInfo>op.language.go!.pageableType;
   const pagerSchema = <SchemaResponse>pager.op.responses![0];
@@ -107,6 +108,7 @@ export async function generateARMPollers(session: Session<CodeModel>): Promise<s
       // for operations that do return a model add a final response method that handles the final get URL scenario
       finalResponseDeclaration = `FinalResponse(ctx context.Context) (${responseType}, error)`;
       pagerFields = `
+      errHandler  ${camelCase(poller.op.language.go!.pageableType.op.responses![0].schema.language.go!.name)}HandleError
       respHandler ${camelCase(poller.op.language.go!.pageableType.op.responses![0].schema.language.go!.name)}HandleResponse`;
       handleResponse = `
       func (p *${pollerName}) handleResponse(resp *azcore.Response) (${responseType}, error) {

--- a/src/generator/arm_pollers.ts
+++ b/src/generator/arm_pollers.ts
@@ -100,7 +100,7 @@ export async function generateARMPollers(session: Session<CodeModel>): Promise<s
                 if err != nil {
                   return nil, err
                 }
-                return p.handleResponse(&azcore.Response{resp})`;
+                return p.handleResponse(&azcore.Response{Response: resp})`;
       }
       responseType = poller.op.language.go!.pageableType.name;
       pollUntilDoneResponse = `(${responseType}, error)`;

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -6,7 +6,7 @@
 import { Session } from '@azure-tools/autorest-extension-base';
 import { values } from '@azure-tools/linq';
 import { comment, camelCase, pascalCase } from '@azure-tools/codegen';
-import { aggregateParameters } from '../common/helpers';
+import { aggregateParameters, isSchemaResponse } from '../common/helpers';
 import { ArraySchema, CodeModel, DictionarySchema, Language, Parameter, Schema, SchemaType, Operation, GroupProperty, ImplementationLocation, SerializationStyle, ByteArraySchema, ConstantSchema, NumberSchema, DateTimeSchema } from '@azure-tools/codemodel';
 import { ImportManager } from './imports';
 
@@ -239,4 +239,14 @@ export function formatParamValue(param: Parameter, imports: ImportManager): stri
     default:
       return paramName;
   }
+}
+
+// returns true if at least one of the responses has a schema
+export function hasSchemaResponse(op: Operation): boolean {
+  for (const resp of values(op.responses)) {
+    if (isSchemaResponse(resp)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -250,3 +250,64 @@ export function hasSchemaResponse(op: Operation): boolean {
   }
   return false;
 }
+
+export function getStatusCodes(op: Operation): string[] {
+  // concat all status codes that return the same schema into one array.
+  // this is to support operations that specify multiple response codes
+  // that return the same schema (or no schema).
+  let statusCodes = new Array<string>();
+  for (const resp of values(op.responses)) {
+    statusCodes = statusCodes.concat(resp.protocol.http?.statusCodes);
+  }
+  /*if (isLROOperation(op) && statusCodes.find(element => element === '204') === undefined) {
+    statusCodes = statusCodes.concat('204');
+  }*/
+  return statusCodes;
+}
+
+export function formatStatusCodes(statusCodes: Array<string>): string {
+  const asHTTPStatus = new Array<string>();
+  for (const rawCode of values(statusCodes)) {
+    asHTTPStatus.push(formatStatusCode(rawCode));
+  }
+  return asHTTPStatus.join(', ');
+}
+
+export function formatStatusCode(statusCode: string): string {
+  switch (statusCode) {
+    case '200':
+      return 'http.StatusOK';
+    case '201':
+      return 'http.StatusCreated';
+    case '202':
+      return 'http.StatusAccepted';
+    case '204':
+      return 'http.StatusNoContent';
+    case '206':
+      return 'http.StatusPartialContent';
+    case '300':
+      return 'http.StatusMultipleChoices';
+    case '301':
+      return 'http.StatusMovedPermanently';
+    case '302':
+      return 'http.StatusFound';
+    case '303':
+      return 'http.StatusSeeOther';
+    case '304':
+      return 'http.StatusNotModified';
+    case '307':
+      return 'http.StatusTemporaryRedirect';
+    case '400':
+      return 'http.StatusBadRequest';
+    case '404':
+      return 'http.StatusNotFound';
+    case '409':
+      return 'http.StatusConflict';
+    case '500':
+      return 'http.StatusInternalServerError';
+    case '501':
+      return 'http.StatusNotImplemented';
+    default:
+      throw console.error(`unhandled status code ${statusCode}`);
+  }
+}

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -9,7 +9,7 @@ import { ArraySchema, ByteArraySchema, CodeModel, ConstantSchema, DateTimeSchema
 import { values } from '@azure-tools/linq';
 import { aggregateParameters, isArraySchema, isPageableOperation, isSchemaResponse, PagerInfo, isLROOperation } from '../common/helpers';
 import { OperationNaming } from '../transform/namer';
-import { contentPreamble, formatParameterTypeName, hasDescription, skipURLEncoding, sortAscending, getCreateRequestParametersSig, getMethodParameters, getParamName, formatParamValue, dateFormat, datetimeRFC1123Format, datetimeRFC3339Format, sortParametersByRequired } from './helpers';
+import { contentPreamble, formatParameterTypeName, hasDescription, hasSchemaResponse, skipURLEncoding, sortAscending, getCreateRequestParametersSig, getMethodParameters, getParamName, formatParamValue, dateFormat, datetimeRFC1123Format, datetimeRFC3339Format, sortParametersByRequired } from './helpers';
 import { ImportManager } from './imports';
 
 // represents the generated content for an operation group
@@ -248,6 +248,9 @@ function generateOperation(op: Operation, imports: ImportManager, isDataPlane: b
       text += '\t\tresult.RawResponse: resp\n';
       text += '\t}\n';
     } else {
+      text += `\tif err := client.${info.protocolNaming.errorMethod}(resp); err != nil {\n`;
+      text += `\t\treturn nil, err\n`;
+      text += '\t}\n';
       text += `\tresult, err := client.${info.protocolNaming.responseMethod}(resp)\n`;
       text += `\tif err != nil {\n`;
       text += `\t\treturn nil, err\n`;
@@ -264,11 +267,27 @@ function generateOperation(op: Operation, imports: ImportManager, isDataPlane: b
     text += '\t\treturn nil, err\n';
     text += '\t}\n';
     text += `\tpoller := &${camelCase(op.language.go!.pollerType.name)}{\n`;
-    text += '\t\t\tpt: pt,\n';
+    text += '\t\tpt: pt,\n';
     if (isPageableOperation(op)) {
-      text += `\t\t\trespHandler: client.${camelCase(op.language.go!.pageableType.name)}HandleResponse,\n`;
+      const statusCodes = getStatusCodes(op);
+      if (statusCodes.indexOf('200') < 0) {
+        statusCodes.push('200');
+      }
+      if (statusCodes.indexOf('204') < 0) {
+        statusCodes.push('204');
+      }
+      statusCodes.sort();
+      text += `\t\terrHandler: func(resp *azcore.Response) error {\n`;
+      text += `\t\t\tif resp.HasStatusCode(${formatStatusCodes(statusCodes)}) {\n`;
+      text += `\t\t\t\treturn nil\n`;
+      text += '\t\t\t}\n';
+      text += `\t\t\treturn client.${info.protocolNaming.errorMethod}(resp)\n`;
+      text += '\t\t},\n';
+      text += `\t\trespHandler: func(resp *azcore.Response) (*ProductResultResponse, error) {\n`;
+      text += generateResponseUnmarshaller(op.responses![0], false, imports);
+      text += '\t\t},\n';
     }
-    text += '\t\t\tpipeline: client.p,\n';
+    text += '\t\tpipeline: client.p,\n';
     text += '\t}\n';
     text += '\tresult.Poller = poller\n';
     // determine the poller response based on the name and whether is is a pageable operation
@@ -294,6 +313,7 @@ function generateOperation(op: Operation, imports: ImportManager, isDataPlane: b
     text += `\t\t\treturn client.${info.protocolNaming.requestMethod}(${reqParams.join(', ')})\n`;
     text += '\t\t},\n';
     text += `\t\tresponder: client.${info.protocolNaming.responseMethod},\n`;
+    text += `\t\terrorer:   client.${info.protocolNaming.errorMethod},\n`;
     const pager = <PagerInfo>op.language.go!.pageableType;
     const schemaResponse = <SchemaResponse>pager.op.responses![0];
     const nextLink = pager.op.language.go!.paging.nextLinkName;
@@ -334,14 +354,35 @@ function generateOperation(op: Operation, imports: ImportManager, isDataPlane: b
   text += `\tif err != nil {\n`;
   text += `\t\treturn nil, err\n`;
   text += `\t}\n`;
-  // also cheating here as at present the only param to the responder is an azcore.Response
-  text += `\tresult, err := client.${info.protocolNaming.responseMethod}(resp)\n`;
-  text += `\tif err != nil {\n`;
+  text += `\tif err := client.${info.protocolNaming.errorMethod}(resp); err != nil {\n`;
   text += `\t\treturn nil, err\n`;
-  text += `\t}\n`;
-  text += `\treturn result, nil\n`;
+  text += '\t}\n';
+  if (needsResponseHandler(op)) {
+    // also cheating here as at present the only param to the responder is an azcore.Response
+    text += `\tresult, err := client.${info.protocolNaming.responseMethod}(resp)\n`;
+    text += `\tif err != nil {\n`;
+    text += `\t\treturn nil, err\n`;
+    text += `\t}\n`;
+    text += `\treturn result, nil\n`;
+  } else {
+    text += '\treturn resp.Response, nil\n';
+  }
   text += '}\n\n';
   return text;
+}
+
+function getStatusCodes(op: Operation): string[] {
+  // concat all status codes that return the same schema into one array.
+  // this is to support operations that specify multiple response codes
+  // that return the same schema (or no schema).
+  let statusCodes = new Array<string>();
+  for (const resp of values(op.responses)) {
+    statusCodes = statusCodes.concat(resp.protocol.http?.statusCodes);
+  }
+  if (isLROOperation(op) && statusCodes.find(element => element === '204') === undefined) {
+    statusCodes = statusCodes.concat('204');
+  }
+  return statusCodes;
 }
 
 function createProtocolRequest(codeModel: CodeModel, op: Operation, imports: ImportManager): string {
@@ -632,126 +673,99 @@ function isArrayOfTimesForMarshalling(schema: Schema): boolean {
   return (<DateTimeSchema>arrayElem).format === 'date-time-rfc1123';
 }
 
+function needsResponseHandler(op: Operation): boolean {
+  return hasSchemaResponse(op) || isLROOperation(op) || isPageableOperation(op);
+}
+
+function generateResponseUnmarshaller(response: Response, isLRO: boolean, imports: ImportManager): string {
+  let unmarshallerText = '';
+  if (!isSchemaResponse(response)) {
+    if (isLRO) {
+      unmarshallerText += '\treturn &HTTPPollerResponse{RawResponse: resp.Response}, nil\n';
+      return unmarshallerText;
+    }
+    throw console.error('TODO');
+  } else if (response.schema.type === SchemaType.DateTime || response.schema.type === SchemaType.UnixTime) {
+    // use the designated time type for unmarshalling
+    unmarshallerText += `\tvar aux *${response.schema.language.go!.internalTimeType}\n`;
+    unmarshallerText += `\terr := resp.UnmarshalAs${getMediaType(response.protocol)}(&aux)\n`;
+    const resp = `${response.schema.language.go!.responseType.name}{RawResponse: resp.Response, ${response.schema.language.go!.responseType.value}: (*time.Time)(aux)}`;
+    unmarshallerText += `\treturn &${resp}, err\n`;
+    return unmarshallerText;
+  } else if (isArrayOfDateTime(response.schema)) {
+    // unmarshalling arrays of date/time is a little more involved
+    unmarshallerText += `\tvar aux *[]${(<ArraySchema>response.schema).elementType.language.go!.internalTimeType}\n`;
+    unmarshallerText += `\tif err := resp.UnmarshalAs${getMediaType(response.protocol)}(&aux); err != nil {\n`;
+    unmarshallerText += '\t\treturn nil, err\n';
+    unmarshallerText += '\t}\n';
+    unmarshallerText += '\tcp := make([]time.Time, len(*aux), len(*aux))\n';
+    unmarshallerText += '\tfor i := 0; i < len(*aux); i++ {\n';
+    unmarshallerText += '\t\tcp[i] = time.Time((*aux)[i])\n';
+    unmarshallerText += '\t}\n';
+    const resp = `${response.schema.language.go!.responseType.name}{RawResponse: resp.Response, ${response.schema.language.go!.responseType.value}: &cp}`;
+    unmarshallerText += `\treturn &${resp}, nil\n`;
+    return unmarshallerText;
+  } else if (isMapOfDateTime(response.schema)) {
+    unmarshallerText += `\taux := map[string]${(<DictionarySchema>response.schema).elementType.language.go!.internalTimeType}{}\n`;
+    unmarshallerText += `\tif err := resp.UnmarshalAs${getMediaType(response.protocol)}(&aux); err != nil {\n`;
+    unmarshallerText += '\t\treturn nil, err\n';
+    unmarshallerText += '\t}\n';
+    unmarshallerText += `\tcp := map[string]time.Time{}\n`;
+    unmarshallerText += `\tfor k, v := range aux {\n`;
+    unmarshallerText += `\t\tcp[k] = time.Time(v)\n`;
+    unmarshallerText += `\t}\n`;
+    const resp = `${response.schema.language.go!.responseType.name}{RawResponse: resp.Response, ${response.schema.language.go!.responseType.value}: &cp}`;
+    unmarshallerText += `\treturn &${resp}, nil\n`;
+    return unmarshallerText;
+  }
+  const schemaResponse = <SchemaResponse>response;
+  if (isLRO) {
+    unmarshallerText += `\treturn &${schemaResponse.schema.language.go!.lroResponseType.language.go!.name}{RawResponse: resp.Response}, nil\n`;
+    return unmarshallerText;
+  }
+  let respObj = `${schemaResponse.schema.language.go!.responseType.name}{RawResponse: resp.Response}`;
+  unmarshallerText += `\tresult := ${respObj}\n`;
+  // assign any header values
+  for (const prop of values(<Array<Property>>schemaResponse.schema.language.go!.properties)) {
+    if (prop.language.go!.fromHeader) {
+      unmarshallerText += formatHeaderResponseValue(prop.language.go!.name, prop.language.go!.fromHeader, prop.schema, imports, 'result');
+    }
+  }
+  const mediaType = getMediaType(response.protocol);
+  if (mediaType === 'JSON' || mediaType === 'XML') {
+    let target = `result.${schemaResponse.schema.language.go!.responseType.value}`;
+    // when unmarshalling a wrapped XML array or discriminated type, unmarshal into the response type, not the field
+    if ((mediaType === 'XML' && schemaResponse.schema.type === SchemaType.Array) || schemaResponse.schema.language.go!.discriminatorInterface) {
+      target = 'result';
+    }
+    unmarshallerText += `\treturn &result, resp.UnmarshalAs${getMediaFormat(response.schema, mediaType, `&${target}`)}\n`;
+    return unmarshallerText;
+  }
+  // nothing to unmarshal
+  unmarshallerText += '\treturn &result, nil\n';
+  return unmarshallerText;
+}
+
 function createProtocolResponse(op: Operation, imports: ImportManager): string {
+  if (!needsResponseHandler(op)) {
+    return '';
+  }
   const info = <OperationNaming>op.language.go!;
   const name = info.protocolNaming.responseMethod;
   const clientName = op.language.go!.clientName;
   let text = `${comment(name, '// ')} handles the ${info.name} response.\n`;
   text += `func (client *${clientName}) ${name}(resp *azcore.Response) (${generateReturnsInfo(op, true).join(', ')}) {\n`;
-  if (!op.responses) {
-    text += `\treturn nil, client.${info.protocolNaming.errorMethod}(resp)`;
-    text += '}\n\n';
-    return text;
-  }
-  const generateResponseUnmarshaller = function (response: Response, isLRO: boolean): string {
-    let unmarshallerText = '';
-    if (!isSchemaResponse(response)) {
-      if (isLRO) {
-        unmarshallerText += '\treturn &HTTPPollerResponse{RawResponse: resp.Response}, nil\n';
-        return unmarshallerText;
-      }
-      // no response body, return the *http.Response
-      unmarshallerText += `\treturn resp.Response, nil\n`;
-      return unmarshallerText;
-    } else if (response.schema.type === SchemaType.DateTime || response.schema.type === SchemaType.UnixTime) {
-      // use the designated time type for unmarshalling
-      unmarshallerText += `\tvar aux *${response.schema.language.go!.internalTimeType}\n`;
-      unmarshallerText += `\terr := resp.UnmarshalAs${getMediaType(response.protocol)}(&aux)\n`;
-      const resp = `${response.schema.language.go!.responseType.name}{RawResponse: resp.Response, ${response.schema.language.go!.responseType.value}: (*time.Time)(aux)}`;
-      unmarshallerText += `\treturn &${resp}, err\n`;
-      return unmarshallerText;
-    } else if (isArrayOfDateTime(response.schema)) {
-      // unmarshalling arrays of date/time is a little more involved
-      unmarshallerText += `\tvar aux *[]${(<ArraySchema>response.schema).elementType.language.go!.internalTimeType}\n`;
-      unmarshallerText += `\tif err := resp.UnmarshalAs${getMediaType(response.protocol)}(&aux); err != nil {\n`;
-      unmarshallerText += '\t\treturn nil, err\n';
-      unmarshallerText += '\t}\n';
-      unmarshallerText += '\tcp := make([]time.Time, len(*aux), len(*aux))\n';
-      unmarshallerText += '\tfor i := 0; i < len(*aux); i++ {\n';
-      unmarshallerText += '\t\tcp[i] = time.Time((*aux)[i])\n';
-      unmarshallerText += '\t}\n';
-      const resp = `${response.schema.language.go!.responseType.name}{RawResponse: resp.Response, ${response.schema.language.go!.responseType.value}: &cp}`;
-      unmarshallerText += `\treturn &${resp}, nil\n`;
-      return unmarshallerText;
-    } else if (isMapOfDateTime(response.schema)) {
-      unmarshallerText += `\taux := map[string]${(<DictionarySchema>response.schema).elementType.language.go!.internalTimeType}{}\n`;
-      unmarshallerText += `\tif err := resp.UnmarshalAs${getMediaType(response.protocol)}(&aux); err != nil {\n`;
-      unmarshallerText += '\t\treturn nil, err\n';
-      unmarshallerText += '\t}\n';
-      unmarshallerText += `\tcp := map[string]time.Time{}\n`;
-      unmarshallerText += `\tfor k, v := range aux {\n`;
-      unmarshallerText += `\t\tcp[k] = time.Time(v)\n`;
-      unmarshallerText += `\t}\n`;
-      const resp = `${response.schema.language.go!.responseType.name}{RawResponse: resp.Response, ${response.schema.language.go!.responseType.value}: &cp}`;
-      unmarshallerText += `\treturn &${resp}, nil\n`;
-      return unmarshallerText;
-    }
-    const schemaResponse = <SchemaResponse>response;
-    if (isLRO) {
-      unmarshallerText += `\treturn &${schemaResponse.schema.language.go!.lroResponseType.language.go!.name}{RawResponse: resp.Response}, nil\n`;
-      return unmarshallerText;
-    }
-    let respObj = `${schemaResponse.schema.language.go!.responseType.name}{RawResponse: resp.Response}`;
-    unmarshallerText += `\tresult := ${respObj}\n`;
-    // assign any header values
-    for (const prop of values(<Array<Property>>schemaResponse.schema.language.go!.properties)) {
-      if (prop.language.go!.fromHeader) {
-        unmarshallerText += formatHeaderResponseValue(prop.language.go!.name, prop.language.go!.fromHeader, prop.schema, imports, 'result');
-      }
-    }
-    const mediaType = getMediaType(response.protocol);
-    if (mediaType === 'JSON' || mediaType === 'XML') {
-      let target = `result.${schemaResponse.schema.language.go!.responseType.value}`;
-      // when unmarshalling a wrapped XML array or discriminated type, unmarshal into the response type, not the field
-      if ((mediaType === 'XML' && schemaResponse.schema.type === SchemaType.Array) || schemaResponse.schema.language.go!.discriminatorInterface) {
-        target = 'result';
-      }
-      unmarshallerText += `\treturn &result, resp.UnmarshalAs${getMediaFormat(response.schema, mediaType, `&${target}`)}\n`;
-      return unmarshallerText;
-    }
-    // nothing to unmarshal
-    unmarshallerText += '\treturn &result, nil\n';
-    return unmarshallerText;
-  };
   if (!isMultiRespOperation(op)) {
-    // concat all status codes that return the same schema into one array.
-    // this is to support operations that specify multiple response codes
-    // that return the same schema (or no schema).
-    let statusCodes = new Array<string>();
-    for (let i = 0; i < op.responses.length; ++i) {
-      statusCodes = statusCodes.concat(op.responses[i].protocol.http?.statusCodes);
-    }
-    if (isLROOperation(op) && statusCodes.find(element => element === '204') === undefined) {
-      statusCodes = statusCodes.concat('204');
-    }
-    text += `\tif !resp.HasStatusCode(${formatStatusCodes(statusCodes)}) {\n`;
-    text += `\t\treturn nil, client.${info.protocolNaming.errorMethod}(resp)\n`;
-    text += '\t}\n';
-    if (isLROOperation(op) && isPageableOperation(op)) {
-      text += generateResponseUnmarshaller(op.responses![0], true);
-      text += '}\n\n';
-      text += `${comment(name, '// ')} handles the ${info.name} response.\n`;
-      text += `func (client *${clientName}) ${camelCase(op.language.go!.pageableType.name)}HandleResponse(resp *azcore.Response) (*${(<SchemaResponse>op.responses![0]).schema.language.go!.responseType.value}Response, error) {\n`;
-      const index = statusCodes.indexOf('204');
-      if (index > -1) {
-        statusCodes.splice(index, 1);
-      }
-      statusCodes.push('200');
-      text += `\tif !resp.HasStatusCode(${formatStatusCodes(statusCodes)}) {\n`;
-      text += `\t\treturn nil, client.${info.protocolNaming.errorMethod}(resp)\n`;
-      text += '\t}\n';
-      text += generateResponseUnmarshaller(op.responses![0], false);
-    } else {
-      text += generateResponseUnmarshaller(op.responses![0], isLROOperation(op));
-    }
+    text += generateResponseUnmarshaller(op.responses![0], isLROOperation(op), imports);
   } else {
+    imports.add('fmt');
     text += '\tswitch resp.StatusCode {\n';
     for (const response of values(op.responses)) {
       text += `\tcase ${formatStatusCodes(response.protocol.http!.statusCodes)}:\n`
-      text += generateResponseUnmarshaller(response, isLROOperation(op));
+      text += generateResponseUnmarshaller(response, isLROOperation(op), imports);
     }
     text += '\tdefault:\n';
-    text += `\t\treturn nil, client.${info.protocolNaming.errorMethod}(resp)\n`;
+    text += `\t\treturn nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)\n`;
     text += '\t}\n';
   }
   text += '}\n\n';
@@ -763,7 +777,11 @@ function createProtocolErrHandler(op: Operation, imports: ImportManager): string
   const name = info.protocolNaming.errorMethod;
   let text = `${comment(name, '// ')} handles the ${info.name} error response.\n`;
   text += `func (client *${op.language.go!.clientName}) ${name}(resp *azcore.Response) error {\n`;
-
+  // exit early on successful status codes
+  const statusCodes = getStatusCodes(op);
+  text += `\tif resp.HasStatusCode(${formatStatusCodes(statusCodes)}) {\n`;
+  text += `\t\treturn nil\n`;
+  text += '\t}\n';
   // define a generic error for when there are no exceptions or no error schema
   const generateGenericError = function () {
     imports.add('errors');

--- a/test/autorest/additionalpropsgroup/zz_generated_pets.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_pets.go
@@ -53,6 +53,9 @@ func (client *PetsClient) CreateApInProperties(ctx context.Context, createParame
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateApInPropertiesHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateApInPropertiesHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -73,15 +76,15 @@ func (client *PetsClient) CreateApInPropertiesCreateRequest(ctx context.Context,
 
 // CreateApInPropertiesHandleResponse handles the CreateApInProperties response.
 func (client *PetsClient) CreateApInPropertiesHandleResponse(resp *azcore.Response) (*PetApInPropertiesResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.CreateApInPropertiesHandleError(resp)
-	}
 	result := PetApInPropertiesResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PetApInProperties)
 }
 
 // CreateApInPropertiesHandleError handles the CreateApInProperties error response.
 func (client *PetsClient) CreateApInPropertiesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -97,6 +100,9 @@ func (client *PetsClient) CreateApInPropertiesWithApstring(ctx context.Context, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CreateApInPropertiesWithApstringHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CreateApInPropertiesWithApstringHandleResponse(resp)
@@ -119,15 +125,15 @@ func (client *PetsClient) CreateApInPropertiesWithApstringCreateRequest(ctx cont
 
 // CreateApInPropertiesWithApstringHandleResponse handles the CreateApInPropertiesWithApstring response.
 func (client *PetsClient) CreateApInPropertiesWithApstringHandleResponse(resp *azcore.Response) (*PetApInPropertiesWithApstringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.CreateApInPropertiesWithApstringHandleError(resp)
-	}
 	result := PetApInPropertiesWithApstringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PetApInPropertiesWithApstring)
 }
 
 // CreateApInPropertiesWithApstringHandleError handles the CreateApInPropertiesWithApstring error response.
 func (client *PetsClient) CreateApInPropertiesWithApstringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -143,6 +149,9 @@ func (client *PetsClient) CreateApObject(ctx context.Context, createParameters P
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CreateApObjectHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CreateApObjectHandleResponse(resp)
@@ -165,15 +174,15 @@ func (client *PetsClient) CreateApObjectCreateRequest(ctx context.Context, creat
 
 // CreateApObjectHandleResponse handles the CreateApObject response.
 func (client *PetsClient) CreateApObjectHandleResponse(resp *azcore.Response) (*PetApObjectResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.CreateApObjectHandleError(resp)
-	}
 	result := PetApObjectResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PetApObject)
 }
 
 // CreateApObjectHandleError handles the CreateApObject error response.
 func (client *PetsClient) CreateApObjectHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -189,6 +198,9 @@ func (client *PetsClient) CreateApString(ctx context.Context, createParameters P
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CreateApStringHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CreateApStringHandleResponse(resp)
@@ -211,15 +223,15 @@ func (client *PetsClient) CreateApStringCreateRequest(ctx context.Context, creat
 
 // CreateApStringHandleResponse handles the CreateApString response.
 func (client *PetsClient) CreateApStringHandleResponse(resp *azcore.Response) (*PetApStringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.CreateApStringHandleError(resp)
-	}
 	result := PetApStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PetApString)
 }
 
 // CreateApStringHandleError handles the CreateApString error response.
 func (client *PetsClient) CreateApStringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -235,6 +247,9 @@ func (client *PetsClient) CreateApTrue(ctx context.Context, createParameters Pet
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CreateApTrueHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CreateApTrueHandleResponse(resp)
@@ -257,15 +272,15 @@ func (client *PetsClient) CreateApTrueCreateRequest(ctx context.Context, createP
 
 // CreateApTrueHandleResponse handles the CreateApTrue response.
 func (client *PetsClient) CreateApTrueHandleResponse(resp *azcore.Response) (*PetApTrueResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.CreateApTrueHandleError(resp)
-	}
 	result := PetApTrueResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PetApTrue)
 }
 
 // CreateApTrueHandleError handles the CreateApTrue error response.
 func (client *PetsClient) CreateApTrueHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -281,6 +296,9 @@ func (client *PetsClient) CreateCatApTrue(ctx context.Context, createParameters 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CreateCatApTrueHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CreateCatApTrueHandleResponse(resp)
@@ -303,15 +321,15 @@ func (client *PetsClient) CreateCatApTrueCreateRequest(ctx context.Context, crea
 
 // CreateCatApTrueHandleResponse handles the CreateCatApTrue response.
 func (client *PetsClient) CreateCatApTrueHandleResponse(resp *azcore.Response) (*CatApTrueResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.CreateCatApTrueHandleError(resp)
-	}
 	result := CatApTrueResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.CatApTrue)
 }
 
 // CreateCatApTrueHandleError handles the CreateCatApTrue error response.
 func (client *PetsClient) CreateCatApTrueHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/additionalpropsgroup/zz_generated_pets.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_pets.go
@@ -53,8 +53,8 @@ func (client *PetsClient) CreateApInProperties(ctx context.Context, createParame
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateApInPropertiesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.CreateApInPropertiesHandleError(resp)
 	}
 	result, err := client.CreateApInPropertiesHandleResponse(resp)
 	if err != nil {
@@ -82,9 +82,6 @@ func (client *PetsClient) CreateApInPropertiesHandleResponse(resp *azcore.Respon
 
 // CreateApInPropertiesHandleError handles the CreateApInProperties error response.
 func (client *PetsClient) CreateApInPropertiesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -102,8 +99,8 @@ func (client *PetsClient) CreateApInPropertiesWithApstring(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateApInPropertiesWithApstringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.CreateApInPropertiesWithApstringHandleError(resp)
 	}
 	result, err := client.CreateApInPropertiesWithApstringHandleResponse(resp)
 	if err != nil {
@@ -131,9 +128,6 @@ func (client *PetsClient) CreateApInPropertiesWithApstringHandleResponse(resp *a
 
 // CreateApInPropertiesWithApstringHandleError handles the CreateApInPropertiesWithApstring error response.
 func (client *PetsClient) CreateApInPropertiesWithApstringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -151,8 +145,8 @@ func (client *PetsClient) CreateApObject(ctx context.Context, createParameters P
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateApObjectHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.CreateApObjectHandleError(resp)
 	}
 	result, err := client.CreateApObjectHandleResponse(resp)
 	if err != nil {
@@ -180,9 +174,6 @@ func (client *PetsClient) CreateApObjectHandleResponse(resp *azcore.Response) (*
 
 // CreateApObjectHandleError handles the CreateApObject error response.
 func (client *PetsClient) CreateApObjectHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -200,8 +191,8 @@ func (client *PetsClient) CreateApString(ctx context.Context, createParameters P
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateApStringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.CreateApStringHandleError(resp)
 	}
 	result, err := client.CreateApStringHandleResponse(resp)
 	if err != nil {
@@ -229,9 +220,6 @@ func (client *PetsClient) CreateApStringHandleResponse(resp *azcore.Response) (*
 
 // CreateApStringHandleError handles the CreateApString error response.
 func (client *PetsClient) CreateApStringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -249,8 +237,8 @@ func (client *PetsClient) CreateApTrue(ctx context.Context, createParameters Pet
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateApTrueHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.CreateApTrueHandleError(resp)
 	}
 	result, err := client.CreateApTrueHandleResponse(resp)
 	if err != nil {
@@ -278,9 +266,6 @@ func (client *PetsClient) CreateApTrueHandleResponse(resp *azcore.Response) (*Pe
 
 // CreateApTrueHandleError handles the CreateApTrue error response.
 func (client *PetsClient) CreateApTrueHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -298,8 +283,8 @@ func (client *PetsClient) CreateCatApTrue(ctx context.Context, createParameters 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateCatApTrueHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.CreateCatApTrueHandleError(resp)
 	}
 	result, err := client.CreateCatApTrueHandleResponse(resp)
 	if err != nil {
@@ -327,9 +312,6 @@ func (client *PetsClient) CreateCatApTrueHandleResponse(resp *azcore.Response) (
 
 // CreateCatApTrueHandleError handles the CreateCatApTrue error response.
 func (client *PetsClient) CreateCatApTrueHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/arraygroup/zz_generated_array.go
+++ b/test/autorest/arraygroup/zz_generated_array.go
@@ -180,6 +180,9 @@ func (client *ArrayClient) GetArrayEmpty(ctx context.Context) (*StringArrayArray
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetArrayEmptyHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetArrayEmptyHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -200,15 +203,15 @@ func (client *ArrayClient) GetArrayEmptyCreateRequest(ctx context.Context) (*azc
 
 // GetArrayEmptyHandleResponse handles the GetArrayEmpty response.
 func (client *ArrayClient) GetArrayEmptyHandleResponse(resp *azcore.Response) (*StringArrayArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetArrayEmptyHandleError(resp)
-	}
 	result := StringArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArrayArray)
 }
 
 // GetArrayEmptyHandleError handles the GetArrayEmpty error response.
 func (client *ArrayClient) GetArrayEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -224,6 +227,9 @@ func (client *ArrayClient) GetArrayItemEmpty(ctx context.Context) (*StringArrayA
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetArrayItemEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetArrayItemEmptyHandleResponse(resp)
@@ -246,15 +252,15 @@ func (client *ArrayClient) GetArrayItemEmptyCreateRequest(ctx context.Context) (
 
 // GetArrayItemEmptyHandleResponse handles the GetArrayItemEmpty response.
 func (client *ArrayClient) GetArrayItemEmptyHandleResponse(resp *azcore.Response) (*StringArrayArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetArrayItemEmptyHandleError(resp)
-	}
 	result := StringArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArrayArray)
 }
 
 // GetArrayItemEmptyHandleError handles the GetArrayItemEmpty error response.
 func (client *ArrayClient) GetArrayItemEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -270,6 +276,9 @@ func (client *ArrayClient) GetArrayItemNull(ctx context.Context) (*StringArrayAr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetArrayItemNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetArrayItemNullHandleResponse(resp)
@@ -292,15 +301,15 @@ func (client *ArrayClient) GetArrayItemNullCreateRequest(ctx context.Context) (*
 
 // GetArrayItemNullHandleResponse handles the GetArrayItemNull response.
 func (client *ArrayClient) GetArrayItemNullHandleResponse(resp *azcore.Response) (*StringArrayArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetArrayItemNullHandleError(resp)
-	}
 	result := StringArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArrayArray)
 }
 
 // GetArrayItemNullHandleError handles the GetArrayItemNull error response.
 func (client *ArrayClient) GetArrayItemNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -316,6 +325,9 @@ func (client *ArrayClient) GetArrayNull(ctx context.Context) (*StringArrayArrayR
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetArrayNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetArrayNullHandleResponse(resp)
@@ -338,15 +350,15 @@ func (client *ArrayClient) GetArrayNullCreateRequest(ctx context.Context) (*azco
 
 // GetArrayNullHandleResponse handles the GetArrayNull response.
 func (client *ArrayClient) GetArrayNullHandleResponse(resp *azcore.Response) (*StringArrayArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetArrayNullHandleError(resp)
-	}
 	result := StringArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArrayArray)
 }
 
 // GetArrayNullHandleError handles the GetArrayNull error response.
 func (client *ArrayClient) GetArrayNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -362,6 +374,9 @@ func (client *ArrayClient) GetArrayValid(ctx context.Context) (*StringArrayArray
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetArrayValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetArrayValidHandleResponse(resp)
@@ -384,15 +399,15 @@ func (client *ArrayClient) GetArrayValidCreateRequest(ctx context.Context) (*azc
 
 // GetArrayValidHandleResponse handles the GetArrayValid response.
 func (client *ArrayClient) GetArrayValidHandleResponse(resp *azcore.Response) (*StringArrayArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetArrayValidHandleError(resp)
-	}
 	result := StringArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArrayArray)
 }
 
 // GetArrayValidHandleError handles the GetArrayValid error response.
 func (client *ArrayClient) GetArrayValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -408,6 +423,9 @@ func (client *ArrayClient) GetBase64URL(ctx context.Context) (*ByteArrayArrayRes
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBase64URLHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBase64URLHandleResponse(resp)
@@ -430,15 +448,15 @@ func (client *ArrayClient) GetBase64URLCreateRequest(ctx context.Context) (*azco
 
 // GetBase64URLHandleResponse handles the GetBase64URL response.
 func (client *ArrayClient) GetBase64URLHandleResponse(resp *azcore.Response) (*ByteArrayArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBase64URLHandleError(resp)
-	}
 	result := ByteArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ByteArrayArray)
 }
 
 // GetBase64URLHandleError handles the GetBase64URL error response.
 func (client *ArrayClient) GetBase64URLHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -454,6 +472,9 @@ func (client *ArrayClient) GetBooleanInvalidNull(ctx context.Context) (*BoolArra
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBooleanInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBooleanInvalidNullHandleResponse(resp)
@@ -476,15 +497,15 @@ func (client *ArrayClient) GetBooleanInvalidNullCreateRequest(ctx context.Contex
 
 // GetBooleanInvalidNullHandleResponse handles the GetBooleanInvalidNull response.
 func (client *ArrayClient) GetBooleanInvalidNullHandleResponse(resp *azcore.Response) (*BoolArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBooleanInvalidNullHandleError(resp)
-	}
 	result := BoolArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.BoolArray)
 }
 
 // GetBooleanInvalidNullHandleError handles the GetBooleanInvalidNull error response.
 func (client *ArrayClient) GetBooleanInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -500,6 +521,9 @@ func (client *ArrayClient) GetBooleanInvalidString(ctx context.Context) (*BoolAr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBooleanInvalidStringHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBooleanInvalidStringHandleResponse(resp)
@@ -522,15 +546,15 @@ func (client *ArrayClient) GetBooleanInvalidStringCreateRequest(ctx context.Cont
 
 // GetBooleanInvalidStringHandleResponse handles the GetBooleanInvalidString response.
 func (client *ArrayClient) GetBooleanInvalidStringHandleResponse(resp *azcore.Response) (*BoolArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBooleanInvalidStringHandleError(resp)
-	}
 	result := BoolArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.BoolArray)
 }
 
 // GetBooleanInvalidStringHandleError handles the GetBooleanInvalidString error response.
 func (client *ArrayClient) GetBooleanInvalidStringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -546,6 +570,9 @@ func (client *ArrayClient) GetBooleanTfft(ctx context.Context) (*BoolArrayRespon
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBooleanTfftHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBooleanTfftHandleResponse(resp)
@@ -568,15 +595,15 @@ func (client *ArrayClient) GetBooleanTfftCreateRequest(ctx context.Context) (*az
 
 // GetBooleanTfftHandleResponse handles the GetBooleanTfft response.
 func (client *ArrayClient) GetBooleanTfftHandleResponse(resp *azcore.Response) (*BoolArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBooleanTfftHandleError(resp)
-	}
 	result := BoolArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.BoolArray)
 }
 
 // GetBooleanTfftHandleError handles the GetBooleanTfft error response.
 func (client *ArrayClient) GetBooleanTfftHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -592,6 +619,9 @@ func (client *ArrayClient) GetByteInvalidNull(ctx context.Context) (*ByteArrayAr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetByteInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetByteInvalidNullHandleResponse(resp)
@@ -614,15 +644,15 @@ func (client *ArrayClient) GetByteInvalidNullCreateRequest(ctx context.Context) 
 
 // GetByteInvalidNullHandleResponse handles the GetByteInvalidNull response.
 func (client *ArrayClient) GetByteInvalidNullHandleResponse(resp *azcore.Response) (*ByteArrayArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetByteInvalidNullHandleError(resp)
-	}
 	result := ByteArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ByteArrayArray)
 }
 
 // GetByteInvalidNullHandleError handles the GetByteInvalidNull error response.
 func (client *ArrayClient) GetByteInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -638,6 +668,9 @@ func (client *ArrayClient) GetByteValid(ctx context.Context) (*ByteArrayArrayRes
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetByteValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetByteValidHandleResponse(resp)
@@ -660,15 +693,15 @@ func (client *ArrayClient) GetByteValidCreateRequest(ctx context.Context) (*azco
 
 // GetByteValidHandleResponse handles the GetByteValid response.
 func (client *ArrayClient) GetByteValidHandleResponse(resp *azcore.Response) (*ByteArrayArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetByteValidHandleError(resp)
-	}
 	result := ByteArrayArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ByteArrayArray)
 }
 
 // GetByteValidHandleError handles the GetByteValid error response.
 func (client *ArrayClient) GetByteValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -684,6 +717,9 @@ func (client *ArrayClient) GetComplexEmpty(ctx context.Context) (*ProductArrayRe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetComplexEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetComplexEmptyHandleResponse(resp)
@@ -706,15 +742,15 @@ func (client *ArrayClient) GetComplexEmptyCreateRequest(ctx context.Context) (*a
 
 // GetComplexEmptyHandleResponse handles the GetComplexEmpty response.
 func (client *ArrayClient) GetComplexEmptyHandleResponse(resp *azcore.Response) (*ProductArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetComplexEmptyHandleError(resp)
-	}
 	result := ProductArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductArray)
 }
 
 // GetComplexEmptyHandleError handles the GetComplexEmpty error response.
 func (client *ArrayClient) GetComplexEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -730,6 +766,9 @@ func (client *ArrayClient) GetComplexItemEmpty(ctx context.Context) (*ProductArr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetComplexItemEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetComplexItemEmptyHandleResponse(resp)
@@ -752,15 +791,15 @@ func (client *ArrayClient) GetComplexItemEmptyCreateRequest(ctx context.Context)
 
 // GetComplexItemEmptyHandleResponse handles the GetComplexItemEmpty response.
 func (client *ArrayClient) GetComplexItemEmptyHandleResponse(resp *azcore.Response) (*ProductArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetComplexItemEmptyHandleError(resp)
-	}
 	result := ProductArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductArray)
 }
 
 // GetComplexItemEmptyHandleError handles the GetComplexItemEmpty error response.
 func (client *ArrayClient) GetComplexItemEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -776,6 +815,9 @@ func (client *ArrayClient) GetComplexItemNull(ctx context.Context) (*ProductArra
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetComplexItemNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetComplexItemNullHandleResponse(resp)
@@ -798,15 +840,15 @@ func (client *ArrayClient) GetComplexItemNullCreateRequest(ctx context.Context) 
 
 // GetComplexItemNullHandleResponse handles the GetComplexItemNull response.
 func (client *ArrayClient) GetComplexItemNullHandleResponse(resp *azcore.Response) (*ProductArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetComplexItemNullHandleError(resp)
-	}
 	result := ProductArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductArray)
 }
 
 // GetComplexItemNullHandleError handles the GetComplexItemNull error response.
 func (client *ArrayClient) GetComplexItemNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -822,6 +864,9 @@ func (client *ArrayClient) GetComplexNull(ctx context.Context) (*ProductArrayRes
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetComplexNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetComplexNullHandleResponse(resp)
@@ -844,15 +889,15 @@ func (client *ArrayClient) GetComplexNullCreateRequest(ctx context.Context) (*az
 
 // GetComplexNullHandleResponse handles the GetComplexNull response.
 func (client *ArrayClient) GetComplexNullHandleResponse(resp *azcore.Response) (*ProductArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetComplexNullHandleError(resp)
-	}
 	result := ProductArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductArray)
 }
 
 // GetComplexNullHandleError handles the GetComplexNull error response.
 func (client *ArrayClient) GetComplexNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -868,6 +913,9 @@ func (client *ArrayClient) GetComplexValid(ctx context.Context) (*ProductArrayRe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetComplexValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetComplexValidHandleResponse(resp)
@@ -890,15 +938,15 @@ func (client *ArrayClient) GetComplexValidCreateRequest(ctx context.Context) (*a
 
 // GetComplexValidHandleResponse handles the GetComplexValid response.
 func (client *ArrayClient) GetComplexValidHandleResponse(resp *azcore.Response) (*ProductArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetComplexValidHandleError(resp)
-	}
 	result := ProductArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductArray)
 }
 
 // GetComplexValidHandleError handles the GetComplexValid error response.
 func (client *ArrayClient) GetComplexValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -914,6 +962,9 @@ func (client *ArrayClient) GetDateInvalidChars(ctx context.Context) (*TimeArrayR
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateInvalidCharsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateInvalidCharsHandleResponse(resp)
@@ -936,15 +987,15 @@ func (client *ArrayClient) GetDateInvalidCharsCreateRequest(ctx context.Context)
 
 // GetDateInvalidCharsHandleResponse handles the GetDateInvalidChars response.
 func (client *ArrayClient) GetDateInvalidCharsHandleResponse(resp *azcore.Response) (*TimeArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateInvalidCharsHandleError(resp)
-	}
 	result := TimeArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.TimeArray)
 }
 
 // GetDateInvalidCharsHandleError handles the GetDateInvalidChars error response.
 func (client *ArrayClient) GetDateInvalidCharsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -960,6 +1011,9 @@ func (client *ArrayClient) GetDateInvalidNull(ctx context.Context) (*TimeArrayRe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateInvalidNullHandleResponse(resp)
@@ -982,15 +1036,15 @@ func (client *ArrayClient) GetDateInvalidNullCreateRequest(ctx context.Context) 
 
 // GetDateInvalidNullHandleResponse handles the GetDateInvalidNull response.
 func (client *ArrayClient) GetDateInvalidNullHandleResponse(resp *azcore.Response) (*TimeArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateInvalidNullHandleError(resp)
-	}
 	result := TimeArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.TimeArray)
 }
 
 // GetDateInvalidNullHandleError handles the GetDateInvalidNull error response.
 func (client *ArrayClient) GetDateInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1006,6 +1060,9 @@ func (client *ArrayClient) GetDateTimeInvalidChars(ctx context.Context) (*TimeAr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateTimeInvalidCharsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateTimeInvalidCharsHandleResponse(resp)
@@ -1028,9 +1085,6 @@ func (client *ArrayClient) GetDateTimeInvalidCharsCreateRequest(ctx context.Cont
 
 // GetDateTimeInvalidCharsHandleResponse handles the GetDateTimeInvalidChars response.
 func (client *ArrayClient) GetDateTimeInvalidCharsHandleResponse(resp *azcore.Response) (*TimeArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateTimeInvalidCharsHandleError(resp)
-	}
 	var aux *[]timeRFC3339
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return nil, err
@@ -1044,6 +1098,9 @@ func (client *ArrayClient) GetDateTimeInvalidCharsHandleResponse(resp *azcore.Re
 
 // GetDateTimeInvalidCharsHandleError handles the GetDateTimeInvalidChars error response.
 func (client *ArrayClient) GetDateTimeInvalidCharsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1059,6 +1116,9 @@ func (client *ArrayClient) GetDateTimeInvalidNull(ctx context.Context) (*TimeArr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateTimeInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateTimeInvalidNullHandleResponse(resp)
@@ -1081,9 +1141,6 @@ func (client *ArrayClient) GetDateTimeInvalidNullCreateRequest(ctx context.Conte
 
 // GetDateTimeInvalidNullHandleResponse handles the GetDateTimeInvalidNull response.
 func (client *ArrayClient) GetDateTimeInvalidNullHandleResponse(resp *azcore.Response) (*TimeArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateTimeInvalidNullHandleError(resp)
-	}
 	var aux *[]timeRFC3339
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return nil, err
@@ -1097,6 +1154,9 @@ func (client *ArrayClient) GetDateTimeInvalidNullHandleResponse(resp *azcore.Res
 
 // GetDateTimeInvalidNullHandleError handles the GetDateTimeInvalidNull error response.
 func (client *ArrayClient) GetDateTimeInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1112,6 +1172,9 @@ func (client *ArrayClient) GetDateTimeRFC1123Valid(ctx context.Context) (*TimeAr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateTimeRFC1123ValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateTimeRFC1123ValidHandleResponse(resp)
@@ -1134,9 +1197,6 @@ func (client *ArrayClient) GetDateTimeRFC1123ValidCreateRequest(ctx context.Cont
 
 // GetDateTimeRFC1123ValidHandleResponse handles the GetDateTimeRFC1123Valid response.
 func (client *ArrayClient) GetDateTimeRFC1123ValidHandleResponse(resp *azcore.Response) (*TimeArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateTimeRFC1123ValidHandleError(resp)
-	}
 	var aux *[]timeRFC1123
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return nil, err
@@ -1150,6 +1210,9 @@ func (client *ArrayClient) GetDateTimeRFC1123ValidHandleResponse(resp *azcore.Re
 
 // GetDateTimeRFC1123ValidHandleError handles the GetDateTimeRFC1123Valid error response.
 func (client *ArrayClient) GetDateTimeRFC1123ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1165,6 +1228,9 @@ func (client *ArrayClient) GetDateTimeValid(ctx context.Context) (*TimeArrayResp
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateTimeValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateTimeValidHandleResponse(resp)
@@ -1187,9 +1253,6 @@ func (client *ArrayClient) GetDateTimeValidCreateRequest(ctx context.Context) (*
 
 // GetDateTimeValidHandleResponse handles the GetDateTimeValid response.
 func (client *ArrayClient) GetDateTimeValidHandleResponse(resp *azcore.Response) (*TimeArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateTimeValidHandleError(resp)
-	}
 	var aux *[]timeRFC3339
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return nil, err
@@ -1203,6 +1266,9 @@ func (client *ArrayClient) GetDateTimeValidHandleResponse(resp *azcore.Response)
 
 // GetDateTimeValidHandleError handles the GetDateTimeValid error response.
 func (client *ArrayClient) GetDateTimeValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1218,6 +1284,9 @@ func (client *ArrayClient) GetDateValid(ctx context.Context) (*TimeArrayResponse
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateValidHandleResponse(resp)
@@ -1240,15 +1309,15 @@ func (client *ArrayClient) GetDateValidCreateRequest(ctx context.Context) (*azco
 
 // GetDateValidHandleResponse handles the GetDateValid response.
 func (client *ArrayClient) GetDateValidHandleResponse(resp *azcore.Response) (*TimeArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateValidHandleError(resp)
-	}
 	result := TimeArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.TimeArray)
 }
 
 // GetDateValidHandleError handles the GetDateValid error response.
 func (client *ArrayClient) GetDateValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1264,6 +1333,9 @@ func (client *ArrayClient) GetDictionaryEmpty(ctx context.Context) (*MapOfString
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDictionaryEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDictionaryEmptyHandleResponse(resp)
@@ -1286,15 +1358,15 @@ func (client *ArrayClient) GetDictionaryEmptyCreateRequest(ctx context.Context) 
 
 // GetDictionaryEmptyHandleResponse handles the GetDictionaryEmpty response.
 func (client *ArrayClient) GetDictionaryEmptyHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDictionaryEmptyHandleError(resp)
-	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MapOfStringArray)
 }
 
 // GetDictionaryEmptyHandleError handles the GetDictionaryEmpty error response.
 func (client *ArrayClient) GetDictionaryEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1310,6 +1382,9 @@ func (client *ArrayClient) GetDictionaryItemEmpty(ctx context.Context) (*MapOfSt
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDictionaryItemEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDictionaryItemEmptyHandleResponse(resp)
@@ -1332,15 +1407,15 @@ func (client *ArrayClient) GetDictionaryItemEmptyCreateRequest(ctx context.Conte
 
 // GetDictionaryItemEmptyHandleResponse handles the GetDictionaryItemEmpty response.
 func (client *ArrayClient) GetDictionaryItemEmptyHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDictionaryItemEmptyHandleError(resp)
-	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MapOfStringArray)
 }
 
 // GetDictionaryItemEmptyHandleError handles the GetDictionaryItemEmpty error response.
 func (client *ArrayClient) GetDictionaryItemEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1356,6 +1431,9 @@ func (client *ArrayClient) GetDictionaryItemNull(ctx context.Context) (*MapOfStr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDictionaryItemNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDictionaryItemNullHandleResponse(resp)
@@ -1378,15 +1456,15 @@ func (client *ArrayClient) GetDictionaryItemNullCreateRequest(ctx context.Contex
 
 // GetDictionaryItemNullHandleResponse handles the GetDictionaryItemNull response.
 func (client *ArrayClient) GetDictionaryItemNullHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDictionaryItemNullHandleError(resp)
-	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MapOfStringArray)
 }
 
 // GetDictionaryItemNullHandleError handles the GetDictionaryItemNull error response.
 func (client *ArrayClient) GetDictionaryItemNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1402,6 +1480,9 @@ func (client *ArrayClient) GetDictionaryNull(ctx context.Context) (*MapOfStringA
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDictionaryNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDictionaryNullHandleResponse(resp)
@@ -1424,15 +1505,15 @@ func (client *ArrayClient) GetDictionaryNullCreateRequest(ctx context.Context) (
 
 // GetDictionaryNullHandleResponse handles the GetDictionaryNull response.
 func (client *ArrayClient) GetDictionaryNullHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDictionaryNullHandleError(resp)
-	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MapOfStringArray)
 }
 
 // GetDictionaryNullHandleError handles the GetDictionaryNull error response.
 func (client *ArrayClient) GetDictionaryNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1448,6 +1529,9 @@ func (client *ArrayClient) GetDictionaryValid(ctx context.Context) (*MapOfString
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDictionaryValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDictionaryValidHandleResponse(resp)
@@ -1470,15 +1554,15 @@ func (client *ArrayClient) GetDictionaryValidCreateRequest(ctx context.Context) 
 
 // GetDictionaryValidHandleResponse handles the GetDictionaryValid response.
 func (client *ArrayClient) GetDictionaryValidHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDictionaryValidHandleError(resp)
-	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MapOfStringArray)
 }
 
 // GetDictionaryValidHandleError handles the GetDictionaryValid error response.
 func (client *ArrayClient) GetDictionaryValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1494,6 +1578,9 @@ func (client *ArrayClient) GetDoubleInvalidNull(ctx context.Context) (*Float64Ar
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDoubleInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDoubleInvalidNullHandleResponse(resp)
@@ -1516,15 +1603,15 @@ func (client *ArrayClient) GetDoubleInvalidNullCreateRequest(ctx context.Context
 
 // GetDoubleInvalidNullHandleResponse handles the GetDoubleInvalidNull response.
 func (client *ArrayClient) GetDoubleInvalidNullHandleResponse(resp *azcore.Response) (*Float64ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDoubleInvalidNullHandleError(resp)
-	}
 	result := Float64ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Float64Array)
 }
 
 // GetDoubleInvalidNullHandleError handles the GetDoubleInvalidNull error response.
 func (client *ArrayClient) GetDoubleInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1540,6 +1627,9 @@ func (client *ArrayClient) GetDoubleInvalidString(ctx context.Context) (*Float64
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDoubleInvalidStringHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDoubleInvalidStringHandleResponse(resp)
@@ -1562,15 +1652,15 @@ func (client *ArrayClient) GetDoubleInvalidStringCreateRequest(ctx context.Conte
 
 // GetDoubleInvalidStringHandleResponse handles the GetDoubleInvalidString response.
 func (client *ArrayClient) GetDoubleInvalidStringHandleResponse(resp *azcore.Response) (*Float64ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDoubleInvalidStringHandleError(resp)
-	}
 	result := Float64ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Float64Array)
 }
 
 // GetDoubleInvalidStringHandleError handles the GetDoubleInvalidString error response.
 func (client *ArrayClient) GetDoubleInvalidStringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1586,6 +1676,9 @@ func (client *ArrayClient) GetDoubleValid(ctx context.Context) (*Float64ArrayRes
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDoubleValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDoubleValidHandleResponse(resp)
@@ -1608,15 +1701,15 @@ func (client *ArrayClient) GetDoubleValidCreateRequest(ctx context.Context) (*az
 
 // GetDoubleValidHandleResponse handles the GetDoubleValid response.
 func (client *ArrayClient) GetDoubleValidHandleResponse(resp *azcore.Response) (*Float64ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDoubleValidHandleError(resp)
-	}
 	result := Float64ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Float64Array)
 }
 
 // GetDoubleValidHandleError handles the GetDoubleValid error response.
 func (client *ArrayClient) GetDoubleValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1632,6 +1725,9 @@ func (client *ArrayClient) GetDurationValid(ctx context.Context) (*StringArrayRe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDurationValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDurationValidHandleResponse(resp)
@@ -1654,15 +1750,15 @@ func (client *ArrayClient) GetDurationValidCreateRequest(ctx context.Context) (*
 
 // GetDurationValidHandleResponse handles the GetDurationValid response.
 func (client *ArrayClient) GetDurationValidHandleResponse(resp *azcore.Response) (*StringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDurationValidHandleError(resp)
-	}
 	result := StringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArray)
 }
 
 // GetDurationValidHandleError handles the GetDurationValid error response.
 func (client *ArrayClient) GetDurationValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1678,6 +1774,9 @@ func (client *ArrayClient) GetEmpty(ctx context.Context) (*Int32ArrayResponse, e
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetEmptyHandleResponse(resp)
@@ -1700,15 +1799,15 @@ func (client *ArrayClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.R
 
 // GetEmptyHandleResponse handles the GetEmpty response.
 func (client *ArrayClient) GetEmptyHandleResponse(resp *azcore.Response) (*Int32ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyHandleError(resp)
-	}
 	result := Int32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int32Array)
 }
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *ArrayClient) GetEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1724,6 +1823,9 @@ func (client *ArrayClient) GetEnumValid(ctx context.Context) (*FooEnumArrayRespo
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetEnumValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetEnumValidHandleResponse(resp)
@@ -1746,15 +1848,15 @@ func (client *ArrayClient) GetEnumValidCreateRequest(ctx context.Context) (*azco
 
 // GetEnumValidHandleResponse handles the GetEnumValid response.
 func (client *ArrayClient) GetEnumValidHandleResponse(resp *azcore.Response) (*FooEnumArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEnumValidHandleError(resp)
-	}
 	result := FooEnumArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.FooEnumArray)
 }
 
 // GetEnumValidHandleError handles the GetEnumValid error response.
 func (client *ArrayClient) GetEnumValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1770,6 +1872,9 @@ func (client *ArrayClient) GetFloatInvalidNull(ctx context.Context) (*Float32Arr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetFloatInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetFloatInvalidNullHandleResponse(resp)
@@ -1792,15 +1897,15 @@ func (client *ArrayClient) GetFloatInvalidNullCreateRequest(ctx context.Context)
 
 // GetFloatInvalidNullHandleResponse handles the GetFloatInvalidNull response.
 func (client *ArrayClient) GetFloatInvalidNullHandleResponse(resp *azcore.Response) (*Float32ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetFloatInvalidNullHandleError(resp)
-	}
 	result := Float32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Float32Array)
 }
 
 // GetFloatInvalidNullHandleError handles the GetFloatInvalidNull error response.
 func (client *ArrayClient) GetFloatInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1816,6 +1921,9 @@ func (client *ArrayClient) GetFloatInvalidString(ctx context.Context) (*Float32A
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetFloatInvalidStringHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetFloatInvalidStringHandleResponse(resp)
@@ -1838,15 +1946,15 @@ func (client *ArrayClient) GetFloatInvalidStringCreateRequest(ctx context.Contex
 
 // GetFloatInvalidStringHandleResponse handles the GetFloatInvalidString response.
 func (client *ArrayClient) GetFloatInvalidStringHandleResponse(resp *azcore.Response) (*Float32ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetFloatInvalidStringHandleError(resp)
-	}
 	result := Float32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Float32Array)
 }
 
 // GetFloatInvalidStringHandleError handles the GetFloatInvalidString error response.
 func (client *ArrayClient) GetFloatInvalidStringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1862,6 +1970,9 @@ func (client *ArrayClient) GetFloatValid(ctx context.Context) (*Float32ArrayResp
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetFloatValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetFloatValidHandleResponse(resp)
@@ -1884,15 +1995,15 @@ func (client *ArrayClient) GetFloatValidCreateRequest(ctx context.Context) (*azc
 
 // GetFloatValidHandleResponse handles the GetFloatValid response.
 func (client *ArrayClient) GetFloatValidHandleResponse(resp *azcore.Response) (*Float32ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetFloatValidHandleError(resp)
-	}
 	result := Float32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Float32Array)
 }
 
 // GetFloatValidHandleError handles the GetFloatValid error response.
 func (client *ArrayClient) GetFloatValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1908,6 +2019,9 @@ func (client *ArrayClient) GetIntInvalidNull(ctx context.Context) (*Int32ArrayRe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetIntInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetIntInvalidNullHandleResponse(resp)
@@ -1930,15 +2044,15 @@ func (client *ArrayClient) GetIntInvalidNullCreateRequest(ctx context.Context) (
 
 // GetIntInvalidNullHandleResponse handles the GetIntInvalidNull response.
 func (client *ArrayClient) GetIntInvalidNullHandleResponse(resp *azcore.Response) (*Int32ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetIntInvalidNullHandleError(resp)
-	}
 	result := Int32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int32Array)
 }
 
 // GetIntInvalidNullHandleError handles the GetIntInvalidNull error response.
 func (client *ArrayClient) GetIntInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1954,6 +2068,9 @@ func (client *ArrayClient) GetIntInvalidString(ctx context.Context) (*Int32Array
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetIntInvalidStringHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetIntInvalidStringHandleResponse(resp)
@@ -1976,15 +2093,15 @@ func (client *ArrayClient) GetIntInvalidStringCreateRequest(ctx context.Context)
 
 // GetIntInvalidStringHandleResponse handles the GetIntInvalidString response.
 func (client *ArrayClient) GetIntInvalidStringHandleResponse(resp *azcore.Response) (*Int32ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetIntInvalidStringHandleError(resp)
-	}
 	result := Int32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int32Array)
 }
 
 // GetIntInvalidStringHandleError handles the GetIntInvalidString error response.
 func (client *ArrayClient) GetIntInvalidStringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2000,6 +2117,9 @@ func (client *ArrayClient) GetIntegerValid(ctx context.Context) (*Int32ArrayResp
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetIntegerValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetIntegerValidHandleResponse(resp)
@@ -2022,15 +2142,15 @@ func (client *ArrayClient) GetIntegerValidCreateRequest(ctx context.Context) (*a
 
 // GetIntegerValidHandleResponse handles the GetIntegerValid response.
 func (client *ArrayClient) GetIntegerValidHandleResponse(resp *azcore.Response) (*Int32ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetIntegerValidHandleError(resp)
-	}
 	result := Int32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int32Array)
 }
 
 // GetIntegerValidHandleError handles the GetIntegerValid error response.
 func (client *ArrayClient) GetIntegerValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2046,6 +2166,9 @@ func (client *ArrayClient) GetInvalid(ctx context.Context) (*Int32ArrayResponse,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetInvalidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetInvalidHandleResponse(resp)
@@ -2068,15 +2191,15 @@ func (client *ArrayClient) GetInvalidCreateRequest(ctx context.Context) (*azcore
 
 // GetInvalidHandleResponse handles the GetInvalid response.
 func (client *ArrayClient) GetInvalidHandleResponse(resp *azcore.Response) (*Int32ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetInvalidHandleError(resp)
-	}
 	result := Int32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int32Array)
 }
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *ArrayClient) GetInvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2092,6 +2215,9 @@ func (client *ArrayClient) GetLongInvalidNull(ctx context.Context) (*Int64ArrayR
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetLongInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetLongInvalidNullHandleResponse(resp)
@@ -2114,15 +2240,15 @@ func (client *ArrayClient) GetLongInvalidNullCreateRequest(ctx context.Context) 
 
 // GetLongInvalidNullHandleResponse handles the GetLongInvalidNull response.
 func (client *ArrayClient) GetLongInvalidNullHandleResponse(resp *azcore.Response) (*Int64ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLongInvalidNullHandleError(resp)
-	}
 	result := Int64ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int64Array)
 }
 
 // GetLongInvalidNullHandleError handles the GetLongInvalidNull error response.
 func (client *ArrayClient) GetLongInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2138,6 +2264,9 @@ func (client *ArrayClient) GetLongInvalidString(ctx context.Context) (*Int64Arra
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetLongInvalidStringHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetLongInvalidStringHandleResponse(resp)
@@ -2160,15 +2289,15 @@ func (client *ArrayClient) GetLongInvalidStringCreateRequest(ctx context.Context
 
 // GetLongInvalidStringHandleResponse handles the GetLongInvalidString response.
 func (client *ArrayClient) GetLongInvalidStringHandleResponse(resp *azcore.Response) (*Int64ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLongInvalidStringHandleError(resp)
-	}
 	result := Int64ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int64Array)
 }
 
 // GetLongInvalidStringHandleError handles the GetLongInvalidString error response.
 func (client *ArrayClient) GetLongInvalidStringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2184,6 +2313,9 @@ func (client *ArrayClient) GetLongValid(ctx context.Context) (*Int64ArrayRespons
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetLongValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetLongValidHandleResponse(resp)
@@ -2206,15 +2338,15 @@ func (client *ArrayClient) GetLongValidCreateRequest(ctx context.Context) (*azco
 
 // GetLongValidHandleResponse handles the GetLongValid response.
 func (client *ArrayClient) GetLongValidHandleResponse(resp *azcore.Response) (*Int64ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLongValidHandleError(resp)
-	}
 	result := Int64ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int64Array)
 }
 
 // GetLongValidHandleError handles the GetLongValid error response.
 func (client *ArrayClient) GetLongValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2230,6 +2362,9 @@ func (client *ArrayClient) GetNull(ctx context.Context) (*Int32ArrayResponse, er
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullHandleResponse(resp)
@@ -2252,15 +2387,15 @@ func (client *ArrayClient) GetNullCreateRequest(ctx context.Context) (*azcore.Re
 
 // GetNullHandleResponse handles the GetNull response.
 func (client *ArrayClient) GetNullHandleResponse(resp *azcore.Response) (*Int32ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullHandleError(resp)
-	}
 	result := Int32ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Int32Array)
 }
 
 // GetNullHandleError handles the GetNull error response.
 func (client *ArrayClient) GetNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2276,6 +2411,9 @@ func (client *ArrayClient) GetStringEnumValid(ctx context.Context) (*Enum0ArrayR
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetStringEnumValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetStringEnumValidHandleResponse(resp)
@@ -2298,15 +2436,15 @@ func (client *ArrayClient) GetStringEnumValidCreateRequest(ctx context.Context) 
 
 // GetStringEnumValidHandleResponse handles the GetStringEnumValid response.
 func (client *ArrayClient) GetStringEnumValidHandleResponse(resp *azcore.Response) (*Enum0ArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetStringEnumValidHandleError(resp)
-	}
 	result := Enum0ArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Enum0Array)
 }
 
 // GetStringEnumValidHandleError handles the GetStringEnumValid error response.
 func (client *ArrayClient) GetStringEnumValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2322,6 +2460,9 @@ func (client *ArrayClient) GetStringValid(ctx context.Context) (*StringArrayResp
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetStringValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetStringValidHandleResponse(resp)
@@ -2344,15 +2485,15 @@ func (client *ArrayClient) GetStringValidCreateRequest(ctx context.Context) (*az
 
 // GetStringValidHandleResponse handles the GetStringValid response.
 func (client *ArrayClient) GetStringValidHandleResponse(resp *azcore.Response) (*StringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetStringValidHandleError(resp)
-	}
 	result := StringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArray)
 }
 
 // GetStringValidHandleError handles the GetStringValid error response.
 func (client *ArrayClient) GetStringValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2368,6 +2509,9 @@ func (client *ArrayClient) GetStringWithInvalid(ctx context.Context) (*StringArr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetStringWithInvalidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetStringWithInvalidHandleResponse(resp)
@@ -2390,15 +2534,15 @@ func (client *ArrayClient) GetStringWithInvalidCreateRequest(ctx context.Context
 
 // GetStringWithInvalidHandleResponse handles the GetStringWithInvalid response.
 func (client *ArrayClient) GetStringWithInvalidHandleResponse(resp *azcore.Response) (*StringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetStringWithInvalidHandleError(resp)
-	}
 	result := StringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArray)
 }
 
 // GetStringWithInvalidHandleError handles the GetStringWithInvalid error response.
 func (client *ArrayClient) GetStringWithInvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2414,6 +2558,9 @@ func (client *ArrayClient) GetStringWithNull(ctx context.Context) (*StringArrayR
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetStringWithNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetStringWithNullHandleResponse(resp)
@@ -2436,15 +2583,15 @@ func (client *ArrayClient) GetStringWithNullCreateRequest(ctx context.Context) (
 
 // GetStringWithNullHandleResponse handles the GetStringWithNull response.
 func (client *ArrayClient) GetStringWithNullHandleResponse(resp *azcore.Response) (*StringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetStringWithNullHandleError(resp)
-	}
 	result := StringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArray)
 }
 
 // GetStringWithNullHandleError handles the GetStringWithNull error response.
 func (client *ArrayClient) GetStringWithNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2460,6 +2607,9 @@ func (client *ArrayClient) GetUUIDInvalidChars(ctx context.Context) (*StringArra
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetUUIDInvalidCharsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetUUIDInvalidCharsHandleResponse(resp)
@@ -2482,15 +2632,15 @@ func (client *ArrayClient) GetUUIDInvalidCharsCreateRequest(ctx context.Context)
 
 // GetUUIDInvalidCharsHandleResponse handles the GetUUIDInvalidChars response.
 func (client *ArrayClient) GetUUIDInvalidCharsHandleResponse(resp *azcore.Response) (*StringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetUUIDInvalidCharsHandleError(resp)
-	}
 	result := StringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArray)
 }
 
 // GetUUIDInvalidCharsHandleError handles the GetUUIDInvalidChars error response.
 func (client *ArrayClient) GetUUIDInvalidCharsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2506,6 +2656,9 @@ func (client *ArrayClient) GetUUIDValid(ctx context.Context) (*StringArrayRespon
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetUUIDValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetUUIDValidHandleResponse(resp)
@@ -2528,15 +2681,15 @@ func (client *ArrayClient) GetUUIDValidCreateRequest(ctx context.Context) (*azco
 
 // GetUUIDValidHandleResponse handles the GetUUIDValid response.
 func (client *ArrayClient) GetUUIDValidHandleResponse(resp *azcore.Response) (*StringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetUUIDValidHandleError(resp)
-	}
 	result := StringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArray)
 }
 
 // GetUUIDValidHandleError handles the GetUUIDValid error response.
 func (client *ArrayClient) GetUUIDValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2554,11 +2707,10 @@ func (client *ArrayClient) PutArrayValid(ctx context.Context, arrayBody [][]stri
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutArrayValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutArrayValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutArrayValidCreateRequest creates the PutArrayValid request.
@@ -2572,16 +2724,11 @@ func (client *ArrayClient) PutArrayValidCreateRequest(ctx context.Context, array
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutArrayValidHandleResponse handles the PutArrayValid response.
-func (client *ArrayClient) PutArrayValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutArrayValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutArrayValidHandleError handles the PutArrayValid error response.
 func (client *ArrayClient) PutArrayValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2599,11 +2746,10 @@ func (client *ArrayClient) PutBooleanTfft(ctx context.Context, arrayBody []bool)
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutBooleanTfftHandleResponse(resp)
-	if err != nil {
+	if err := client.PutBooleanTfftHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutBooleanTfftCreateRequest creates the PutBooleanTfft request.
@@ -2617,16 +2763,11 @@ func (client *ArrayClient) PutBooleanTfftCreateRequest(ctx context.Context, arra
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutBooleanTfftHandleResponse handles the PutBooleanTfft response.
-func (client *ArrayClient) PutBooleanTfftHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutBooleanTfftHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutBooleanTfftHandleError handles the PutBooleanTfft error response.
 func (client *ArrayClient) PutBooleanTfftHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2644,11 +2785,10 @@ func (client *ArrayClient) PutByteValid(ctx context.Context, arrayBody [][]byte)
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutByteValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutByteValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutByteValidCreateRequest creates the PutByteValid request.
@@ -2662,16 +2802,11 @@ func (client *ArrayClient) PutByteValidCreateRequest(ctx context.Context, arrayB
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutByteValidHandleResponse handles the PutByteValid response.
-func (client *ArrayClient) PutByteValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutByteValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutByteValidHandleError handles the PutByteValid error response.
 func (client *ArrayClient) PutByteValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2689,11 +2824,10 @@ func (client *ArrayClient) PutComplexValid(ctx context.Context, arrayBody []Prod
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutComplexValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutComplexValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutComplexValidCreateRequest creates the PutComplexValid request.
@@ -2707,16 +2841,11 @@ func (client *ArrayClient) PutComplexValidCreateRequest(ctx context.Context, arr
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutComplexValidHandleResponse handles the PutComplexValid response.
-func (client *ArrayClient) PutComplexValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutComplexValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutComplexValidHandleError handles the PutComplexValid error response.
 func (client *ArrayClient) PutComplexValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2734,11 +2863,10 @@ func (client *ArrayClient) PutDateTimeRFC1123Valid(ctx context.Context, arrayBod
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDateTimeRFC1123ValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDateTimeRFC1123ValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDateTimeRFC1123ValidCreateRequest creates the PutDateTimeRFC1123Valid request.
@@ -2756,16 +2884,11 @@ func (client *ArrayClient) PutDateTimeRFC1123ValidCreateRequest(ctx context.Cont
 	return req, req.MarshalAsJSON(aux)
 }
 
-// PutDateTimeRFC1123ValidHandleResponse handles the PutDateTimeRFC1123Valid response.
-func (client *ArrayClient) PutDateTimeRFC1123ValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDateTimeRFC1123ValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDateTimeRFC1123ValidHandleError handles the PutDateTimeRFC1123Valid error response.
 func (client *ArrayClient) PutDateTimeRFC1123ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2783,11 +2906,10 @@ func (client *ArrayClient) PutDateTimeValid(ctx context.Context, arrayBody []tim
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDateTimeValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDateTimeValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDateTimeValidCreateRequest creates the PutDateTimeValid request.
@@ -2801,16 +2923,11 @@ func (client *ArrayClient) PutDateTimeValidCreateRequest(ctx context.Context, ar
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutDateTimeValidHandleResponse handles the PutDateTimeValid response.
-func (client *ArrayClient) PutDateTimeValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDateTimeValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDateTimeValidHandleError handles the PutDateTimeValid error response.
 func (client *ArrayClient) PutDateTimeValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2828,11 +2945,10 @@ func (client *ArrayClient) PutDateValid(ctx context.Context, arrayBody []time.Ti
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDateValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDateValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDateValidCreateRequest creates the PutDateValid request.
@@ -2846,16 +2962,11 @@ func (client *ArrayClient) PutDateValidCreateRequest(ctx context.Context, arrayB
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutDateValidHandleResponse handles the PutDateValid response.
-func (client *ArrayClient) PutDateValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDateValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDateValidHandleError handles the PutDateValid error response.
 func (client *ArrayClient) PutDateValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2873,11 +2984,10 @@ func (client *ArrayClient) PutDictionaryValid(ctx context.Context, arrayBody []m
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDictionaryValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDictionaryValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDictionaryValidCreateRequest creates the PutDictionaryValid request.
@@ -2891,16 +3001,11 @@ func (client *ArrayClient) PutDictionaryValidCreateRequest(ctx context.Context, 
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutDictionaryValidHandleResponse handles the PutDictionaryValid response.
-func (client *ArrayClient) PutDictionaryValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDictionaryValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDictionaryValidHandleError handles the PutDictionaryValid error response.
 func (client *ArrayClient) PutDictionaryValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2918,11 +3023,10 @@ func (client *ArrayClient) PutDoubleValid(ctx context.Context, arrayBody []float
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDoubleValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDoubleValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDoubleValidCreateRequest creates the PutDoubleValid request.
@@ -2936,16 +3040,11 @@ func (client *ArrayClient) PutDoubleValidCreateRequest(ctx context.Context, arra
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutDoubleValidHandleResponse handles the PutDoubleValid response.
-func (client *ArrayClient) PutDoubleValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDoubleValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDoubleValidHandleError handles the PutDoubleValid error response.
 func (client *ArrayClient) PutDoubleValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2963,11 +3062,10 @@ func (client *ArrayClient) PutDurationValid(ctx context.Context, arrayBody []str
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDurationValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDurationValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDurationValidCreateRequest creates the PutDurationValid request.
@@ -2981,16 +3079,11 @@ func (client *ArrayClient) PutDurationValidCreateRequest(ctx context.Context, ar
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutDurationValidHandleResponse handles the PutDurationValid response.
-func (client *ArrayClient) PutDurationValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDurationValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDurationValidHandleError handles the PutDurationValid error response.
 func (client *ArrayClient) PutDurationValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3008,11 +3101,10 @@ func (client *ArrayClient) PutEmpty(ctx context.Context, arrayBody []string) (*h
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutEmptyHandleResponse(resp)
-	if err != nil {
+	if err := client.PutEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutEmptyCreateRequest creates the PutEmpty request.
@@ -3026,16 +3118,11 @@ func (client *ArrayClient) PutEmptyCreateRequest(ctx context.Context, arrayBody 
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutEmptyHandleResponse handles the PutEmpty response.
-func (client *ArrayClient) PutEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutEmptyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutEmptyHandleError handles the PutEmpty error response.
 func (client *ArrayClient) PutEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3053,11 +3140,10 @@ func (client *ArrayClient) PutEnumValid(ctx context.Context, arrayBody []FooEnum
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutEnumValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutEnumValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutEnumValidCreateRequest creates the PutEnumValid request.
@@ -3071,16 +3157,11 @@ func (client *ArrayClient) PutEnumValidCreateRequest(ctx context.Context, arrayB
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutEnumValidHandleResponse handles the PutEnumValid response.
-func (client *ArrayClient) PutEnumValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutEnumValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutEnumValidHandleError handles the PutEnumValid error response.
 func (client *ArrayClient) PutEnumValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3098,11 +3179,10 @@ func (client *ArrayClient) PutFloatValid(ctx context.Context, arrayBody []float3
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutFloatValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutFloatValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutFloatValidCreateRequest creates the PutFloatValid request.
@@ -3116,16 +3196,11 @@ func (client *ArrayClient) PutFloatValidCreateRequest(ctx context.Context, array
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutFloatValidHandleResponse handles the PutFloatValid response.
-func (client *ArrayClient) PutFloatValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutFloatValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutFloatValidHandleError handles the PutFloatValid error response.
 func (client *ArrayClient) PutFloatValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3143,11 +3218,10 @@ func (client *ArrayClient) PutIntegerValid(ctx context.Context, arrayBody []int3
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutIntegerValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutIntegerValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutIntegerValidCreateRequest creates the PutIntegerValid request.
@@ -3161,16 +3235,11 @@ func (client *ArrayClient) PutIntegerValidCreateRequest(ctx context.Context, arr
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutIntegerValidHandleResponse handles the PutIntegerValid response.
-func (client *ArrayClient) PutIntegerValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutIntegerValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutIntegerValidHandleError handles the PutIntegerValid error response.
 func (client *ArrayClient) PutIntegerValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3188,11 +3257,10 @@ func (client *ArrayClient) PutLongValid(ctx context.Context, arrayBody []int64) 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutLongValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutLongValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutLongValidCreateRequest creates the PutLongValid request.
@@ -3206,16 +3274,11 @@ func (client *ArrayClient) PutLongValidCreateRequest(ctx context.Context, arrayB
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutLongValidHandleResponse handles the PutLongValid response.
-func (client *ArrayClient) PutLongValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutLongValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutLongValidHandleError handles the PutLongValid error response.
 func (client *ArrayClient) PutLongValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3233,11 +3296,10 @@ func (client *ArrayClient) PutStringEnumValid(ctx context.Context, arrayBody []E
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutStringEnumValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutStringEnumValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutStringEnumValidCreateRequest creates the PutStringEnumValid request.
@@ -3251,16 +3313,11 @@ func (client *ArrayClient) PutStringEnumValidCreateRequest(ctx context.Context, 
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutStringEnumValidHandleResponse handles the PutStringEnumValid response.
-func (client *ArrayClient) PutStringEnumValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutStringEnumValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutStringEnumValidHandleError handles the PutStringEnumValid error response.
 func (client *ArrayClient) PutStringEnumValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3278,11 +3335,10 @@ func (client *ArrayClient) PutStringValid(ctx context.Context, arrayBody []strin
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutStringValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutStringValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutStringValidCreateRequest creates the PutStringValid request.
@@ -3296,16 +3352,11 @@ func (client *ArrayClient) PutStringValidCreateRequest(ctx context.Context, arra
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutStringValidHandleResponse handles the PutStringValid response.
-func (client *ArrayClient) PutStringValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutStringValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutStringValidHandleError handles the PutStringValid error response.
 func (client *ArrayClient) PutStringValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3323,11 +3374,10 @@ func (client *ArrayClient) PutUUIDValid(ctx context.Context, arrayBody []string)
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutUUIDValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutUUIDValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutUUIDValidCreateRequest creates the PutUUIDValid request.
@@ -3341,16 +3391,11 @@ func (client *ArrayClient) PutUUIDValidCreateRequest(ctx context.Context, arrayB
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutUUIDValidHandleResponse handles the PutUUIDValid response.
-func (client *ArrayClient) PutUUIDValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutUUIDValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutUUIDValidHandleError handles the PutUUIDValid error response.
 func (client *ArrayClient) PutUUIDValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/arraygroup/zz_generated_array.go
+++ b/test/autorest/arraygroup/zz_generated_array.go
@@ -180,8 +180,8 @@ func (client *ArrayClient) GetArrayEmpty(ctx context.Context) (*StringArrayArray
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetArrayEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetArrayEmptyHandleError(resp)
 	}
 	result, err := client.GetArrayEmptyHandleResponse(resp)
 	if err != nil {
@@ -209,9 +209,6 @@ func (client *ArrayClient) GetArrayEmptyHandleResponse(resp *azcore.Response) (*
 
 // GetArrayEmptyHandleError handles the GetArrayEmpty error response.
 func (client *ArrayClient) GetArrayEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -229,8 +226,8 @@ func (client *ArrayClient) GetArrayItemEmpty(ctx context.Context) (*StringArrayA
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetArrayItemEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetArrayItemEmptyHandleError(resp)
 	}
 	result, err := client.GetArrayItemEmptyHandleResponse(resp)
 	if err != nil {
@@ -258,9 +255,6 @@ func (client *ArrayClient) GetArrayItemEmptyHandleResponse(resp *azcore.Response
 
 // GetArrayItemEmptyHandleError handles the GetArrayItemEmpty error response.
 func (client *ArrayClient) GetArrayItemEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -278,8 +272,8 @@ func (client *ArrayClient) GetArrayItemNull(ctx context.Context) (*StringArrayAr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetArrayItemNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetArrayItemNullHandleError(resp)
 	}
 	result, err := client.GetArrayItemNullHandleResponse(resp)
 	if err != nil {
@@ -307,9 +301,6 @@ func (client *ArrayClient) GetArrayItemNullHandleResponse(resp *azcore.Response)
 
 // GetArrayItemNullHandleError handles the GetArrayItemNull error response.
 func (client *ArrayClient) GetArrayItemNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -327,8 +318,8 @@ func (client *ArrayClient) GetArrayNull(ctx context.Context) (*StringArrayArrayR
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetArrayNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetArrayNullHandleError(resp)
 	}
 	result, err := client.GetArrayNullHandleResponse(resp)
 	if err != nil {
@@ -356,9 +347,6 @@ func (client *ArrayClient) GetArrayNullHandleResponse(resp *azcore.Response) (*S
 
 // GetArrayNullHandleError handles the GetArrayNull error response.
 func (client *ArrayClient) GetArrayNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -376,8 +364,8 @@ func (client *ArrayClient) GetArrayValid(ctx context.Context) (*StringArrayArray
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetArrayValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetArrayValidHandleError(resp)
 	}
 	result, err := client.GetArrayValidHandleResponse(resp)
 	if err != nil {
@@ -405,9 +393,6 @@ func (client *ArrayClient) GetArrayValidHandleResponse(resp *azcore.Response) (*
 
 // GetArrayValidHandleError handles the GetArrayValid error response.
 func (client *ArrayClient) GetArrayValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -425,8 +410,8 @@ func (client *ArrayClient) GetBase64URL(ctx context.Context) (*ByteArrayArrayRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBase64URLHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBase64URLHandleError(resp)
 	}
 	result, err := client.GetBase64URLHandleResponse(resp)
 	if err != nil {
@@ -454,9 +439,6 @@ func (client *ArrayClient) GetBase64URLHandleResponse(resp *azcore.Response) (*B
 
 // GetBase64URLHandleError handles the GetBase64URL error response.
 func (client *ArrayClient) GetBase64URLHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -474,8 +456,8 @@ func (client *ArrayClient) GetBooleanInvalidNull(ctx context.Context) (*BoolArra
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBooleanInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBooleanInvalidNullHandleError(resp)
 	}
 	result, err := client.GetBooleanInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -503,9 +485,6 @@ func (client *ArrayClient) GetBooleanInvalidNullHandleResponse(resp *azcore.Resp
 
 // GetBooleanInvalidNullHandleError handles the GetBooleanInvalidNull error response.
 func (client *ArrayClient) GetBooleanInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -523,8 +502,8 @@ func (client *ArrayClient) GetBooleanInvalidString(ctx context.Context) (*BoolAr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBooleanInvalidStringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBooleanInvalidStringHandleError(resp)
 	}
 	result, err := client.GetBooleanInvalidStringHandleResponse(resp)
 	if err != nil {
@@ -552,9 +531,6 @@ func (client *ArrayClient) GetBooleanInvalidStringHandleResponse(resp *azcore.Re
 
 // GetBooleanInvalidStringHandleError handles the GetBooleanInvalidString error response.
 func (client *ArrayClient) GetBooleanInvalidStringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -572,8 +548,8 @@ func (client *ArrayClient) GetBooleanTfft(ctx context.Context) (*BoolArrayRespon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBooleanTfftHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBooleanTfftHandleError(resp)
 	}
 	result, err := client.GetBooleanTfftHandleResponse(resp)
 	if err != nil {
@@ -601,9 +577,6 @@ func (client *ArrayClient) GetBooleanTfftHandleResponse(resp *azcore.Response) (
 
 // GetBooleanTfftHandleError handles the GetBooleanTfft error response.
 func (client *ArrayClient) GetBooleanTfftHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -621,8 +594,8 @@ func (client *ArrayClient) GetByteInvalidNull(ctx context.Context) (*ByteArrayAr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetByteInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetByteInvalidNullHandleError(resp)
 	}
 	result, err := client.GetByteInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -650,9 +623,6 @@ func (client *ArrayClient) GetByteInvalidNullHandleResponse(resp *azcore.Respons
 
 // GetByteInvalidNullHandleError handles the GetByteInvalidNull error response.
 func (client *ArrayClient) GetByteInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -670,8 +640,8 @@ func (client *ArrayClient) GetByteValid(ctx context.Context) (*ByteArrayArrayRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetByteValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetByteValidHandleError(resp)
 	}
 	result, err := client.GetByteValidHandleResponse(resp)
 	if err != nil {
@@ -699,9 +669,6 @@ func (client *ArrayClient) GetByteValidHandleResponse(resp *azcore.Response) (*B
 
 // GetByteValidHandleError handles the GetByteValid error response.
 func (client *ArrayClient) GetByteValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -719,8 +686,8 @@ func (client *ArrayClient) GetComplexEmpty(ctx context.Context) (*ProductArrayRe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetComplexEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetComplexEmptyHandleError(resp)
 	}
 	result, err := client.GetComplexEmptyHandleResponse(resp)
 	if err != nil {
@@ -748,9 +715,6 @@ func (client *ArrayClient) GetComplexEmptyHandleResponse(resp *azcore.Response) 
 
 // GetComplexEmptyHandleError handles the GetComplexEmpty error response.
 func (client *ArrayClient) GetComplexEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -768,8 +732,8 @@ func (client *ArrayClient) GetComplexItemEmpty(ctx context.Context) (*ProductArr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetComplexItemEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetComplexItemEmptyHandleError(resp)
 	}
 	result, err := client.GetComplexItemEmptyHandleResponse(resp)
 	if err != nil {
@@ -797,9 +761,6 @@ func (client *ArrayClient) GetComplexItemEmptyHandleResponse(resp *azcore.Respon
 
 // GetComplexItemEmptyHandleError handles the GetComplexItemEmpty error response.
 func (client *ArrayClient) GetComplexItemEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -817,8 +778,8 @@ func (client *ArrayClient) GetComplexItemNull(ctx context.Context) (*ProductArra
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetComplexItemNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetComplexItemNullHandleError(resp)
 	}
 	result, err := client.GetComplexItemNullHandleResponse(resp)
 	if err != nil {
@@ -846,9 +807,6 @@ func (client *ArrayClient) GetComplexItemNullHandleResponse(resp *azcore.Respons
 
 // GetComplexItemNullHandleError handles the GetComplexItemNull error response.
 func (client *ArrayClient) GetComplexItemNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -866,8 +824,8 @@ func (client *ArrayClient) GetComplexNull(ctx context.Context) (*ProductArrayRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetComplexNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetComplexNullHandleError(resp)
 	}
 	result, err := client.GetComplexNullHandleResponse(resp)
 	if err != nil {
@@ -895,9 +853,6 @@ func (client *ArrayClient) GetComplexNullHandleResponse(resp *azcore.Response) (
 
 // GetComplexNullHandleError handles the GetComplexNull error response.
 func (client *ArrayClient) GetComplexNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -915,8 +870,8 @@ func (client *ArrayClient) GetComplexValid(ctx context.Context) (*ProductArrayRe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetComplexValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetComplexValidHandleError(resp)
 	}
 	result, err := client.GetComplexValidHandleResponse(resp)
 	if err != nil {
@@ -944,9 +899,6 @@ func (client *ArrayClient) GetComplexValidHandleResponse(resp *azcore.Response) 
 
 // GetComplexValidHandleError handles the GetComplexValid error response.
 func (client *ArrayClient) GetComplexValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -964,8 +916,8 @@ func (client *ArrayClient) GetDateInvalidChars(ctx context.Context) (*TimeArrayR
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateInvalidCharsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateInvalidCharsHandleError(resp)
 	}
 	result, err := client.GetDateInvalidCharsHandleResponse(resp)
 	if err != nil {
@@ -993,9 +945,6 @@ func (client *ArrayClient) GetDateInvalidCharsHandleResponse(resp *azcore.Respon
 
 // GetDateInvalidCharsHandleError handles the GetDateInvalidChars error response.
 func (client *ArrayClient) GetDateInvalidCharsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1013,8 +962,8 @@ func (client *ArrayClient) GetDateInvalidNull(ctx context.Context) (*TimeArrayRe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateInvalidNullHandleError(resp)
 	}
 	result, err := client.GetDateInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -1042,9 +991,6 @@ func (client *ArrayClient) GetDateInvalidNullHandleResponse(resp *azcore.Respons
 
 // GetDateInvalidNullHandleError handles the GetDateInvalidNull error response.
 func (client *ArrayClient) GetDateInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1062,8 +1008,8 @@ func (client *ArrayClient) GetDateTimeInvalidChars(ctx context.Context) (*TimeAr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateTimeInvalidCharsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateTimeInvalidCharsHandleError(resp)
 	}
 	result, err := client.GetDateTimeInvalidCharsHandleResponse(resp)
 	if err != nil {
@@ -1098,9 +1044,6 @@ func (client *ArrayClient) GetDateTimeInvalidCharsHandleResponse(resp *azcore.Re
 
 // GetDateTimeInvalidCharsHandleError handles the GetDateTimeInvalidChars error response.
 func (client *ArrayClient) GetDateTimeInvalidCharsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1118,8 +1061,8 @@ func (client *ArrayClient) GetDateTimeInvalidNull(ctx context.Context) (*TimeArr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateTimeInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateTimeInvalidNullHandleError(resp)
 	}
 	result, err := client.GetDateTimeInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -1154,9 +1097,6 @@ func (client *ArrayClient) GetDateTimeInvalidNullHandleResponse(resp *azcore.Res
 
 // GetDateTimeInvalidNullHandleError handles the GetDateTimeInvalidNull error response.
 func (client *ArrayClient) GetDateTimeInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1174,8 +1114,8 @@ func (client *ArrayClient) GetDateTimeRFC1123Valid(ctx context.Context) (*TimeAr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateTimeRFC1123ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateTimeRFC1123ValidHandleError(resp)
 	}
 	result, err := client.GetDateTimeRFC1123ValidHandleResponse(resp)
 	if err != nil {
@@ -1210,9 +1150,6 @@ func (client *ArrayClient) GetDateTimeRFC1123ValidHandleResponse(resp *azcore.Re
 
 // GetDateTimeRFC1123ValidHandleError handles the GetDateTimeRFC1123Valid error response.
 func (client *ArrayClient) GetDateTimeRFC1123ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1230,8 +1167,8 @@ func (client *ArrayClient) GetDateTimeValid(ctx context.Context) (*TimeArrayResp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateTimeValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateTimeValidHandleError(resp)
 	}
 	result, err := client.GetDateTimeValidHandleResponse(resp)
 	if err != nil {
@@ -1266,9 +1203,6 @@ func (client *ArrayClient) GetDateTimeValidHandleResponse(resp *azcore.Response)
 
 // GetDateTimeValidHandleError handles the GetDateTimeValid error response.
 func (client *ArrayClient) GetDateTimeValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1286,8 +1220,8 @@ func (client *ArrayClient) GetDateValid(ctx context.Context) (*TimeArrayResponse
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateValidHandleError(resp)
 	}
 	result, err := client.GetDateValidHandleResponse(resp)
 	if err != nil {
@@ -1315,9 +1249,6 @@ func (client *ArrayClient) GetDateValidHandleResponse(resp *azcore.Response) (*T
 
 // GetDateValidHandleError handles the GetDateValid error response.
 func (client *ArrayClient) GetDateValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1335,8 +1266,8 @@ func (client *ArrayClient) GetDictionaryEmpty(ctx context.Context) (*MapOfString
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDictionaryEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDictionaryEmptyHandleError(resp)
 	}
 	result, err := client.GetDictionaryEmptyHandleResponse(resp)
 	if err != nil {
@@ -1364,9 +1295,6 @@ func (client *ArrayClient) GetDictionaryEmptyHandleResponse(resp *azcore.Respons
 
 // GetDictionaryEmptyHandleError handles the GetDictionaryEmpty error response.
 func (client *ArrayClient) GetDictionaryEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1384,8 +1312,8 @@ func (client *ArrayClient) GetDictionaryItemEmpty(ctx context.Context) (*MapOfSt
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDictionaryItemEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDictionaryItemEmptyHandleError(resp)
 	}
 	result, err := client.GetDictionaryItemEmptyHandleResponse(resp)
 	if err != nil {
@@ -1413,9 +1341,6 @@ func (client *ArrayClient) GetDictionaryItemEmptyHandleResponse(resp *azcore.Res
 
 // GetDictionaryItemEmptyHandleError handles the GetDictionaryItemEmpty error response.
 func (client *ArrayClient) GetDictionaryItemEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1433,8 +1358,8 @@ func (client *ArrayClient) GetDictionaryItemNull(ctx context.Context) (*MapOfStr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDictionaryItemNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDictionaryItemNullHandleError(resp)
 	}
 	result, err := client.GetDictionaryItemNullHandleResponse(resp)
 	if err != nil {
@@ -1462,9 +1387,6 @@ func (client *ArrayClient) GetDictionaryItemNullHandleResponse(resp *azcore.Resp
 
 // GetDictionaryItemNullHandleError handles the GetDictionaryItemNull error response.
 func (client *ArrayClient) GetDictionaryItemNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1482,8 +1404,8 @@ func (client *ArrayClient) GetDictionaryNull(ctx context.Context) (*MapOfStringA
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDictionaryNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDictionaryNullHandleError(resp)
 	}
 	result, err := client.GetDictionaryNullHandleResponse(resp)
 	if err != nil {
@@ -1511,9 +1433,6 @@ func (client *ArrayClient) GetDictionaryNullHandleResponse(resp *azcore.Response
 
 // GetDictionaryNullHandleError handles the GetDictionaryNull error response.
 func (client *ArrayClient) GetDictionaryNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1531,8 +1450,8 @@ func (client *ArrayClient) GetDictionaryValid(ctx context.Context) (*MapOfString
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDictionaryValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDictionaryValidHandleError(resp)
 	}
 	result, err := client.GetDictionaryValidHandleResponse(resp)
 	if err != nil {
@@ -1560,9 +1479,6 @@ func (client *ArrayClient) GetDictionaryValidHandleResponse(resp *azcore.Respons
 
 // GetDictionaryValidHandleError handles the GetDictionaryValid error response.
 func (client *ArrayClient) GetDictionaryValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1580,8 +1496,8 @@ func (client *ArrayClient) GetDoubleInvalidNull(ctx context.Context) (*Float64Ar
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDoubleInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDoubleInvalidNullHandleError(resp)
 	}
 	result, err := client.GetDoubleInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -1609,9 +1525,6 @@ func (client *ArrayClient) GetDoubleInvalidNullHandleResponse(resp *azcore.Respo
 
 // GetDoubleInvalidNullHandleError handles the GetDoubleInvalidNull error response.
 func (client *ArrayClient) GetDoubleInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1629,8 +1542,8 @@ func (client *ArrayClient) GetDoubleInvalidString(ctx context.Context) (*Float64
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDoubleInvalidStringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDoubleInvalidStringHandleError(resp)
 	}
 	result, err := client.GetDoubleInvalidStringHandleResponse(resp)
 	if err != nil {
@@ -1658,9 +1571,6 @@ func (client *ArrayClient) GetDoubleInvalidStringHandleResponse(resp *azcore.Res
 
 // GetDoubleInvalidStringHandleError handles the GetDoubleInvalidString error response.
 func (client *ArrayClient) GetDoubleInvalidStringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1678,8 +1588,8 @@ func (client *ArrayClient) GetDoubleValid(ctx context.Context) (*Float64ArrayRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDoubleValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDoubleValidHandleError(resp)
 	}
 	result, err := client.GetDoubleValidHandleResponse(resp)
 	if err != nil {
@@ -1707,9 +1617,6 @@ func (client *ArrayClient) GetDoubleValidHandleResponse(resp *azcore.Response) (
 
 // GetDoubleValidHandleError handles the GetDoubleValid error response.
 func (client *ArrayClient) GetDoubleValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1727,8 +1634,8 @@ func (client *ArrayClient) GetDurationValid(ctx context.Context) (*StringArrayRe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDurationValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDurationValidHandleError(resp)
 	}
 	result, err := client.GetDurationValidHandleResponse(resp)
 	if err != nil {
@@ -1756,9 +1663,6 @@ func (client *ArrayClient) GetDurationValidHandleResponse(resp *azcore.Response)
 
 // GetDurationValidHandleError handles the GetDurationValid error response.
 func (client *ArrayClient) GetDurationValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1776,8 +1680,8 @@ func (client *ArrayClient) GetEmpty(ctx context.Context) (*Int32ArrayResponse, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyHandleError(resp)
 	}
 	result, err := client.GetEmptyHandleResponse(resp)
 	if err != nil {
@@ -1805,9 +1709,6 @@ func (client *ArrayClient) GetEmptyHandleResponse(resp *azcore.Response) (*Int32
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *ArrayClient) GetEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1825,8 +1726,8 @@ func (client *ArrayClient) GetEnumValid(ctx context.Context) (*FooEnumArrayRespo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEnumValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEnumValidHandleError(resp)
 	}
 	result, err := client.GetEnumValidHandleResponse(resp)
 	if err != nil {
@@ -1854,9 +1755,6 @@ func (client *ArrayClient) GetEnumValidHandleResponse(resp *azcore.Response) (*F
 
 // GetEnumValidHandleError handles the GetEnumValid error response.
 func (client *ArrayClient) GetEnumValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1874,8 +1772,8 @@ func (client *ArrayClient) GetFloatInvalidNull(ctx context.Context) (*Float32Arr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetFloatInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetFloatInvalidNullHandleError(resp)
 	}
 	result, err := client.GetFloatInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -1903,9 +1801,6 @@ func (client *ArrayClient) GetFloatInvalidNullHandleResponse(resp *azcore.Respon
 
 // GetFloatInvalidNullHandleError handles the GetFloatInvalidNull error response.
 func (client *ArrayClient) GetFloatInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1923,8 +1818,8 @@ func (client *ArrayClient) GetFloatInvalidString(ctx context.Context) (*Float32A
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetFloatInvalidStringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetFloatInvalidStringHandleError(resp)
 	}
 	result, err := client.GetFloatInvalidStringHandleResponse(resp)
 	if err != nil {
@@ -1952,9 +1847,6 @@ func (client *ArrayClient) GetFloatInvalidStringHandleResponse(resp *azcore.Resp
 
 // GetFloatInvalidStringHandleError handles the GetFloatInvalidString error response.
 func (client *ArrayClient) GetFloatInvalidStringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1972,8 +1864,8 @@ func (client *ArrayClient) GetFloatValid(ctx context.Context) (*Float32ArrayResp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetFloatValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetFloatValidHandleError(resp)
 	}
 	result, err := client.GetFloatValidHandleResponse(resp)
 	if err != nil {
@@ -2001,9 +1893,6 @@ func (client *ArrayClient) GetFloatValidHandleResponse(resp *azcore.Response) (*
 
 // GetFloatValidHandleError handles the GetFloatValid error response.
 func (client *ArrayClient) GetFloatValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2021,8 +1910,8 @@ func (client *ArrayClient) GetIntInvalidNull(ctx context.Context) (*Int32ArrayRe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetIntInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetIntInvalidNullHandleError(resp)
 	}
 	result, err := client.GetIntInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -2050,9 +1939,6 @@ func (client *ArrayClient) GetIntInvalidNullHandleResponse(resp *azcore.Response
 
 // GetIntInvalidNullHandleError handles the GetIntInvalidNull error response.
 func (client *ArrayClient) GetIntInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2070,8 +1956,8 @@ func (client *ArrayClient) GetIntInvalidString(ctx context.Context) (*Int32Array
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetIntInvalidStringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetIntInvalidStringHandleError(resp)
 	}
 	result, err := client.GetIntInvalidStringHandleResponse(resp)
 	if err != nil {
@@ -2099,9 +1985,6 @@ func (client *ArrayClient) GetIntInvalidStringHandleResponse(resp *azcore.Respon
 
 // GetIntInvalidStringHandleError handles the GetIntInvalidString error response.
 func (client *ArrayClient) GetIntInvalidStringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2119,8 +2002,8 @@ func (client *ArrayClient) GetIntegerValid(ctx context.Context) (*Int32ArrayResp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetIntegerValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetIntegerValidHandleError(resp)
 	}
 	result, err := client.GetIntegerValidHandleResponse(resp)
 	if err != nil {
@@ -2148,9 +2031,6 @@ func (client *ArrayClient) GetIntegerValidHandleResponse(resp *azcore.Response) 
 
 // GetIntegerValidHandleError handles the GetIntegerValid error response.
 func (client *ArrayClient) GetIntegerValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2168,8 +2048,8 @@ func (client *ArrayClient) GetInvalid(ctx context.Context) (*Int32ArrayResponse,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetInvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetInvalidHandleError(resp)
 	}
 	result, err := client.GetInvalidHandleResponse(resp)
 	if err != nil {
@@ -2197,9 +2077,6 @@ func (client *ArrayClient) GetInvalidHandleResponse(resp *azcore.Response) (*Int
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *ArrayClient) GetInvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2217,8 +2094,8 @@ func (client *ArrayClient) GetLongInvalidNull(ctx context.Context) (*Int64ArrayR
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLongInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLongInvalidNullHandleError(resp)
 	}
 	result, err := client.GetLongInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -2246,9 +2123,6 @@ func (client *ArrayClient) GetLongInvalidNullHandleResponse(resp *azcore.Respons
 
 // GetLongInvalidNullHandleError handles the GetLongInvalidNull error response.
 func (client *ArrayClient) GetLongInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2266,8 +2140,8 @@ func (client *ArrayClient) GetLongInvalidString(ctx context.Context) (*Int64Arra
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLongInvalidStringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLongInvalidStringHandleError(resp)
 	}
 	result, err := client.GetLongInvalidStringHandleResponse(resp)
 	if err != nil {
@@ -2295,9 +2169,6 @@ func (client *ArrayClient) GetLongInvalidStringHandleResponse(resp *azcore.Respo
 
 // GetLongInvalidStringHandleError handles the GetLongInvalidString error response.
 func (client *ArrayClient) GetLongInvalidStringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2315,8 +2186,8 @@ func (client *ArrayClient) GetLongValid(ctx context.Context) (*Int64ArrayRespons
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLongValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLongValidHandleError(resp)
 	}
 	result, err := client.GetLongValidHandleResponse(resp)
 	if err != nil {
@@ -2344,9 +2215,6 @@ func (client *ArrayClient) GetLongValidHandleResponse(resp *azcore.Response) (*I
 
 // GetLongValidHandleError handles the GetLongValid error response.
 func (client *ArrayClient) GetLongValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2364,8 +2232,8 @@ func (client *ArrayClient) GetNull(ctx context.Context) (*Int32ArrayResponse, er
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullHandleError(resp)
 	}
 	result, err := client.GetNullHandleResponse(resp)
 	if err != nil {
@@ -2393,9 +2261,6 @@ func (client *ArrayClient) GetNullHandleResponse(resp *azcore.Response) (*Int32A
 
 // GetNullHandleError handles the GetNull error response.
 func (client *ArrayClient) GetNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2413,8 +2278,8 @@ func (client *ArrayClient) GetStringEnumValid(ctx context.Context) (*Enum0ArrayR
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetStringEnumValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetStringEnumValidHandleError(resp)
 	}
 	result, err := client.GetStringEnumValidHandleResponse(resp)
 	if err != nil {
@@ -2442,9 +2307,6 @@ func (client *ArrayClient) GetStringEnumValidHandleResponse(resp *azcore.Respons
 
 // GetStringEnumValidHandleError handles the GetStringEnumValid error response.
 func (client *ArrayClient) GetStringEnumValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2462,8 +2324,8 @@ func (client *ArrayClient) GetStringValid(ctx context.Context) (*StringArrayResp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetStringValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetStringValidHandleError(resp)
 	}
 	result, err := client.GetStringValidHandleResponse(resp)
 	if err != nil {
@@ -2491,9 +2353,6 @@ func (client *ArrayClient) GetStringValidHandleResponse(resp *azcore.Response) (
 
 // GetStringValidHandleError handles the GetStringValid error response.
 func (client *ArrayClient) GetStringValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2511,8 +2370,8 @@ func (client *ArrayClient) GetStringWithInvalid(ctx context.Context) (*StringArr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetStringWithInvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetStringWithInvalidHandleError(resp)
 	}
 	result, err := client.GetStringWithInvalidHandleResponse(resp)
 	if err != nil {
@@ -2540,9 +2399,6 @@ func (client *ArrayClient) GetStringWithInvalidHandleResponse(resp *azcore.Respo
 
 // GetStringWithInvalidHandleError handles the GetStringWithInvalid error response.
 func (client *ArrayClient) GetStringWithInvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2560,8 +2416,8 @@ func (client *ArrayClient) GetStringWithNull(ctx context.Context) (*StringArrayR
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetStringWithNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetStringWithNullHandleError(resp)
 	}
 	result, err := client.GetStringWithNullHandleResponse(resp)
 	if err != nil {
@@ -2589,9 +2445,6 @@ func (client *ArrayClient) GetStringWithNullHandleResponse(resp *azcore.Response
 
 // GetStringWithNullHandleError handles the GetStringWithNull error response.
 func (client *ArrayClient) GetStringWithNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2609,8 +2462,8 @@ func (client *ArrayClient) GetUUIDInvalidChars(ctx context.Context) (*StringArra
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetUUIDInvalidCharsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetUUIDInvalidCharsHandleError(resp)
 	}
 	result, err := client.GetUUIDInvalidCharsHandleResponse(resp)
 	if err != nil {
@@ -2638,9 +2491,6 @@ func (client *ArrayClient) GetUUIDInvalidCharsHandleResponse(resp *azcore.Respon
 
 // GetUUIDInvalidCharsHandleError handles the GetUUIDInvalidChars error response.
 func (client *ArrayClient) GetUUIDInvalidCharsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2658,8 +2508,8 @@ func (client *ArrayClient) GetUUIDValid(ctx context.Context) (*StringArrayRespon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetUUIDValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetUUIDValidHandleError(resp)
 	}
 	result, err := client.GetUUIDValidHandleResponse(resp)
 	if err != nil {
@@ -2687,9 +2537,6 @@ func (client *ArrayClient) GetUUIDValidHandleResponse(resp *azcore.Response) (*S
 
 // GetUUIDValidHandleError handles the GetUUIDValid error response.
 func (client *ArrayClient) GetUUIDValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2707,8 +2554,8 @@ func (client *ArrayClient) PutArrayValid(ctx context.Context, arrayBody [][]stri
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutArrayValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutArrayValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2726,9 +2573,6 @@ func (client *ArrayClient) PutArrayValidCreateRequest(ctx context.Context, array
 
 // PutArrayValidHandleError handles the PutArrayValid error response.
 func (client *ArrayClient) PutArrayValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2746,8 +2590,8 @@ func (client *ArrayClient) PutBooleanTfft(ctx context.Context, arrayBody []bool)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutBooleanTfftHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutBooleanTfftHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2765,9 +2609,6 @@ func (client *ArrayClient) PutBooleanTfftCreateRequest(ctx context.Context, arra
 
 // PutBooleanTfftHandleError handles the PutBooleanTfft error response.
 func (client *ArrayClient) PutBooleanTfftHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2785,8 +2626,8 @@ func (client *ArrayClient) PutByteValid(ctx context.Context, arrayBody [][]byte)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutByteValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutByteValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2804,9 +2645,6 @@ func (client *ArrayClient) PutByteValidCreateRequest(ctx context.Context, arrayB
 
 // PutByteValidHandleError handles the PutByteValid error response.
 func (client *ArrayClient) PutByteValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2824,8 +2662,8 @@ func (client *ArrayClient) PutComplexValid(ctx context.Context, arrayBody []Prod
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutComplexValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutComplexValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2843,9 +2681,6 @@ func (client *ArrayClient) PutComplexValidCreateRequest(ctx context.Context, arr
 
 // PutComplexValidHandleError handles the PutComplexValid error response.
 func (client *ArrayClient) PutComplexValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2863,8 +2698,8 @@ func (client *ArrayClient) PutDateTimeRFC1123Valid(ctx context.Context, arrayBod
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDateTimeRFC1123ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDateTimeRFC1123ValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2886,9 +2721,6 @@ func (client *ArrayClient) PutDateTimeRFC1123ValidCreateRequest(ctx context.Cont
 
 // PutDateTimeRFC1123ValidHandleError handles the PutDateTimeRFC1123Valid error response.
 func (client *ArrayClient) PutDateTimeRFC1123ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2906,8 +2738,8 @@ func (client *ArrayClient) PutDateTimeValid(ctx context.Context, arrayBody []tim
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDateTimeValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDateTimeValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2925,9 +2757,6 @@ func (client *ArrayClient) PutDateTimeValidCreateRequest(ctx context.Context, ar
 
 // PutDateTimeValidHandleError handles the PutDateTimeValid error response.
 func (client *ArrayClient) PutDateTimeValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2945,8 +2774,8 @@ func (client *ArrayClient) PutDateValid(ctx context.Context, arrayBody []time.Ti
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDateValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDateValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2964,9 +2793,6 @@ func (client *ArrayClient) PutDateValidCreateRequest(ctx context.Context, arrayB
 
 // PutDateValidHandleError handles the PutDateValid error response.
 func (client *ArrayClient) PutDateValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2984,8 +2810,8 @@ func (client *ArrayClient) PutDictionaryValid(ctx context.Context, arrayBody []m
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDictionaryValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDictionaryValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3003,9 +2829,6 @@ func (client *ArrayClient) PutDictionaryValidCreateRequest(ctx context.Context, 
 
 // PutDictionaryValidHandleError handles the PutDictionaryValid error response.
 func (client *ArrayClient) PutDictionaryValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3023,8 +2846,8 @@ func (client *ArrayClient) PutDoubleValid(ctx context.Context, arrayBody []float
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDoubleValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDoubleValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3042,9 +2865,6 @@ func (client *ArrayClient) PutDoubleValidCreateRequest(ctx context.Context, arra
 
 // PutDoubleValidHandleError handles the PutDoubleValid error response.
 func (client *ArrayClient) PutDoubleValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3062,8 +2882,8 @@ func (client *ArrayClient) PutDurationValid(ctx context.Context, arrayBody []str
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDurationValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDurationValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3081,9 +2901,6 @@ func (client *ArrayClient) PutDurationValidCreateRequest(ctx context.Context, ar
 
 // PutDurationValidHandleError handles the PutDurationValid error response.
 func (client *ArrayClient) PutDurationValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3101,8 +2918,8 @@ func (client *ArrayClient) PutEmpty(ctx context.Context, arrayBody []string) (*h
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutEmptyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3120,9 +2937,6 @@ func (client *ArrayClient) PutEmptyCreateRequest(ctx context.Context, arrayBody 
 
 // PutEmptyHandleError handles the PutEmpty error response.
 func (client *ArrayClient) PutEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3140,8 +2954,8 @@ func (client *ArrayClient) PutEnumValid(ctx context.Context, arrayBody []FooEnum
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutEnumValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutEnumValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3159,9 +2973,6 @@ func (client *ArrayClient) PutEnumValidCreateRequest(ctx context.Context, arrayB
 
 // PutEnumValidHandleError handles the PutEnumValid error response.
 func (client *ArrayClient) PutEnumValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3179,8 +2990,8 @@ func (client *ArrayClient) PutFloatValid(ctx context.Context, arrayBody []float3
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutFloatValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutFloatValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3198,9 +3009,6 @@ func (client *ArrayClient) PutFloatValidCreateRequest(ctx context.Context, array
 
 // PutFloatValidHandleError handles the PutFloatValid error response.
 func (client *ArrayClient) PutFloatValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3218,8 +3026,8 @@ func (client *ArrayClient) PutIntegerValid(ctx context.Context, arrayBody []int3
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutIntegerValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutIntegerValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3237,9 +3045,6 @@ func (client *ArrayClient) PutIntegerValidCreateRequest(ctx context.Context, arr
 
 // PutIntegerValidHandleError handles the PutIntegerValid error response.
 func (client *ArrayClient) PutIntegerValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3257,8 +3062,8 @@ func (client *ArrayClient) PutLongValid(ctx context.Context, arrayBody []int64) 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutLongValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutLongValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3276,9 +3081,6 @@ func (client *ArrayClient) PutLongValidCreateRequest(ctx context.Context, arrayB
 
 // PutLongValidHandleError handles the PutLongValid error response.
 func (client *ArrayClient) PutLongValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3296,8 +3098,8 @@ func (client *ArrayClient) PutStringEnumValid(ctx context.Context, arrayBody []E
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutStringEnumValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutStringEnumValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3315,9 +3117,6 @@ func (client *ArrayClient) PutStringEnumValidCreateRequest(ctx context.Context, 
 
 // PutStringEnumValidHandleError handles the PutStringEnumValid error response.
 func (client *ArrayClient) PutStringEnumValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3335,8 +3134,8 @@ func (client *ArrayClient) PutStringValid(ctx context.Context, arrayBody []strin
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutStringValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutStringValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3354,9 +3153,6 @@ func (client *ArrayClient) PutStringValidCreateRequest(ctx context.Context, arra
 
 // PutStringValidHandleError handles the PutStringValid error response.
 func (client *ArrayClient) PutStringValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3374,8 +3170,8 @@ func (client *ArrayClient) PutUUIDValid(ctx context.Context, arrayBody []string)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutUUIDValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutUUIDValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3393,9 +3189,6 @@ func (client *ArrayClient) PutUUIDValidCreateRequest(ctx context.Context, arrayB
 
 // PutUUIDValidHandleError handles the PutUUIDValid error response.
 func (client *ArrayClient) PutUUIDValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
+++ b/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
@@ -43,8 +43,8 @@ func (client *AutoRestReportServiceForAzureClient) GetReport(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetReportHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetReportHandleError(resp)
 	}
 	result, err := client.GetReportHandleResponse(resp)
 	if err != nil {
@@ -77,9 +77,6 @@ func (client *AutoRestReportServiceForAzureClient) GetReportHandleResponse(resp 
 
 // GetReportHandleError handles the GetReport error response.
 func (client *AutoRestReportServiceForAzureClient) GetReportHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
+++ b/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
@@ -43,6 +43,9 @@ func (client *AutoRestReportServiceForAzureClient) GetReport(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetReportHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetReportHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -68,15 +71,15 @@ func (client *AutoRestReportServiceForAzureClient) GetReportCreateRequest(ctx co
 
 // GetReportHandleResponse handles the GetReport response.
 func (client *AutoRestReportServiceForAzureClient) GetReportHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetReportHandleError(resp)
-	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetReportHandleError handles the GetReport error response.
 func (client *AutoRestReportServiceForAzureClient) GetReportHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault.go
@@ -49,8 +49,8 @@ func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValid(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetMethodGlobalNotProvidedValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetMethodGlobalNotProvidedValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -71,9 +71,6 @@ func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValidCreateRequ
 
 // GetMethodGlobalNotProvidedValidHandleError handles the GetMethodGlobalNotProvidedValid error response.
 func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -91,8 +88,8 @@ func (client *APIVersionDefaultClient) GetMethodGlobalValid(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetMethodGlobalValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetMethodGlobalValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -113,9 +110,6 @@ func (client *APIVersionDefaultClient) GetMethodGlobalValidCreateRequest(ctx con
 
 // GetMethodGlobalValidHandleError handles the GetMethodGlobalValid error response.
 func (client *APIVersionDefaultClient) GetMethodGlobalValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,8 +127,8 @@ func (client *APIVersionDefaultClient) GetPathGlobalValid(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetPathGlobalValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetPathGlobalValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -155,9 +149,6 @@ func (client *APIVersionDefaultClient) GetPathGlobalValidCreateRequest(ctx conte
 
 // GetPathGlobalValidHandleError handles the GetPathGlobalValid error response.
 func (client *APIVersionDefaultClient) GetPathGlobalValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -175,8 +166,8 @@ func (client *APIVersionDefaultClient) GetSwaggerGlobalValid(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetSwaggerGlobalValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetSwaggerGlobalValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -197,9 +188,6 @@ func (client *APIVersionDefaultClient) GetSwaggerGlobalValidCreateRequest(ctx co
 
 // GetSwaggerGlobalValidHandleError handles the GetSwaggerGlobalValid error response.
 func (client *APIVersionDefaultClient) GetSwaggerGlobalValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault.go
@@ -49,11 +49,10 @@ func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValid(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetMethodGlobalNotProvidedValidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetMethodGlobalNotProvidedValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetMethodGlobalNotProvidedValidCreateRequest creates the GetMethodGlobalNotProvidedValid request.
@@ -70,16 +69,11 @@ func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValidCreateRequ
 	return req, nil
 }
 
-// GetMethodGlobalNotProvidedValidHandleResponse handles the GetMethodGlobalNotProvidedValid response.
-func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMethodGlobalNotProvidedValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetMethodGlobalNotProvidedValidHandleError handles the GetMethodGlobalNotProvidedValid error response.
 func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -97,11 +91,10 @@ func (client *APIVersionDefaultClient) GetMethodGlobalValid(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetMethodGlobalValidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetMethodGlobalValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetMethodGlobalValidCreateRequest creates the GetMethodGlobalValid request.
@@ -118,16 +111,11 @@ func (client *APIVersionDefaultClient) GetMethodGlobalValidCreateRequest(ctx con
 	return req, nil
 }
 
-// GetMethodGlobalValidHandleResponse handles the GetMethodGlobalValid response.
-func (client *APIVersionDefaultClient) GetMethodGlobalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMethodGlobalValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetMethodGlobalValidHandleError handles the GetMethodGlobalValid error response.
 func (client *APIVersionDefaultClient) GetMethodGlobalValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -145,11 +133,10 @@ func (client *APIVersionDefaultClient) GetPathGlobalValid(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetPathGlobalValidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetPathGlobalValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetPathGlobalValidCreateRequest creates the GetPathGlobalValid request.
@@ -166,16 +153,11 @@ func (client *APIVersionDefaultClient) GetPathGlobalValidCreateRequest(ctx conte
 	return req, nil
 }
 
-// GetPathGlobalValidHandleResponse handles the GetPathGlobalValid response.
-func (client *APIVersionDefaultClient) GetPathGlobalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetPathGlobalValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetPathGlobalValidHandleError handles the GetPathGlobalValid error response.
 func (client *APIVersionDefaultClient) GetPathGlobalValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -193,11 +175,10 @@ func (client *APIVersionDefaultClient) GetSwaggerGlobalValid(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetSwaggerGlobalValidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetSwaggerGlobalValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetSwaggerGlobalValidCreateRequest creates the GetSwaggerGlobalValid request.
@@ -214,16 +195,11 @@ func (client *APIVersionDefaultClient) GetSwaggerGlobalValidCreateRequest(ctx co
 	return req, nil
 }
 
-// GetSwaggerGlobalValidHandleResponse handles the GetSwaggerGlobalValid response.
-func (client *APIVersionDefaultClient) GetSwaggerGlobalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetSwaggerGlobalValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetSwaggerGlobalValidHandleError handles the GetSwaggerGlobalValid error response.
 func (client *APIVersionDefaultClient) GetSwaggerGlobalValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal.go
@@ -49,11 +49,10 @@ func (client *APIVersionLocalClient) GetMethodLocalNull(ctx context.Context, api
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetMethodLocalNullHandleResponse(resp)
-	if err != nil {
+	if err := client.GetMethodLocalNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetMethodLocalNullCreateRequest creates the GetMethodLocalNull request.
@@ -72,16 +71,11 @@ func (client *APIVersionLocalClient) GetMethodLocalNullCreateRequest(ctx context
 	return req, nil
 }
 
-// GetMethodLocalNullHandleResponse handles the GetMethodLocalNull response.
-func (client *APIVersionLocalClient) GetMethodLocalNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMethodLocalNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetMethodLocalNullHandleError handles the GetMethodLocalNull error response.
 func (client *APIVersionLocalClient) GetMethodLocalNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -99,11 +93,10 @@ func (client *APIVersionLocalClient) GetMethodLocalValid(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetMethodLocalValidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetMethodLocalValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetMethodLocalValidCreateRequest creates the GetMethodLocalValid request.
@@ -120,16 +113,11 @@ func (client *APIVersionLocalClient) GetMethodLocalValidCreateRequest(ctx contex
 	return req, nil
 }
 
-// GetMethodLocalValidHandleResponse handles the GetMethodLocalValid response.
-func (client *APIVersionLocalClient) GetMethodLocalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMethodLocalValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetMethodLocalValidHandleError handles the GetMethodLocalValid error response.
 func (client *APIVersionLocalClient) GetMethodLocalValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -147,11 +135,10 @@ func (client *APIVersionLocalClient) GetPathLocalValid(ctx context.Context) (*ht
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetPathLocalValidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetPathLocalValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetPathLocalValidCreateRequest creates the GetPathLocalValid request.
@@ -168,16 +155,11 @@ func (client *APIVersionLocalClient) GetPathLocalValidCreateRequest(ctx context.
 	return req, nil
 }
 
-// GetPathLocalValidHandleResponse handles the GetPathLocalValid response.
-func (client *APIVersionLocalClient) GetPathLocalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetPathLocalValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetPathLocalValidHandleError handles the GetPathLocalValid error response.
 func (client *APIVersionLocalClient) GetPathLocalValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -195,11 +177,10 @@ func (client *APIVersionLocalClient) GetSwaggerLocalValid(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetSwaggerLocalValidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetSwaggerLocalValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetSwaggerLocalValidCreateRequest creates the GetSwaggerLocalValid request.
@@ -216,16 +197,11 @@ func (client *APIVersionLocalClient) GetSwaggerLocalValidCreateRequest(ctx conte
 	return req, nil
 }
 
-// GetSwaggerLocalValidHandleResponse handles the GetSwaggerLocalValid response.
-func (client *APIVersionLocalClient) GetSwaggerLocalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetSwaggerLocalValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetSwaggerLocalValidHandleError handles the GetSwaggerLocalValid error response.
 func (client *APIVersionLocalClient) GetSwaggerLocalValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal.go
@@ -49,8 +49,8 @@ func (client *APIVersionLocalClient) GetMethodLocalNull(ctx context.Context, api
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetMethodLocalNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetMethodLocalNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -73,9 +73,6 @@ func (client *APIVersionLocalClient) GetMethodLocalNullCreateRequest(ctx context
 
 // GetMethodLocalNullHandleError handles the GetMethodLocalNull error response.
 func (client *APIVersionLocalClient) GetMethodLocalNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -93,8 +90,8 @@ func (client *APIVersionLocalClient) GetMethodLocalValid(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetMethodLocalValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetMethodLocalValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -115,9 +112,6 @@ func (client *APIVersionLocalClient) GetMethodLocalValidCreateRequest(ctx contex
 
 // GetMethodLocalValidHandleError handles the GetMethodLocalValid error response.
 func (client *APIVersionLocalClient) GetMethodLocalValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -135,8 +129,8 @@ func (client *APIVersionLocalClient) GetPathLocalValid(ctx context.Context) (*ht
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetPathLocalValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetPathLocalValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -157,9 +151,6 @@ func (client *APIVersionLocalClient) GetPathLocalValidCreateRequest(ctx context.
 
 // GetPathLocalValidHandleError handles the GetPathLocalValid error response.
 func (client *APIVersionLocalClient) GetPathLocalValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -177,8 +168,8 @@ func (client *APIVersionLocalClient) GetSwaggerLocalValid(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetSwaggerLocalValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetSwaggerLocalValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -199,9 +190,6 @@ func (client *APIVersionLocalClient) GetSwaggerLocalValidCreateRequest(ctx conte
 
 // GetSwaggerLocalValidHandleError handles the GetSwaggerLocalValid error response.
 func (client *APIVersionLocalClient) GetSwaggerLocalValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_header.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_header.go
@@ -47,6 +47,9 @@ func (client *HeaderClient) CustomNamedRequestID(ctx context.Context, fooClientR
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CustomNamedRequestIDHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CustomNamedRequestIDHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -68,9 +71,6 @@ func (client *HeaderClient) CustomNamedRequestIDCreateRequest(ctx context.Contex
 
 // CustomNamedRequestIDHandleResponse handles the CustomNamedRequestID response.
 func (client *HeaderClient) CustomNamedRequestIDHandleResponse(resp *azcore.Response) (*HeaderCustomNamedRequestIDResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.CustomNamedRequestIDHandleError(resp)
-	}
 	result := HeaderCustomNamedRequestIDResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("foo-request-id"); val != "" {
 		result.FooRequestID = &val
@@ -80,6 +80,9 @@ func (client *HeaderClient) CustomNamedRequestIDHandleResponse(resp *azcore.Resp
 
 // CustomNamedRequestIDHandleError handles the CustomNamedRequestID error response.
 func (client *HeaderClient) CustomNamedRequestIDHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -95,6 +98,9 @@ func (client *HeaderClient) CustomNamedRequestIDHead(ctx context.Context, fooCli
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CustomNamedRequestIDHeadHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CustomNamedRequestIDHeadHandleResponse(resp)
@@ -118,9 +124,6 @@ func (client *HeaderClient) CustomNamedRequestIDHeadCreateRequest(ctx context.Co
 
 // CustomNamedRequestIDHeadHandleResponse handles the CustomNamedRequestIDHead response.
 func (client *HeaderClient) CustomNamedRequestIDHeadHandleResponse(resp *azcore.Response) (*HeaderCustomNamedRequestIDHeadResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNotFound) {
-		return nil, client.CustomNamedRequestIDHeadHandleError(resp)
-	}
 	result := HeaderCustomNamedRequestIDHeadResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("foo-request-id"); val != "" {
 		result.FooRequestID = &val
@@ -130,6 +133,9 @@ func (client *HeaderClient) CustomNamedRequestIDHeadHandleResponse(resp *azcore.
 
 // CustomNamedRequestIDHeadHandleError handles the CustomNamedRequestIDHead error response.
 func (client *HeaderClient) CustomNamedRequestIDHeadHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNotFound) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -145,6 +151,9 @@ func (client *HeaderClient) CustomNamedRequestIDParamGrouping(ctx context.Contex
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CustomNamedRequestIDParamGroupingHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CustomNamedRequestIDParamGroupingHandleResponse(resp)
@@ -168,9 +177,6 @@ func (client *HeaderClient) CustomNamedRequestIDParamGroupingCreateRequest(ctx c
 
 // CustomNamedRequestIDParamGroupingHandleResponse handles the CustomNamedRequestIDParamGrouping response.
 func (client *HeaderClient) CustomNamedRequestIDParamGroupingHandleResponse(resp *azcore.Response) (*HeaderCustomNamedRequestIDParamGroupingResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.CustomNamedRequestIDParamGroupingHandleError(resp)
-	}
 	result := HeaderCustomNamedRequestIDParamGroupingResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("foo-request-id"); val != "" {
 		result.FooRequestID = &val
@@ -180,6 +186,9 @@ func (client *HeaderClient) CustomNamedRequestIDParamGroupingHandleResponse(resp
 
 // CustomNamedRequestIDParamGroupingHandleError handles the CustomNamedRequestIDParamGrouping error response.
 func (client *HeaderClient) CustomNamedRequestIDParamGroupingHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_header.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_header.go
@@ -47,8 +47,8 @@ func (client *HeaderClient) CustomNamedRequestID(ctx context.Context, fooClientR
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CustomNamedRequestIDHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.CustomNamedRequestIDHandleError(resp)
 	}
 	result, err := client.CustomNamedRequestIDHandleResponse(resp)
 	if err != nil {
@@ -80,9 +80,6 @@ func (client *HeaderClient) CustomNamedRequestIDHandleResponse(resp *azcore.Resp
 
 // CustomNamedRequestIDHandleError handles the CustomNamedRequestID error response.
 func (client *HeaderClient) CustomNamedRequestIDHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -100,8 +97,8 @@ func (client *HeaderClient) CustomNamedRequestIDHead(ctx context.Context, fooCli
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CustomNamedRequestIDHeadHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusNotFound) {
+		return nil, client.CustomNamedRequestIDHeadHandleError(resp)
 	}
 	result, err := client.CustomNamedRequestIDHeadHandleResponse(resp)
 	if err != nil {
@@ -133,9 +130,6 @@ func (client *HeaderClient) CustomNamedRequestIDHeadHandleResponse(resp *azcore.
 
 // CustomNamedRequestIDHeadHandleError handles the CustomNamedRequestIDHead error response.
 func (client *HeaderClient) CustomNamedRequestIDHeadHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNotFound) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -153,8 +147,8 @@ func (client *HeaderClient) CustomNamedRequestIDParamGrouping(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CustomNamedRequestIDParamGroupingHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.CustomNamedRequestIDParamGroupingHandleError(resp)
 	}
 	result, err := client.CustomNamedRequestIDParamGroupingHandleResponse(resp)
 	if err != nil {
@@ -186,9 +180,6 @@ func (client *HeaderClient) CustomNamedRequestIDParamGroupingHandleResponse(resp
 
 // CustomNamedRequestIDParamGroupingHandleError handles the CustomNamedRequestIDParamGrouping error response.
 func (client *HeaderClient) CustomNamedRequestIDParamGroupingHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_odata.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_odata.go
@@ -44,8 +44,8 @@ func (client *OdataClient) GetWithFilter(ctx context.Context, odataGetWithFilter
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetWithFilterHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetWithFilterHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -74,9 +74,6 @@ func (client *OdataClient) GetWithFilterCreateRequest(ctx context.Context, odata
 
 // GetWithFilterHandleError handles the GetWithFilter error response.
 func (client *OdataClient) GetWithFilterHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_odata.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_odata.go
@@ -44,11 +44,10 @@ func (client *OdataClient) GetWithFilter(ctx context.Context, odataGetWithFilter
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetWithFilterHandleResponse(resp)
-	if err != nil {
+	if err := client.GetWithFilterHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetWithFilterCreateRequest creates the GetWithFilter request.
@@ -73,16 +72,11 @@ func (client *OdataClient) GetWithFilterCreateRequest(ctx context.Context, odata
 	return req, nil
 }
 
-// GetWithFilterHandleResponse handles the GetWithFilter response.
-func (client *OdataClient) GetWithFilterHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetWithFilterHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetWithFilterHandleError handles the GetWithFilter error response.
 func (client *OdataClient) GetWithFilterHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding.go
@@ -56,8 +56,8 @@ func (client *SkipURLEncodingClient) GetMethodPathValid(ctx context.Context, une
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetMethodPathValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetMethodPathValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -76,9 +76,6 @@ func (client *SkipURLEncodingClient) GetMethodPathValidCreateRequest(ctx context
 
 // GetMethodPathValidHandleError handles the GetMethodPathValid error response.
 func (client *SkipURLEncodingClient) GetMethodPathValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -96,8 +93,8 @@ func (client *SkipURLEncodingClient) GetMethodQueryNull(ctx context.Context, ski
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetMethodQueryNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetMethodQueryNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -120,9 +117,6 @@ func (client *SkipURLEncodingClient) GetMethodQueryNullCreateRequest(ctx context
 
 // GetMethodQueryNullHandleError handles the GetMethodQueryNull error response.
 func (client *SkipURLEncodingClient) GetMethodQueryNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -140,8 +134,8 @@ func (client *SkipURLEncodingClient) GetMethodQueryValid(ctx context.Context, q1
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetMethodQueryValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetMethodQueryValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -162,9 +156,6 @@ func (client *SkipURLEncodingClient) GetMethodQueryValidCreateRequest(ctx contex
 
 // GetMethodQueryValidHandleError handles the GetMethodQueryValid error response.
 func (client *SkipURLEncodingClient) GetMethodQueryValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -182,8 +173,8 @@ func (client *SkipURLEncodingClient) GetPathQueryValid(ctx context.Context, q1 s
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetPathQueryValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetPathQueryValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -204,9 +195,6 @@ func (client *SkipURLEncodingClient) GetPathQueryValidCreateRequest(ctx context.
 
 // GetPathQueryValidHandleError handles the GetPathQueryValid error response.
 func (client *SkipURLEncodingClient) GetPathQueryValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -224,8 +212,8 @@ func (client *SkipURLEncodingClient) GetPathValid(ctx context.Context, unencoded
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetPathValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetPathValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -244,9 +232,6 @@ func (client *SkipURLEncodingClient) GetPathValidCreateRequest(ctx context.Conte
 
 // GetPathValidHandleError handles the GetPathValid error response.
 func (client *SkipURLEncodingClient) GetPathValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -264,8 +249,8 @@ func (client *SkipURLEncodingClient) GetSwaggerPathValid(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetSwaggerPathValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetSwaggerPathValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -284,9 +269,6 @@ func (client *SkipURLEncodingClient) GetSwaggerPathValidCreateRequest(ctx contex
 
 // GetSwaggerPathValidHandleError handles the GetSwaggerPathValid error response.
 func (client *SkipURLEncodingClient) GetSwaggerPathValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -304,8 +286,8 @@ func (client *SkipURLEncodingClient) GetSwaggerQueryValid(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetSwaggerQueryValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetSwaggerQueryValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -326,9 +308,6 @@ func (client *SkipURLEncodingClient) GetSwaggerQueryValidCreateRequest(ctx conte
 
 // GetSwaggerQueryValidHandleError handles the GetSwaggerQueryValid error response.
 func (client *SkipURLEncodingClient) GetSwaggerQueryValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding.go
@@ -56,11 +56,10 @@ func (client *SkipURLEncodingClient) GetMethodPathValid(ctx context.Context, une
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetMethodPathValidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetMethodPathValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetMethodPathValidCreateRequest creates the GetMethodPathValid request.
@@ -75,16 +74,11 @@ func (client *SkipURLEncodingClient) GetMethodPathValidCreateRequest(ctx context
 	return req, nil
 }
 
-// GetMethodPathValidHandleResponse handles the GetMethodPathValid response.
-func (client *SkipURLEncodingClient) GetMethodPathValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMethodPathValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetMethodPathValidHandleError handles the GetMethodPathValid error response.
 func (client *SkipURLEncodingClient) GetMethodPathValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -102,11 +96,10 @@ func (client *SkipURLEncodingClient) GetMethodQueryNull(ctx context.Context, ski
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetMethodQueryNullHandleResponse(resp)
-	if err != nil {
+	if err := client.GetMethodQueryNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetMethodQueryNullCreateRequest creates the GetMethodQueryNull request.
@@ -125,16 +118,11 @@ func (client *SkipURLEncodingClient) GetMethodQueryNullCreateRequest(ctx context
 	return req, nil
 }
 
-// GetMethodQueryNullHandleResponse handles the GetMethodQueryNull response.
-func (client *SkipURLEncodingClient) GetMethodQueryNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMethodQueryNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetMethodQueryNullHandleError handles the GetMethodQueryNull error response.
 func (client *SkipURLEncodingClient) GetMethodQueryNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -152,11 +140,10 @@ func (client *SkipURLEncodingClient) GetMethodQueryValid(ctx context.Context, q1
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetMethodQueryValidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetMethodQueryValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetMethodQueryValidCreateRequest creates the GetMethodQueryValid request.
@@ -173,16 +160,11 @@ func (client *SkipURLEncodingClient) GetMethodQueryValidCreateRequest(ctx contex
 	return req, nil
 }
 
-// GetMethodQueryValidHandleResponse handles the GetMethodQueryValid response.
-func (client *SkipURLEncodingClient) GetMethodQueryValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMethodQueryValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetMethodQueryValidHandleError handles the GetMethodQueryValid error response.
 func (client *SkipURLEncodingClient) GetMethodQueryValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -200,11 +182,10 @@ func (client *SkipURLEncodingClient) GetPathQueryValid(ctx context.Context, q1 s
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetPathQueryValidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetPathQueryValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetPathQueryValidCreateRequest creates the GetPathQueryValid request.
@@ -221,16 +202,11 @@ func (client *SkipURLEncodingClient) GetPathQueryValidCreateRequest(ctx context.
 	return req, nil
 }
 
-// GetPathQueryValidHandleResponse handles the GetPathQueryValid response.
-func (client *SkipURLEncodingClient) GetPathQueryValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetPathQueryValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetPathQueryValidHandleError handles the GetPathQueryValid error response.
 func (client *SkipURLEncodingClient) GetPathQueryValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -248,11 +224,10 @@ func (client *SkipURLEncodingClient) GetPathValid(ctx context.Context, unencoded
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetPathValidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetPathValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetPathValidCreateRequest creates the GetPathValid request.
@@ -267,16 +242,11 @@ func (client *SkipURLEncodingClient) GetPathValidCreateRequest(ctx context.Conte
 	return req, nil
 }
 
-// GetPathValidHandleResponse handles the GetPathValid response.
-func (client *SkipURLEncodingClient) GetPathValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetPathValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetPathValidHandleError handles the GetPathValid error response.
 func (client *SkipURLEncodingClient) GetPathValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -294,11 +264,10 @@ func (client *SkipURLEncodingClient) GetSwaggerPathValid(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetSwaggerPathValidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetSwaggerPathValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetSwaggerPathValidCreateRequest creates the GetSwaggerPathValid request.
@@ -313,16 +282,11 @@ func (client *SkipURLEncodingClient) GetSwaggerPathValidCreateRequest(ctx contex
 	return req, nil
 }
 
-// GetSwaggerPathValidHandleResponse handles the GetSwaggerPathValid response.
-func (client *SkipURLEncodingClient) GetSwaggerPathValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetSwaggerPathValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetSwaggerPathValidHandleError handles the GetSwaggerPathValid error response.
 func (client *SkipURLEncodingClient) GetSwaggerPathValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -340,11 +304,10 @@ func (client *SkipURLEncodingClient) GetSwaggerQueryValid(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetSwaggerQueryValidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetSwaggerQueryValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetSwaggerQueryValidCreateRequest creates the GetSwaggerQueryValid request.
@@ -361,16 +324,11 @@ func (client *SkipURLEncodingClient) GetSwaggerQueryValidCreateRequest(ctx conte
 	return req, nil
 }
 
-// GetSwaggerQueryValidHandleResponse handles the GetSwaggerQueryValid response.
-func (client *SkipURLEncodingClient) GetSwaggerQueryValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetSwaggerQueryValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetSwaggerQueryValidHandleError handles the GetSwaggerQueryValid error response.
 func (client *SkipURLEncodingClient) GetSwaggerQueryValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials.go
@@ -54,11 +54,10 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValid(
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostMethodGlobalNotProvidedValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PostMethodGlobalNotProvidedValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostMethodGlobalNotProvidedValidCreateRequest creates the PostMethodGlobalNotProvidedValid request.
@@ -76,16 +75,11 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValidC
 	return req, nil
 }
 
-// PostMethodGlobalNotProvidedValidHandleResponse handles the PostMethodGlobalNotProvidedValid response.
-func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostMethodGlobalNotProvidedValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostMethodGlobalNotProvidedValidHandleError handles the PostMethodGlobalNotProvidedValid error response.
 func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -103,11 +97,10 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNull(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostMethodGlobalNullHandleResponse(resp)
-	if err != nil {
+	if err := client.PostMethodGlobalNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostMethodGlobalNullCreateRequest creates the PostMethodGlobalNull request.
@@ -122,16 +115,11 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNullCreateRequest
 	return req, nil
 }
 
-// PostMethodGlobalNullHandleResponse handles the PostMethodGlobalNull response.
-func (client *SubscriptionInCredentialsClient) PostMethodGlobalNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostMethodGlobalNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostMethodGlobalNullHandleError handles the PostMethodGlobalNull error response.
 func (client *SubscriptionInCredentialsClient) PostMethodGlobalNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -149,11 +137,10 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalValid(ctx context
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostMethodGlobalValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PostMethodGlobalValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostMethodGlobalValidCreateRequest creates the PostMethodGlobalValid request.
@@ -168,16 +155,11 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalValidCreateReques
 	return req, nil
 }
 
-// PostMethodGlobalValidHandleResponse handles the PostMethodGlobalValid response.
-func (client *SubscriptionInCredentialsClient) PostMethodGlobalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostMethodGlobalValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostMethodGlobalValidHandleError handles the PostMethodGlobalValid error response.
 func (client *SubscriptionInCredentialsClient) PostMethodGlobalValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -195,11 +177,10 @@ func (client *SubscriptionInCredentialsClient) PostPathGlobalValid(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostPathGlobalValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PostPathGlobalValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostPathGlobalValidCreateRequest creates the PostPathGlobalValid request.
@@ -214,16 +195,11 @@ func (client *SubscriptionInCredentialsClient) PostPathGlobalValidCreateRequest(
 	return req, nil
 }
 
-// PostPathGlobalValidHandleResponse handles the PostPathGlobalValid response.
-func (client *SubscriptionInCredentialsClient) PostPathGlobalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostPathGlobalValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostPathGlobalValidHandleError handles the PostPathGlobalValid error response.
 func (client *SubscriptionInCredentialsClient) PostPathGlobalValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -241,11 +217,10 @@ func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValid(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostSwaggerGlobalValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PostSwaggerGlobalValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostSwaggerGlobalValidCreateRequest creates the PostSwaggerGlobalValid request.
@@ -260,16 +235,11 @@ func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValidCreateReque
 	return req, nil
 }
 
-// PostSwaggerGlobalValidHandleResponse handles the PostSwaggerGlobalValid response.
-func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostSwaggerGlobalValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostSwaggerGlobalValidHandleError handles the PostSwaggerGlobalValid error response.
 func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials.go
@@ -54,8 +54,8 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValid(
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostMethodGlobalNotProvidedValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostMethodGlobalNotProvidedValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -77,9 +77,6 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValidC
 
 // PostMethodGlobalNotProvidedValidHandleError handles the PostMethodGlobalNotProvidedValid error response.
 func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -97,8 +94,8 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNull(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostMethodGlobalNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostMethodGlobalNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -117,9 +114,6 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNullCreateRequest
 
 // PostMethodGlobalNullHandleError handles the PostMethodGlobalNull error response.
 func (client *SubscriptionInCredentialsClient) PostMethodGlobalNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -137,8 +131,8 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalValid(ctx context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostMethodGlobalValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostMethodGlobalValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -157,9 +151,6 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalValidCreateReques
 
 // PostMethodGlobalValidHandleError handles the PostMethodGlobalValid error response.
 func (client *SubscriptionInCredentialsClient) PostMethodGlobalValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -177,8 +168,8 @@ func (client *SubscriptionInCredentialsClient) PostPathGlobalValid(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostPathGlobalValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostPathGlobalValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -197,9 +188,6 @@ func (client *SubscriptionInCredentialsClient) PostPathGlobalValidCreateRequest(
 
 // PostPathGlobalValidHandleError handles the PostPathGlobalValid error response.
 func (client *SubscriptionInCredentialsClient) PostPathGlobalValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -217,8 +205,8 @@ func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValid(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostSwaggerGlobalValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostSwaggerGlobalValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -237,9 +225,6 @@ func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValidCreateReque
 
 // PostSwaggerGlobalValidHandleError handles the PostSwaggerGlobalValid error response.
 func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod.go
@@ -51,8 +51,8 @@ func (client *SubscriptionInMethodClient) PostMethodLocalNull(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostMethodLocalNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostMethodLocalNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -71,9 +71,6 @@ func (client *SubscriptionInMethodClient) PostMethodLocalNullCreateRequest(ctx c
 
 // PostMethodLocalNullHandleError handles the PostMethodLocalNull error response.
 func (client *SubscriptionInMethodClient) PostMethodLocalNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -91,8 +88,8 @@ func (client *SubscriptionInMethodClient) PostMethodLocalValid(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostMethodLocalValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostMethodLocalValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -111,9 +108,6 @@ func (client *SubscriptionInMethodClient) PostMethodLocalValidCreateRequest(ctx 
 
 // PostMethodLocalValidHandleError handles the PostMethodLocalValid error response.
 func (client *SubscriptionInMethodClient) PostMethodLocalValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -131,8 +125,8 @@ func (client *SubscriptionInMethodClient) PostPathLocalValid(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostPathLocalValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostPathLocalValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -151,9 +145,6 @@ func (client *SubscriptionInMethodClient) PostPathLocalValidCreateRequest(ctx co
 
 // PostPathLocalValidHandleError handles the PostPathLocalValid error response.
 func (client *SubscriptionInMethodClient) PostPathLocalValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -171,8 +162,8 @@ func (client *SubscriptionInMethodClient) PostSwaggerLocalValid(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostSwaggerLocalValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostSwaggerLocalValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -191,9 +182,6 @@ func (client *SubscriptionInMethodClient) PostSwaggerLocalValidCreateRequest(ctx
 
 // PostSwaggerLocalValidHandleError handles the PostSwaggerLocalValid error response.
 func (client *SubscriptionInMethodClient) PostSwaggerLocalValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod.go
@@ -51,11 +51,10 @@ func (client *SubscriptionInMethodClient) PostMethodLocalNull(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostMethodLocalNullHandleResponse(resp)
-	if err != nil {
+	if err := client.PostMethodLocalNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostMethodLocalNullCreateRequest creates the PostMethodLocalNull request.
@@ -70,16 +69,11 @@ func (client *SubscriptionInMethodClient) PostMethodLocalNullCreateRequest(ctx c
 	return req, nil
 }
 
-// PostMethodLocalNullHandleResponse handles the PostMethodLocalNull response.
-func (client *SubscriptionInMethodClient) PostMethodLocalNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostMethodLocalNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostMethodLocalNullHandleError handles the PostMethodLocalNull error response.
 func (client *SubscriptionInMethodClient) PostMethodLocalNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -97,11 +91,10 @@ func (client *SubscriptionInMethodClient) PostMethodLocalValid(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostMethodLocalValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PostMethodLocalValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostMethodLocalValidCreateRequest creates the PostMethodLocalValid request.
@@ -116,16 +109,11 @@ func (client *SubscriptionInMethodClient) PostMethodLocalValidCreateRequest(ctx 
 	return req, nil
 }
 
-// PostMethodLocalValidHandleResponse handles the PostMethodLocalValid response.
-func (client *SubscriptionInMethodClient) PostMethodLocalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostMethodLocalValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostMethodLocalValidHandleError handles the PostMethodLocalValid error response.
 func (client *SubscriptionInMethodClient) PostMethodLocalValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -143,11 +131,10 @@ func (client *SubscriptionInMethodClient) PostPathLocalValid(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostPathLocalValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PostPathLocalValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostPathLocalValidCreateRequest creates the PostPathLocalValid request.
@@ -162,16 +149,11 @@ func (client *SubscriptionInMethodClient) PostPathLocalValidCreateRequest(ctx co
 	return req, nil
 }
 
-// PostPathLocalValidHandleResponse handles the PostPathLocalValid response.
-func (client *SubscriptionInMethodClient) PostPathLocalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostPathLocalValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostPathLocalValidHandleError handles the PostPathLocalValid error response.
 func (client *SubscriptionInMethodClient) PostPathLocalValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -189,11 +171,10 @@ func (client *SubscriptionInMethodClient) PostSwaggerLocalValid(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostSwaggerLocalValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PostSwaggerLocalValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostSwaggerLocalValidCreateRequest creates the PostSwaggerLocalValid request.
@@ -208,16 +189,11 @@ func (client *SubscriptionInMethodClient) PostSwaggerLocalValidCreateRequest(ctx
 	return req, nil
 }
 
-// PostSwaggerLocalValidHandleResponse handles the PostSwaggerLocalValid response.
-func (client *SubscriptionInMethodClient) PostSwaggerLocalValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostSwaggerLocalValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostSwaggerLocalValidHandleError handles the PostSwaggerLocalValid error response.
 func (client *SubscriptionInMethodClient) PostSwaggerLocalValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid.go
@@ -48,8 +48,8 @@ func (client *XMSClientRequestIDClient) Get(ctx context.Context) (*http.Response
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -66,9 +66,6 @@ func (client *XMSClientRequestIDClient) GetCreateRequest(ctx context.Context) (*
 
 // GetHandleError handles the Get error response.
 func (client *XMSClientRequestIDClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -89,8 +86,8 @@ func (client *XMSClientRequestIDClient) ParamGet(ctx context.Context, xMSClientR
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ParamGetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ParamGetHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -109,9 +106,6 @@ func (client *XMSClientRequestIDClient) ParamGetCreateRequest(ctx context.Contex
 
 // ParamGetHandleError handles the ParamGet error response.
 func (client *XMSClientRequestIDClient) ParamGetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid.go
@@ -48,11 +48,10 @@ func (client *XMSClientRequestIDClient) Get(ctx context.Context) (*http.Response
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetHandleResponse(resp)
-	if err != nil {
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetCreateRequest creates the Get request.
@@ -65,16 +64,11 @@ func (client *XMSClientRequestIDClient) GetCreateRequest(ctx context.Context) (*
 	return req, nil
 }
 
-// GetHandleResponse handles the Get response.
-func (client *XMSClientRequestIDClient) GetHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetHandleError handles the Get error response.
 func (client *XMSClientRequestIDClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -95,11 +89,10 @@ func (client *XMSClientRequestIDClient) ParamGet(ctx context.Context, xMSClientR
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ParamGetHandleResponse(resp)
-	if err != nil {
+	if err := client.ParamGetHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ParamGetCreateRequest creates the ParamGet request.
@@ -114,16 +107,11 @@ func (client *XMSClientRequestIDClient) ParamGetCreateRequest(ctx context.Contex
 	return req, nil
 }
 
-// ParamGetHandleResponse handles the ParamGet response.
-func (client *XMSClientRequestIDClient) ParamGetHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ParamGetHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ParamGetHandleError handles the ParamGet error response.
 func (client *XMSClientRequestIDClient) ParamGetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/booleangroup/zz_generated_bool.go
+++ b/test/autorest/booleangroup/zz_generated_bool.go
@@ -53,6 +53,9 @@ func (client *BoolClient) GetFalse(ctx context.Context) (*BoolResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetFalseHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetFalseHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -73,15 +76,15 @@ func (client *BoolClient) GetFalseCreateRequest(ctx context.Context) (*azcore.Re
 
 // GetFalseHandleResponse handles the GetFalse response.
 func (client *BoolClient) GetFalseHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetFalseHandleError(resp)
-	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetFalseHandleError handles the GetFalse error response.
 func (client *BoolClient) GetFalseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -97,6 +100,9 @@ func (client *BoolClient) GetInvalid(ctx context.Context) (*BoolResponse, error)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetInvalidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetInvalidHandleResponse(resp)
@@ -119,15 +125,15 @@ func (client *BoolClient) GetInvalidCreateRequest(ctx context.Context) (*azcore.
 
 // GetInvalidHandleResponse handles the GetInvalid response.
 func (client *BoolClient) GetInvalidHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetInvalidHandleError(resp)
-	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *BoolClient) GetInvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -143,6 +149,9 @@ func (client *BoolClient) GetNull(ctx context.Context) (*BoolResponse, error) {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullHandleResponse(resp)
@@ -165,15 +174,15 @@ func (client *BoolClient) GetNullCreateRequest(ctx context.Context) (*azcore.Req
 
 // GetNullHandleResponse handles the GetNull response.
 func (client *BoolClient) GetNullHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullHandleError(resp)
-	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNullHandleError handles the GetNull error response.
 func (client *BoolClient) GetNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -189,6 +198,9 @@ func (client *BoolClient) GetTrue(ctx context.Context) (*BoolResponse, error) {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetTrueHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetTrueHandleResponse(resp)
@@ -211,15 +223,15 @@ func (client *BoolClient) GetTrueCreateRequest(ctx context.Context) (*azcore.Req
 
 // GetTrueHandleResponse handles the GetTrue response.
 func (client *BoolClient) GetTrueHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetTrueHandleError(resp)
-	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetTrueHandleError handles the GetTrue error response.
 func (client *BoolClient) GetTrueHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -237,11 +249,10 @@ func (client *BoolClient) PutFalse(ctx context.Context) (*http.Response, error) 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutFalseHandleResponse(resp)
-	if err != nil {
+	if err := client.PutFalseHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutFalseCreateRequest creates the PutFalse request.
@@ -255,16 +266,11 @@ func (client *BoolClient) PutFalseCreateRequest(ctx context.Context) (*azcore.Re
 	return req, req.MarshalAsJSON(false)
 }
 
-// PutFalseHandleResponse handles the PutFalse response.
-func (client *BoolClient) PutFalseHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutFalseHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutFalseHandleError handles the PutFalse error response.
 func (client *BoolClient) PutFalseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -282,11 +288,10 @@ func (client *BoolClient) PutTrue(ctx context.Context) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutTrueHandleResponse(resp)
-	if err != nil {
+	if err := client.PutTrueHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutTrueCreateRequest creates the PutTrue request.
@@ -300,16 +305,11 @@ func (client *BoolClient) PutTrueCreateRequest(ctx context.Context) (*azcore.Req
 	return req, req.MarshalAsJSON(true)
 }
 
-// PutTrueHandleResponse handles the PutTrue response.
-func (client *BoolClient) PutTrueHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutTrueHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutTrueHandleError handles the PutTrue error response.
 func (client *BoolClient) PutTrueHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/booleangroup/zz_generated_bool.go
+++ b/test/autorest/booleangroup/zz_generated_bool.go
@@ -53,8 +53,8 @@ func (client *BoolClient) GetFalse(ctx context.Context) (*BoolResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetFalseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetFalseHandleError(resp)
 	}
 	result, err := client.GetFalseHandleResponse(resp)
 	if err != nil {
@@ -82,9 +82,6 @@ func (client *BoolClient) GetFalseHandleResponse(resp *azcore.Response) (*BoolRe
 
 // GetFalseHandleError handles the GetFalse error response.
 func (client *BoolClient) GetFalseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -102,8 +99,8 @@ func (client *BoolClient) GetInvalid(ctx context.Context) (*BoolResponse, error)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetInvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetInvalidHandleError(resp)
 	}
 	result, err := client.GetInvalidHandleResponse(resp)
 	if err != nil {
@@ -131,9 +128,6 @@ func (client *BoolClient) GetInvalidHandleResponse(resp *azcore.Response) (*Bool
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *BoolClient) GetInvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -151,8 +145,8 @@ func (client *BoolClient) GetNull(ctx context.Context) (*BoolResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullHandleError(resp)
 	}
 	result, err := client.GetNullHandleResponse(resp)
 	if err != nil {
@@ -180,9 +174,6 @@ func (client *BoolClient) GetNullHandleResponse(resp *azcore.Response) (*BoolRes
 
 // GetNullHandleError handles the GetNull error response.
 func (client *BoolClient) GetNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -200,8 +191,8 @@ func (client *BoolClient) GetTrue(ctx context.Context) (*BoolResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetTrueHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetTrueHandleError(resp)
 	}
 	result, err := client.GetTrueHandleResponse(resp)
 	if err != nil {
@@ -229,9 +220,6 @@ func (client *BoolClient) GetTrueHandleResponse(resp *azcore.Response) (*BoolRes
 
 // GetTrueHandleError handles the GetTrue error response.
 func (client *BoolClient) GetTrueHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -249,8 +237,8 @@ func (client *BoolClient) PutFalse(ctx context.Context) (*http.Response, error) 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutFalseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutFalseHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -268,9 +256,6 @@ func (client *BoolClient) PutFalseCreateRequest(ctx context.Context) (*azcore.Re
 
 // PutFalseHandleError handles the PutFalse error response.
 func (client *BoolClient) PutFalseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -288,8 +273,8 @@ func (client *BoolClient) PutTrue(ctx context.Context) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutTrueHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutTrueHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -307,9 +292,6 @@ func (client *BoolClient) PutTrueCreateRequest(ctx context.Context) (*azcore.Req
 
 // PutTrueHandleError handles the PutTrue error response.
 func (client *BoolClient) PutTrueHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/bytegroup/zz_generated_byte.go
+++ b/test/autorest/bytegroup/zz_generated_byte.go
@@ -51,8 +51,8 @@ func (client *ByteClient) GetEmpty(ctx context.Context) (*ByteArrayResponse, err
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyHandleError(resp)
 	}
 	result, err := client.GetEmptyHandleResponse(resp)
 	if err != nil {
@@ -80,9 +80,6 @@ func (client *ByteClient) GetEmptyHandleResponse(resp *azcore.Response) (*ByteAr
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *ByteClient) GetEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -100,8 +97,8 @@ func (client *ByteClient) GetInvalid(ctx context.Context) (*ByteArrayResponse, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetInvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetInvalidHandleError(resp)
 	}
 	result, err := client.GetInvalidHandleResponse(resp)
 	if err != nil {
@@ -129,9 +126,6 @@ func (client *ByteClient) GetInvalidHandleResponse(resp *azcore.Response) (*Byte
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *ByteClient) GetInvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -149,8 +143,8 @@ func (client *ByteClient) GetNonASCII(ctx context.Context) (*ByteArrayResponse, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNonASCIIHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNonASCIIHandleError(resp)
 	}
 	result, err := client.GetNonASCIIHandleResponse(resp)
 	if err != nil {
@@ -178,9 +172,6 @@ func (client *ByteClient) GetNonASCIIHandleResponse(resp *azcore.Response) (*Byt
 
 // GetNonASCIIHandleError handles the GetNonASCII error response.
 func (client *ByteClient) GetNonASCIIHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -198,8 +189,8 @@ func (client *ByteClient) GetNull(ctx context.Context) (*ByteArrayResponse, erro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullHandleError(resp)
 	}
 	result, err := client.GetNullHandleResponse(resp)
 	if err != nil {
@@ -227,9 +218,6 @@ func (client *ByteClient) GetNullHandleResponse(resp *azcore.Response) (*ByteArr
 
 // GetNullHandleError handles the GetNull error response.
 func (client *ByteClient) GetNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -247,8 +235,8 @@ func (client *ByteClient) PutNonASCII(ctx context.Context, byteBody []byte) (*ht
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutNonASCIIHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutNonASCIIHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -266,9 +254,6 @@ func (client *ByteClient) PutNonASCIICreateRequest(ctx context.Context, byteBody
 
 // PutNonASCIIHandleError handles the PutNonASCII error response.
 func (client *ByteClient) PutNonASCIIHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/bytegroup/zz_generated_byte.go
+++ b/test/autorest/bytegroup/zz_generated_byte.go
@@ -51,6 +51,9 @@ func (client *ByteClient) GetEmpty(ctx context.Context) (*ByteArrayResponse, err
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetEmptyHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetEmptyHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -71,15 +74,15 @@ func (client *ByteClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.Re
 
 // GetEmptyHandleResponse handles the GetEmpty response.
 func (client *ByteClient) GetEmptyHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyHandleError(resp)
-	}
 	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsByteArray(&result.Value, azcore.Base64StdFormat)
 }
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *ByteClient) GetEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -95,6 +98,9 @@ func (client *ByteClient) GetInvalid(ctx context.Context) (*ByteArrayResponse, e
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetInvalidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetInvalidHandleResponse(resp)
@@ -117,15 +123,15 @@ func (client *ByteClient) GetInvalidCreateRequest(ctx context.Context) (*azcore.
 
 // GetInvalidHandleResponse handles the GetInvalid response.
 func (client *ByteClient) GetInvalidHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetInvalidHandleError(resp)
-	}
 	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsByteArray(&result.Value, azcore.Base64StdFormat)
 }
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *ByteClient) GetInvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,6 +147,9 @@ func (client *ByteClient) GetNonASCII(ctx context.Context) (*ByteArrayResponse, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNonASCIIHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNonASCIIHandleResponse(resp)
@@ -163,15 +172,15 @@ func (client *ByteClient) GetNonASCIICreateRequest(ctx context.Context) (*azcore
 
 // GetNonASCIIHandleResponse handles the GetNonASCII response.
 func (client *ByteClient) GetNonASCIIHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNonASCIIHandleError(resp)
-	}
 	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsByteArray(&result.Value, azcore.Base64StdFormat)
 }
 
 // GetNonASCIIHandleError handles the GetNonASCII error response.
 func (client *ByteClient) GetNonASCIIHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -187,6 +196,9 @@ func (client *ByteClient) GetNull(ctx context.Context) (*ByteArrayResponse, erro
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullHandleResponse(resp)
@@ -209,15 +221,15 @@ func (client *ByteClient) GetNullCreateRequest(ctx context.Context) (*azcore.Req
 
 // GetNullHandleResponse handles the GetNull response.
 func (client *ByteClient) GetNullHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullHandleError(resp)
-	}
 	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsByteArray(&result.Value, azcore.Base64StdFormat)
 }
 
 // GetNullHandleError handles the GetNull error response.
 func (client *ByteClient) GetNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -235,11 +247,10 @@ func (client *ByteClient) PutNonASCII(ctx context.Context, byteBody []byte) (*ht
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutNonASCIIHandleResponse(resp)
-	if err != nil {
+	if err := client.PutNonASCIIHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutNonASCIICreateRequest creates the PutNonASCII request.
@@ -253,16 +264,11 @@ func (client *ByteClient) PutNonASCIICreateRequest(ctx context.Context, byteBody
 	return req, req.MarshalAsByteArray(byteBody, azcore.Base64StdFormat)
 }
 
-// PutNonASCIIHandleResponse handles the PutNonASCII response.
-func (client *ByteClient) PutNonASCIIHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutNonASCIIHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutNonASCIIHandleError handles the PutNonASCII error response.
 func (client *ByteClient) PutNonASCIIHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_array.go
+++ b/test/autorest/complexgroup/zz_generated_array.go
@@ -51,6 +51,9 @@ func (client *ArrayClient) GetEmpty(ctx context.Context) (*ArrayWrapperResponse,
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetEmptyHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetEmptyHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -71,15 +74,15 @@ func (client *ArrayClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.R
 
 // GetEmptyHandleResponse handles the GetEmpty response.
 func (client *ArrayClient) GetEmptyHandleResponse(resp *azcore.Response) (*ArrayWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyHandleError(resp)
-	}
 	result := ArrayWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ArrayWrapper)
 }
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *ArrayClient) GetEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -95,6 +98,9 @@ func (client *ArrayClient) GetNotProvided(ctx context.Context) (*ArrayWrapperRes
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNotProvidedHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNotProvidedHandleResponse(resp)
@@ -117,15 +123,15 @@ func (client *ArrayClient) GetNotProvidedCreateRequest(ctx context.Context) (*az
 
 // GetNotProvidedHandleResponse handles the GetNotProvided response.
 func (client *ArrayClient) GetNotProvidedHandleResponse(resp *azcore.Response) (*ArrayWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNotProvidedHandleError(resp)
-	}
 	result := ArrayWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ArrayWrapper)
 }
 
 // GetNotProvidedHandleError handles the GetNotProvided error response.
 func (client *ArrayClient) GetNotProvidedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,6 +147,9 @@ func (client *ArrayClient) GetValid(ctx context.Context) (*ArrayWrapperResponse,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetValidHandleResponse(resp)
@@ -163,15 +172,15 @@ func (client *ArrayClient) GetValidCreateRequest(ctx context.Context) (*azcore.R
 
 // GetValidHandleResponse handles the GetValid response.
 func (client *ArrayClient) GetValidHandleResponse(resp *azcore.Response) (*ArrayWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetValidHandleError(resp)
-	}
 	result := ArrayWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ArrayWrapper)
 }
 
 // GetValidHandleError handles the GetValid error response.
 func (client *ArrayClient) GetValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -189,11 +198,10 @@ func (client *ArrayClient) PutEmpty(ctx context.Context, complexBody ArrayWrappe
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutEmptyHandleResponse(resp)
-	if err != nil {
+	if err := client.PutEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutEmptyCreateRequest creates the PutEmpty request.
@@ -207,16 +215,11 @@ func (client *ArrayClient) PutEmptyCreateRequest(ctx context.Context, complexBod
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutEmptyHandleResponse handles the PutEmpty response.
-func (client *ArrayClient) PutEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutEmptyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutEmptyHandleError handles the PutEmpty error response.
 func (client *ArrayClient) PutEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -234,11 +237,10 @@ func (client *ArrayClient) PutValid(ctx context.Context, complexBody ArrayWrappe
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutValidCreateRequest creates the PutValid request.
@@ -252,16 +254,11 @@ func (client *ArrayClient) PutValidCreateRequest(ctx context.Context, complexBod
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutValidHandleResponse handles the PutValid response.
-func (client *ArrayClient) PutValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutValidHandleError handles the PutValid error response.
 func (client *ArrayClient) PutValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_array.go
+++ b/test/autorest/complexgroup/zz_generated_array.go
@@ -51,8 +51,8 @@ func (client *ArrayClient) GetEmpty(ctx context.Context) (*ArrayWrapperResponse,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyHandleError(resp)
 	}
 	result, err := client.GetEmptyHandleResponse(resp)
 	if err != nil {
@@ -80,9 +80,6 @@ func (client *ArrayClient) GetEmptyHandleResponse(resp *azcore.Response) (*Array
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *ArrayClient) GetEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -100,8 +97,8 @@ func (client *ArrayClient) GetNotProvided(ctx context.Context) (*ArrayWrapperRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNotProvidedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNotProvidedHandleError(resp)
 	}
 	result, err := client.GetNotProvidedHandleResponse(resp)
 	if err != nil {
@@ -129,9 +126,6 @@ func (client *ArrayClient) GetNotProvidedHandleResponse(resp *azcore.Response) (
 
 // GetNotProvidedHandleError handles the GetNotProvided error response.
 func (client *ArrayClient) GetNotProvidedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -149,8 +143,8 @@ func (client *ArrayClient) GetValid(ctx context.Context) (*ArrayWrapperResponse,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetValidHandleError(resp)
 	}
 	result, err := client.GetValidHandleResponse(resp)
 	if err != nil {
@@ -178,9 +172,6 @@ func (client *ArrayClient) GetValidHandleResponse(resp *azcore.Response) (*Array
 
 // GetValidHandleError handles the GetValid error response.
 func (client *ArrayClient) GetValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -198,8 +189,8 @@ func (client *ArrayClient) PutEmpty(ctx context.Context, complexBody ArrayWrappe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutEmptyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -217,9 +208,6 @@ func (client *ArrayClient) PutEmptyCreateRequest(ctx context.Context, complexBod
 
 // PutEmptyHandleError handles the PutEmpty error response.
 func (client *ArrayClient) PutEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -237,8 +225,8 @@ func (client *ArrayClient) PutValid(ctx context.Context, complexBody ArrayWrappe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -256,9 +244,6 @@ func (client *ArrayClient) PutValidCreateRequest(ctx context.Context, complexBod
 
 // PutValidHandleError handles the PutValid error response.
 func (client *ArrayClient) PutValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_basic.go
+++ b/test/autorest/complexgroup/zz_generated_basic.go
@@ -53,6 +53,9 @@ func (client *BasicClient) GetEmpty(ctx context.Context) (*BasicResponse, error)
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetEmptyHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetEmptyHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -73,15 +76,15 @@ func (client *BasicClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.R
 
 // GetEmptyHandleResponse handles the GetEmpty response.
 func (client *BasicClient) GetEmptyHandleResponse(resp *azcore.Response) (*BasicResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyHandleError(resp)
-	}
 	result := BasicResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Basic)
 }
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *BasicClient) GetEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -97,6 +100,9 @@ func (client *BasicClient) GetInvalid(ctx context.Context) (*BasicResponse, erro
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetInvalidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetInvalidHandleResponse(resp)
@@ -119,15 +125,15 @@ func (client *BasicClient) GetInvalidCreateRequest(ctx context.Context) (*azcore
 
 // GetInvalidHandleResponse handles the GetInvalid response.
 func (client *BasicClient) GetInvalidHandleResponse(resp *azcore.Response) (*BasicResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetInvalidHandleError(resp)
-	}
 	result := BasicResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Basic)
 }
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *BasicClient) GetInvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -143,6 +149,9 @@ func (client *BasicClient) GetNotProvided(ctx context.Context) (*BasicResponse, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNotProvidedHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNotProvidedHandleResponse(resp)
@@ -165,15 +174,15 @@ func (client *BasicClient) GetNotProvidedCreateRequest(ctx context.Context) (*az
 
 // GetNotProvidedHandleResponse handles the GetNotProvided response.
 func (client *BasicClient) GetNotProvidedHandleResponse(resp *azcore.Response) (*BasicResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNotProvidedHandleError(resp)
-	}
 	result := BasicResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Basic)
 }
 
 // GetNotProvidedHandleError handles the GetNotProvided error response.
 func (client *BasicClient) GetNotProvidedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -189,6 +198,9 @@ func (client *BasicClient) GetNull(ctx context.Context) (*BasicResponse, error) 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullHandleResponse(resp)
@@ -211,15 +223,15 @@ func (client *BasicClient) GetNullCreateRequest(ctx context.Context) (*azcore.Re
 
 // GetNullHandleResponse handles the GetNull response.
 func (client *BasicClient) GetNullHandleResponse(resp *azcore.Response) (*BasicResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullHandleError(resp)
-	}
 	result := BasicResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Basic)
 }
 
 // GetNullHandleError handles the GetNull error response.
 func (client *BasicClient) GetNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -235,6 +247,9 @@ func (client *BasicClient) GetValid(ctx context.Context) (*BasicResponse, error)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetValidHandleResponse(resp)
@@ -257,15 +272,15 @@ func (client *BasicClient) GetValidCreateRequest(ctx context.Context) (*azcore.R
 
 // GetValidHandleResponse handles the GetValid response.
 func (client *BasicClient) GetValidHandleResponse(resp *azcore.Response) (*BasicResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetValidHandleError(resp)
-	}
 	result := BasicResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Basic)
 }
 
 // GetValidHandleError handles the GetValid error response.
 func (client *BasicClient) GetValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -283,11 +298,10 @@ func (client *BasicClient) PutValid(ctx context.Context, complexBody Basic) (*ht
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutValidCreateRequest creates the PutValid request.
@@ -304,16 +318,11 @@ func (client *BasicClient) PutValidCreateRequest(ctx context.Context, complexBod
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutValidHandleResponse handles the PutValid response.
-func (client *BasicClient) PutValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutValidHandleError handles the PutValid error response.
 func (client *BasicClient) PutValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_basic.go
+++ b/test/autorest/complexgroup/zz_generated_basic.go
@@ -53,8 +53,8 @@ func (client *BasicClient) GetEmpty(ctx context.Context) (*BasicResponse, error)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyHandleError(resp)
 	}
 	result, err := client.GetEmptyHandleResponse(resp)
 	if err != nil {
@@ -82,9 +82,6 @@ func (client *BasicClient) GetEmptyHandleResponse(resp *azcore.Response) (*Basic
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *BasicClient) GetEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -102,8 +99,8 @@ func (client *BasicClient) GetInvalid(ctx context.Context) (*BasicResponse, erro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetInvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetInvalidHandleError(resp)
 	}
 	result, err := client.GetInvalidHandleResponse(resp)
 	if err != nil {
@@ -131,9 +128,6 @@ func (client *BasicClient) GetInvalidHandleResponse(resp *azcore.Response) (*Bas
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *BasicClient) GetInvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -151,8 +145,8 @@ func (client *BasicClient) GetNotProvided(ctx context.Context) (*BasicResponse, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNotProvidedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNotProvidedHandleError(resp)
 	}
 	result, err := client.GetNotProvidedHandleResponse(resp)
 	if err != nil {
@@ -180,9 +174,6 @@ func (client *BasicClient) GetNotProvidedHandleResponse(resp *azcore.Response) (
 
 // GetNotProvidedHandleError handles the GetNotProvided error response.
 func (client *BasicClient) GetNotProvidedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -200,8 +191,8 @@ func (client *BasicClient) GetNull(ctx context.Context) (*BasicResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullHandleError(resp)
 	}
 	result, err := client.GetNullHandleResponse(resp)
 	if err != nil {
@@ -229,9 +220,6 @@ func (client *BasicClient) GetNullHandleResponse(resp *azcore.Response) (*BasicR
 
 // GetNullHandleError handles the GetNull error response.
 func (client *BasicClient) GetNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -249,8 +237,8 @@ func (client *BasicClient) GetValid(ctx context.Context) (*BasicResponse, error)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetValidHandleError(resp)
 	}
 	result, err := client.GetValidHandleResponse(resp)
 	if err != nil {
@@ -278,9 +266,6 @@ func (client *BasicClient) GetValidHandleResponse(resp *azcore.Response) (*Basic
 
 // GetValidHandleError handles the GetValid error response.
 func (client *BasicClient) GetValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -298,8 +283,8 @@ func (client *BasicClient) PutValid(ctx context.Context, complexBody Basic) (*ht
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -320,9 +305,6 @@ func (client *BasicClient) PutValidCreateRequest(ctx context.Context, complexBod
 
 // PutValidHandleError handles the PutValid error response.
 func (client *BasicClient) PutValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_dictionary.go
+++ b/test/autorest/complexgroup/zz_generated_dictionary.go
@@ -53,6 +53,9 @@ func (client *DictionaryClient) GetEmpty(ctx context.Context) (*DictionaryWrappe
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetEmptyHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetEmptyHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -73,15 +76,15 @@ func (client *DictionaryClient) GetEmptyCreateRequest(ctx context.Context) (*azc
 
 // GetEmptyHandleResponse handles the GetEmpty response.
 func (client *DictionaryClient) GetEmptyHandleResponse(resp *azcore.Response) (*DictionaryWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyHandleError(resp)
-	}
 	result := DictionaryWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DictionaryWrapper)
 }
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *DictionaryClient) GetEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -97,6 +100,9 @@ func (client *DictionaryClient) GetNotProvided(ctx context.Context) (*Dictionary
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNotProvidedHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNotProvidedHandleResponse(resp)
@@ -119,15 +125,15 @@ func (client *DictionaryClient) GetNotProvidedCreateRequest(ctx context.Context)
 
 // GetNotProvidedHandleResponse handles the GetNotProvided response.
 func (client *DictionaryClient) GetNotProvidedHandleResponse(resp *azcore.Response) (*DictionaryWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNotProvidedHandleError(resp)
-	}
 	result := DictionaryWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DictionaryWrapper)
 }
 
 // GetNotProvidedHandleError handles the GetNotProvided error response.
 func (client *DictionaryClient) GetNotProvidedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -143,6 +149,9 @@ func (client *DictionaryClient) GetNull(ctx context.Context) (*DictionaryWrapper
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullHandleResponse(resp)
@@ -165,15 +174,15 @@ func (client *DictionaryClient) GetNullCreateRequest(ctx context.Context) (*azco
 
 // GetNullHandleResponse handles the GetNull response.
 func (client *DictionaryClient) GetNullHandleResponse(resp *azcore.Response) (*DictionaryWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullHandleError(resp)
-	}
 	result := DictionaryWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DictionaryWrapper)
 }
 
 // GetNullHandleError handles the GetNull error response.
 func (client *DictionaryClient) GetNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -189,6 +198,9 @@ func (client *DictionaryClient) GetValid(ctx context.Context) (*DictionaryWrappe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetValidHandleResponse(resp)
@@ -211,15 +223,15 @@ func (client *DictionaryClient) GetValidCreateRequest(ctx context.Context) (*azc
 
 // GetValidHandleResponse handles the GetValid response.
 func (client *DictionaryClient) GetValidHandleResponse(resp *azcore.Response) (*DictionaryWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetValidHandleError(resp)
-	}
 	result := DictionaryWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DictionaryWrapper)
 }
 
 // GetValidHandleError handles the GetValid error response.
 func (client *DictionaryClient) GetValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -237,11 +249,10 @@ func (client *DictionaryClient) PutEmpty(ctx context.Context, complexBody Dictio
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutEmptyHandleResponse(resp)
-	if err != nil {
+	if err := client.PutEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutEmptyCreateRequest creates the PutEmpty request.
@@ -255,16 +266,11 @@ func (client *DictionaryClient) PutEmptyCreateRequest(ctx context.Context, compl
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutEmptyHandleResponse handles the PutEmpty response.
-func (client *DictionaryClient) PutEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutEmptyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutEmptyHandleError handles the PutEmpty error response.
 func (client *DictionaryClient) PutEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -282,11 +288,10 @@ func (client *DictionaryClient) PutValid(ctx context.Context, complexBody Dictio
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutValidCreateRequest creates the PutValid request.
@@ -300,16 +305,11 @@ func (client *DictionaryClient) PutValidCreateRequest(ctx context.Context, compl
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutValidHandleResponse handles the PutValid response.
-func (client *DictionaryClient) PutValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutValidHandleError handles the PutValid error response.
 func (client *DictionaryClient) PutValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_dictionary.go
+++ b/test/autorest/complexgroup/zz_generated_dictionary.go
@@ -53,8 +53,8 @@ func (client *DictionaryClient) GetEmpty(ctx context.Context) (*DictionaryWrappe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyHandleError(resp)
 	}
 	result, err := client.GetEmptyHandleResponse(resp)
 	if err != nil {
@@ -82,9 +82,6 @@ func (client *DictionaryClient) GetEmptyHandleResponse(resp *azcore.Response) (*
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *DictionaryClient) GetEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -102,8 +99,8 @@ func (client *DictionaryClient) GetNotProvided(ctx context.Context) (*Dictionary
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNotProvidedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNotProvidedHandleError(resp)
 	}
 	result, err := client.GetNotProvidedHandleResponse(resp)
 	if err != nil {
@@ -131,9 +128,6 @@ func (client *DictionaryClient) GetNotProvidedHandleResponse(resp *azcore.Respon
 
 // GetNotProvidedHandleError handles the GetNotProvided error response.
 func (client *DictionaryClient) GetNotProvidedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -151,8 +145,8 @@ func (client *DictionaryClient) GetNull(ctx context.Context) (*DictionaryWrapper
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullHandleError(resp)
 	}
 	result, err := client.GetNullHandleResponse(resp)
 	if err != nil {
@@ -180,9 +174,6 @@ func (client *DictionaryClient) GetNullHandleResponse(resp *azcore.Response) (*D
 
 // GetNullHandleError handles the GetNull error response.
 func (client *DictionaryClient) GetNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -200,8 +191,8 @@ func (client *DictionaryClient) GetValid(ctx context.Context) (*DictionaryWrappe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetValidHandleError(resp)
 	}
 	result, err := client.GetValidHandleResponse(resp)
 	if err != nil {
@@ -229,9 +220,6 @@ func (client *DictionaryClient) GetValidHandleResponse(resp *azcore.Response) (*
 
 // GetValidHandleError handles the GetValid error response.
 func (client *DictionaryClient) GetValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -249,8 +237,8 @@ func (client *DictionaryClient) PutEmpty(ctx context.Context, complexBody Dictio
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutEmptyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -268,9 +256,6 @@ func (client *DictionaryClient) PutEmptyCreateRequest(ctx context.Context, compl
 
 // PutEmptyHandleError handles the PutEmpty error response.
 func (client *DictionaryClient) PutEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -288,8 +273,8 @@ func (client *DictionaryClient) PutValid(ctx context.Context, complexBody Dictio
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -307,9 +292,6 @@ func (client *DictionaryClient) PutValidCreateRequest(ctx context.Context, compl
 
 // PutValidHandleError handles the PutValid error response.
 func (client *DictionaryClient) PutValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_flattencomplex.go
+++ b/test/autorest/complexgroup/zz_generated_flattencomplex.go
@@ -44,8 +44,8 @@ func (client *FlattencomplexClient) GetValid(ctx context.Context) (*MyBaseTypeRe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetValidHandleError(resp)
 	}
 	result, err := client.GetValidHandleResponse(resp)
 	if err != nil {
@@ -73,9 +73,6 @@ func (client *FlattencomplexClient) GetValidHandleResponse(resp *azcore.Response
 
 // GetValidHandleError handles the GetValid error response.
 func (client *FlattencomplexClient) GetValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/complexgroup/zz_generated_flattencomplex.go
+++ b/test/autorest/complexgroup/zz_generated_flattencomplex.go
@@ -44,6 +44,9 @@ func (client *FlattencomplexClient) GetValid(ctx context.Context) (*MyBaseTypeRe
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetValidHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetValidHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -64,15 +67,15 @@ func (client *FlattencomplexClient) GetValidCreateRequest(ctx context.Context) (
 
 // GetValidHandleResponse handles the GetValid response.
 func (client *FlattencomplexClient) GetValidHandleResponse(resp *azcore.Response) (*MyBaseTypeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetValidHandleError(resp)
-	}
 	result := MyBaseTypeResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result)
 }
 
 // GetValidHandleError handles the GetValid error response.
 func (client *FlattencomplexClient) GetValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/complexgroup/zz_generated_inheritance.go
+++ b/test/autorest/complexgroup/zz_generated_inheritance.go
@@ -45,8 +45,8 @@ func (client *InheritanceClient) GetValid(ctx context.Context) (*SiameseResponse
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetValidHandleError(resp)
 	}
 	result, err := client.GetValidHandleResponse(resp)
 	if err != nil {
@@ -74,9 +74,6 @@ func (client *InheritanceClient) GetValidHandleResponse(resp *azcore.Response) (
 
 // GetValidHandleError handles the GetValid error response.
 func (client *InheritanceClient) GetValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -94,8 +91,8 @@ func (client *InheritanceClient) PutValid(ctx context.Context, complexBody Siame
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -113,9 +110,6 @@ func (client *InheritanceClient) PutValidCreateRequest(ctx context.Context, comp
 
 // PutValidHandleError handles the PutValid error response.
 func (client *InheritanceClient) PutValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_inheritance.go
+++ b/test/autorest/complexgroup/zz_generated_inheritance.go
@@ -45,6 +45,9 @@ func (client *InheritanceClient) GetValid(ctx context.Context) (*SiameseResponse
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetValidHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetValidHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -65,15 +68,15 @@ func (client *InheritanceClient) GetValidCreateRequest(ctx context.Context) (*az
 
 // GetValidHandleResponse handles the GetValid response.
 func (client *InheritanceClient) GetValidHandleResponse(resp *azcore.Response) (*SiameseResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetValidHandleError(resp)
-	}
 	result := SiameseResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Siamese)
 }
 
 // GetValidHandleError handles the GetValid error response.
 func (client *InheritanceClient) GetValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -91,11 +94,10 @@ func (client *InheritanceClient) PutValid(ctx context.Context, complexBody Siame
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutValidCreateRequest creates the PutValid request.
@@ -109,16 +111,11 @@ func (client *InheritanceClient) PutValidCreateRequest(ctx context.Context, comp
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutValidHandleResponse handles the PutValid response.
-func (client *InheritanceClient) PutValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutValidHandleError handles the PutValid error response.
 func (client *InheritanceClient) PutValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_polymorphicrecursive.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphicrecursive.go
@@ -45,6 +45,9 @@ func (client *PolymorphicrecursiveClient) GetValid(ctx context.Context) (*FishRe
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetValidHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetValidHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -65,15 +68,15 @@ func (client *PolymorphicrecursiveClient) GetValidCreateRequest(ctx context.Cont
 
 // GetValidHandleResponse handles the GetValid response.
 func (client *PolymorphicrecursiveClient) GetValidHandleResponse(resp *azcore.Response) (*FishResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetValidHandleError(resp)
-	}
 	result := FishResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result)
 }
 
 // GetValidHandleError handles the GetValid error response.
 func (client *PolymorphicrecursiveClient) GetValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -91,11 +94,10 @@ func (client *PolymorphicrecursiveClient) PutValid(ctx context.Context, complexB
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutValidCreateRequest creates the PutValid request.
@@ -109,16 +111,11 @@ func (client *PolymorphicrecursiveClient) PutValidCreateRequest(ctx context.Cont
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutValidHandleResponse handles the PutValid response.
-func (client *PolymorphicrecursiveClient) PutValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutValidHandleError handles the PutValid error response.
 func (client *PolymorphicrecursiveClient) PutValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_polymorphicrecursive.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphicrecursive.go
@@ -45,8 +45,8 @@ func (client *PolymorphicrecursiveClient) GetValid(ctx context.Context) (*FishRe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetValidHandleError(resp)
 	}
 	result, err := client.GetValidHandleResponse(resp)
 	if err != nil {
@@ -74,9 +74,6 @@ func (client *PolymorphicrecursiveClient) GetValidHandleResponse(resp *azcore.Re
 
 // GetValidHandleError handles the GetValid error response.
 func (client *PolymorphicrecursiveClient) GetValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -94,8 +91,8 @@ func (client *PolymorphicrecursiveClient) PutValid(ctx context.Context, complexB
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -113,9 +110,6 @@ func (client *PolymorphicrecursiveClient) PutValidCreateRequest(ctx context.Cont
 
 // PutValidHandleError handles the PutValid error response.
 func (client *PolymorphicrecursiveClient) PutValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_polymorphism.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphism.go
@@ -59,6 +59,9 @@ func (client *PolymorphismClient) GetComplicated(ctx context.Context) (*SalmonRe
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetComplicatedHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetComplicatedHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -79,15 +82,15 @@ func (client *PolymorphismClient) GetComplicatedCreateRequest(ctx context.Contex
 
 // GetComplicatedHandleResponse handles the GetComplicated response.
 func (client *PolymorphismClient) GetComplicatedHandleResponse(resp *azcore.Response) (*SalmonResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetComplicatedHandleError(resp)
-	}
 	result := SalmonResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result)
 }
 
 // GetComplicatedHandleError handles the GetComplicated error response.
 func (client *PolymorphismClient) GetComplicatedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -103,6 +106,9 @@ func (client *PolymorphismClient) GetComposedWithDiscriminator(ctx context.Conte
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetComposedWithDiscriminatorHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetComposedWithDiscriminatorHandleResponse(resp)
@@ -125,15 +131,15 @@ func (client *PolymorphismClient) GetComposedWithDiscriminatorCreateRequest(ctx 
 
 // GetComposedWithDiscriminatorHandleResponse handles the GetComposedWithDiscriminator response.
 func (client *PolymorphismClient) GetComposedWithDiscriminatorHandleResponse(resp *azcore.Response) (*DotFishMarketResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetComposedWithDiscriminatorHandleError(resp)
-	}
 	result := DotFishMarketResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DotFishMarket)
 }
 
 // GetComposedWithDiscriminatorHandleError handles the GetComposedWithDiscriminator error response.
 func (client *PolymorphismClient) GetComposedWithDiscriminatorHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -149,6 +155,9 @@ func (client *PolymorphismClient) GetComposedWithoutDiscriminator(ctx context.Co
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetComposedWithoutDiscriminatorHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetComposedWithoutDiscriminatorHandleResponse(resp)
@@ -171,15 +180,15 @@ func (client *PolymorphismClient) GetComposedWithoutDiscriminatorCreateRequest(c
 
 // GetComposedWithoutDiscriminatorHandleResponse handles the GetComposedWithoutDiscriminator response.
 func (client *PolymorphismClient) GetComposedWithoutDiscriminatorHandleResponse(resp *azcore.Response) (*DotFishMarketResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetComposedWithoutDiscriminatorHandleError(resp)
-	}
 	result := DotFishMarketResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DotFishMarket)
 }
 
 // GetComposedWithoutDiscriminatorHandleError handles the GetComposedWithoutDiscriminator error response.
 func (client *PolymorphismClient) GetComposedWithoutDiscriminatorHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -195,6 +204,9 @@ func (client *PolymorphismClient) GetDotSyntax(ctx context.Context) (*DotFishRes
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDotSyntaxHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDotSyntaxHandleResponse(resp)
@@ -217,15 +229,15 @@ func (client *PolymorphismClient) GetDotSyntaxCreateRequest(ctx context.Context)
 
 // GetDotSyntaxHandleResponse handles the GetDotSyntax response.
 func (client *PolymorphismClient) GetDotSyntaxHandleResponse(resp *azcore.Response) (*DotFishResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDotSyntaxHandleError(resp)
-	}
 	result := DotFishResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result)
 }
 
 // GetDotSyntaxHandleError handles the GetDotSyntax error response.
 func (client *PolymorphismClient) GetDotSyntaxHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -241,6 +253,9 @@ func (client *PolymorphismClient) GetValid(ctx context.Context) (*FishResponse, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetValidHandleResponse(resp)
@@ -263,15 +278,15 @@ func (client *PolymorphismClient) GetValidCreateRequest(ctx context.Context) (*a
 
 // GetValidHandleResponse handles the GetValid response.
 func (client *PolymorphismClient) GetValidHandleResponse(resp *azcore.Response) (*FishResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetValidHandleError(resp)
-	}
 	result := FishResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result)
 }
 
 // GetValidHandleError handles the GetValid error response.
 func (client *PolymorphismClient) GetValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -289,11 +304,10 @@ func (client *PolymorphismClient) PutComplicated(ctx context.Context, complexBod
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutComplicatedHandleResponse(resp)
-	if err != nil {
+	if err := client.PutComplicatedHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutComplicatedCreateRequest creates the PutComplicated request.
@@ -307,16 +321,11 @@ func (client *PolymorphismClient) PutComplicatedCreateRequest(ctx context.Contex
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutComplicatedHandleResponse handles the PutComplicated response.
-func (client *PolymorphismClient) PutComplicatedHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutComplicatedHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutComplicatedHandleError handles the PutComplicated error response.
 func (client *PolymorphismClient) PutComplicatedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -332,6 +341,9 @@ func (client *PolymorphismClient) PutMissingDiscriminator(ctx context.Context, c
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutMissingDiscriminatorHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutMissingDiscriminatorHandleResponse(resp)
@@ -354,15 +366,15 @@ func (client *PolymorphismClient) PutMissingDiscriminatorCreateRequest(ctx conte
 
 // PutMissingDiscriminatorHandleResponse handles the PutMissingDiscriminator response.
 func (client *PolymorphismClient) PutMissingDiscriminatorHandleResponse(resp *azcore.Response) (*SalmonResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutMissingDiscriminatorHandleError(resp)
-	}
 	result := SalmonResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result)
 }
 
 // PutMissingDiscriminatorHandleError handles the PutMissingDiscriminator error response.
 func (client *PolymorphismClient) PutMissingDiscriminatorHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -380,11 +392,10 @@ func (client *PolymorphismClient) PutValid(ctx context.Context, complexBody Fish
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutValidCreateRequest creates the PutValid request.
@@ -398,16 +409,11 @@ func (client *PolymorphismClient) PutValidCreateRequest(ctx context.Context, com
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutValidHandleResponse handles the PutValid response.
-func (client *PolymorphismClient) PutValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutValidHandleError handles the PutValid error response.
 func (client *PolymorphismClient) PutValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -425,11 +431,10 @@ func (client *PolymorphismClient) PutValidMissingRequired(ctx context.Context, c
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutValidMissingRequiredHandleResponse(resp)
-	if err != nil {
+	if err := client.PutValidMissingRequiredHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutValidMissingRequiredCreateRequest creates the PutValidMissingRequired request.
@@ -443,16 +448,11 @@ func (client *PolymorphismClient) PutValidMissingRequiredCreateRequest(ctx conte
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutValidMissingRequiredHandleResponse handles the PutValidMissingRequired response.
-func (client *PolymorphismClient) PutValidMissingRequiredHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutValidMissingRequiredHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutValidMissingRequiredHandleError handles the PutValidMissingRequired error response.
 func (client *PolymorphismClient) PutValidMissingRequiredHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_polymorphism.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphism.go
@@ -59,8 +59,8 @@ func (client *PolymorphismClient) GetComplicated(ctx context.Context) (*SalmonRe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetComplicatedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetComplicatedHandleError(resp)
 	}
 	result, err := client.GetComplicatedHandleResponse(resp)
 	if err != nil {
@@ -88,9 +88,6 @@ func (client *PolymorphismClient) GetComplicatedHandleResponse(resp *azcore.Resp
 
 // GetComplicatedHandleError handles the GetComplicated error response.
 func (client *PolymorphismClient) GetComplicatedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -108,8 +105,8 @@ func (client *PolymorphismClient) GetComposedWithDiscriminator(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetComposedWithDiscriminatorHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetComposedWithDiscriminatorHandleError(resp)
 	}
 	result, err := client.GetComposedWithDiscriminatorHandleResponse(resp)
 	if err != nil {
@@ -137,9 +134,6 @@ func (client *PolymorphismClient) GetComposedWithDiscriminatorHandleResponse(res
 
 // GetComposedWithDiscriminatorHandleError handles the GetComposedWithDiscriminator error response.
 func (client *PolymorphismClient) GetComposedWithDiscriminatorHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -157,8 +151,8 @@ func (client *PolymorphismClient) GetComposedWithoutDiscriminator(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetComposedWithoutDiscriminatorHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetComposedWithoutDiscriminatorHandleError(resp)
 	}
 	result, err := client.GetComposedWithoutDiscriminatorHandleResponse(resp)
 	if err != nil {
@@ -186,9 +180,6 @@ func (client *PolymorphismClient) GetComposedWithoutDiscriminatorHandleResponse(
 
 // GetComposedWithoutDiscriminatorHandleError handles the GetComposedWithoutDiscriminator error response.
 func (client *PolymorphismClient) GetComposedWithoutDiscriminatorHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -206,8 +197,8 @@ func (client *PolymorphismClient) GetDotSyntax(ctx context.Context) (*DotFishRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDotSyntaxHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDotSyntaxHandleError(resp)
 	}
 	result, err := client.GetDotSyntaxHandleResponse(resp)
 	if err != nil {
@@ -235,9 +226,6 @@ func (client *PolymorphismClient) GetDotSyntaxHandleResponse(resp *azcore.Respon
 
 // GetDotSyntaxHandleError handles the GetDotSyntax error response.
 func (client *PolymorphismClient) GetDotSyntaxHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -255,8 +243,8 @@ func (client *PolymorphismClient) GetValid(ctx context.Context) (*FishResponse, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetValidHandleError(resp)
 	}
 	result, err := client.GetValidHandleResponse(resp)
 	if err != nil {
@@ -284,9 +272,6 @@ func (client *PolymorphismClient) GetValidHandleResponse(resp *azcore.Response) 
 
 // GetValidHandleError handles the GetValid error response.
 func (client *PolymorphismClient) GetValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -304,8 +289,8 @@ func (client *PolymorphismClient) PutComplicated(ctx context.Context, complexBod
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutComplicatedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutComplicatedHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -323,9 +308,6 @@ func (client *PolymorphismClient) PutComplicatedCreateRequest(ctx context.Contex
 
 // PutComplicatedHandleError handles the PutComplicated error response.
 func (client *PolymorphismClient) PutComplicatedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -343,8 +325,8 @@ func (client *PolymorphismClient) PutMissingDiscriminator(ctx context.Context, c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutMissingDiscriminatorHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutMissingDiscriminatorHandleError(resp)
 	}
 	result, err := client.PutMissingDiscriminatorHandleResponse(resp)
 	if err != nil {
@@ -372,9 +354,6 @@ func (client *PolymorphismClient) PutMissingDiscriminatorHandleResponse(resp *az
 
 // PutMissingDiscriminatorHandleError handles the PutMissingDiscriminator error response.
 func (client *PolymorphismClient) PutMissingDiscriminatorHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -392,8 +371,8 @@ func (client *PolymorphismClient) PutValid(ctx context.Context, complexBody Fish
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -411,9 +390,6 @@ func (client *PolymorphismClient) PutValidCreateRequest(ctx context.Context, com
 
 // PutValidHandleError handles the PutValid error response.
 func (client *PolymorphismClient) PutValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -431,8 +407,8 @@ func (client *PolymorphismClient) PutValidMissingRequired(ctx context.Context, c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutValidMissingRequiredHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutValidMissingRequiredHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -450,9 +426,6 @@ func (client *PolymorphismClient) PutValidMissingRequiredCreateRequest(ctx conte
 
 // PutValidMissingRequiredHandleError handles the PutValidMissingRequired error response.
 func (client *PolymorphismClient) PutValidMissingRequiredHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_primitive.go
+++ b/test/autorest/complexgroup/zz_generated_primitive.go
@@ -85,6 +85,9 @@ func (client *PrimitiveClient) GetBool(ctx context.Context) (*BooleanWrapperResp
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetBoolHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetBoolHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -105,15 +108,15 @@ func (client *PrimitiveClient) GetBoolCreateRequest(ctx context.Context) (*azcor
 
 // GetBoolHandleResponse handles the GetBool response.
 func (client *PrimitiveClient) GetBoolHandleResponse(resp *azcore.Response) (*BooleanWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBoolHandleError(resp)
-	}
 	result := BooleanWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.BooleanWrapper)
 }
 
 // GetBoolHandleError handles the GetBool error response.
 func (client *PrimitiveClient) GetBoolHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -129,6 +132,9 @@ func (client *PrimitiveClient) GetByte(ctx context.Context) (*ByteWrapperRespons
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetByteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetByteHandleResponse(resp)
@@ -151,15 +157,15 @@ func (client *PrimitiveClient) GetByteCreateRequest(ctx context.Context) (*azcor
 
 // GetByteHandleResponse handles the GetByte response.
 func (client *PrimitiveClient) GetByteHandleResponse(resp *azcore.Response) (*ByteWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetByteHandleError(resp)
-	}
 	result := ByteWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ByteWrapper)
 }
 
 // GetByteHandleError handles the GetByte error response.
 func (client *PrimitiveClient) GetByteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -175,6 +181,9 @@ func (client *PrimitiveClient) GetDate(ctx context.Context) (*DateWrapperRespons
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateHandleResponse(resp)
@@ -197,15 +206,15 @@ func (client *PrimitiveClient) GetDateCreateRequest(ctx context.Context) (*azcor
 
 // GetDateHandleResponse handles the GetDate response.
 func (client *PrimitiveClient) GetDateHandleResponse(resp *azcore.Response) (*DateWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateHandleError(resp)
-	}
 	result := DateWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DateWrapper)
 }
 
 // GetDateHandleError handles the GetDate error response.
 func (client *PrimitiveClient) GetDateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -221,6 +230,9 @@ func (client *PrimitiveClient) GetDateTime(ctx context.Context) (*DatetimeWrappe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateTimeHandleResponse(resp)
@@ -243,15 +255,15 @@ func (client *PrimitiveClient) GetDateTimeCreateRequest(ctx context.Context) (*a
 
 // GetDateTimeHandleResponse handles the GetDateTime response.
 func (client *PrimitiveClient) GetDateTimeHandleResponse(resp *azcore.Response) (*DatetimeWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateTimeHandleError(resp)
-	}
 	result := DatetimeWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DatetimeWrapper)
 }
 
 // GetDateTimeHandleError handles the GetDateTime error response.
 func (client *PrimitiveClient) GetDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -267,6 +279,9 @@ func (client *PrimitiveClient) GetDateTimeRFC1123(ctx context.Context) (*Datetim
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateTimeRFC1123HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateTimeRFC1123HandleResponse(resp)
@@ -289,15 +304,15 @@ func (client *PrimitiveClient) GetDateTimeRFC1123CreateRequest(ctx context.Conte
 
 // GetDateTimeRFC1123HandleResponse handles the GetDateTimeRFC1123 response.
 func (client *PrimitiveClient) GetDateTimeRFC1123HandleResponse(resp *azcore.Response) (*Datetimerfc1123WrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateTimeRFC1123HandleError(resp)
-	}
 	result := Datetimerfc1123WrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Datetimerfc1123Wrapper)
 }
 
 // GetDateTimeRFC1123HandleError handles the GetDateTimeRFC1123 error response.
 func (client *PrimitiveClient) GetDateTimeRFC1123HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -313,6 +328,9 @@ func (client *PrimitiveClient) GetDouble(ctx context.Context) (*DoubleWrapperRes
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDoubleHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDoubleHandleResponse(resp)
@@ -335,15 +353,15 @@ func (client *PrimitiveClient) GetDoubleCreateRequest(ctx context.Context) (*azc
 
 // GetDoubleHandleResponse handles the GetDouble response.
 func (client *PrimitiveClient) GetDoubleHandleResponse(resp *azcore.Response) (*DoubleWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDoubleHandleError(resp)
-	}
 	result := DoubleWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DoubleWrapper)
 }
 
 // GetDoubleHandleError handles the GetDouble error response.
 func (client *PrimitiveClient) GetDoubleHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -359,6 +377,9 @@ func (client *PrimitiveClient) GetDuration(ctx context.Context) (*DurationWrappe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDurationHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDurationHandleResponse(resp)
@@ -381,15 +402,15 @@ func (client *PrimitiveClient) GetDurationCreateRequest(ctx context.Context) (*a
 
 // GetDurationHandleResponse handles the GetDuration response.
 func (client *PrimitiveClient) GetDurationHandleResponse(resp *azcore.Response) (*DurationWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDurationHandleError(resp)
-	}
 	result := DurationWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DurationWrapper)
 }
 
 // GetDurationHandleError handles the GetDuration error response.
 func (client *PrimitiveClient) GetDurationHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -405,6 +426,9 @@ func (client *PrimitiveClient) GetFloat(ctx context.Context) (*FloatWrapperRespo
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetFloatHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetFloatHandleResponse(resp)
@@ -427,15 +451,15 @@ func (client *PrimitiveClient) GetFloatCreateRequest(ctx context.Context) (*azco
 
 // GetFloatHandleResponse handles the GetFloat response.
 func (client *PrimitiveClient) GetFloatHandleResponse(resp *azcore.Response) (*FloatWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetFloatHandleError(resp)
-	}
 	result := FloatWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.FloatWrapper)
 }
 
 // GetFloatHandleError handles the GetFloat error response.
 func (client *PrimitiveClient) GetFloatHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -451,6 +475,9 @@ func (client *PrimitiveClient) GetInt(ctx context.Context) (*IntWrapperResponse,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetIntHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetIntHandleResponse(resp)
@@ -473,15 +500,15 @@ func (client *PrimitiveClient) GetIntCreateRequest(ctx context.Context) (*azcore
 
 // GetIntHandleResponse handles the GetInt response.
 func (client *PrimitiveClient) GetIntHandleResponse(resp *azcore.Response) (*IntWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetIntHandleError(resp)
-	}
 	result := IntWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.IntWrapper)
 }
 
 // GetIntHandleError handles the GetInt error response.
 func (client *PrimitiveClient) GetIntHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -497,6 +524,9 @@ func (client *PrimitiveClient) GetLong(ctx context.Context) (*LongWrapperRespons
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetLongHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetLongHandleResponse(resp)
@@ -519,15 +549,15 @@ func (client *PrimitiveClient) GetLongCreateRequest(ctx context.Context) (*azcor
 
 // GetLongHandleResponse handles the GetLong response.
 func (client *PrimitiveClient) GetLongHandleResponse(resp *azcore.Response) (*LongWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLongHandleError(resp)
-	}
 	result := LongWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.LongWrapper)
 }
 
 // GetLongHandleError handles the GetLong error response.
 func (client *PrimitiveClient) GetLongHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -543,6 +573,9 @@ func (client *PrimitiveClient) GetString(ctx context.Context) (*StringWrapperRes
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetStringHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetStringHandleResponse(resp)
@@ -565,15 +598,15 @@ func (client *PrimitiveClient) GetStringCreateRequest(ctx context.Context) (*azc
 
 // GetStringHandleResponse handles the GetString response.
 func (client *PrimitiveClient) GetStringHandleResponse(resp *azcore.Response) (*StringWrapperResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetStringHandleError(resp)
-	}
 	result := StringWrapperResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringWrapper)
 }
 
 // GetStringHandleError handles the GetString error response.
 func (client *PrimitiveClient) GetStringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -591,11 +624,10 @@ func (client *PrimitiveClient) PutBool(ctx context.Context, complexBody BooleanW
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutBoolHandleResponse(resp)
-	if err != nil {
+	if err := client.PutBoolHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutBoolCreateRequest creates the PutBool request.
@@ -609,16 +641,11 @@ func (client *PrimitiveClient) PutBoolCreateRequest(ctx context.Context, complex
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutBoolHandleResponse handles the PutBool response.
-func (client *PrimitiveClient) PutBoolHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutBoolHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutBoolHandleError handles the PutBool error response.
 func (client *PrimitiveClient) PutBoolHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -636,11 +663,10 @@ func (client *PrimitiveClient) PutByte(ctx context.Context, complexBody ByteWrap
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutByteHandleResponse(resp)
-	if err != nil {
+	if err := client.PutByteHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutByteCreateRequest creates the PutByte request.
@@ -654,16 +680,11 @@ func (client *PrimitiveClient) PutByteCreateRequest(ctx context.Context, complex
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutByteHandleResponse handles the PutByte response.
-func (client *PrimitiveClient) PutByteHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutByteHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutByteHandleError handles the PutByte error response.
 func (client *PrimitiveClient) PutByteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -681,11 +702,10 @@ func (client *PrimitiveClient) PutDate(ctx context.Context, complexBody DateWrap
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDateHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDateHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDateCreateRequest creates the PutDate request.
@@ -699,16 +719,11 @@ func (client *PrimitiveClient) PutDateCreateRequest(ctx context.Context, complex
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutDateHandleResponse handles the PutDate response.
-func (client *PrimitiveClient) PutDateHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDateHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDateHandleError handles the PutDate error response.
 func (client *PrimitiveClient) PutDateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -726,11 +741,10 @@ func (client *PrimitiveClient) PutDateTime(ctx context.Context, complexBody Date
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDateTimeHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDateTimeCreateRequest creates the PutDateTime request.
@@ -744,16 +758,11 @@ func (client *PrimitiveClient) PutDateTimeCreateRequest(ctx context.Context, com
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutDateTimeHandleResponse handles the PutDateTime response.
-func (client *PrimitiveClient) PutDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDateTimeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDateTimeHandleError handles the PutDateTime error response.
 func (client *PrimitiveClient) PutDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -771,11 +780,10 @@ func (client *PrimitiveClient) PutDateTimeRFC1123(ctx context.Context, complexBo
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDateTimeRFC1123HandleResponse(resp)
-	if err != nil {
+	if err := client.PutDateTimeRFC1123HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDateTimeRFC1123CreateRequest creates the PutDateTimeRFC1123 request.
@@ -789,16 +797,11 @@ func (client *PrimitiveClient) PutDateTimeRFC1123CreateRequest(ctx context.Conte
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutDateTimeRFC1123HandleResponse handles the PutDateTimeRFC1123 response.
-func (client *PrimitiveClient) PutDateTimeRFC1123HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDateTimeRFC1123HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDateTimeRFC1123HandleError handles the PutDateTimeRFC1123 error response.
 func (client *PrimitiveClient) PutDateTimeRFC1123HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -816,11 +819,10 @@ func (client *PrimitiveClient) PutDouble(ctx context.Context, complexBody Double
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDoubleHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDoubleHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDoubleCreateRequest creates the PutDouble request.
@@ -834,16 +836,11 @@ func (client *PrimitiveClient) PutDoubleCreateRequest(ctx context.Context, compl
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutDoubleHandleResponse handles the PutDouble response.
-func (client *PrimitiveClient) PutDoubleHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDoubleHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDoubleHandleError handles the PutDouble error response.
 func (client *PrimitiveClient) PutDoubleHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -861,11 +858,10 @@ func (client *PrimitiveClient) PutDuration(ctx context.Context, complexBody Dura
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDurationHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDurationHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDurationCreateRequest creates the PutDuration request.
@@ -879,16 +875,11 @@ func (client *PrimitiveClient) PutDurationCreateRequest(ctx context.Context, com
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutDurationHandleResponse handles the PutDuration response.
-func (client *PrimitiveClient) PutDurationHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDurationHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDurationHandleError handles the PutDuration error response.
 func (client *PrimitiveClient) PutDurationHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -906,11 +897,10 @@ func (client *PrimitiveClient) PutFloat(ctx context.Context, complexBody FloatWr
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutFloatHandleResponse(resp)
-	if err != nil {
+	if err := client.PutFloatHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutFloatCreateRequest creates the PutFloat request.
@@ -924,16 +914,11 @@ func (client *PrimitiveClient) PutFloatCreateRequest(ctx context.Context, comple
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutFloatHandleResponse handles the PutFloat response.
-func (client *PrimitiveClient) PutFloatHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutFloatHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutFloatHandleError handles the PutFloat error response.
 func (client *PrimitiveClient) PutFloatHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -951,11 +936,10 @@ func (client *PrimitiveClient) PutInt(ctx context.Context, complexBody IntWrappe
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutIntHandleResponse(resp)
-	if err != nil {
+	if err := client.PutIntHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutIntCreateRequest creates the PutInt request.
@@ -969,16 +953,11 @@ func (client *PrimitiveClient) PutIntCreateRequest(ctx context.Context, complexB
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutIntHandleResponse handles the PutInt response.
-func (client *PrimitiveClient) PutIntHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutIntHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutIntHandleError handles the PutInt error response.
 func (client *PrimitiveClient) PutIntHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -996,11 +975,10 @@ func (client *PrimitiveClient) PutLong(ctx context.Context, complexBody LongWrap
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutLongHandleResponse(resp)
-	if err != nil {
+	if err := client.PutLongHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutLongCreateRequest creates the PutLong request.
@@ -1014,16 +992,11 @@ func (client *PrimitiveClient) PutLongCreateRequest(ctx context.Context, complex
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutLongHandleResponse handles the PutLong response.
-func (client *PrimitiveClient) PutLongHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutLongHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutLongHandleError handles the PutLong error response.
 func (client *PrimitiveClient) PutLongHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1041,11 +1014,10 @@ func (client *PrimitiveClient) PutString(ctx context.Context, complexBody String
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutStringHandleResponse(resp)
-	if err != nil {
+	if err := client.PutStringHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutStringCreateRequest creates the PutString request.
@@ -1059,16 +1031,11 @@ func (client *PrimitiveClient) PutStringCreateRequest(ctx context.Context, compl
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutStringHandleResponse handles the PutString response.
-func (client *PrimitiveClient) PutStringHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutStringHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutStringHandleError handles the PutString error response.
 func (client *PrimitiveClient) PutStringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_primitive.go
+++ b/test/autorest/complexgroup/zz_generated_primitive.go
@@ -85,8 +85,8 @@ func (client *PrimitiveClient) GetBool(ctx context.Context) (*BooleanWrapperResp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBoolHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBoolHandleError(resp)
 	}
 	result, err := client.GetBoolHandleResponse(resp)
 	if err != nil {
@@ -114,9 +114,6 @@ func (client *PrimitiveClient) GetBoolHandleResponse(resp *azcore.Response) (*Bo
 
 // GetBoolHandleError handles the GetBool error response.
 func (client *PrimitiveClient) GetBoolHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,8 +131,8 @@ func (client *PrimitiveClient) GetByte(ctx context.Context) (*ByteWrapperRespons
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetByteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetByteHandleError(resp)
 	}
 	result, err := client.GetByteHandleResponse(resp)
 	if err != nil {
@@ -163,9 +160,6 @@ func (client *PrimitiveClient) GetByteHandleResponse(resp *azcore.Response) (*By
 
 // GetByteHandleError handles the GetByte error response.
 func (client *PrimitiveClient) GetByteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -183,8 +177,8 @@ func (client *PrimitiveClient) GetDate(ctx context.Context) (*DateWrapperRespons
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateHandleError(resp)
 	}
 	result, err := client.GetDateHandleResponse(resp)
 	if err != nil {
@@ -212,9 +206,6 @@ func (client *PrimitiveClient) GetDateHandleResponse(resp *azcore.Response) (*Da
 
 // GetDateHandleError handles the GetDate error response.
 func (client *PrimitiveClient) GetDateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -232,8 +223,8 @@ func (client *PrimitiveClient) GetDateTime(ctx context.Context) (*DatetimeWrappe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateTimeHandleError(resp)
 	}
 	result, err := client.GetDateTimeHandleResponse(resp)
 	if err != nil {
@@ -261,9 +252,6 @@ func (client *PrimitiveClient) GetDateTimeHandleResponse(resp *azcore.Response) 
 
 // GetDateTimeHandleError handles the GetDateTime error response.
 func (client *PrimitiveClient) GetDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -281,8 +269,8 @@ func (client *PrimitiveClient) GetDateTimeRFC1123(ctx context.Context) (*Datetim
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateTimeRFC1123HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateTimeRFC1123HandleError(resp)
 	}
 	result, err := client.GetDateTimeRFC1123HandleResponse(resp)
 	if err != nil {
@@ -310,9 +298,6 @@ func (client *PrimitiveClient) GetDateTimeRFC1123HandleResponse(resp *azcore.Res
 
 // GetDateTimeRFC1123HandleError handles the GetDateTimeRFC1123 error response.
 func (client *PrimitiveClient) GetDateTimeRFC1123HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -330,8 +315,8 @@ func (client *PrimitiveClient) GetDouble(ctx context.Context) (*DoubleWrapperRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDoubleHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDoubleHandleError(resp)
 	}
 	result, err := client.GetDoubleHandleResponse(resp)
 	if err != nil {
@@ -359,9 +344,6 @@ func (client *PrimitiveClient) GetDoubleHandleResponse(resp *azcore.Response) (*
 
 // GetDoubleHandleError handles the GetDouble error response.
 func (client *PrimitiveClient) GetDoubleHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -379,8 +361,8 @@ func (client *PrimitiveClient) GetDuration(ctx context.Context) (*DurationWrappe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDurationHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDurationHandleError(resp)
 	}
 	result, err := client.GetDurationHandleResponse(resp)
 	if err != nil {
@@ -408,9 +390,6 @@ func (client *PrimitiveClient) GetDurationHandleResponse(resp *azcore.Response) 
 
 // GetDurationHandleError handles the GetDuration error response.
 func (client *PrimitiveClient) GetDurationHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -428,8 +407,8 @@ func (client *PrimitiveClient) GetFloat(ctx context.Context) (*FloatWrapperRespo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetFloatHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetFloatHandleError(resp)
 	}
 	result, err := client.GetFloatHandleResponse(resp)
 	if err != nil {
@@ -457,9 +436,6 @@ func (client *PrimitiveClient) GetFloatHandleResponse(resp *azcore.Response) (*F
 
 // GetFloatHandleError handles the GetFloat error response.
 func (client *PrimitiveClient) GetFloatHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -477,8 +453,8 @@ func (client *PrimitiveClient) GetInt(ctx context.Context) (*IntWrapperResponse,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetIntHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetIntHandleError(resp)
 	}
 	result, err := client.GetIntHandleResponse(resp)
 	if err != nil {
@@ -506,9 +482,6 @@ func (client *PrimitiveClient) GetIntHandleResponse(resp *azcore.Response) (*Int
 
 // GetIntHandleError handles the GetInt error response.
 func (client *PrimitiveClient) GetIntHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -526,8 +499,8 @@ func (client *PrimitiveClient) GetLong(ctx context.Context) (*LongWrapperRespons
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLongHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLongHandleError(resp)
 	}
 	result, err := client.GetLongHandleResponse(resp)
 	if err != nil {
@@ -555,9 +528,6 @@ func (client *PrimitiveClient) GetLongHandleResponse(resp *azcore.Response) (*Lo
 
 // GetLongHandleError handles the GetLong error response.
 func (client *PrimitiveClient) GetLongHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -575,8 +545,8 @@ func (client *PrimitiveClient) GetString(ctx context.Context) (*StringWrapperRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetStringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetStringHandleError(resp)
 	}
 	result, err := client.GetStringHandleResponse(resp)
 	if err != nil {
@@ -604,9 +574,6 @@ func (client *PrimitiveClient) GetStringHandleResponse(resp *azcore.Response) (*
 
 // GetStringHandleError handles the GetString error response.
 func (client *PrimitiveClient) GetStringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -624,8 +591,8 @@ func (client *PrimitiveClient) PutBool(ctx context.Context, complexBody BooleanW
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutBoolHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutBoolHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -643,9 +610,6 @@ func (client *PrimitiveClient) PutBoolCreateRequest(ctx context.Context, complex
 
 // PutBoolHandleError handles the PutBool error response.
 func (client *PrimitiveClient) PutBoolHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -663,8 +627,8 @@ func (client *PrimitiveClient) PutByte(ctx context.Context, complexBody ByteWrap
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutByteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutByteHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -682,9 +646,6 @@ func (client *PrimitiveClient) PutByteCreateRequest(ctx context.Context, complex
 
 // PutByteHandleError handles the PutByte error response.
 func (client *PrimitiveClient) PutByteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -702,8 +663,8 @@ func (client *PrimitiveClient) PutDate(ctx context.Context, complexBody DateWrap
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDateHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -721,9 +682,6 @@ func (client *PrimitiveClient) PutDateCreateRequest(ctx context.Context, complex
 
 // PutDateHandleError handles the PutDate error response.
 func (client *PrimitiveClient) PutDateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -741,8 +699,8 @@ func (client *PrimitiveClient) PutDateTime(ctx context.Context, complexBody Date
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -760,9 +718,6 @@ func (client *PrimitiveClient) PutDateTimeCreateRequest(ctx context.Context, com
 
 // PutDateTimeHandleError handles the PutDateTime error response.
 func (client *PrimitiveClient) PutDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -780,8 +735,8 @@ func (client *PrimitiveClient) PutDateTimeRFC1123(ctx context.Context, complexBo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDateTimeRFC1123HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDateTimeRFC1123HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -799,9 +754,6 @@ func (client *PrimitiveClient) PutDateTimeRFC1123CreateRequest(ctx context.Conte
 
 // PutDateTimeRFC1123HandleError handles the PutDateTimeRFC1123 error response.
 func (client *PrimitiveClient) PutDateTimeRFC1123HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -819,8 +771,8 @@ func (client *PrimitiveClient) PutDouble(ctx context.Context, complexBody Double
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDoubleHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDoubleHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -838,9 +790,6 @@ func (client *PrimitiveClient) PutDoubleCreateRequest(ctx context.Context, compl
 
 // PutDoubleHandleError handles the PutDouble error response.
 func (client *PrimitiveClient) PutDoubleHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -858,8 +807,8 @@ func (client *PrimitiveClient) PutDuration(ctx context.Context, complexBody Dura
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDurationHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDurationHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -877,9 +826,6 @@ func (client *PrimitiveClient) PutDurationCreateRequest(ctx context.Context, com
 
 // PutDurationHandleError handles the PutDuration error response.
 func (client *PrimitiveClient) PutDurationHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -897,8 +843,8 @@ func (client *PrimitiveClient) PutFloat(ctx context.Context, complexBody FloatWr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutFloatHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutFloatHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -916,9 +862,6 @@ func (client *PrimitiveClient) PutFloatCreateRequest(ctx context.Context, comple
 
 // PutFloatHandleError handles the PutFloat error response.
 func (client *PrimitiveClient) PutFloatHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -936,8 +879,8 @@ func (client *PrimitiveClient) PutInt(ctx context.Context, complexBody IntWrappe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutIntHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutIntHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -955,9 +898,6 @@ func (client *PrimitiveClient) PutIntCreateRequest(ctx context.Context, complexB
 
 // PutIntHandleError handles the PutInt error response.
 func (client *PrimitiveClient) PutIntHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -975,8 +915,8 @@ func (client *PrimitiveClient) PutLong(ctx context.Context, complexBody LongWrap
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutLongHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutLongHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -994,9 +934,6 @@ func (client *PrimitiveClient) PutLongCreateRequest(ctx context.Context, complex
 
 // PutLongHandleError handles the PutLong error response.
 func (client *PrimitiveClient) PutLongHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1014,8 +951,8 @@ func (client *PrimitiveClient) PutString(ctx context.Context, complexBody String
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutStringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutStringHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1033,9 +970,6 @@ func (client *PrimitiveClient) PutStringCreateRequest(ctx context.Context, compl
 
 // PutStringHandleError handles the PutString error response.
 func (client *PrimitiveClient) PutStringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_readonlyproperty.go
+++ b/test/autorest/complexgroup/zz_generated_readonlyproperty.go
@@ -45,6 +45,9 @@ func (client *ReadonlypropertyClient) GetValid(ctx context.Context) (*ReadonlyOb
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetValidHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetValidHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -65,15 +68,15 @@ func (client *ReadonlypropertyClient) GetValidCreateRequest(ctx context.Context)
 
 // GetValidHandleResponse handles the GetValid response.
 func (client *ReadonlypropertyClient) GetValidHandleResponse(resp *azcore.Response) (*ReadonlyObjResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetValidHandleError(resp)
-	}
 	result := ReadonlyObjResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ReadonlyObj)
 }
 
 // GetValidHandleError handles the GetValid error response.
 func (client *ReadonlypropertyClient) GetValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -91,11 +94,10 @@ func (client *ReadonlypropertyClient) PutValid(ctx context.Context, complexBody 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutValidCreateRequest creates the PutValid request.
@@ -109,16 +111,11 @@ func (client *ReadonlypropertyClient) PutValidCreateRequest(ctx context.Context,
 	return req, req.MarshalAsJSON(complexBody)
 }
 
-// PutValidHandleResponse handles the PutValid response.
-func (client *ReadonlypropertyClient) PutValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutValidHandleError handles the PutValid error response.
 func (client *ReadonlypropertyClient) PutValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexgroup/zz_generated_readonlyproperty.go
+++ b/test/autorest/complexgroup/zz_generated_readonlyproperty.go
@@ -45,8 +45,8 @@ func (client *ReadonlypropertyClient) GetValid(ctx context.Context) (*ReadonlyOb
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetValidHandleError(resp)
 	}
 	result, err := client.GetValidHandleResponse(resp)
 	if err != nil {
@@ -74,9 +74,6 @@ func (client *ReadonlypropertyClient) GetValidHandleResponse(resp *azcore.Respon
 
 // GetValidHandleError handles the GetValid error response.
 func (client *ReadonlypropertyClient) GetValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -94,8 +91,8 @@ func (client *ReadonlypropertyClient) PutValid(ctx context.Context, complexBody 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -113,9 +110,6 @@ func (client *ReadonlypropertyClient) PutValidCreateRequest(ctx context.Context,
 
 // PutValidHandleError handles the PutValid error response.
 func (client *ReadonlypropertyClient) PutValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexmodelgroup/zz_generated_complexmodelclient.go
+++ b/test/autorest/complexmodelgroup/zz_generated_complexmodelclient.go
@@ -49,6 +49,9 @@ func (client *ComplexModelClient) Create(ctx context.Context, subscriptionId str
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -74,15 +77,15 @@ func (client *ComplexModelClient) CreateCreateRequest(ctx context.Context, subsc
 
 // CreateHandleResponse handles the Create response.
 func (client *ComplexModelClient) CreateHandleResponse(resp *azcore.Response) (*CatalogDictionaryResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.CreateHandleError(resp)
-	}
 	result := CatalogDictionaryResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.CatalogDictionary)
 }
 
 // CreateHandleError handles the Create error response.
 func (client *ComplexModelClient) CreateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -98,6 +101,9 @@ func (client *ComplexModelClient) List(ctx context.Context, resourceGroupName st
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListHandleResponse(resp)
@@ -125,15 +131,15 @@ func (client *ComplexModelClient) ListCreateRequest(ctx context.Context, resourc
 
 // ListHandleResponse handles the List response.
 func (client *ComplexModelClient) ListHandleResponse(resp *azcore.Response) (*CatalogArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := CatalogArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.CatalogArray)
 }
 
 // ListHandleError handles the List error response.
 func (client *ComplexModelClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -149,6 +155,9 @@ func (client *ComplexModelClient) Update(ctx context.Context, subscriptionId str
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateHandleResponse(resp)
@@ -176,15 +185,15 @@ func (client *ComplexModelClient) UpdateCreateRequest(ctx context.Context, subsc
 
 // UpdateHandleResponse handles the Update response.
 func (client *ComplexModelClient) UpdateHandleResponse(resp *azcore.Response) (*CatalogArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateHandleError(resp)
-	}
 	result := CatalogArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.CatalogArray)
 }
 
 // UpdateHandleError handles the Update error response.
 func (client *ComplexModelClient) UpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/complexmodelgroup/zz_generated_complexmodelclient.go
+++ b/test/autorest/complexmodelgroup/zz_generated_complexmodelclient.go
@@ -49,8 +49,8 @@ func (client *ComplexModelClient) Create(ctx context.Context, subscriptionId str
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.CreateHandleError(resp)
 	}
 	result, err := client.CreateHandleResponse(resp)
 	if err != nil {
@@ -83,9 +83,6 @@ func (client *ComplexModelClient) CreateHandleResponse(resp *azcore.Response) (*
 
 // CreateHandleError handles the Create error response.
 func (client *ComplexModelClient) CreateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -103,8 +100,8 @@ func (client *ComplexModelClient) List(ctx context.Context, resourceGroupName st
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListHandleError(resp)
 	}
 	result, err := client.ListHandleResponse(resp)
 	if err != nil {
@@ -137,9 +134,6 @@ func (client *ComplexModelClient) ListHandleResponse(resp *azcore.Response) (*Ca
 
 // ListHandleError handles the List error response.
 func (client *ComplexModelClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -157,8 +151,8 @@ func (client *ComplexModelClient) Update(ctx context.Context, subscriptionId str
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateHandleError(resp)
 	}
 	result, err := client.UpdateHandleResponse(resp)
 	if err != nil {
@@ -191,9 +185,6 @@ func (client *ComplexModelClient) UpdateHandleResponse(resp *azcore.Response) (*
 
 // UpdateHandleError handles the Update error response.
 func (client *ComplexModelClient) UpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/custombaseurlgroup/zz_generated_paths.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_paths.go
@@ -44,11 +44,10 @@ func (client *PathsClient) GetEmpty(ctx context.Context, accountName string) (*h
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetEmptyHandleResponse(resp)
-	if err != nil {
+	if err := client.GetEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetEmptyCreateRequest creates the GetEmpty request.
@@ -65,16 +64,11 @@ func (client *PathsClient) GetEmptyCreateRequest(ctx context.Context, accountNam
 	return req, nil
 }
 
-// GetEmptyHandleResponse handles the GetEmpty response.
-func (client *PathsClient) GetEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *PathsClient) GetEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/custombaseurlgroup/zz_generated_paths.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_paths.go
@@ -44,8 +44,8 @@ func (client *PathsClient) GetEmpty(ctx context.Context, accountName string) (*h
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -66,9 +66,6 @@ func (client *PathsClient) GetEmptyCreateRequest(ctx context.Context, accountNam
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *PathsClient) GetEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/datetimegroup/zz_generated_datetime.go
+++ b/test/autorest/datetimegroup/zz_generated_datetime.go
@@ -86,8 +86,8 @@ func (client *DatetimeClient) GetInvalid(ctx context.Context) (*TimeResponse, er
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetInvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetInvalidHandleError(resp)
 	}
 	result, err := client.GetInvalidHandleResponse(resp)
 	if err != nil {
@@ -116,9 +116,6 @@ func (client *DatetimeClient) GetInvalidHandleResponse(resp *azcore.Response) (*
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *DatetimeClient) GetInvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,8 +133,8 @@ func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTime(ctx con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLocalNegativeOffsetLowercaseMaxDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLocalNegativeOffsetLowercaseMaxDateTimeHandleError(resp)
 	}
 	result, err := client.GetLocalNegativeOffsetLowercaseMaxDateTimeHandleResponse(resp)
 	if err != nil {
@@ -166,9 +163,6 @@ func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTimeHandleRe
 
 // GetLocalNegativeOffsetLowercaseMaxDateTimeHandleError handles the GetLocalNegativeOffsetLowercaseMaxDateTime error response.
 func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -186,8 +180,8 @@ func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTime(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLocalNegativeOffsetMinDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLocalNegativeOffsetMinDateTimeHandleError(resp)
 	}
 	result, err := client.GetLocalNegativeOffsetMinDateTimeHandleResponse(resp)
 	if err != nil {
@@ -216,9 +210,6 @@ func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTimeHandleResponse(re
 
 // GetLocalNegativeOffsetMinDateTimeHandleError handles the GetLocalNegativeOffsetMinDateTime error response.
 func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -236,8 +227,8 @@ func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTime(ctx con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLocalNegativeOffsetUppercaseMaxDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLocalNegativeOffsetUppercaseMaxDateTimeHandleError(resp)
 	}
 	result, err := client.GetLocalNegativeOffsetUppercaseMaxDateTimeHandleResponse(resp)
 	if err != nil {
@@ -266,9 +257,6 @@ func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTimeHandleRe
 
 // GetLocalNegativeOffsetUppercaseMaxDateTimeHandleError handles the GetLocalNegativeOffsetUppercaseMaxDateTime error response.
 func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -286,8 +274,8 @@ func (client *DatetimeClient) GetLocalNoOffsetMinDateTime(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLocalNoOffsetMinDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLocalNoOffsetMinDateTimeHandleError(resp)
 	}
 	result, err := client.GetLocalNoOffsetMinDateTimeHandleResponse(resp)
 	if err != nil {
@@ -316,9 +304,6 @@ func (client *DatetimeClient) GetLocalNoOffsetMinDateTimeHandleResponse(resp *az
 
 // GetLocalNoOffsetMinDateTimeHandleError handles the GetLocalNoOffsetMinDateTime error response.
 func (client *DatetimeClient) GetLocalNoOffsetMinDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -336,8 +321,8 @@ func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTime(ctx con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLocalPositiveOffsetLowercaseMaxDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLocalPositiveOffsetLowercaseMaxDateTimeHandleError(resp)
 	}
 	result, err := client.GetLocalPositiveOffsetLowercaseMaxDateTimeHandleResponse(resp)
 	if err != nil {
@@ -366,9 +351,6 @@ func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTimeHandleRe
 
 // GetLocalPositiveOffsetLowercaseMaxDateTimeHandleError handles the GetLocalPositiveOffsetLowercaseMaxDateTime error response.
 func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -386,8 +368,8 @@ func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTime(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLocalPositiveOffsetMinDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLocalPositiveOffsetMinDateTimeHandleError(resp)
 	}
 	result, err := client.GetLocalPositiveOffsetMinDateTimeHandleResponse(resp)
 	if err != nil {
@@ -416,9 +398,6 @@ func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTimeHandleResponse(re
 
 // GetLocalPositiveOffsetMinDateTimeHandleError handles the GetLocalPositiveOffsetMinDateTime error response.
 func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -436,8 +415,8 @@ func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTime(ctx con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLocalPositiveOffsetUppercaseMaxDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLocalPositiveOffsetUppercaseMaxDateTimeHandleError(resp)
 	}
 	result, err := client.GetLocalPositiveOffsetUppercaseMaxDateTimeHandleResponse(resp)
 	if err != nil {
@@ -466,9 +445,6 @@ func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTimeHandleRe
 
 // GetLocalPositiveOffsetUppercaseMaxDateTimeHandleError handles the GetLocalPositiveOffsetUppercaseMaxDateTime error response.
 func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -486,8 +462,8 @@ func (client *DatetimeClient) GetNull(ctx context.Context) (*TimeResponse, error
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullHandleError(resp)
 	}
 	result, err := client.GetNullHandleResponse(resp)
 	if err != nil {
@@ -516,9 +492,6 @@ func (client *DatetimeClient) GetNullHandleResponse(resp *azcore.Response) (*Tim
 
 // GetNullHandleError handles the GetNull error response.
 func (client *DatetimeClient) GetNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -536,8 +509,8 @@ func (client *DatetimeClient) GetOverflow(ctx context.Context) (*TimeResponse, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetOverflowHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetOverflowHandleError(resp)
 	}
 	result, err := client.GetOverflowHandleResponse(resp)
 	if err != nil {
@@ -566,9 +539,6 @@ func (client *DatetimeClient) GetOverflowHandleResponse(resp *azcore.Response) (
 
 // GetOverflowHandleError handles the GetOverflow error response.
 func (client *DatetimeClient) GetOverflowHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -586,8 +556,8 @@ func (client *DatetimeClient) GetUTCLowercaseMaxDateTime(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetUTCLowercaseMaxDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetUTCLowercaseMaxDateTimeHandleError(resp)
 	}
 	result, err := client.GetUTCLowercaseMaxDateTimeHandleResponse(resp)
 	if err != nil {
@@ -616,9 +586,6 @@ func (client *DatetimeClient) GetUTCLowercaseMaxDateTimeHandleResponse(resp *azc
 
 // GetUTCLowercaseMaxDateTimeHandleError handles the GetUTCLowercaseMaxDateTime error response.
 func (client *DatetimeClient) GetUTCLowercaseMaxDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -636,8 +603,8 @@ func (client *DatetimeClient) GetUTCMinDateTime(ctx context.Context) (*TimeRespo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetUTCMinDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetUTCMinDateTimeHandleError(resp)
 	}
 	result, err := client.GetUTCMinDateTimeHandleResponse(resp)
 	if err != nil {
@@ -666,9 +633,6 @@ func (client *DatetimeClient) GetUTCMinDateTimeHandleResponse(resp *azcore.Respo
 
 // GetUTCMinDateTimeHandleError handles the GetUTCMinDateTime error response.
 func (client *DatetimeClient) GetUTCMinDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -686,8 +650,8 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTime(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetUTCUppercaseMaxDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetUTCUppercaseMaxDateTimeHandleError(resp)
 	}
 	result, err := client.GetUTCUppercaseMaxDateTimeHandleResponse(resp)
 	if err != nil {
@@ -716,9 +680,6 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTimeHandleResponse(resp *azc
 
 // GetUTCUppercaseMaxDateTimeHandleError handles the GetUTCUppercaseMaxDateTime error response.
 func (client *DatetimeClient) GetUTCUppercaseMaxDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -736,8 +697,8 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7Digits(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetUTCUppercaseMaxDateTime7DigitsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetUTCUppercaseMaxDateTime7DigitsHandleError(resp)
 	}
 	result, err := client.GetUTCUppercaseMaxDateTime7DigitsHandleResponse(resp)
 	if err != nil {
@@ -766,9 +727,6 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7DigitsHandleResponse(re
 
 // GetUTCUppercaseMaxDateTime7DigitsHandleError handles the GetUTCUppercaseMaxDateTime7Digits error response.
 func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7DigitsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -786,8 +744,8 @@ func (client *DatetimeClient) GetUnderflow(ctx context.Context) (*TimeResponse, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetUnderflowHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetUnderflowHandleError(resp)
 	}
 	result, err := client.GetUnderflowHandleResponse(resp)
 	if err != nil {
@@ -816,9 +774,6 @@ func (client *DatetimeClient) GetUnderflowHandleResponse(resp *azcore.Response) 
 
 // GetUnderflowHandleError handles the GetUnderflow error response.
 func (client *DatetimeClient) GetUnderflowHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -836,8 +791,8 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTime(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutLocalNegativeOffsetMaxDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutLocalNegativeOffsetMaxDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -855,9 +810,6 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTimeCreateRequest(ctx
 
 // PutLocalNegativeOffsetMaxDateTimeHandleError handles the PutLocalNegativeOffsetMaxDateTime error response.
 func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -875,8 +827,8 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTime(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutLocalNegativeOffsetMinDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutLocalNegativeOffsetMinDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -894,9 +846,6 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTimeCreateRequest(ctx
 
 // PutLocalNegativeOffsetMinDateTimeHandleError handles the PutLocalNegativeOffsetMinDateTime error response.
 func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -914,8 +863,8 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTime(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutLocalPositiveOffsetMaxDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutLocalPositiveOffsetMaxDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -933,9 +882,6 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTimeCreateRequest(ctx
 
 // PutLocalPositiveOffsetMaxDateTimeHandleError handles the PutLocalPositiveOffsetMaxDateTime error response.
 func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -953,8 +899,8 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTime(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutLocalPositiveOffsetMinDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutLocalPositiveOffsetMinDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -972,9 +918,6 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTimeCreateRequest(ctx
 
 // PutLocalPositiveOffsetMinDateTimeHandleError handles the PutLocalPositiveOffsetMinDateTime error response.
 func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -992,8 +935,8 @@ func (client *DatetimeClient) PutUTCMaxDateTime(ctx context.Context, datetimeBod
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutUTCMaxDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutUTCMaxDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1011,9 +954,6 @@ func (client *DatetimeClient) PutUTCMaxDateTimeCreateRequest(ctx context.Context
 
 // PutUTCMaxDateTimeHandleError handles the PutUTCMaxDateTime error response.
 func (client *DatetimeClient) PutUTCMaxDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1031,8 +971,8 @@ func (client *DatetimeClient) PutUTCMaxDateTime7Digits(ctx context.Context, date
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutUTCMaxDateTime7DigitsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutUTCMaxDateTime7DigitsHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1050,9 +990,6 @@ func (client *DatetimeClient) PutUTCMaxDateTime7DigitsCreateRequest(ctx context.
 
 // PutUTCMaxDateTime7DigitsHandleError handles the PutUTCMaxDateTime7Digits error response.
 func (client *DatetimeClient) PutUTCMaxDateTime7DigitsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1070,8 +1007,8 @@ func (client *DatetimeClient) PutUTCMinDateTime(ctx context.Context, datetimeBod
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutUTCMinDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutUTCMinDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1089,9 +1026,6 @@ func (client *DatetimeClient) PutUTCMinDateTimeCreateRequest(ctx context.Context
 
 // PutUTCMinDateTimeHandleError handles the PutUTCMinDateTime error response.
 func (client *DatetimeClient) PutUTCMinDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/datetimegroup/zz_generated_datetime.go
+++ b/test/autorest/datetimegroup/zz_generated_datetime.go
@@ -86,6 +86,9 @@ func (client *DatetimeClient) GetInvalid(ctx context.Context) (*TimeResponse, er
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetInvalidHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetInvalidHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -106,9 +109,6 @@ func (client *DatetimeClient) GetInvalidCreateRequest(ctx context.Context) (*azc
 
 // GetInvalidHandleResponse handles the GetInvalid response.
 func (client *DatetimeClient) GetInvalidHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetInvalidHandleError(resp)
-	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -116,6 +116,9 @@ func (client *DatetimeClient) GetInvalidHandleResponse(resp *azcore.Response) (*
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *DatetimeClient) GetInvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -131,6 +134,9 @@ func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTime(ctx con
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetLocalNegativeOffsetLowercaseMaxDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetLocalNegativeOffsetLowercaseMaxDateTimeHandleResponse(resp)
@@ -153,9 +159,6 @@ func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTimeCreateRe
 
 // GetLocalNegativeOffsetLowercaseMaxDateTimeHandleResponse handles the GetLocalNegativeOffsetLowercaseMaxDateTime response.
 func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLocalNegativeOffsetLowercaseMaxDateTimeHandleError(resp)
-	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -163,6 +166,9 @@ func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTimeHandleRe
 
 // GetLocalNegativeOffsetLowercaseMaxDateTimeHandleError handles the GetLocalNegativeOffsetLowercaseMaxDateTime error response.
 func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -178,6 +184,9 @@ func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTime(ctx context.Cont
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetLocalNegativeOffsetMinDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetLocalNegativeOffsetMinDateTimeHandleResponse(resp)
@@ -200,9 +209,6 @@ func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTimeCreateRequest(ctx
 
 // GetLocalNegativeOffsetMinDateTimeHandleResponse handles the GetLocalNegativeOffsetMinDateTime response.
 func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLocalNegativeOffsetMinDateTimeHandleError(resp)
-	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -210,6 +216,9 @@ func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTimeHandleResponse(re
 
 // GetLocalNegativeOffsetMinDateTimeHandleError handles the GetLocalNegativeOffsetMinDateTime error response.
 func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -225,6 +234,9 @@ func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTime(ctx con
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetLocalNegativeOffsetUppercaseMaxDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetLocalNegativeOffsetUppercaseMaxDateTimeHandleResponse(resp)
@@ -247,9 +259,6 @@ func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTimeCreateRe
 
 // GetLocalNegativeOffsetUppercaseMaxDateTimeHandleResponse handles the GetLocalNegativeOffsetUppercaseMaxDateTime response.
 func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLocalNegativeOffsetUppercaseMaxDateTimeHandleError(resp)
-	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -257,6 +266,9 @@ func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTimeHandleRe
 
 // GetLocalNegativeOffsetUppercaseMaxDateTimeHandleError handles the GetLocalNegativeOffsetUppercaseMaxDateTime error response.
 func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -272,6 +284,9 @@ func (client *DatetimeClient) GetLocalNoOffsetMinDateTime(ctx context.Context) (
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetLocalNoOffsetMinDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetLocalNoOffsetMinDateTimeHandleResponse(resp)
@@ -294,9 +309,6 @@ func (client *DatetimeClient) GetLocalNoOffsetMinDateTimeCreateRequest(ctx conte
 
 // GetLocalNoOffsetMinDateTimeHandleResponse handles the GetLocalNoOffsetMinDateTime response.
 func (client *DatetimeClient) GetLocalNoOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLocalNoOffsetMinDateTimeHandleError(resp)
-	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -304,6 +316,9 @@ func (client *DatetimeClient) GetLocalNoOffsetMinDateTimeHandleResponse(resp *az
 
 // GetLocalNoOffsetMinDateTimeHandleError handles the GetLocalNoOffsetMinDateTime error response.
 func (client *DatetimeClient) GetLocalNoOffsetMinDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -319,6 +334,9 @@ func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTime(ctx con
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetLocalPositiveOffsetLowercaseMaxDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetLocalPositiveOffsetLowercaseMaxDateTimeHandleResponse(resp)
@@ -341,9 +359,6 @@ func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTimeCreateRe
 
 // GetLocalPositiveOffsetLowercaseMaxDateTimeHandleResponse handles the GetLocalPositiveOffsetLowercaseMaxDateTime response.
 func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLocalPositiveOffsetLowercaseMaxDateTimeHandleError(resp)
-	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -351,6 +366,9 @@ func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTimeHandleRe
 
 // GetLocalPositiveOffsetLowercaseMaxDateTimeHandleError handles the GetLocalPositiveOffsetLowercaseMaxDateTime error response.
 func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -366,6 +384,9 @@ func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTime(ctx context.Cont
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetLocalPositiveOffsetMinDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetLocalPositiveOffsetMinDateTimeHandleResponse(resp)
@@ -388,9 +409,6 @@ func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTimeCreateRequest(ctx
 
 // GetLocalPositiveOffsetMinDateTimeHandleResponse handles the GetLocalPositiveOffsetMinDateTime response.
 func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLocalPositiveOffsetMinDateTimeHandleError(resp)
-	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -398,6 +416,9 @@ func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTimeHandleResponse(re
 
 // GetLocalPositiveOffsetMinDateTimeHandleError handles the GetLocalPositiveOffsetMinDateTime error response.
 func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -413,6 +434,9 @@ func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTime(ctx con
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetLocalPositiveOffsetUppercaseMaxDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetLocalPositiveOffsetUppercaseMaxDateTimeHandleResponse(resp)
@@ -435,9 +459,6 @@ func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTimeCreateRe
 
 // GetLocalPositiveOffsetUppercaseMaxDateTimeHandleResponse handles the GetLocalPositiveOffsetUppercaseMaxDateTime response.
 func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLocalPositiveOffsetUppercaseMaxDateTimeHandleError(resp)
-	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -445,6 +466,9 @@ func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTimeHandleRe
 
 // GetLocalPositiveOffsetUppercaseMaxDateTimeHandleError handles the GetLocalPositiveOffsetUppercaseMaxDateTime error response.
 func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -460,6 +484,9 @@ func (client *DatetimeClient) GetNull(ctx context.Context) (*TimeResponse, error
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullHandleResponse(resp)
@@ -482,9 +509,6 @@ func (client *DatetimeClient) GetNullCreateRequest(ctx context.Context) (*azcore
 
 // GetNullHandleResponse handles the GetNull response.
 func (client *DatetimeClient) GetNullHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullHandleError(resp)
-	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -492,6 +516,9 @@ func (client *DatetimeClient) GetNullHandleResponse(resp *azcore.Response) (*Tim
 
 // GetNullHandleError handles the GetNull error response.
 func (client *DatetimeClient) GetNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -507,6 +534,9 @@ func (client *DatetimeClient) GetOverflow(ctx context.Context) (*TimeResponse, e
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetOverflowHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetOverflowHandleResponse(resp)
@@ -529,9 +559,6 @@ func (client *DatetimeClient) GetOverflowCreateRequest(ctx context.Context) (*az
 
 // GetOverflowHandleResponse handles the GetOverflow response.
 func (client *DatetimeClient) GetOverflowHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetOverflowHandleError(resp)
-	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -539,6 +566,9 @@ func (client *DatetimeClient) GetOverflowHandleResponse(resp *azcore.Response) (
 
 // GetOverflowHandleError handles the GetOverflow error response.
 func (client *DatetimeClient) GetOverflowHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -554,6 +584,9 @@ func (client *DatetimeClient) GetUTCLowercaseMaxDateTime(ctx context.Context) (*
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetUTCLowercaseMaxDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetUTCLowercaseMaxDateTimeHandleResponse(resp)
@@ -576,9 +609,6 @@ func (client *DatetimeClient) GetUTCLowercaseMaxDateTimeCreateRequest(ctx contex
 
 // GetUTCLowercaseMaxDateTimeHandleResponse handles the GetUTCLowercaseMaxDateTime response.
 func (client *DatetimeClient) GetUTCLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetUTCLowercaseMaxDateTimeHandleError(resp)
-	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -586,6 +616,9 @@ func (client *DatetimeClient) GetUTCLowercaseMaxDateTimeHandleResponse(resp *azc
 
 // GetUTCLowercaseMaxDateTimeHandleError handles the GetUTCLowercaseMaxDateTime error response.
 func (client *DatetimeClient) GetUTCLowercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -601,6 +634,9 @@ func (client *DatetimeClient) GetUTCMinDateTime(ctx context.Context) (*TimeRespo
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetUTCMinDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetUTCMinDateTimeHandleResponse(resp)
@@ -623,9 +659,6 @@ func (client *DatetimeClient) GetUTCMinDateTimeCreateRequest(ctx context.Context
 
 // GetUTCMinDateTimeHandleResponse handles the GetUTCMinDateTime response.
 func (client *DatetimeClient) GetUTCMinDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetUTCMinDateTimeHandleError(resp)
-	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -633,6 +666,9 @@ func (client *DatetimeClient) GetUTCMinDateTimeHandleResponse(resp *azcore.Respo
 
 // GetUTCMinDateTimeHandleError handles the GetUTCMinDateTime error response.
 func (client *DatetimeClient) GetUTCMinDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -648,6 +684,9 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTime(ctx context.Context) (*
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetUTCUppercaseMaxDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetUTCUppercaseMaxDateTimeHandleResponse(resp)
@@ -670,9 +709,6 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTimeCreateRequest(ctx contex
 
 // GetUTCUppercaseMaxDateTimeHandleResponse handles the GetUTCUppercaseMaxDateTime response.
 func (client *DatetimeClient) GetUTCUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetUTCUppercaseMaxDateTimeHandleError(resp)
-	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -680,6 +716,9 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTimeHandleResponse(resp *azc
 
 // GetUTCUppercaseMaxDateTimeHandleError handles the GetUTCUppercaseMaxDateTime error response.
 func (client *DatetimeClient) GetUTCUppercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -695,6 +734,9 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7Digits(ctx context.Cont
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetUTCUppercaseMaxDateTime7DigitsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetUTCUppercaseMaxDateTime7DigitsHandleResponse(resp)
@@ -717,9 +759,6 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7DigitsCreateRequest(ctx
 
 // GetUTCUppercaseMaxDateTime7DigitsHandleResponse handles the GetUTCUppercaseMaxDateTime7Digits response.
 func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7DigitsHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetUTCUppercaseMaxDateTime7DigitsHandleError(resp)
-	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -727,6 +766,9 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7DigitsHandleResponse(re
 
 // GetUTCUppercaseMaxDateTime7DigitsHandleError handles the GetUTCUppercaseMaxDateTime7Digits error response.
 func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7DigitsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -742,6 +784,9 @@ func (client *DatetimeClient) GetUnderflow(ctx context.Context) (*TimeResponse, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetUnderflowHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetUnderflowHandleResponse(resp)
@@ -764,9 +809,6 @@ func (client *DatetimeClient) GetUnderflowCreateRequest(ctx context.Context) (*a
 
 // GetUnderflowHandleResponse handles the GetUnderflow response.
 func (client *DatetimeClient) GetUnderflowHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetUnderflowHandleError(resp)
-	}
 	var aux *timeRFC3339
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -774,6 +816,9 @@ func (client *DatetimeClient) GetUnderflowHandleResponse(resp *azcore.Response) 
 
 // GetUnderflowHandleError handles the GetUnderflow error response.
 func (client *DatetimeClient) GetUnderflowHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -791,11 +836,10 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTime(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutLocalNegativeOffsetMaxDateTimeHandleResponse(resp)
-	if err != nil {
+	if err := client.PutLocalNegativeOffsetMaxDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutLocalNegativeOffsetMaxDateTimeCreateRequest creates the PutLocalNegativeOffsetMaxDateTime request.
@@ -809,16 +853,11 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTimeCreateRequest(ctx
 	return req, req.MarshalAsJSON(datetimeBody)
 }
 
-// PutLocalNegativeOffsetMaxDateTimeHandleResponse handles the PutLocalNegativeOffsetMaxDateTime response.
-func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutLocalNegativeOffsetMaxDateTimeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutLocalNegativeOffsetMaxDateTimeHandleError handles the PutLocalNegativeOffsetMaxDateTime error response.
 func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -836,11 +875,10 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTime(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutLocalNegativeOffsetMinDateTimeHandleResponse(resp)
-	if err != nil {
+	if err := client.PutLocalNegativeOffsetMinDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutLocalNegativeOffsetMinDateTimeCreateRequest creates the PutLocalNegativeOffsetMinDateTime request.
@@ -854,16 +892,11 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTimeCreateRequest(ctx
 	return req, req.MarshalAsJSON(datetimeBody)
 }
 
-// PutLocalNegativeOffsetMinDateTimeHandleResponse handles the PutLocalNegativeOffsetMinDateTime response.
-func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutLocalNegativeOffsetMinDateTimeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutLocalNegativeOffsetMinDateTimeHandleError handles the PutLocalNegativeOffsetMinDateTime error response.
 func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -881,11 +914,10 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTime(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutLocalPositiveOffsetMaxDateTimeHandleResponse(resp)
-	if err != nil {
+	if err := client.PutLocalPositiveOffsetMaxDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutLocalPositiveOffsetMaxDateTimeCreateRequest creates the PutLocalPositiveOffsetMaxDateTime request.
@@ -899,16 +931,11 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTimeCreateRequest(ctx
 	return req, req.MarshalAsJSON(datetimeBody)
 }
 
-// PutLocalPositiveOffsetMaxDateTimeHandleResponse handles the PutLocalPositiveOffsetMaxDateTime response.
-func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutLocalPositiveOffsetMaxDateTimeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutLocalPositiveOffsetMaxDateTimeHandleError handles the PutLocalPositiveOffsetMaxDateTime error response.
 func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -926,11 +953,10 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTime(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutLocalPositiveOffsetMinDateTimeHandleResponse(resp)
-	if err != nil {
+	if err := client.PutLocalPositiveOffsetMinDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutLocalPositiveOffsetMinDateTimeCreateRequest creates the PutLocalPositiveOffsetMinDateTime request.
@@ -944,16 +970,11 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTimeCreateRequest(ctx
 	return req, req.MarshalAsJSON(datetimeBody)
 }
 
-// PutLocalPositiveOffsetMinDateTimeHandleResponse handles the PutLocalPositiveOffsetMinDateTime response.
-func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutLocalPositiveOffsetMinDateTimeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutLocalPositiveOffsetMinDateTimeHandleError handles the PutLocalPositiveOffsetMinDateTime error response.
 func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -971,11 +992,10 @@ func (client *DatetimeClient) PutUTCMaxDateTime(ctx context.Context, datetimeBod
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutUTCMaxDateTimeHandleResponse(resp)
-	if err != nil {
+	if err := client.PutUTCMaxDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutUTCMaxDateTimeCreateRequest creates the PutUTCMaxDateTime request.
@@ -989,16 +1009,11 @@ func (client *DatetimeClient) PutUTCMaxDateTimeCreateRequest(ctx context.Context
 	return req, req.MarshalAsJSON(datetimeBody)
 }
 
-// PutUTCMaxDateTimeHandleResponse handles the PutUTCMaxDateTime response.
-func (client *DatetimeClient) PutUTCMaxDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutUTCMaxDateTimeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutUTCMaxDateTimeHandleError handles the PutUTCMaxDateTime error response.
 func (client *DatetimeClient) PutUTCMaxDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1016,11 +1031,10 @@ func (client *DatetimeClient) PutUTCMaxDateTime7Digits(ctx context.Context, date
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutUTCMaxDateTime7DigitsHandleResponse(resp)
-	if err != nil {
+	if err := client.PutUTCMaxDateTime7DigitsHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutUTCMaxDateTime7DigitsCreateRequest creates the PutUTCMaxDateTime7Digits request.
@@ -1034,16 +1048,11 @@ func (client *DatetimeClient) PutUTCMaxDateTime7DigitsCreateRequest(ctx context.
 	return req, req.MarshalAsJSON(datetimeBody)
 }
 
-// PutUTCMaxDateTime7DigitsHandleResponse handles the PutUTCMaxDateTime7Digits response.
-func (client *DatetimeClient) PutUTCMaxDateTime7DigitsHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutUTCMaxDateTime7DigitsHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutUTCMaxDateTime7DigitsHandleError handles the PutUTCMaxDateTime7Digits error response.
 func (client *DatetimeClient) PutUTCMaxDateTime7DigitsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1061,11 +1070,10 @@ func (client *DatetimeClient) PutUTCMinDateTime(ctx context.Context, datetimeBod
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutUTCMinDateTimeHandleResponse(resp)
-	if err != nil {
+	if err := client.PutUTCMinDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutUTCMinDateTimeCreateRequest creates the PutUTCMinDateTime request.
@@ -1079,16 +1087,11 @@ func (client *DatetimeClient) PutUTCMinDateTimeCreateRequest(ctx context.Context
 	return req, req.MarshalAsJSON(datetimeBody)
 }
 
-// PutUTCMinDateTimeHandleResponse handles the PutUTCMinDateTime response.
-func (client *DatetimeClient) PutUTCMinDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutUTCMinDateTimeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutUTCMinDateTimeHandleError handles the PutUTCMinDateTime error response.
 func (client *DatetimeClient) PutUTCMinDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123.go
@@ -60,6 +60,9 @@ func (client *Datetimerfc1123Client) GetInvalid(ctx context.Context) (*TimeRespo
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetInvalidHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetInvalidHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -80,9 +83,6 @@ func (client *Datetimerfc1123Client) GetInvalidCreateRequest(ctx context.Context
 
 // GetInvalidHandleResponse handles the GetInvalid response.
 func (client *Datetimerfc1123Client) GetInvalidHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetInvalidHandleError(resp)
-	}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -90,6 +90,9 @@ func (client *Datetimerfc1123Client) GetInvalidHandleResponse(resp *azcore.Respo
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *Datetimerfc1123Client) GetInvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -105,6 +108,9 @@ func (client *Datetimerfc1123Client) GetNull(ctx context.Context) (*TimeResponse
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullHandleResponse(resp)
@@ -127,9 +133,6 @@ func (client *Datetimerfc1123Client) GetNullCreateRequest(ctx context.Context) (
 
 // GetNullHandleResponse handles the GetNull response.
 func (client *Datetimerfc1123Client) GetNullHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullHandleError(resp)
-	}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -137,6 +140,9 @@ func (client *Datetimerfc1123Client) GetNullHandleResponse(resp *azcore.Response
 
 // GetNullHandleError handles the GetNull error response.
 func (client *Datetimerfc1123Client) GetNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -152,6 +158,9 @@ func (client *Datetimerfc1123Client) GetOverflow(ctx context.Context) (*TimeResp
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetOverflowHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetOverflowHandleResponse(resp)
@@ -174,9 +183,6 @@ func (client *Datetimerfc1123Client) GetOverflowCreateRequest(ctx context.Contex
 
 // GetOverflowHandleResponse handles the GetOverflow response.
 func (client *Datetimerfc1123Client) GetOverflowHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetOverflowHandleError(resp)
-	}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -184,6 +190,9 @@ func (client *Datetimerfc1123Client) GetOverflowHandleResponse(resp *azcore.Resp
 
 // GetOverflowHandleError handles the GetOverflow error response.
 func (client *Datetimerfc1123Client) GetOverflowHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -199,6 +208,9 @@ func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTime(ctx context.Cont
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetUTCLowercaseMaxDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetUTCLowercaseMaxDateTimeHandleResponse(resp)
@@ -221,9 +233,6 @@ func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTimeCreateRequest(ctx
 
 // GetUTCLowercaseMaxDateTimeHandleResponse handles the GetUTCLowercaseMaxDateTime response.
 func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetUTCLowercaseMaxDateTimeHandleError(resp)
-	}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -231,6 +240,9 @@ func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTimeHandleResponse(re
 
 // GetUTCLowercaseMaxDateTimeHandleError handles the GetUTCLowercaseMaxDateTime error response.
 func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -246,6 +258,9 @@ func (client *Datetimerfc1123Client) GetUTCMinDateTime(ctx context.Context) (*Ti
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetUTCMinDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetUTCMinDateTimeHandleResponse(resp)
@@ -268,9 +283,6 @@ func (client *Datetimerfc1123Client) GetUTCMinDateTimeCreateRequest(ctx context.
 
 // GetUTCMinDateTimeHandleResponse handles the GetUTCMinDateTime response.
 func (client *Datetimerfc1123Client) GetUTCMinDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetUTCMinDateTimeHandleError(resp)
-	}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -278,6 +290,9 @@ func (client *Datetimerfc1123Client) GetUTCMinDateTimeHandleResponse(resp *azcor
 
 // GetUTCMinDateTimeHandleError handles the GetUTCMinDateTime error response.
 func (client *Datetimerfc1123Client) GetUTCMinDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -293,6 +308,9 @@ func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTime(ctx context.Cont
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetUTCUppercaseMaxDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetUTCUppercaseMaxDateTimeHandleResponse(resp)
@@ -315,9 +333,6 @@ func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTimeCreateRequest(ctx
 
 // GetUTCUppercaseMaxDateTimeHandleResponse handles the GetUTCUppercaseMaxDateTime response.
 func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetUTCUppercaseMaxDateTimeHandleError(resp)
-	}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -325,6 +340,9 @@ func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTimeHandleResponse(re
 
 // GetUTCUppercaseMaxDateTimeHandleError handles the GetUTCUppercaseMaxDateTime error response.
 func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -340,6 +358,9 @@ func (client *Datetimerfc1123Client) GetUnderflow(ctx context.Context) (*TimeRes
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetUnderflowHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetUnderflowHandleResponse(resp)
@@ -362,9 +383,6 @@ func (client *Datetimerfc1123Client) GetUnderflowCreateRequest(ctx context.Conte
 
 // GetUnderflowHandleResponse handles the GetUnderflow response.
 func (client *Datetimerfc1123Client) GetUnderflowHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetUnderflowHandleError(resp)
-	}
 	var aux *timeRFC1123
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -372,6 +390,9 @@ func (client *Datetimerfc1123Client) GetUnderflowHandleResponse(resp *azcore.Res
 
 // GetUnderflowHandleError handles the GetUnderflow error response.
 func (client *Datetimerfc1123Client) GetUnderflowHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -389,11 +410,10 @@ func (client *Datetimerfc1123Client) PutUTCMaxDateTime(ctx context.Context, date
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutUTCMaxDateTimeHandleResponse(resp)
-	if err != nil {
+	if err := client.PutUTCMaxDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutUTCMaxDateTimeCreateRequest creates the PutUTCMaxDateTime request.
@@ -408,16 +428,11 @@ func (client *Datetimerfc1123Client) PutUTCMaxDateTimeCreateRequest(ctx context.
 	return req, req.MarshalAsJSON(aux)
 }
 
-// PutUTCMaxDateTimeHandleResponse handles the PutUTCMaxDateTime response.
-func (client *Datetimerfc1123Client) PutUTCMaxDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutUTCMaxDateTimeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutUTCMaxDateTimeHandleError handles the PutUTCMaxDateTime error response.
 func (client *Datetimerfc1123Client) PutUTCMaxDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -435,11 +450,10 @@ func (client *Datetimerfc1123Client) PutUTCMinDateTime(ctx context.Context, date
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutUTCMinDateTimeHandleResponse(resp)
-	if err != nil {
+	if err := client.PutUTCMinDateTimeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutUTCMinDateTimeCreateRequest creates the PutUTCMinDateTime request.
@@ -454,16 +468,11 @@ func (client *Datetimerfc1123Client) PutUTCMinDateTimeCreateRequest(ctx context.
 	return req, req.MarshalAsJSON(aux)
 }
 
-// PutUTCMinDateTimeHandleResponse handles the PutUTCMinDateTime response.
-func (client *Datetimerfc1123Client) PutUTCMinDateTimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutUTCMinDateTimeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutUTCMinDateTimeHandleError handles the PutUTCMinDateTime error response.
 func (client *Datetimerfc1123Client) PutUTCMinDateTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123.go
@@ -60,8 +60,8 @@ func (client *Datetimerfc1123Client) GetInvalid(ctx context.Context) (*TimeRespo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetInvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetInvalidHandleError(resp)
 	}
 	result, err := client.GetInvalidHandleResponse(resp)
 	if err != nil {
@@ -90,9 +90,6 @@ func (client *Datetimerfc1123Client) GetInvalidHandleResponse(resp *azcore.Respo
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *Datetimerfc1123Client) GetInvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -110,8 +107,8 @@ func (client *Datetimerfc1123Client) GetNull(ctx context.Context) (*TimeResponse
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullHandleError(resp)
 	}
 	result, err := client.GetNullHandleResponse(resp)
 	if err != nil {
@@ -140,9 +137,6 @@ func (client *Datetimerfc1123Client) GetNullHandleResponse(resp *azcore.Response
 
 // GetNullHandleError handles the GetNull error response.
 func (client *Datetimerfc1123Client) GetNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -160,8 +154,8 @@ func (client *Datetimerfc1123Client) GetOverflow(ctx context.Context) (*TimeResp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetOverflowHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetOverflowHandleError(resp)
 	}
 	result, err := client.GetOverflowHandleResponse(resp)
 	if err != nil {
@@ -190,9 +184,6 @@ func (client *Datetimerfc1123Client) GetOverflowHandleResponse(resp *azcore.Resp
 
 // GetOverflowHandleError handles the GetOverflow error response.
 func (client *Datetimerfc1123Client) GetOverflowHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,8 +201,8 @@ func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTime(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetUTCLowercaseMaxDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetUTCLowercaseMaxDateTimeHandleError(resp)
 	}
 	result, err := client.GetUTCLowercaseMaxDateTimeHandleResponse(resp)
 	if err != nil {
@@ -240,9 +231,6 @@ func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTimeHandleResponse(re
 
 // GetUTCLowercaseMaxDateTimeHandleError handles the GetUTCLowercaseMaxDateTime error response.
 func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -260,8 +248,8 @@ func (client *Datetimerfc1123Client) GetUTCMinDateTime(ctx context.Context) (*Ti
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetUTCMinDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetUTCMinDateTimeHandleError(resp)
 	}
 	result, err := client.GetUTCMinDateTimeHandleResponse(resp)
 	if err != nil {
@@ -290,9 +278,6 @@ func (client *Datetimerfc1123Client) GetUTCMinDateTimeHandleResponse(resp *azcor
 
 // GetUTCMinDateTimeHandleError handles the GetUTCMinDateTime error response.
 func (client *Datetimerfc1123Client) GetUTCMinDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -310,8 +295,8 @@ func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTime(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetUTCUppercaseMaxDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetUTCUppercaseMaxDateTimeHandleError(resp)
 	}
 	result, err := client.GetUTCUppercaseMaxDateTimeHandleResponse(resp)
 	if err != nil {
@@ -340,9 +325,6 @@ func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTimeHandleResponse(re
 
 // GetUTCUppercaseMaxDateTimeHandleError handles the GetUTCUppercaseMaxDateTime error response.
 func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -360,8 +342,8 @@ func (client *Datetimerfc1123Client) GetUnderflow(ctx context.Context) (*TimeRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetUnderflowHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetUnderflowHandleError(resp)
 	}
 	result, err := client.GetUnderflowHandleResponse(resp)
 	if err != nil {
@@ -390,9 +372,6 @@ func (client *Datetimerfc1123Client) GetUnderflowHandleResponse(resp *azcore.Res
 
 // GetUnderflowHandleError handles the GetUnderflow error response.
 func (client *Datetimerfc1123Client) GetUnderflowHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -410,8 +389,8 @@ func (client *Datetimerfc1123Client) PutUTCMaxDateTime(ctx context.Context, date
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutUTCMaxDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutUTCMaxDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -430,9 +409,6 @@ func (client *Datetimerfc1123Client) PutUTCMaxDateTimeCreateRequest(ctx context.
 
 // PutUTCMaxDateTimeHandleError handles the PutUTCMaxDateTime error response.
 func (client *Datetimerfc1123Client) PutUTCMaxDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -450,8 +426,8 @@ func (client *Datetimerfc1123Client) PutUTCMinDateTime(ctx context.Context, date
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutUTCMinDateTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutUTCMinDateTimeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -470,9 +446,6 @@ func (client *Datetimerfc1123Client) PutUTCMinDateTimeCreateRequest(ctx context.
 
 // PutUTCMinDateTimeHandleError handles the PutUTCMinDateTime error response.
 func (client *Datetimerfc1123Client) PutUTCMinDateTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/dictionarygroup/zz_generated_dictionary.go
+++ b/test/autorest/dictionarygroup/zz_generated_dictionary.go
@@ -172,6 +172,9 @@ func (client *DictionaryClient) GetArrayEmpty(ctx context.Context) (*MapOfString
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetArrayEmptyHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetArrayEmptyHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -192,15 +195,15 @@ func (client *DictionaryClient) GetArrayEmptyCreateRequest(ctx context.Context) 
 
 // GetArrayEmptyHandleResponse handles the GetArrayEmpty response.
 func (client *DictionaryClient) GetArrayEmptyHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetArrayEmptyHandleError(resp)
-	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetArrayEmptyHandleError handles the GetArrayEmpty error response.
 func (client *DictionaryClient) GetArrayEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,6 +219,9 @@ func (client *DictionaryClient) GetArrayItemEmpty(ctx context.Context) (*MapOfSt
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetArrayItemEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetArrayItemEmptyHandleResponse(resp)
@@ -238,15 +244,15 @@ func (client *DictionaryClient) GetArrayItemEmptyCreateRequest(ctx context.Conte
 
 // GetArrayItemEmptyHandleResponse handles the GetArrayItemEmpty response.
 func (client *DictionaryClient) GetArrayItemEmptyHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetArrayItemEmptyHandleError(resp)
-	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetArrayItemEmptyHandleError handles the GetArrayItemEmpty error response.
 func (client *DictionaryClient) GetArrayItemEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -262,6 +268,9 @@ func (client *DictionaryClient) GetArrayItemNull(ctx context.Context) (*MapOfStr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetArrayItemNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetArrayItemNullHandleResponse(resp)
@@ -284,15 +293,15 @@ func (client *DictionaryClient) GetArrayItemNullCreateRequest(ctx context.Contex
 
 // GetArrayItemNullHandleResponse handles the GetArrayItemNull response.
 func (client *DictionaryClient) GetArrayItemNullHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetArrayItemNullHandleError(resp)
-	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetArrayItemNullHandleError handles the GetArrayItemNull error response.
 func (client *DictionaryClient) GetArrayItemNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -308,6 +317,9 @@ func (client *DictionaryClient) GetArrayNull(ctx context.Context) (*MapOfStringA
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetArrayNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetArrayNullHandleResponse(resp)
@@ -330,15 +342,15 @@ func (client *DictionaryClient) GetArrayNullCreateRequest(ctx context.Context) (
 
 // GetArrayNullHandleResponse handles the GetArrayNull response.
 func (client *DictionaryClient) GetArrayNullHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetArrayNullHandleError(resp)
-	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetArrayNullHandleError handles the GetArrayNull error response.
 func (client *DictionaryClient) GetArrayNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -354,6 +366,9 @@ func (client *DictionaryClient) GetArrayValid(ctx context.Context) (*MapOfString
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetArrayValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetArrayValidHandleResponse(resp)
@@ -376,15 +391,15 @@ func (client *DictionaryClient) GetArrayValidCreateRequest(ctx context.Context) 
 
 // GetArrayValidHandleResponse handles the GetArrayValid response.
 func (client *DictionaryClient) GetArrayValidHandleResponse(resp *azcore.Response) (*MapOfStringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetArrayValidHandleError(resp)
-	}
 	result := MapOfStringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetArrayValidHandleError handles the GetArrayValid error response.
 func (client *DictionaryClient) GetArrayValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -400,6 +415,9 @@ func (client *DictionaryClient) GetBase64URL(ctx context.Context) (*MapOfByteArr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBase64URLHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBase64URLHandleResponse(resp)
@@ -422,15 +440,15 @@ func (client *DictionaryClient) GetBase64URLCreateRequest(ctx context.Context) (
 
 // GetBase64URLHandleResponse handles the GetBase64URL response.
 func (client *DictionaryClient) GetBase64URLHandleResponse(resp *azcore.Response) (*MapOfByteArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBase64URLHandleError(resp)
-	}
 	result := MapOfByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBase64URLHandleError handles the GetBase64URL error response.
 func (client *DictionaryClient) GetBase64URLHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -446,6 +464,9 @@ func (client *DictionaryClient) GetBooleanInvalidNull(ctx context.Context) (*Map
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBooleanInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBooleanInvalidNullHandleResponse(resp)
@@ -468,15 +489,15 @@ func (client *DictionaryClient) GetBooleanInvalidNullCreateRequest(ctx context.C
 
 // GetBooleanInvalidNullHandleResponse handles the GetBooleanInvalidNull response.
 func (client *DictionaryClient) GetBooleanInvalidNullHandleResponse(resp *azcore.Response) (*MapOfBoolResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBooleanInvalidNullHandleError(resp)
-	}
 	result := MapOfBoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBooleanInvalidNullHandleError handles the GetBooleanInvalidNull error response.
 func (client *DictionaryClient) GetBooleanInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -492,6 +513,9 @@ func (client *DictionaryClient) GetBooleanInvalidString(ctx context.Context) (*M
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBooleanInvalidStringHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBooleanInvalidStringHandleResponse(resp)
@@ -514,15 +538,15 @@ func (client *DictionaryClient) GetBooleanInvalidStringCreateRequest(ctx context
 
 // GetBooleanInvalidStringHandleResponse handles the GetBooleanInvalidString response.
 func (client *DictionaryClient) GetBooleanInvalidStringHandleResponse(resp *azcore.Response) (*MapOfBoolResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBooleanInvalidStringHandleError(resp)
-	}
 	result := MapOfBoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBooleanInvalidStringHandleError handles the GetBooleanInvalidString error response.
 func (client *DictionaryClient) GetBooleanInvalidStringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -538,6 +562,9 @@ func (client *DictionaryClient) GetBooleanTfft(ctx context.Context) (*MapOfBoolR
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBooleanTfftHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBooleanTfftHandleResponse(resp)
@@ -560,15 +587,15 @@ func (client *DictionaryClient) GetBooleanTfftCreateRequest(ctx context.Context)
 
 // GetBooleanTfftHandleResponse handles the GetBooleanTfft response.
 func (client *DictionaryClient) GetBooleanTfftHandleResponse(resp *azcore.Response) (*MapOfBoolResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBooleanTfftHandleError(resp)
-	}
 	result := MapOfBoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBooleanTfftHandleError handles the GetBooleanTfft error response.
 func (client *DictionaryClient) GetBooleanTfftHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -584,6 +611,9 @@ func (client *DictionaryClient) GetByteInvalidNull(ctx context.Context) (*MapOfB
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetByteInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetByteInvalidNullHandleResponse(resp)
@@ -606,15 +636,15 @@ func (client *DictionaryClient) GetByteInvalidNullCreateRequest(ctx context.Cont
 
 // GetByteInvalidNullHandleResponse handles the GetByteInvalidNull response.
 func (client *DictionaryClient) GetByteInvalidNullHandleResponse(resp *azcore.Response) (*MapOfByteArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetByteInvalidNullHandleError(resp)
-	}
 	result := MapOfByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetByteInvalidNullHandleError handles the GetByteInvalidNull error response.
 func (client *DictionaryClient) GetByteInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -630,6 +660,9 @@ func (client *DictionaryClient) GetByteValid(ctx context.Context) (*MapOfByteArr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetByteValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetByteValidHandleResponse(resp)
@@ -652,15 +685,15 @@ func (client *DictionaryClient) GetByteValidCreateRequest(ctx context.Context) (
 
 // GetByteValidHandleResponse handles the GetByteValid response.
 func (client *DictionaryClient) GetByteValidHandleResponse(resp *azcore.Response) (*MapOfByteArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetByteValidHandleError(resp)
-	}
 	result := MapOfByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetByteValidHandleError handles the GetByteValid error response.
 func (client *DictionaryClient) GetByteValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -676,6 +709,9 @@ func (client *DictionaryClient) GetComplexEmpty(ctx context.Context) (*MapOfWidg
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetComplexEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetComplexEmptyHandleResponse(resp)
@@ -698,15 +734,15 @@ func (client *DictionaryClient) GetComplexEmptyCreateRequest(ctx context.Context
 
 // GetComplexEmptyHandleResponse handles the GetComplexEmpty response.
 func (client *DictionaryClient) GetComplexEmptyHandleResponse(resp *azcore.Response) (*MapOfWidgetResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetComplexEmptyHandleError(resp)
-	}
 	result := MapOfWidgetResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetComplexEmptyHandleError handles the GetComplexEmpty error response.
 func (client *DictionaryClient) GetComplexEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -722,6 +758,9 @@ func (client *DictionaryClient) GetComplexItemEmpty(ctx context.Context) (*MapOf
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetComplexItemEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetComplexItemEmptyHandleResponse(resp)
@@ -744,15 +783,15 @@ func (client *DictionaryClient) GetComplexItemEmptyCreateRequest(ctx context.Con
 
 // GetComplexItemEmptyHandleResponse handles the GetComplexItemEmpty response.
 func (client *DictionaryClient) GetComplexItemEmptyHandleResponse(resp *azcore.Response) (*MapOfWidgetResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetComplexItemEmptyHandleError(resp)
-	}
 	result := MapOfWidgetResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetComplexItemEmptyHandleError handles the GetComplexItemEmpty error response.
 func (client *DictionaryClient) GetComplexItemEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -768,6 +807,9 @@ func (client *DictionaryClient) GetComplexItemNull(ctx context.Context) (*MapOfW
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetComplexItemNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetComplexItemNullHandleResponse(resp)
@@ -790,15 +832,15 @@ func (client *DictionaryClient) GetComplexItemNullCreateRequest(ctx context.Cont
 
 // GetComplexItemNullHandleResponse handles the GetComplexItemNull response.
 func (client *DictionaryClient) GetComplexItemNullHandleResponse(resp *azcore.Response) (*MapOfWidgetResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetComplexItemNullHandleError(resp)
-	}
 	result := MapOfWidgetResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetComplexItemNullHandleError handles the GetComplexItemNull error response.
 func (client *DictionaryClient) GetComplexItemNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -814,6 +856,9 @@ func (client *DictionaryClient) GetComplexNull(ctx context.Context) (*MapOfWidge
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetComplexNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetComplexNullHandleResponse(resp)
@@ -836,15 +881,15 @@ func (client *DictionaryClient) GetComplexNullCreateRequest(ctx context.Context)
 
 // GetComplexNullHandleResponse handles the GetComplexNull response.
 func (client *DictionaryClient) GetComplexNullHandleResponse(resp *azcore.Response) (*MapOfWidgetResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetComplexNullHandleError(resp)
-	}
 	result := MapOfWidgetResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetComplexNullHandleError handles the GetComplexNull error response.
 func (client *DictionaryClient) GetComplexNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -860,6 +905,9 @@ func (client *DictionaryClient) GetComplexValid(ctx context.Context) (*MapOfWidg
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetComplexValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetComplexValidHandleResponse(resp)
@@ -882,15 +930,15 @@ func (client *DictionaryClient) GetComplexValidCreateRequest(ctx context.Context
 
 // GetComplexValidHandleResponse handles the GetComplexValid response.
 func (client *DictionaryClient) GetComplexValidHandleResponse(resp *azcore.Response) (*MapOfWidgetResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetComplexValidHandleError(resp)
-	}
 	result := MapOfWidgetResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetComplexValidHandleError handles the GetComplexValid error response.
 func (client *DictionaryClient) GetComplexValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -906,6 +954,9 @@ func (client *DictionaryClient) GetDateInvalidChars(ctx context.Context) (*MapOf
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateInvalidCharsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateInvalidCharsHandleResponse(resp)
@@ -928,15 +979,15 @@ func (client *DictionaryClient) GetDateInvalidCharsCreateRequest(ctx context.Con
 
 // GetDateInvalidCharsHandleResponse handles the GetDateInvalidChars response.
 func (client *DictionaryClient) GetDateInvalidCharsHandleResponse(resp *azcore.Response) (*MapOfTimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateInvalidCharsHandleError(resp)
-	}
 	result := MapOfTimeResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetDateInvalidCharsHandleError handles the GetDateInvalidChars error response.
 func (client *DictionaryClient) GetDateInvalidCharsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -952,6 +1003,9 @@ func (client *DictionaryClient) GetDateInvalidNull(ctx context.Context) (*MapOfT
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateInvalidNullHandleResponse(resp)
@@ -974,15 +1028,15 @@ func (client *DictionaryClient) GetDateInvalidNullCreateRequest(ctx context.Cont
 
 // GetDateInvalidNullHandleResponse handles the GetDateInvalidNull response.
 func (client *DictionaryClient) GetDateInvalidNullHandleResponse(resp *azcore.Response) (*MapOfTimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateInvalidNullHandleError(resp)
-	}
 	result := MapOfTimeResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetDateInvalidNullHandleError handles the GetDateInvalidNull error response.
 func (client *DictionaryClient) GetDateInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -998,6 +1052,9 @@ func (client *DictionaryClient) GetDateTimeInvalidChars(ctx context.Context) (*M
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateTimeInvalidCharsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateTimeInvalidCharsHandleResponse(resp)
@@ -1020,9 +1077,6 @@ func (client *DictionaryClient) GetDateTimeInvalidCharsCreateRequest(ctx context
 
 // GetDateTimeInvalidCharsHandleResponse handles the GetDateTimeInvalidChars response.
 func (client *DictionaryClient) GetDateTimeInvalidCharsHandleResponse(resp *azcore.Response) (*MapOfTimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateTimeInvalidCharsHandleError(resp)
-	}
 	aux := map[string]timeRFC3339{}
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return nil, err
@@ -1036,6 +1090,9 @@ func (client *DictionaryClient) GetDateTimeInvalidCharsHandleResponse(resp *azco
 
 // GetDateTimeInvalidCharsHandleError handles the GetDateTimeInvalidChars error response.
 func (client *DictionaryClient) GetDateTimeInvalidCharsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1051,6 +1108,9 @@ func (client *DictionaryClient) GetDateTimeInvalidNull(ctx context.Context) (*Ma
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateTimeInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateTimeInvalidNullHandleResponse(resp)
@@ -1073,9 +1133,6 @@ func (client *DictionaryClient) GetDateTimeInvalidNullCreateRequest(ctx context.
 
 // GetDateTimeInvalidNullHandleResponse handles the GetDateTimeInvalidNull response.
 func (client *DictionaryClient) GetDateTimeInvalidNullHandleResponse(resp *azcore.Response) (*MapOfTimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateTimeInvalidNullHandleError(resp)
-	}
 	aux := map[string]timeRFC3339{}
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return nil, err
@@ -1089,6 +1146,9 @@ func (client *DictionaryClient) GetDateTimeInvalidNullHandleResponse(resp *azcor
 
 // GetDateTimeInvalidNullHandleError handles the GetDateTimeInvalidNull error response.
 func (client *DictionaryClient) GetDateTimeInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1104,6 +1164,9 @@ func (client *DictionaryClient) GetDateTimeRFC1123Valid(ctx context.Context) (*M
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateTimeRFC1123ValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateTimeRFC1123ValidHandleResponse(resp)
@@ -1126,9 +1189,6 @@ func (client *DictionaryClient) GetDateTimeRFC1123ValidCreateRequest(ctx context
 
 // GetDateTimeRFC1123ValidHandleResponse handles the GetDateTimeRFC1123Valid response.
 func (client *DictionaryClient) GetDateTimeRFC1123ValidHandleResponse(resp *azcore.Response) (*MapOfTimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateTimeRFC1123ValidHandleError(resp)
-	}
 	aux := map[string]timeRFC1123{}
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return nil, err
@@ -1142,6 +1202,9 @@ func (client *DictionaryClient) GetDateTimeRFC1123ValidHandleResponse(resp *azco
 
 // GetDateTimeRFC1123ValidHandleError handles the GetDateTimeRFC1123Valid error response.
 func (client *DictionaryClient) GetDateTimeRFC1123ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1157,6 +1220,9 @@ func (client *DictionaryClient) GetDateTimeValid(ctx context.Context) (*MapOfTim
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateTimeValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateTimeValidHandleResponse(resp)
@@ -1179,9 +1245,6 @@ func (client *DictionaryClient) GetDateTimeValidCreateRequest(ctx context.Contex
 
 // GetDateTimeValidHandleResponse handles the GetDateTimeValid response.
 func (client *DictionaryClient) GetDateTimeValidHandleResponse(resp *azcore.Response) (*MapOfTimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateTimeValidHandleError(resp)
-	}
 	aux := map[string]timeRFC3339{}
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return nil, err
@@ -1195,6 +1258,9 @@ func (client *DictionaryClient) GetDateTimeValidHandleResponse(resp *azcore.Resp
 
 // GetDateTimeValidHandleError handles the GetDateTimeValid error response.
 func (client *DictionaryClient) GetDateTimeValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1210,6 +1276,9 @@ func (client *DictionaryClient) GetDateValid(ctx context.Context) (*MapOfTimeRes
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDateValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDateValidHandleResponse(resp)
@@ -1232,15 +1301,15 @@ func (client *DictionaryClient) GetDateValidCreateRequest(ctx context.Context) (
 
 // GetDateValidHandleResponse handles the GetDateValid response.
 func (client *DictionaryClient) GetDateValidHandleResponse(resp *azcore.Response) (*MapOfTimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDateValidHandleError(resp)
-	}
 	result := MapOfTimeResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetDateValidHandleError handles the GetDateValid error response.
 func (client *DictionaryClient) GetDateValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1256,6 +1325,9 @@ func (client *DictionaryClient) GetDictionaryEmpty(ctx context.Context) (*MapOfI
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDictionaryEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDictionaryEmptyHandleResponse(resp)
@@ -1278,15 +1350,15 @@ func (client *DictionaryClient) GetDictionaryEmptyCreateRequest(ctx context.Cont
 
 // GetDictionaryEmptyHandleResponse handles the GetDictionaryEmpty response.
 func (client *DictionaryClient) GetDictionaryEmptyHandleResponse(resp *azcore.Response) (*MapOfInterfaceResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDictionaryEmptyHandleError(resp)
-	}
 	result := MapOfInterfaceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetDictionaryEmptyHandleError handles the GetDictionaryEmpty error response.
 func (client *DictionaryClient) GetDictionaryEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1302,6 +1374,9 @@ func (client *DictionaryClient) GetDictionaryItemEmpty(ctx context.Context) (*Ma
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDictionaryItemEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDictionaryItemEmptyHandleResponse(resp)
@@ -1324,15 +1399,15 @@ func (client *DictionaryClient) GetDictionaryItemEmptyCreateRequest(ctx context.
 
 // GetDictionaryItemEmptyHandleResponse handles the GetDictionaryItemEmpty response.
 func (client *DictionaryClient) GetDictionaryItemEmptyHandleResponse(resp *azcore.Response) (*MapOfInterfaceResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDictionaryItemEmptyHandleError(resp)
-	}
 	result := MapOfInterfaceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetDictionaryItemEmptyHandleError handles the GetDictionaryItemEmpty error response.
 func (client *DictionaryClient) GetDictionaryItemEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1348,6 +1423,9 @@ func (client *DictionaryClient) GetDictionaryItemNull(ctx context.Context) (*Map
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDictionaryItemNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDictionaryItemNullHandleResponse(resp)
@@ -1370,15 +1448,15 @@ func (client *DictionaryClient) GetDictionaryItemNullCreateRequest(ctx context.C
 
 // GetDictionaryItemNullHandleResponse handles the GetDictionaryItemNull response.
 func (client *DictionaryClient) GetDictionaryItemNullHandleResponse(resp *azcore.Response) (*MapOfInterfaceResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDictionaryItemNullHandleError(resp)
-	}
 	result := MapOfInterfaceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetDictionaryItemNullHandleError handles the GetDictionaryItemNull error response.
 func (client *DictionaryClient) GetDictionaryItemNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1394,6 +1472,9 @@ func (client *DictionaryClient) GetDictionaryNull(ctx context.Context) (*MapOfIn
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDictionaryNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDictionaryNullHandleResponse(resp)
@@ -1416,15 +1497,15 @@ func (client *DictionaryClient) GetDictionaryNullCreateRequest(ctx context.Conte
 
 // GetDictionaryNullHandleResponse handles the GetDictionaryNull response.
 func (client *DictionaryClient) GetDictionaryNullHandleResponse(resp *azcore.Response) (*MapOfInterfaceResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDictionaryNullHandleError(resp)
-	}
 	result := MapOfInterfaceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetDictionaryNullHandleError handles the GetDictionaryNull error response.
 func (client *DictionaryClient) GetDictionaryNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1440,6 +1521,9 @@ func (client *DictionaryClient) GetDictionaryValid(ctx context.Context) (*MapOfI
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDictionaryValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDictionaryValidHandleResponse(resp)
@@ -1462,15 +1546,15 @@ func (client *DictionaryClient) GetDictionaryValidCreateRequest(ctx context.Cont
 
 // GetDictionaryValidHandleResponse handles the GetDictionaryValid response.
 func (client *DictionaryClient) GetDictionaryValidHandleResponse(resp *azcore.Response) (*MapOfInterfaceResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDictionaryValidHandleError(resp)
-	}
 	result := MapOfInterfaceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetDictionaryValidHandleError handles the GetDictionaryValid error response.
 func (client *DictionaryClient) GetDictionaryValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1486,6 +1570,9 @@ func (client *DictionaryClient) GetDoubleInvalidNull(ctx context.Context) (*MapO
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDoubleInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDoubleInvalidNullHandleResponse(resp)
@@ -1508,15 +1595,15 @@ func (client *DictionaryClient) GetDoubleInvalidNullCreateRequest(ctx context.Co
 
 // GetDoubleInvalidNullHandleResponse handles the GetDoubleInvalidNull response.
 func (client *DictionaryClient) GetDoubleInvalidNullHandleResponse(resp *azcore.Response) (*MapOfFloat64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDoubleInvalidNullHandleError(resp)
-	}
 	result := MapOfFloat64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetDoubleInvalidNullHandleError handles the GetDoubleInvalidNull error response.
 func (client *DictionaryClient) GetDoubleInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1532,6 +1619,9 @@ func (client *DictionaryClient) GetDoubleInvalidString(ctx context.Context) (*Ma
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDoubleInvalidStringHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDoubleInvalidStringHandleResponse(resp)
@@ -1554,15 +1644,15 @@ func (client *DictionaryClient) GetDoubleInvalidStringCreateRequest(ctx context.
 
 // GetDoubleInvalidStringHandleResponse handles the GetDoubleInvalidString response.
 func (client *DictionaryClient) GetDoubleInvalidStringHandleResponse(resp *azcore.Response) (*MapOfFloat64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDoubleInvalidStringHandleError(resp)
-	}
 	result := MapOfFloat64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetDoubleInvalidStringHandleError handles the GetDoubleInvalidString error response.
 func (client *DictionaryClient) GetDoubleInvalidStringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1578,6 +1668,9 @@ func (client *DictionaryClient) GetDoubleValid(ctx context.Context) (*MapOfFloat
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDoubleValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDoubleValidHandleResponse(resp)
@@ -1600,15 +1693,15 @@ func (client *DictionaryClient) GetDoubleValidCreateRequest(ctx context.Context)
 
 // GetDoubleValidHandleResponse handles the GetDoubleValid response.
 func (client *DictionaryClient) GetDoubleValidHandleResponse(resp *azcore.Response) (*MapOfFloat64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDoubleValidHandleError(resp)
-	}
 	result := MapOfFloat64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetDoubleValidHandleError handles the GetDoubleValid error response.
 func (client *DictionaryClient) GetDoubleValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1624,6 +1717,9 @@ func (client *DictionaryClient) GetDurationValid(ctx context.Context) (*MapOfStr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDurationValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDurationValidHandleResponse(resp)
@@ -1646,15 +1742,15 @@ func (client *DictionaryClient) GetDurationValidCreateRequest(ctx context.Contex
 
 // GetDurationValidHandleResponse handles the GetDurationValid response.
 func (client *DictionaryClient) GetDurationValidHandleResponse(resp *azcore.Response) (*MapOfStringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDurationValidHandleError(resp)
-	}
 	result := MapOfStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetDurationValidHandleError handles the GetDurationValid error response.
 func (client *DictionaryClient) GetDurationValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1670,6 +1766,9 @@ func (client *DictionaryClient) GetEmpty(ctx context.Context) (*MapOfInt32Respon
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetEmptyHandleResponse(resp)
@@ -1692,15 +1791,15 @@ func (client *DictionaryClient) GetEmptyCreateRequest(ctx context.Context) (*azc
 
 // GetEmptyHandleResponse handles the GetEmpty response.
 func (client *DictionaryClient) GetEmptyHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyHandleError(resp)
-	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *DictionaryClient) GetEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1716,6 +1815,9 @@ func (client *DictionaryClient) GetEmptyStringKey(ctx context.Context) (*MapOfSt
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetEmptyStringKeyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetEmptyStringKeyHandleResponse(resp)
@@ -1738,15 +1840,15 @@ func (client *DictionaryClient) GetEmptyStringKeyCreateRequest(ctx context.Conte
 
 // GetEmptyStringKeyHandleResponse handles the GetEmptyStringKey response.
 func (client *DictionaryClient) GetEmptyStringKeyHandleResponse(resp *azcore.Response) (*MapOfStringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyStringKeyHandleError(resp)
-	}
 	result := MapOfStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetEmptyStringKeyHandleError handles the GetEmptyStringKey error response.
 func (client *DictionaryClient) GetEmptyStringKeyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1762,6 +1864,9 @@ func (client *DictionaryClient) GetFloatInvalidNull(ctx context.Context) (*MapOf
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetFloatInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetFloatInvalidNullHandleResponse(resp)
@@ -1784,15 +1889,15 @@ func (client *DictionaryClient) GetFloatInvalidNullCreateRequest(ctx context.Con
 
 // GetFloatInvalidNullHandleResponse handles the GetFloatInvalidNull response.
 func (client *DictionaryClient) GetFloatInvalidNullHandleResponse(resp *azcore.Response) (*MapOfFloat32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetFloatInvalidNullHandleError(resp)
-	}
 	result := MapOfFloat32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetFloatInvalidNullHandleError handles the GetFloatInvalidNull error response.
 func (client *DictionaryClient) GetFloatInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1808,6 +1913,9 @@ func (client *DictionaryClient) GetFloatInvalidString(ctx context.Context) (*Map
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetFloatInvalidStringHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetFloatInvalidStringHandleResponse(resp)
@@ -1830,15 +1938,15 @@ func (client *DictionaryClient) GetFloatInvalidStringCreateRequest(ctx context.C
 
 // GetFloatInvalidStringHandleResponse handles the GetFloatInvalidString response.
 func (client *DictionaryClient) GetFloatInvalidStringHandleResponse(resp *azcore.Response) (*MapOfFloat32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetFloatInvalidStringHandleError(resp)
-	}
 	result := MapOfFloat32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetFloatInvalidStringHandleError handles the GetFloatInvalidString error response.
 func (client *DictionaryClient) GetFloatInvalidStringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1854,6 +1962,9 @@ func (client *DictionaryClient) GetFloatValid(ctx context.Context) (*MapOfFloat3
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetFloatValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetFloatValidHandleResponse(resp)
@@ -1876,15 +1987,15 @@ func (client *DictionaryClient) GetFloatValidCreateRequest(ctx context.Context) 
 
 // GetFloatValidHandleResponse handles the GetFloatValid response.
 func (client *DictionaryClient) GetFloatValidHandleResponse(resp *azcore.Response) (*MapOfFloat32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetFloatValidHandleError(resp)
-	}
 	result := MapOfFloat32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetFloatValidHandleError handles the GetFloatValid error response.
 func (client *DictionaryClient) GetFloatValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1900,6 +2011,9 @@ func (client *DictionaryClient) GetIntInvalidNull(ctx context.Context) (*MapOfIn
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetIntInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetIntInvalidNullHandleResponse(resp)
@@ -1922,15 +2036,15 @@ func (client *DictionaryClient) GetIntInvalidNullCreateRequest(ctx context.Conte
 
 // GetIntInvalidNullHandleResponse handles the GetIntInvalidNull response.
 func (client *DictionaryClient) GetIntInvalidNullHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetIntInvalidNullHandleError(resp)
-	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetIntInvalidNullHandleError handles the GetIntInvalidNull error response.
 func (client *DictionaryClient) GetIntInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1946,6 +2060,9 @@ func (client *DictionaryClient) GetIntInvalidString(ctx context.Context) (*MapOf
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetIntInvalidStringHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetIntInvalidStringHandleResponse(resp)
@@ -1968,15 +2085,15 @@ func (client *DictionaryClient) GetIntInvalidStringCreateRequest(ctx context.Con
 
 // GetIntInvalidStringHandleResponse handles the GetIntInvalidString response.
 func (client *DictionaryClient) GetIntInvalidStringHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetIntInvalidStringHandleError(resp)
-	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetIntInvalidStringHandleError handles the GetIntInvalidString error response.
 func (client *DictionaryClient) GetIntInvalidStringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1992,6 +2109,9 @@ func (client *DictionaryClient) GetIntegerValid(ctx context.Context) (*MapOfInt3
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetIntegerValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetIntegerValidHandleResponse(resp)
@@ -2014,15 +2134,15 @@ func (client *DictionaryClient) GetIntegerValidCreateRequest(ctx context.Context
 
 // GetIntegerValidHandleResponse handles the GetIntegerValid response.
 func (client *DictionaryClient) GetIntegerValidHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetIntegerValidHandleError(resp)
-	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetIntegerValidHandleError handles the GetIntegerValid error response.
 func (client *DictionaryClient) GetIntegerValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2038,6 +2158,9 @@ func (client *DictionaryClient) GetInvalid(ctx context.Context) (*MapOfStringRes
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetInvalidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetInvalidHandleResponse(resp)
@@ -2060,15 +2183,15 @@ func (client *DictionaryClient) GetInvalidCreateRequest(ctx context.Context) (*a
 
 // GetInvalidHandleResponse handles the GetInvalid response.
 func (client *DictionaryClient) GetInvalidHandleResponse(resp *azcore.Response) (*MapOfStringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetInvalidHandleError(resp)
-	}
 	result := MapOfStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *DictionaryClient) GetInvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2084,6 +2207,9 @@ func (client *DictionaryClient) GetLongInvalidNull(ctx context.Context) (*MapOfI
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetLongInvalidNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetLongInvalidNullHandleResponse(resp)
@@ -2106,15 +2232,15 @@ func (client *DictionaryClient) GetLongInvalidNullCreateRequest(ctx context.Cont
 
 // GetLongInvalidNullHandleResponse handles the GetLongInvalidNull response.
 func (client *DictionaryClient) GetLongInvalidNullHandleResponse(resp *azcore.Response) (*MapOfInt64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLongInvalidNullHandleError(resp)
-	}
 	result := MapOfInt64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetLongInvalidNullHandleError handles the GetLongInvalidNull error response.
 func (client *DictionaryClient) GetLongInvalidNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2130,6 +2256,9 @@ func (client *DictionaryClient) GetLongInvalidString(ctx context.Context) (*MapO
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetLongInvalidStringHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetLongInvalidStringHandleResponse(resp)
@@ -2152,15 +2281,15 @@ func (client *DictionaryClient) GetLongInvalidStringCreateRequest(ctx context.Co
 
 // GetLongInvalidStringHandleResponse handles the GetLongInvalidString response.
 func (client *DictionaryClient) GetLongInvalidStringHandleResponse(resp *azcore.Response) (*MapOfInt64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLongInvalidStringHandleError(resp)
-	}
 	result := MapOfInt64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetLongInvalidStringHandleError handles the GetLongInvalidString error response.
 func (client *DictionaryClient) GetLongInvalidStringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2176,6 +2305,9 @@ func (client *DictionaryClient) GetLongValid(ctx context.Context) (*MapOfInt64Re
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetLongValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetLongValidHandleResponse(resp)
@@ -2198,15 +2330,15 @@ func (client *DictionaryClient) GetLongValidCreateRequest(ctx context.Context) (
 
 // GetLongValidHandleResponse handles the GetLongValid response.
 func (client *DictionaryClient) GetLongValidHandleResponse(resp *azcore.Response) (*MapOfInt64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLongValidHandleError(resp)
-	}
 	result := MapOfInt64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetLongValidHandleError handles the GetLongValid error response.
 func (client *DictionaryClient) GetLongValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2222,6 +2354,9 @@ func (client *DictionaryClient) GetNull(ctx context.Context) (*MapOfInt32Respons
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullHandleResponse(resp)
@@ -2244,15 +2379,15 @@ func (client *DictionaryClient) GetNullCreateRequest(ctx context.Context) (*azco
 
 // GetNullHandleResponse handles the GetNull response.
 func (client *DictionaryClient) GetNullHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullHandleError(resp)
-	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNullHandleError handles the GetNull error response.
 func (client *DictionaryClient) GetNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2268,6 +2403,9 @@ func (client *DictionaryClient) GetNullKey(ctx context.Context) (*MapOfStringRes
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullKeyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullKeyHandleResponse(resp)
@@ -2290,15 +2428,15 @@ func (client *DictionaryClient) GetNullKeyCreateRequest(ctx context.Context) (*a
 
 // GetNullKeyHandleResponse handles the GetNullKey response.
 func (client *DictionaryClient) GetNullKeyHandleResponse(resp *azcore.Response) (*MapOfStringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullKeyHandleError(resp)
-	}
 	result := MapOfStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNullKeyHandleError handles the GetNullKey error response.
 func (client *DictionaryClient) GetNullKeyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2314,6 +2452,9 @@ func (client *DictionaryClient) GetNullValue(ctx context.Context) (*MapOfStringR
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullValueHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullValueHandleResponse(resp)
@@ -2336,15 +2477,15 @@ func (client *DictionaryClient) GetNullValueCreateRequest(ctx context.Context) (
 
 // GetNullValueHandleResponse handles the GetNullValue response.
 func (client *DictionaryClient) GetNullValueHandleResponse(resp *azcore.Response) (*MapOfStringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullValueHandleError(resp)
-	}
 	result := MapOfStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNullValueHandleError handles the GetNullValue error response.
 func (client *DictionaryClient) GetNullValueHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2360,6 +2501,9 @@ func (client *DictionaryClient) GetStringValid(ctx context.Context) (*MapOfStrin
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetStringValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetStringValidHandleResponse(resp)
@@ -2382,15 +2526,15 @@ func (client *DictionaryClient) GetStringValidCreateRequest(ctx context.Context)
 
 // GetStringValidHandleResponse handles the GetStringValid response.
 func (client *DictionaryClient) GetStringValidHandleResponse(resp *azcore.Response) (*MapOfStringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetStringValidHandleError(resp)
-	}
 	result := MapOfStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetStringValidHandleError handles the GetStringValid error response.
 func (client *DictionaryClient) GetStringValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2406,6 +2550,9 @@ func (client *DictionaryClient) GetStringWithInvalid(ctx context.Context) (*MapO
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetStringWithInvalidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetStringWithInvalidHandleResponse(resp)
@@ -2428,15 +2575,15 @@ func (client *DictionaryClient) GetStringWithInvalidCreateRequest(ctx context.Co
 
 // GetStringWithInvalidHandleResponse handles the GetStringWithInvalid response.
 func (client *DictionaryClient) GetStringWithInvalidHandleResponse(resp *azcore.Response) (*MapOfStringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetStringWithInvalidHandleError(resp)
-	}
 	result := MapOfStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetStringWithInvalidHandleError handles the GetStringWithInvalid error response.
 func (client *DictionaryClient) GetStringWithInvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2452,6 +2599,9 @@ func (client *DictionaryClient) GetStringWithNull(ctx context.Context) (*MapOfSt
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetStringWithNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetStringWithNullHandleResponse(resp)
@@ -2474,15 +2624,15 @@ func (client *DictionaryClient) GetStringWithNullCreateRequest(ctx context.Conte
 
 // GetStringWithNullHandleResponse handles the GetStringWithNull response.
 func (client *DictionaryClient) GetStringWithNullHandleResponse(resp *azcore.Response) (*MapOfStringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetStringWithNullHandleError(resp)
-	}
 	result := MapOfStringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetStringWithNullHandleError handles the GetStringWithNull error response.
 func (client *DictionaryClient) GetStringWithNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2500,11 +2650,10 @@ func (client *DictionaryClient) PutArrayValid(ctx context.Context, arrayBody map
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutArrayValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutArrayValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutArrayValidCreateRequest creates the PutArrayValid request.
@@ -2518,16 +2667,11 @@ func (client *DictionaryClient) PutArrayValidCreateRequest(ctx context.Context, 
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutArrayValidHandleResponse handles the PutArrayValid response.
-func (client *DictionaryClient) PutArrayValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutArrayValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutArrayValidHandleError handles the PutArrayValid error response.
 func (client *DictionaryClient) PutArrayValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2545,11 +2689,10 @@ func (client *DictionaryClient) PutBooleanTfft(ctx context.Context, arrayBody ma
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutBooleanTfftHandleResponse(resp)
-	if err != nil {
+	if err := client.PutBooleanTfftHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutBooleanTfftCreateRequest creates the PutBooleanTfft request.
@@ -2563,16 +2706,11 @@ func (client *DictionaryClient) PutBooleanTfftCreateRequest(ctx context.Context,
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutBooleanTfftHandleResponse handles the PutBooleanTfft response.
-func (client *DictionaryClient) PutBooleanTfftHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutBooleanTfftHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutBooleanTfftHandleError handles the PutBooleanTfft error response.
 func (client *DictionaryClient) PutBooleanTfftHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2590,11 +2728,10 @@ func (client *DictionaryClient) PutByteValid(ctx context.Context, arrayBody map[
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutByteValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutByteValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutByteValidCreateRequest creates the PutByteValid request.
@@ -2608,16 +2745,11 @@ func (client *DictionaryClient) PutByteValidCreateRequest(ctx context.Context, a
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutByteValidHandleResponse handles the PutByteValid response.
-func (client *DictionaryClient) PutByteValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutByteValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutByteValidHandleError handles the PutByteValid error response.
 func (client *DictionaryClient) PutByteValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2635,11 +2767,10 @@ func (client *DictionaryClient) PutComplexValid(ctx context.Context, arrayBody m
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutComplexValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutComplexValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutComplexValidCreateRequest creates the PutComplexValid request.
@@ -2653,16 +2784,11 @@ func (client *DictionaryClient) PutComplexValidCreateRequest(ctx context.Context
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutComplexValidHandleResponse handles the PutComplexValid response.
-func (client *DictionaryClient) PutComplexValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutComplexValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutComplexValidHandleError handles the PutComplexValid error response.
 func (client *DictionaryClient) PutComplexValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2680,11 +2806,10 @@ func (client *DictionaryClient) PutDateTimeRFC1123Valid(ctx context.Context, arr
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDateTimeRFC1123ValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDateTimeRFC1123ValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDateTimeRFC1123ValidCreateRequest creates the PutDateTimeRFC1123Valid request.
@@ -2702,16 +2827,11 @@ func (client *DictionaryClient) PutDateTimeRFC1123ValidCreateRequest(ctx context
 	return req, req.MarshalAsJSON(aux)
 }
 
-// PutDateTimeRFC1123ValidHandleResponse handles the PutDateTimeRFC1123Valid response.
-func (client *DictionaryClient) PutDateTimeRFC1123ValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDateTimeRFC1123ValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDateTimeRFC1123ValidHandleError handles the PutDateTimeRFC1123Valid error response.
 func (client *DictionaryClient) PutDateTimeRFC1123ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2729,11 +2849,10 @@ func (client *DictionaryClient) PutDateTimeValid(ctx context.Context, arrayBody 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDateTimeValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDateTimeValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDateTimeValidCreateRequest creates the PutDateTimeValid request.
@@ -2751,16 +2870,11 @@ func (client *DictionaryClient) PutDateTimeValidCreateRequest(ctx context.Contex
 	return req, req.MarshalAsJSON(aux)
 }
 
-// PutDateTimeValidHandleResponse handles the PutDateTimeValid response.
-func (client *DictionaryClient) PutDateTimeValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDateTimeValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDateTimeValidHandleError handles the PutDateTimeValid error response.
 func (client *DictionaryClient) PutDateTimeValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2778,11 +2892,10 @@ func (client *DictionaryClient) PutDateValid(ctx context.Context, arrayBody map[
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDateValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDateValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDateValidCreateRequest creates the PutDateValid request.
@@ -2796,16 +2909,11 @@ func (client *DictionaryClient) PutDateValidCreateRequest(ctx context.Context, a
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutDateValidHandleResponse handles the PutDateValid response.
-func (client *DictionaryClient) PutDateValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDateValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDateValidHandleError handles the PutDateValid error response.
 func (client *DictionaryClient) PutDateValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2823,11 +2931,10 @@ func (client *DictionaryClient) PutDictionaryValid(ctx context.Context, arrayBod
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDictionaryValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDictionaryValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDictionaryValidCreateRequest creates the PutDictionaryValid request.
@@ -2841,16 +2948,11 @@ func (client *DictionaryClient) PutDictionaryValidCreateRequest(ctx context.Cont
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutDictionaryValidHandleResponse handles the PutDictionaryValid response.
-func (client *DictionaryClient) PutDictionaryValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDictionaryValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDictionaryValidHandleError handles the PutDictionaryValid error response.
 func (client *DictionaryClient) PutDictionaryValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2868,11 +2970,10 @@ func (client *DictionaryClient) PutDoubleValid(ctx context.Context, arrayBody ma
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDoubleValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDoubleValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDoubleValidCreateRequest creates the PutDoubleValid request.
@@ -2886,16 +2987,11 @@ func (client *DictionaryClient) PutDoubleValidCreateRequest(ctx context.Context,
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutDoubleValidHandleResponse handles the PutDoubleValid response.
-func (client *DictionaryClient) PutDoubleValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDoubleValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDoubleValidHandleError handles the PutDoubleValid error response.
 func (client *DictionaryClient) PutDoubleValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2913,11 +3009,10 @@ func (client *DictionaryClient) PutDurationValid(ctx context.Context, arrayBody 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutDurationValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutDurationValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutDurationValidCreateRequest creates the PutDurationValid request.
@@ -2931,16 +3026,11 @@ func (client *DictionaryClient) PutDurationValidCreateRequest(ctx context.Contex
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutDurationValidHandleResponse handles the PutDurationValid response.
-func (client *DictionaryClient) PutDurationValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutDurationValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutDurationValidHandleError handles the PutDurationValid error response.
 func (client *DictionaryClient) PutDurationValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2958,11 +3048,10 @@ func (client *DictionaryClient) PutEmpty(ctx context.Context, arrayBody map[stri
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutEmptyHandleResponse(resp)
-	if err != nil {
+	if err := client.PutEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutEmptyCreateRequest creates the PutEmpty request.
@@ -2976,16 +3065,11 @@ func (client *DictionaryClient) PutEmptyCreateRequest(ctx context.Context, array
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutEmptyHandleResponse handles the PutEmpty response.
-func (client *DictionaryClient) PutEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutEmptyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutEmptyHandleError handles the PutEmpty error response.
 func (client *DictionaryClient) PutEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3003,11 +3087,10 @@ func (client *DictionaryClient) PutFloatValid(ctx context.Context, arrayBody map
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutFloatValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutFloatValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutFloatValidCreateRequest creates the PutFloatValid request.
@@ -3021,16 +3104,11 @@ func (client *DictionaryClient) PutFloatValidCreateRequest(ctx context.Context, 
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutFloatValidHandleResponse handles the PutFloatValid response.
-func (client *DictionaryClient) PutFloatValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutFloatValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutFloatValidHandleError handles the PutFloatValid error response.
 func (client *DictionaryClient) PutFloatValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3048,11 +3126,10 @@ func (client *DictionaryClient) PutIntegerValid(ctx context.Context, arrayBody m
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutIntegerValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutIntegerValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutIntegerValidCreateRequest creates the PutIntegerValid request.
@@ -3066,16 +3143,11 @@ func (client *DictionaryClient) PutIntegerValidCreateRequest(ctx context.Context
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutIntegerValidHandleResponse handles the PutIntegerValid response.
-func (client *DictionaryClient) PutIntegerValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutIntegerValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutIntegerValidHandleError handles the PutIntegerValid error response.
 func (client *DictionaryClient) PutIntegerValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3093,11 +3165,10 @@ func (client *DictionaryClient) PutLongValid(ctx context.Context, arrayBody map[
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutLongValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutLongValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutLongValidCreateRequest creates the PutLongValid request.
@@ -3111,16 +3182,11 @@ func (client *DictionaryClient) PutLongValidCreateRequest(ctx context.Context, a
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutLongValidHandleResponse handles the PutLongValid response.
-func (client *DictionaryClient) PutLongValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutLongValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutLongValidHandleError handles the PutLongValid error response.
 func (client *DictionaryClient) PutLongValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3138,11 +3204,10 @@ func (client *DictionaryClient) PutStringValid(ctx context.Context, arrayBody ma
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutStringValidHandleResponse(resp)
-	if err != nil {
+	if err := client.PutStringValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutStringValidCreateRequest creates the PutStringValid request.
@@ -3156,16 +3221,11 @@ func (client *DictionaryClient) PutStringValidCreateRequest(ctx context.Context,
 	return req, req.MarshalAsJSON(arrayBody)
 }
 
-// PutStringValidHandleResponse handles the PutStringValid response.
-func (client *DictionaryClient) PutStringValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutStringValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutStringValidHandleError handles the PutStringValid error response.
 func (client *DictionaryClient) PutStringValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/dictionarygroup/zz_generated_dictionary.go
+++ b/test/autorest/dictionarygroup/zz_generated_dictionary.go
@@ -172,8 +172,8 @@ func (client *DictionaryClient) GetArrayEmpty(ctx context.Context) (*MapOfString
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetArrayEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetArrayEmptyHandleError(resp)
 	}
 	result, err := client.GetArrayEmptyHandleResponse(resp)
 	if err != nil {
@@ -201,9 +201,6 @@ func (client *DictionaryClient) GetArrayEmptyHandleResponse(resp *azcore.Respons
 
 // GetArrayEmptyHandleError handles the GetArrayEmpty error response.
 func (client *DictionaryClient) GetArrayEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -221,8 +218,8 @@ func (client *DictionaryClient) GetArrayItemEmpty(ctx context.Context) (*MapOfSt
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetArrayItemEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetArrayItemEmptyHandleError(resp)
 	}
 	result, err := client.GetArrayItemEmptyHandleResponse(resp)
 	if err != nil {
@@ -250,9 +247,6 @@ func (client *DictionaryClient) GetArrayItemEmptyHandleResponse(resp *azcore.Res
 
 // GetArrayItemEmptyHandleError handles the GetArrayItemEmpty error response.
 func (client *DictionaryClient) GetArrayItemEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -270,8 +264,8 @@ func (client *DictionaryClient) GetArrayItemNull(ctx context.Context) (*MapOfStr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetArrayItemNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetArrayItemNullHandleError(resp)
 	}
 	result, err := client.GetArrayItemNullHandleResponse(resp)
 	if err != nil {
@@ -299,9 +293,6 @@ func (client *DictionaryClient) GetArrayItemNullHandleResponse(resp *azcore.Resp
 
 // GetArrayItemNullHandleError handles the GetArrayItemNull error response.
 func (client *DictionaryClient) GetArrayItemNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -319,8 +310,8 @@ func (client *DictionaryClient) GetArrayNull(ctx context.Context) (*MapOfStringA
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetArrayNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetArrayNullHandleError(resp)
 	}
 	result, err := client.GetArrayNullHandleResponse(resp)
 	if err != nil {
@@ -348,9 +339,6 @@ func (client *DictionaryClient) GetArrayNullHandleResponse(resp *azcore.Response
 
 // GetArrayNullHandleError handles the GetArrayNull error response.
 func (client *DictionaryClient) GetArrayNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -368,8 +356,8 @@ func (client *DictionaryClient) GetArrayValid(ctx context.Context) (*MapOfString
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetArrayValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetArrayValidHandleError(resp)
 	}
 	result, err := client.GetArrayValidHandleResponse(resp)
 	if err != nil {
@@ -397,9 +385,6 @@ func (client *DictionaryClient) GetArrayValidHandleResponse(resp *azcore.Respons
 
 // GetArrayValidHandleError handles the GetArrayValid error response.
 func (client *DictionaryClient) GetArrayValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -417,8 +402,8 @@ func (client *DictionaryClient) GetBase64URL(ctx context.Context) (*MapOfByteArr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBase64URLHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBase64URLHandleError(resp)
 	}
 	result, err := client.GetBase64URLHandleResponse(resp)
 	if err != nil {
@@ -446,9 +431,6 @@ func (client *DictionaryClient) GetBase64URLHandleResponse(resp *azcore.Response
 
 // GetBase64URLHandleError handles the GetBase64URL error response.
 func (client *DictionaryClient) GetBase64URLHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -466,8 +448,8 @@ func (client *DictionaryClient) GetBooleanInvalidNull(ctx context.Context) (*Map
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBooleanInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBooleanInvalidNullHandleError(resp)
 	}
 	result, err := client.GetBooleanInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -495,9 +477,6 @@ func (client *DictionaryClient) GetBooleanInvalidNullHandleResponse(resp *azcore
 
 // GetBooleanInvalidNullHandleError handles the GetBooleanInvalidNull error response.
 func (client *DictionaryClient) GetBooleanInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -515,8 +494,8 @@ func (client *DictionaryClient) GetBooleanInvalidString(ctx context.Context) (*M
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBooleanInvalidStringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBooleanInvalidStringHandleError(resp)
 	}
 	result, err := client.GetBooleanInvalidStringHandleResponse(resp)
 	if err != nil {
@@ -544,9 +523,6 @@ func (client *DictionaryClient) GetBooleanInvalidStringHandleResponse(resp *azco
 
 // GetBooleanInvalidStringHandleError handles the GetBooleanInvalidString error response.
 func (client *DictionaryClient) GetBooleanInvalidStringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -564,8 +540,8 @@ func (client *DictionaryClient) GetBooleanTfft(ctx context.Context) (*MapOfBoolR
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBooleanTfftHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBooleanTfftHandleError(resp)
 	}
 	result, err := client.GetBooleanTfftHandleResponse(resp)
 	if err != nil {
@@ -593,9 +569,6 @@ func (client *DictionaryClient) GetBooleanTfftHandleResponse(resp *azcore.Respon
 
 // GetBooleanTfftHandleError handles the GetBooleanTfft error response.
 func (client *DictionaryClient) GetBooleanTfftHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -613,8 +586,8 @@ func (client *DictionaryClient) GetByteInvalidNull(ctx context.Context) (*MapOfB
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetByteInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetByteInvalidNullHandleError(resp)
 	}
 	result, err := client.GetByteInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -642,9 +615,6 @@ func (client *DictionaryClient) GetByteInvalidNullHandleResponse(resp *azcore.Re
 
 // GetByteInvalidNullHandleError handles the GetByteInvalidNull error response.
 func (client *DictionaryClient) GetByteInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -662,8 +632,8 @@ func (client *DictionaryClient) GetByteValid(ctx context.Context) (*MapOfByteArr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetByteValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetByteValidHandleError(resp)
 	}
 	result, err := client.GetByteValidHandleResponse(resp)
 	if err != nil {
@@ -691,9 +661,6 @@ func (client *DictionaryClient) GetByteValidHandleResponse(resp *azcore.Response
 
 // GetByteValidHandleError handles the GetByteValid error response.
 func (client *DictionaryClient) GetByteValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -711,8 +678,8 @@ func (client *DictionaryClient) GetComplexEmpty(ctx context.Context) (*MapOfWidg
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetComplexEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetComplexEmptyHandleError(resp)
 	}
 	result, err := client.GetComplexEmptyHandleResponse(resp)
 	if err != nil {
@@ -740,9 +707,6 @@ func (client *DictionaryClient) GetComplexEmptyHandleResponse(resp *azcore.Respo
 
 // GetComplexEmptyHandleError handles the GetComplexEmpty error response.
 func (client *DictionaryClient) GetComplexEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -760,8 +724,8 @@ func (client *DictionaryClient) GetComplexItemEmpty(ctx context.Context) (*MapOf
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetComplexItemEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetComplexItemEmptyHandleError(resp)
 	}
 	result, err := client.GetComplexItemEmptyHandleResponse(resp)
 	if err != nil {
@@ -789,9 +753,6 @@ func (client *DictionaryClient) GetComplexItemEmptyHandleResponse(resp *azcore.R
 
 // GetComplexItemEmptyHandleError handles the GetComplexItemEmpty error response.
 func (client *DictionaryClient) GetComplexItemEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -809,8 +770,8 @@ func (client *DictionaryClient) GetComplexItemNull(ctx context.Context) (*MapOfW
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetComplexItemNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetComplexItemNullHandleError(resp)
 	}
 	result, err := client.GetComplexItemNullHandleResponse(resp)
 	if err != nil {
@@ -838,9 +799,6 @@ func (client *DictionaryClient) GetComplexItemNullHandleResponse(resp *azcore.Re
 
 // GetComplexItemNullHandleError handles the GetComplexItemNull error response.
 func (client *DictionaryClient) GetComplexItemNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -858,8 +816,8 @@ func (client *DictionaryClient) GetComplexNull(ctx context.Context) (*MapOfWidge
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetComplexNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetComplexNullHandleError(resp)
 	}
 	result, err := client.GetComplexNullHandleResponse(resp)
 	if err != nil {
@@ -887,9 +845,6 @@ func (client *DictionaryClient) GetComplexNullHandleResponse(resp *azcore.Respon
 
 // GetComplexNullHandleError handles the GetComplexNull error response.
 func (client *DictionaryClient) GetComplexNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -907,8 +862,8 @@ func (client *DictionaryClient) GetComplexValid(ctx context.Context) (*MapOfWidg
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetComplexValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetComplexValidHandleError(resp)
 	}
 	result, err := client.GetComplexValidHandleResponse(resp)
 	if err != nil {
@@ -936,9 +891,6 @@ func (client *DictionaryClient) GetComplexValidHandleResponse(resp *azcore.Respo
 
 // GetComplexValidHandleError handles the GetComplexValid error response.
 func (client *DictionaryClient) GetComplexValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -956,8 +908,8 @@ func (client *DictionaryClient) GetDateInvalidChars(ctx context.Context) (*MapOf
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateInvalidCharsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateInvalidCharsHandleError(resp)
 	}
 	result, err := client.GetDateInvalidCharsHandleResponse(resp)
 	if err != nil {
@@ -985,9 +937,6 @@ func (client *DictionaryClient) GetDateInvalidCharsHandleResponse(resp *azcore.R
 
 // GetDateInvalidCharsHandleError handles the GetDateInvalidChars error response.
 func (client *DictionaryClient) GetDateInvalidCharsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1005,8 +954,8 @@ func (client *DictionaryClient) GetDateInvalidNull(ctx context.Context) (*MapOfT
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateInvalidNullHandleError(resp)
 	}
 	result, err := client.GetDateInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -1034,9 +983,6 @@ func (client *DictionaryClient) GetDateInvalidNullHandleResponse(resp *azcore.Re
 
 // GetDateInvalidNullHandleError handles the GetDateInvalidNull error response.
 func (client *DictionaryClient) GetDateInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1054,8 +1000,8 @@ func (client *DictionaryClient) GetDateTimeInvalidChars(ctx context.Context) (*M
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateTimeInvalidCharsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateTimeInvalidCharsHandleError(resp)
 	}
 	result, err := client.GetDateTimeInvalidCharsHandleResponse(resp)
 	if err != nil {
@@ -1090,9 +1036,6 @@ func (client *DictionaryClient) GetDateTimeInvalidCharsHandleResponse(resp *azco
 
 // GetDateTimeInvalidCharsHandleError handles the GetDateTimeInvalidChars error response.
 func (client *DictionaryClient) GetDateTimeInvalidCharsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1110,8 +1053,8 @@ func (client *DictionaryClient) GetDateTimeInvalidNull(ctx context.Context) (*Ma
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateTimeInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateTimeInvalidNullHandleError(resp)
 	}
 	result, err := client.GetDateTimeInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -1146,9 +1089,6 @@ func (client *DictionaryClient) GetDateTimeInvalidNullHandleResponse(resp *azcor
 
 // GetDateTimeInvalidNullHandleError handles the GetDateTimeInvalidNull error response.
 func (client *DictionaryClient) GetDateTimeInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1166,8 +1106,8 @@ func (client *DictionaryClient) GetDateTimeRFC1123Valid(ctx context.Context) (*M
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateTimeRFC1123ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateTimeRFC1123ValidHandleError(resp)
 	}
 	result, err := client.GetDateTimeRFC1123ValidHandleResponse(resp)
 	if err != nil {
@@ -1202,9 +1142,6 @@ func (client *DictionaryClient) GetDateTimeRFC1123ValidHandleResponse(resp *azco
 
 // GetDateTimeRFC1123ValidHandleError handles the GetDateTimeRFC1123Valid error response.
 func (client *DictionaryClient) GetDateTimeRFC1123ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1222,8 +1159,8 @@ func (client *DictionaryClient) GetDateTimeValid(ctx context.Context) (*MapOfTim
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateTimeValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateTimeValidHandleError(resp)
 	}
 	result, err := client.GetDateTimeValidHandleResponse(resp)
 	if err != nil {
@@ -1258,9 +1195,6 @@ func (client *DictionaryClient) GetDateTimeValidHandleResponse(resp *azcore.Resp
 
 // GetDateTimeValidHandleError handles the GetDateTimeValid error response.
 func (client *DictionaryClient) GetDateTimeValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1278,8 +1212,8 @@ func (client *DictionaryClient) GetDateValid(ctx context.Context) (*MapOfTimeRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDateValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDateValidHandleError(resp)
 	}
 	result, err := client.GetDateValidHandleResponse(resp)
 	if err != nil {
@@ -1307,9 +1241,6 @@ func (client *DictionaryClient) GetDateValidHandleResponse(resp *azcore.Response
 
 // GetDateValidHandleError handles the GetDateValid error response.
 func (client *DictionaryClient) GetDateValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1327,8 +1258,8 @@ func (client *DictionaryClient) GetDictionaryEmpty(ctx context.Context) (*MapOfI
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDictionaryEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDictionaryEmptyHandleError(resp)
 	}
 	result, err := client.GetDictionaryEmptyHandleResponse(resp)
 	if err != nil {
@@ -1356,9 +1287,6 @@ func (client *DictionaryClient) GetDictionaryEmptyHandleResponse(resp *azcore.Re
 
 // GetDictionaryEmptyHandleError handles the GetDictionaryEmpty error response.
 func (client *DictionaryClient) GetDictionaryEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1376,8 +1304,8 @@ func (client *DictionaryClient) GetDictionaryItemEmpty(ctx context.Context) (*Ma
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDictionaryItemEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDictionaryItemEmptyHandleError(resp)
 	}
 	result, err := client.GetDictionaryItemEmptyHandleResponse(resp)
 	if err != nil {
@@ -1405,9 +1333,6 @@ func (client *DictionaryClient) GetDictionaryItemEmptyHandleResponse(resp *azcor
 
 // GetDictionaryItemEmptyHandleError handles the GetDictionaryItemEmpty error response.
 func (client *DictionaryClient) GetDictionaryItemEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1425,8 +1350,8 @@ func (client *DictionaryClient) GetDictionaryItemNull(ctx context.Context) (*Map
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDictionaryItemNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDictionaryItemNullHandleError(resp)
 	}
 	result, err := client.GetDictionaryItemNullHandleResponse(resp)
 	if err != nil {
@@ -1454,9 +1379,6 @@ func (client *DictionaryClient) GetDictionaryItemNullHandleResponse(resp *azcore
 
 // GetDictionaryItemNullHandleError handles the GetDictionaryItemNull error response.
 func (client *DictionaryClient) GetDictionaryItemNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1474,8 +1396,8 @@ func (client *DictionaryClient) GetDictionaryNull(ctx context.Context) (*MapOfIn
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDictionaryNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDictionaryNullHandleError(resp)
 	}
 	result, err := client.GetDictionaryNullHandleResponse(resp)
 	if err != nil {
@@ -1503,9 +1425,6 @@ func (client *DictionaryClient) GetDictionaryNullHandleResponse(resp *azcore.Res
 
 // GetDictionaryNullHandleError handles the GetDictionaryNull error response.
 func (client *DictionaryClient) GetDictionaryNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1523,8 +1442,8 @@ func (client *DictionaryClient) GetDictionaryValid(ctx context.Context) (*MapOfI
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDictionaryValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDictionaryValidHandleError(resp)
 	}
 	result, err := client.GetDictionaryValidHandleResponse(resp)
 	if err != nil {
@@ -1552,9 +1471,6 @@ func (client *DictionaryClient) GetDictionaryValidHandleResponse(resp *azcore.Re
 
 // GetDictionaryValidHandleError handles the GetDictionaryValid error response.
 func (client *DictionaryClient) GetDictionaryValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1572,8 +1488,8 @@ func (client *DictionaryClient) GetDoubleInvalidNull(ctx context.Context) (*MapO
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDoubleInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDoubleInvalidNullHandleError(resp)
 	}
 	result, err := client.GetDoubleInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -1601,9 +1517,6 @@ func (client *DictionaryClient) GetDoubleInvalidNullHandleResponse(resp *azcore.
 
 // GetDoubleInvalidNullHandleError handles the GetDoubleInvalidNull error response.
 func (client *DictionaryClient) GetDoubleInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1621,8 +1534,8 @@ func (client *DictionaryClient) GetDoubleInvalidString(ctx context.Context) (*Ma
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDoubleInvalidStringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDoubleInvalidStringHandleError(resp)
 	}
 	result, err := client.GetDoubleInvalidStringHandleResponse(resp)
 	if err != nil {
@@ -1650,9 +1563,6 @@ func (client *DictionaryClient) GetDoubleInvalidStringHandleResponse(resp *azcor
 
 // GetDoubleInvalidStringHandleError handles the GetDoubleInvalidString error response.
 func (client *DictionaryClient) GetDoubleInvalidStringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1670,8 +1580,8 @@ func (client *DictionaryClient) GetDoubleValid(ctx context.Context) (*MapOfFloat
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDoubleValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDoubleValidHandleError(resp)
 	}
 	result, err := client.GetDoubleValidHandleResponse(resp)
 	if err != nil {
@@ -1699,9 +1609,6 @@ func (client *DictionaryClient) GetDoubleValidHandleResponse(resp *azcore.Respon
 
 // GetDoubleValidHandleError handles the GetDoubleValid error response.
 func (client *DictionaryClient) GetDoubleValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1719,8 +1626,8 @@ func (client *DictionaryClient) GetDurationValid(ctx context.Context) (*MapOfStr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDurationValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDurationValidHandleError(resp)
 	}
 	result, err := client.GetDurationValidHandleResponse(resp)
 	if err != nil {
@@ -1748,9 +1655,6 @@ func (client *DictionaryClient) GetDurationValidHandleResponse(resp *azcore.Resp
 
 // GetDurationValidHandleError handles the GetDurationValid error response.
 func (client *DictionaryClient) GetDurationValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1768,8 +1672,8 @@ func (client *DictionaryClient) GetEmpty(ctx context.Context) (*MapOfInt32Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyHandleError(resp)
 	}
 	result, err := client.GetEmptyHandleResponse(resp)
 	if err != nil {
@@ -1797,9 +1701,6 @@ func (client *DictionaryClient) GetEmptyHandleResponse(resp *azcore.Response) (*
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *DictionaryClient) GetEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1817,8 +1718,8 @@ func (client *DictionaryClient) GetEmptyStringKey(ctx context.Context) (*MapOfSt
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyStringKeyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyStringKeyHandleError(resp)
 	}
 	result, err := client.GetEmptyStringKeyHandleResponse(resp)
 	if err != nil {
@@ -1846,9 +1747,6 @@ func (client *DictionaryClient) GetEmptyStringKeyHandleResponse(resp *azcore.Res
 
 // GetEmptyStringKeyHandleError handles the GetEmptyStringKey error response.
 func (client *DictionaryClient) GetEmptyStringKeyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1866,8 +1764,8 @@ func (client *DictionaryClient) GetFloatInvalidNull(ctx context.Context) (*MapOf
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetFloatInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetFloatInvalidNullHandleError(resp)
 	}
 	result, err := client.GetFloatInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -1895,9 +1793,6 @@ func (client *DictionaryClient) GetFloatInvalidNullHandleResponse(resp *azcore.R
 
 // GetFloatInvalidNullHandleError handles the GetFloatInvalidNull error response.
 func (client *DictionaryClient) GetFloatInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1915,8 +1810,8 @@ func (client *DictionaryClient) GetFloatInvalidString(ctx context.Context) (*Map
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetFloatInvalidStringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetFloatInvalidStringHandleError(resp)
 	}
 	result, err := client.GetFloatInvalidStringHandleResponse(resp)
 	if err != nil {
@@ -1944,9 +1839,6 @@ func (client *DictionaryClient) GetFloatInvalidStringHandleResponse(resp *azcore
 
 // GetFloatInvalidStringHandleError handles the GetFloatInvalidString error response.
 func (client *DictionaryClient) GetFloatInvalidStringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1964,8 +1856,8 @@ func (client *DictionaryClient) GetFloatValid(ctx context.Context) (*MapOfFloat3
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetFloatValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetFloatValidHandleError(resp)
 	}
 	result, err := client.GetFloatValidHandleResponse(resp)
 	if err != nil {
@@ -1993,9 +1885,6 @@ func (client *DictionaryClient) GetFloatValidHandleResponse(resp *azcore.Respons
 
 // GetFloatValidHandleError handles the GetFloatValid error response.
 func (client *DictionaryClient) GetFloatValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2013,8 +1902,8 @@ func (client *DictionaryClient) GetIntInvalidNull(ctx context.Context) (*MapOfIn
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetIntInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetIntInvalidNullHandleError(resp)
 	}
 	result, err := client.GetIntInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -2042,9 +1931,6 @@ func (client *DictionaryClient) GetIntInvalidNullHandleResponse(resp *azcore.Res
 
 // GetIntInvalidNullHandleError handles the GetIntInvalidNull error response.
 func (client *DictionaryClient) GetIntInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2062,8 +1948,8 @@ func (client *DictionaryClient) GetIntInvalidString(ctx context.Context) (*MapOf
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetIntInvalidStringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetIntInvalidStringHandleError(resp)
 	}
 	result, err := client.GetIntInvalidStringHandleResponse(resp)
 	if err != nil {
@@ -2091,9 +1977,6 @@ func (client *DictionaryClient) GetIntInvalidStringHandleResponse(resp *azcore.R
 
 // GetIntInvalidStringHandleError handles the GetIntInvalidString error response.
 func (client *DictionaryClient) GetIntInvalidStringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2111,8 +1994,8 @@ func (client *DictionaryClient) GetIntegerValid(ctx context.Context) (*MapOfInt3
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetIntegerValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetIntegerValidHandleError(resp)
 	}
 	result, err := client.GetIntegerValidHandleResponse(resp)
 	if err != nil {
@@ -2140,9 +2023,6 @@ func (client *DictionaryClient) GetIntegerValidHandleResponse(resp *azcore.Respo
 
 // GetIntegerValidHandleError handles the GetIntegerValid error response.
 func (client *DictionaryClient) GetIntegerValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2160,8 +2040,8 @@ func (client *DictionaryClient) GetInvalid(ctx context.Context) (*MapOfStringRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetInvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetInvalidHandleError(resp)
 	}
 	result, err := client.GetInvalidHandleResponse(resp)
 	if err != nil {
@@ -2189,9 +2069,6 @@ func (client *DictionaryClient) GetInvalidHandleResponse(resp *azcore.Response) 
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *DictionaryClient) GetInvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2209,8 +2086,8 @@ func (client *DictionaryClient) GetLongInvalidNull(ctx context.Context) (*MapOfI
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLongInvalidNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLongInvalidNullHandleError(resp)
 	}
 	result, err := client.GetLongInvalidNullHandleResponse(resp)
 	if err != nil {
@@ -2238,9 +2115,6 @@ func (client *DictionaryClient) GetLongInvalidNullHandleResponse(resp *azcore.Re
 
 // GetLongInvalidNullHandleError handles the GetLongInvalidNull error response.
 func (client *DictionaryClient) GetLongInvalidNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2258,8 +2132,8 @@ func (client *DictionaryClient) GetLongInvalidString(ctx context.Context) (*MapO
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLongInvalidStringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLongInvalidStringHandleError(resp)
 	}
 	result, err := client.GetLongInvalidStringHandleResponse(resp)
 	if err != nil {
@@ -2287,9 +2161,6 @@ func (client *DictionaryClient) GetLongInvalidStringHandleResponse(resp *azcore.
 
 // GetLongInvalidStringHandleError handles the GetLongInvalidString error response.
 func (client *DictionaryClient) GetLongInvalidStringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2307,8 +2178,8 @@ func (client *DictionaryClient) GetLongValid(ctx context.Context) (*MapOfInt64Re
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLongValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLongValidHandleError(resp)
 	}
 	result, err := client.GetLongValidHandleResponse(resp)
 	if err != nil {
@@ -2336,9 +2207,6 @@ func (client *DictionaryClient) GetLongValidHandleResponse(resp *azcore.Response
 
 // GetLongValidHandleError handles the GetLongValid error response.
 func (client *DictionaryClient) GetLongValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2356,8 +2224,8 @@ func (client *DictionaryClient) GetNull(ctx context.Context) (*MapOfInt32Respons
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullHandleError(resp)
 	}
 	result, err := client.GetNullHandleResponse(resp)
 	if err != nil {
@@ -2385,9 +2253,6 @@ func (client *DictionaryClient) GetNullHandleResponse(resp *azcore.Response) (*M
 
 // GetNullHandleError handles the GetNull error response.
 func (client *DictionaryClient) GetNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2405,8 +2270,8 @@ func (client *DictionaryClient) GetNullKey(ctx context.Context) (*MapOfStringRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullKeyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullKeyHandleError(resp)
 	}
 	result, err := client.GetNullKeyHandleResponse(resp)
 	if err != nil {
@@ -2434,9 +2299,6 @@ func (client *DictionaryClient) GetNullKeyHandleResponse(resp *azcore.Response) 
 
 // GetNullKeyHandleError handles the GetNullKey error response.
 func (client *DictionaryClient) GetNullKeyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2454,8 +2316,8 @@ func (client *DictionaryClient) GetNullValue(ctx context.Context) (*MapOfStringR
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullValueHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullValueHandleError(resp)
 	}
 	result, err := client.GetNullValueHandleResponse(resp)
 	if err != nil {
@@ -2483,9 +2345,6 @@ func (client *DictionaryClient) GetNullValueHandleResponse(resp *azcore.Response
 
 // GetNullValueHandleError handles the GetNullValue error response.
 func (client *DictionaryClient) GetNullValueHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2503,8 +2362,8 @@ func (client *DictionaryClient) GetStringValid(ctx context.Context) (*MapOfStrin
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetStringValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetStringValidHandleError(resp)
 	}
 	result, err := client.GetStringValidHandleResponse(resp)
 	if err != nil {
@@ -2532,9 +2391,6 @@ func (client *DictionaryClient) GetStringValidHandleResponse(resp *azcore.Respon
 
 // GetStringValidHandleError handles the GetStringValid error response.
 func (client *DictionaryClient) GetStringValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2552,8 +2408,8 @@ func (client *DictionaryClient) GetStringWithInvalid(ctx context.Context) (*MapO
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetStringWithInvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetStringWithInvalidHandleError(resp)
 	}
 	result, err := client.GetStringWithInvalidHandleResponse(resp)
 	if err != nil {
@@ -2581,9 +2437,6 @@ func (client *DictionaryClient) GetStringWithInvalidHandleResponse(resp *azcore.
 
 // GetStringWithInvalidHandleError handles the GetStringWithInvalid error response.
 func (client *DictionaryClient) GetStringWithInvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2601,8 +2454,8 @@ func (client *DictionaryClient) GetStringWithNull(ctx context.Context) (*MapOfSt
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetStringWithNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetStringWithNullHandleError(resp)
 	}
 	result, err := client.GetStringWithNullHandleResponse(resp)
 	if err != nil {
@@ -2630,9 +2483,6 @@ func (client *DictionaryClient) GetStringWithNullHandleResponse(resp *azcore.Res
 
 // GetStringWithNullHandleError handles the GetStringWithNull error response.
 func (client *DictionaryClient) GetStringWithNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2650,8 +2500,8 @@ func (client *DictionaryClient) PutArrayValid(ctx context.Context, arrayBody map
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutArrayValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutArrayValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2669,9 +2519,6 @@ func (client *DictionaryClient) PutArrayValidCreateRequest(ctx context.Context, 
 
 // PutArrayValidHandleError handles the PutArrayValid error response.
 func (client *DictionaryClient) PutArrayValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2689,8 +2536,8 @@ func (client *DictionaryClient) PutBooleanTfft(ctx context.Context, arrayBody ma
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutBooleanTfftHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutBooleanTfftHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2708,9 +2555,6 @@ func (client *DictionaryClient) PutBooleanTfftCreateRequest(ctx context.Context,
 
 // PutBooleanTfftHandleError handles the PutBooleanTfft error response.
 func (client *DictionaryClient) PutBooleanTfftHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2728,8 +2572,8 @@ func (client *DictionaryClient) PutByteValid(ctx context.Context, arrayBody map[
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutByteValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutByteValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2747,9 +2591,6 @@ func (client *DictionaryClient) PutByteValidCreateRequest(ctx context.Context, a
 
 // PutByteValidHandleError handles the PutByteValid error response.
 func (client *DictionaryClient) PutByteValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2767,8 +2608,8 @@ func (client *DictionaryClient) PutComplexValid(ctx context.Context, arrayBody m
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutComplexValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutComplexValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2786,9 +2627,6 @@ func (client *DictionaryClient) PutComplexValidCreateRequest(ctx context.Context
 
 // PutComplexValidHandleError handles the PutComplexValid error response.
 func (client *DictionaryClient) PutComplexValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2806,8 +2644,8 @@ func (client *DictionaryClient) PutDateTimeRFC1123Valid(ctx context.Context, arr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDateTimeRFC1123ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDateTimeRFC1123ValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2829,9 +2667,6 @@ func (client *DictionaryClient) PutDateTimeRFC1123ValidCreateRequest(ctx context
 
 // PutDateTimeRFC1123ValidHandleError handles the PutDateTimeRFC1123Valid error response.
 func (client *DictionaryClient) PutDateTimeRFC1123ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2849,8 +2684,8 @@ func (client *DictionaryClient) PutDateTimeValid(ctx context.Context, arrayBody 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDateTimeValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDateTimeValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2872,9 +2707,6 @@ func (client *DictionaryClient) PutDateTimeValidCreateRequest(ctx context.Contex
 
 // PutDateTimeValidHandleError handles the PutDateTimeValid error response.
 func (client *DictionaryClient) PutDateTimeValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2892,8 +2724,8 @@ func (client *DictionaryClient) PutDateValid(ctx context.Context, arrayBody map[
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDateValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDateValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2911,9 +2743,6 @@ func (client *DictionaryClient) PutDateValidCreateRequest(ctx context.Context, a
 
 // PutDateValidHandleError handles the PutDateValid error response.
 func (client *DictionaryClient) PutDateValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2931,8 +2760,8 @@ func (client *DictionaryClient) PutDictionaryValid(ctx context.Context, arrayBod
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDictionaryValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDictionaryValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2950,9 +2779,6 @@ func (client *DictionaryClient) PutDictionaryValidCreateRequest(ctx context.Cont
 
 // PutDictionaryValidHandleError handles the PutDictionaryValid error response.
 func (client *DictionaryClient) PutDictionaryValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2970,8 +2796,8 @@ func (client *DictionaryClient) PutDoubleValid(ctx context.Context, arrayBody ma
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDoubleValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDoubleValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -2989,9 +2815,6 @@ func (client *DictionaryClient) PutDoubleValidCreateRequest(ctx context.Context,
 
 // PutDoubleValidHandleError handles the PutDoubleValid error response.
 func (client *DictionaryClient) PutDoubleValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3009,8 +2832,8 @@ func (client *DictionaryClient) PutDurationValid(ctx context.Context, arrayBody 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutDurationValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutDurationValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3028,9 +2851,6 @@ func (client *DictionaryClient) PutDurationValidCreateRequest(ctx context.Contex
 
 // PutDurationValidHandleError handles the PutDurationValid error response.
 func (client *DictionaryClient) PutDurationValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3048,8 +2868,8 @@ func (client *DictionaryClient) PutEmpty(ctx context.Context, arrayBody map[stri
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutEmptyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3067,9 +2887,6 @@ func (client *DictionaryClient) PutEmptyCreateRequest(ctx context.Context, array
 
 // PutEmptyHandleError handles the PutEmpty error response.
 func (client *DictionaryClient) PutEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3087,8 +2904,8 @@ func (client *DictionaryClient) PutFloatValid(ctx context.Context, arrayBody map
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutFloatValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutFloatValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3106,9 +2923,6 @@ func (client *DictionaryClient) PutFloatValidCreateRequest(ctx context.Context, 
 
 // PutFloatValidHandleError handles the PutFloatValid error response.
 func (client *DictionaryClient) PutFloatValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3126,8 +2940,8 @@ func (client *DictionaryClient) PutIntegerValid(ctx context.Context, arrayBody m
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutIntegerValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutIntegerValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3145,9 +2959,6 @@ func (client *DictionaryClient) PutIntegerValidCreateRequest(ctx context.Context
 
 // PutIntegerValidHandleError handles the PutIntegerValid error response.
 func (client *DictionaryClient) PutIntegerValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3165,8 +2976,8 @@ func (client *DictionaryClient) PutLongValid(ctx context.Context, arrayBody map[
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutLongValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutLongValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3184,9 +2995,6 @@ func (client *DictionaryClient) PutLongValidCreateRequest(ctx context.Context, a
 
 // PutLongValidHandleError handles the PutLongValid error response.
 func (client *DictionaryClient) PutLongValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3204,8 +3012,8 @@ func (client *DictionaryClient) PutStringValid(ctx context.Context, arrayBody ma
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutStringValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutStringValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -3223,9 +3031,6 @@ func (client *DictionaryClient) PutStringValidCreateRequest(ctx context.Context,
 
 // PutStringValidHandleError handles the PutStringValid error response.
 func (client *DictionaryClient) PutStringValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/durationgroup/zz_generated_duration.go
+++ b/test/autorest/durationgroup/zz_generated_duration.go
@@ -49,6 +49,9 @@ func (client *DurationClient) GetInvalid(ctx context.Context) (*StringResponse, 
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetInvalidHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetInvalidHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -69,15 +72,15 @@ func (client *DurationClient) GetInvalidCreateRequest(ctx context.Context) (*azc
 
 // GetInvalidHandleResponse handles the GetInvalid response.
 func (client *DurationClient) GetInvalidHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetInvalidHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *DurationClient) GetInvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -93,6 +96,9 @@ func (client *DurationClient) GetNull(ctx context.Context) (*StringResponse, err
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullHandleResponse(resp)
@@ -115,15 +121,15 @@ func (client *DurationClient) GetNullCreateRequest(ctx context.Context) (*azcore
 
 // GetNullHandleResponse handles the GetNull response.
 func (client *DurationClient) GetNullHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNullHandleError handles the GetNull error response.
 func (client *DurationClient) GetNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -139,6 +145,9 @@ func (client *DurationClient) GetPositiveDuration(ctx context.Context) (*StringR
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetPositiveDurationHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetPositiveDurationHandleResponse(resp)
@@ -161,15 +170,15 @@ func (client *DurationClient) GetPositiveDurationCreateRequest(ctx context.Conte
 
 // GetPositiveDurationHandleResponse handles the GetPositiveDuration response.
 func (client *DurationClient) GetPositiveDurationHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetPositiveDurationHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetPositiveDurationHandleError handles the GetPositiveDuration error response.
 func (client *DurationClient) GetPositiveDurationHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -187,11 +196,10 @@ func (client *DurationClient) PutPositiveDuration(ctx context.Context, durationB
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutPositiveDurationHandleResponse(resp)
-	if err != nil {
+	if err := client.PutPositiveDurationHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutPositiveDurationCreateRequest creates the PutPositiveDuration request.
@@ -205,16 +213,11 @@ func (client *DurationClient) PutPositiveDurationCreateRequest(ctx context.Conte
 	return req, req.MarshalAsJSON(durationBody)
 }
 
-// PutPositiveDurationHandleResponse handles the PutPositiveDuration response.
-func (client *DurationClient) PutPositiveDurationHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutPositiveDurationHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutPositiveDurationHandleError handles the PutPositiveDuration error response.
 func (client *DurationClient) PutPositiveDurationHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/durationgroup/zz_generated_duration.go
+++ b/test/autorest/durationgroup/zz_generated_duration.go
@@ -49,8 +49,8 @@ func (client *DurationClient) GetInvalid(ctx context.Context) (*StringResponse, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetInvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetInvalidHandleError(resp)
 	}
 	result, err := client.GetInvalidHandleResponse(resp)
 	if err != nil {
@@ -78,9 +78,6 @@ func (client *DurationClient) GetInvalidHandleResponse(resp *azcore.Response) (*
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *DurationClient) GetInvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -98,8 +95,8 @@ func (client *DurationClient) GetNull(ctx context.Context) (*StringResponse, err
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullHandleError(resp)
 	}
 	result, err := client.GetNullHandleResponse(resp)
 	if err != nil {
@@ -127,9 +124,6 @@ func (client *DurationClient) GetNullHandleResponse(resp *azcore.Response) (*Str
 
 // GetNullHandleError handles the GetNull error response.
 func (client *DurationClient) GetNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -147,8 +141,8 @@ func (client *DurationClient) GetPositiveDuration(ctx context.Context) (*StringR
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetPositiveDurationHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetPositiveDurationHandleError(resp)
 	}
 	result, err := client.GetPositiveDurationHandleResponse(resp)
 	if err != nil {
@@ -176,9 +170,6 @@ func (client *DurationClient) GetPositiveDurationHandleResponse(resp *azcore.Res
 
 // GetPositiveDurationHandleError handles the GetPositiveDuration error response.
 func (client *DurationClient) GetPositiveDurationHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -196,8 +187,8 @@ func (client *DurationClient) PutPositiveDuration(ctx context.Context, durationB
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutPositiveDurationHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutPositiveDurationHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -215,9 +206,6 @@ func (client *DurationClient) PutPositiveDurationCreateRequest(ctx context.Conte
 
 // PutPositiveDurationHandleError handles the PutPositiveDuration error response.
 func (client *DurationClient) PutPositiveDurationHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/errorsgroup/zz_generated_pet.go
+++ b/test/autorest/errorsgroup/zz_generated_pet.go
@@ -50,8 +50,8 @@ func (client *PetClient) DoSomething(ctx context.Context, whatAction string) (*P
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DoSomethingHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.DoSomethingHandleError(resp)
 	}
 	result, err := client.DoSomethingHandleResponse(resp)
 	if err != nil {
@@ -80,9 +80,6 @@ func (client *PetClient) DoSomethingHandleResponse(resp *azcore.Response) (*PetA
 
 // DoSomethingHandleError handles the DoSomething error response.
 func (client *PetClient) DoSomethingHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	switch resp.StatusCode {
 	case http.StatusInternalServerError:
 		var err petActionError
@@ -109,8 +106,8 @@ func (client *PetClient) GetPetByID(ctx context.Context, petId string) (*PetResp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetPetByIDHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetPetByIDHandleError(resp)
 	}
 	result, err := client.GetPetByIDHandleResponse(resp)
 	if err != nil {
@@ -139,9 +136,6 @@ func (client *PetClient) GetPetByIDHandleResponse(resp *azcore.Response) (*PetRe
 
 // GetPetByIDHandleError handles the GetPetByID error response.
 func (client *PetClient) GetPetByIDHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
-		return nil
-	}
 	switch resp.StatusCode {
 	case http.StatusBadRequest:
 		var err string

--- a/test/autorest/errorsgroup/zz_generated_pet.go
+++ b/test/autorest/errorsgroup/zz_generated_pet.go
@@ -50,6 +50,9 @@ func (client *PetClient) DoSomething(ctx context.Context, whatAction string) (*P
 	if err != nil {
 		return nil, err
 	}
+	if err := client.DoSomethingHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.DoSomethingHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -71,15 +74,15 @@ func (client *PetClient) DoSomethingCreateRequest(ctx context.Context, whatActio
 
 // DoSomethingHandleResponse handles the DoSomething response.
 func (client *PetClient) DoSomethingHandleResponse(resp *azcore.Response) (*PetActionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.DoSomethingHandleError(resp)
-	}
 	result := PetActionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PetAction)
 }
 
 // DoSomethingHandleError handles the DoSomething error response.
 func (client *PetClient) DoSomethingHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	switch resp.StatusCode {
 	case http.StatusInternalServerError:
 		var err petActionError
@@ -106,6 +109,9 @@ func (client *PetClient) GetPetByID(ctx context.Context, petId string) (*PetResp
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetPetByIDHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetPetByIDHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -127,15 +133,15 @@ func (client *PetClient) GetPetByIDCreateRequest(ctx context.Context, petId stri
 
 // GetPetByIDHandleResponse handles the GetPetByID response.
 func (client *PetClient) GetPetByIDHandleResponse(resp *azcore.Response) (*PetResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
-		return nil, client.GetPetByIDHandleError(resp)
-	}
 	result := PetResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Pet)
 }
 
 // GetPetByIDHandleError handles the GetPetByID error response.
 func (client *PetClient) GetPetByIDHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil
+	}
 	switch resp.StatusCode {
 	case http.StatusBadRequest:
 		var err string

--- a/test/autorest/extenumsgroup/zz_generated_pet.go
+++ b/test/autorest/extenumsgroup/zz_generated_pet.go
@@ -50,8 +50,8 @@ func (client *PetClient) AddPet(ctx context.Context, petAddPetOptions *PetAddPet
 	if err != nil {
 		return nil, err
 	}
-	if err := client.AddPetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.AddPetHandleError(resp)
 	}
 	result, err := client.AddPetHandleResponse(resp)
 	if err != nil {
@@ -82,9 +82,6 @@ func (client *PetClient) AddPetHandleResponse(resp *azcore.Response) (*PetRespon
 
 // AddPetHandleError handles the AddPet error response.
 func (client *PetClient) AddPetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -105,8 +102,8 @@ func (client *PetClient) GetByPetID(ctx context.Context, petId string) (*PetResp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetByPetIDHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetByPetIDHandleError(resp)
 	}
 	result, err := client.GetByPetIDHandleResponse(resp)
 	if err != nil {
@@ -135,9 +132,6 @@ func (client *PetClient) GetByPetIDHandleResponse(resp *azcore.Response) (*PetRe
 
 // GetByPetIDHandleError handles the GetByPetID error response.
 func (client *PetClient) GetByPetIDHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/extenumsgroup/zz_generated_pet.go
+++ b/test/autorest/extenumsgroup/zz_generated_pet.go
@@ -50,6 +50,9 @@ func (client *PetClient) AddPet(ctx context.Context, petAddPetOptions *PetAddPet
 	if err != nil {
 		return nil, err
 	}
+	if err := client.AddPetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.AddPetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -73,15 +76,15 @@ func (client *PetClient) AddPetCreateRequest(ctx context.Context, petAddPetOptio
 
 // AddPetHandleResponse handles the AddPet response.
 func (client *PetClient) AddPetHandleResponse(resp *azcore.Response) (*PetResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.AddPetHandleError(resp)
-	}
 	result := PetResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Pet)
 }
 
 // AddPetHandleError handles the AddPet error response.
 func (client *PetClient) AddPetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -100,6 +103,9 @@ func (client *PetClient) GetByPetID(ctx context.Context, petId string) (*PetResp
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetByPetIDHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetByPetIDHandleResponse(resp)
@@ -123,15 +129,15 @@ func (client *PetClient) GetByPetIDCreateRequest(ctx context.Context, petId stri
 
 // GetByPetIDHandleResponse handles the GetByPetID response.
 func (client *PetClient) GetByPetIDHandleResponse(resp *azcore.Response) (*PetResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetByPetIDHandleError(resp)
-	}
 	result := PetResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Pet)
 }
 
 // GetByPetIDHandleError handles the GetByPetID error response.
 func (client *PetClient) GetByPetIDHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/filegroup/zz_generated_files.go
+++ b/test/autorest/filegroup/zz_generated_files.go
@@ -47,8 +47,8 @@ func (client *FilesClient) GetEmptyFile(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyFileHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyFileHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -67,9 +67,6 @@ func (client *FilesClient) GetEmptyFileCreateRequest(ctx context.Context) (*azco
 
 // GetEmptyFileHandleError handles the GetEmptyFile error response.
 func (client *FilesClient) GetEmptyFileHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -87,8 +84,8 @@ func (client *FilesClient) GetFile(ctx context.Context) (*http.Response, error) 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetFileHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetFileHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -107,9 +104,6 @@ func (client *FilesClient) GetFileCreateRequest(ctx context.Context) (*azcore.Re
 
 // GetFileHandleError handles the GetFile error response.
 func (client *FilesClient) GetFileHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -127,8 +121,8 @@ func (client *FilesClient) GetFileLarge(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetFileLargeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetFileLargeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -147,9 +141,6 @@ func (client *FilesClient) GetFileLargeCreateRequest(ctx context.Context) (*azco
 
 // GetFileLargeHandleError handles the GetFileLarge error response.
 func (client *FilesClient) GetFileLargeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/filegroup/zz_generated_files.go
+++ b/test/autorest/filegroup/zz_generated_files.go
@@ -47,11 +47,10 @@ func (client *FilesClient) GetEmptyFile(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetEmptyFileHandleResponse(resp)
-	if err != nil {
+	if err := client.GetEmptyFileHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetEmptyFileCreateRequest creates the GetEmptyFile request.
@@ -66,16 +65,11 @@ func (client *FilesClient) GetEmptyFileCreateRequest(ctx context.Context) (*azco
 	return req, nil
 }
 
-// GetEmptyFileHandleResponse handles the GetEmptyFile response.
-func (client *FilesClient) GetEmptyFileHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyFileHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetEmptyFileHandleError handles the GetEmptyFile error response.
 func (client *FilesClient) GetEmptyFileHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -93,11 +87,10 @@ func (client *FilesClient) GetFile(ctx context.Context) (*http.Response, error) 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetFileHandleResponse(resp)
-	if err != nil {
+	if err := client.GetFileHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetFileCreateRequest creates the GetFile request.
@@ -112,16 +105,11 @@ func (client *FilesClient) GetFileCreateRequest(ctx context.Context) (*azcore.Re
 	return req, nil
 }
 
-// GetFileHandleResponse handles the GetFile response.
-func (client *FilesClient) GetFileHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetFileHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetFileHandleError handles the GetFile error response.
 func (client *FilesClient) GetFileHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -139,11 +127,10 @@ func (client *FilesClient) GetFileLarge(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetFileLargeHandleResponse(resp)
-	if err != nil {
+	if err := client.GetFileLargeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetFileLargeCreateRequest creates the GetFileLarge request.
@@ -158,16 +145,11 @@ func (client *FilesClient) GetFileLargeCreateRequest(ctx context.Context) (*azco
 	return req, nil
 }
 
-// GetFileLargeHandleResponse handles the GetFileLarge response.
-func (client *FilesClient) GetFileLargeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetFileLargeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetFileLargeHandleError handles the GetFileLarge error response.
 func (client *FilesClient) GetFileLargeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/headergroup/zz_generated_header.go
+++ b/test/autorest/headergroup/zz_generated_header.go
@@ -102,11 +102,10 @@ func (client *HeaderClient) CustomRequestID(ctx context.Context) (*http.Response
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.CustomRequestIDHandleResponse(resp)
-	if err != nil {
+	if err := client.CustomRequestIDHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // CustomRequestIDCreateRequest creates the CustomRequestID request.
@@ -120,16 +119,11 @@ func (client *HeaderClient) CustomRequestIDCreateRequest(ctx context.Context) (*
 	return req, nil
 }
 
-// CustomRequestIDHandleResponse handles the CustomRequestID response.
-func (client *HeaderClient) CustomRequestIDHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.CustomRequestIDHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // CustomRequestIDHandleError handles the CustomRequestID error response.
 func (client *HeaderClient) CustomRequestIDHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -147,11 +141,10 @@ func (client *HeaderClient) ParamBool(ctx context.Context, scenario string, valu
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ParamBoolHandleResponse(resp)
-	if err != nil {
+	if err := client.ParamBoolHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ParamBoolCreateRequest creates the ParamBool request.
@@ -167,16 +160,11 @@ func (client *HeaderClient) ParamBoolCreateRequest(ctx context.Context, scenario
 	return req, nil
 }
 
-// ParamBoolHandleResponse handles the ParamBool response.
-func (client *HeaderClient) ParamBoolHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ParamBoolHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ParamBoolHandleError handles the ParamBool error response.
 func (client *HeaderClient) ParamBoolHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -194,11 +182,10 @@ func (client *HeaderClient) ParamByte(ctx context.Context, scenario string, valu
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ParamByteHandleResponse(resp)
-	if err != nil {
+	if err := client.ParamByteHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ParamByteCreateRequest creates the ParamByte request.
@@ -214,16 +201,11 @@ func (client *HeaderClient) ParamByteCreateRequest(ctx context.Context, scenario
 	return req, nil
 }
 
-// ParamByteHandleResponse handles the ParamByte response.
-func (client *HeaderClient) ParamByteHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ParamByteHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ParamByteHandleError handles the ParamByte error response.
 func (client *HeaderClient) ParamByteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -241,11 +223,10 @@ func (client *HeaderClient) ParamDate(ctx context.Context, scenario string, valu
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ParamDateHandleResponse(resp)
-	if err != nil {
+	if err := client.ParamDateHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ParamDateCreateRequest creates the ParamDate request.
@@ -261,16 +242,11 @@ func (client *HeaderClient) ParamDateCreateRequest(ctx context.Context, scenario
 	return req, nil
 }
 
-// ParamDateHandleResponse handles the ParamDate response.
-func (client *HeaderClient) ParamDateHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ParamDateHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ParamDateHandleError handles the ParamDate error response.
 func (client *HeaderClient) ParamDateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -288,11 +264,10 @@ func (client *HeaderClient) ParamDatetime(ctx context.Context, scenario string, 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ParamDatetimeHandleResponse(resp)
-	if err != nil {
+	if err := client.ParamDatetimeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ParamDatetimeCreateRequest creates the ParamDatetime request.
@@ -308,16 +283,11 @@ func (client *HeaderClient) ParamDatetimeCreateRequest(ctx context.Context, scen
 	return req, nil
 }
 
-// ParamDatetimeHandleResponse handles the ParamDatetime response.
-func (client *HeaderClient) ParamDatetimeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ParamDatetimeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ParamDatetimeHandleError handles the ParamDatetime error response.
 func (client *HeaderClient) ParamDatetimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -335,11 +305,10 @@ func (client *HeaderClient) ParamDatetimeRFC1123(ctx context.Context, scenario s
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ParamDatetimeRFC1123HandleResponse(resp)
-	if err != nil {
+	if err := client.ParamDatetimeRFC1123HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ParamDatetimeRFC1123CreateRequest creates the ParamDatetimeRFC1123 request.
@@ -357,16 +326,11 @@ func (client *HeaderClient) ParamDatetimeRFC1123CreateRequest(ctx context.Contex
 	return req, nil
 }
 
-// ParamDatetimeRFC1123HandleResponse handles the ParamDatetimeRFC1123 response.
-func (client *HeaderClient) ParamDatetimeRFC1123HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ParamDatetimeRFC1123HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ParamDatetimeRFC1123HandleError handles the ParamDatetimeRFC1123 error response.
 func (client *HeaderClient) ParamDatetimeRFC1123HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -384,11 +348,10 @@ func (client *HeaderClient) ParamDouble(ctx context.Context, scenario string, va
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ParamDoubleHandleResponse(resp)
-	if err != nil {
+	if err := client.ParamDoubleHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ParamDoubleCreateRequest creates the ParamDouble request.
@@ -404,16 +367,11 @@ func (client *HeaderClient) ParamDoubleCreateRequest(ctx context.Context, scenar
 	return req, nil
 }
 
-// ParamDoubleHandleResponse handles the ParamDouble response.
-func (client *HeaderClient) ParamDoubleHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ParamDoubleHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ParamDoubleHandleError handles the ParamDouble error response.
 func (client *HeaderClient) ParamDoubleHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -431,11 +389,10 @@ func (client *HeaderClient) ParamDuration(ctx context.Context, scenario string, 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ParamDurationHandleResponse(resp)
-	if err != nil {
+	if err := client.ParamDurationHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ParamDurationCreateRequest creates the ParamDuration request.
@@ -451,16 +408,11 @@ func (client *HeaderClient) ParamDurationCreateRequest(ctx context.Context, scen
 	return req, nil
 }
 
-// ParamDurationHandleResponse handles the ParamDuration response.
-func (client *HeaderClient) ParamDurationHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ParamDurationHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ParamDurationHandleError handles the ParamDuration error response.
 func (client *HeaderClient) ParamDurationHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -478,11 +430,10 @@ func (client *HeaderClient) ParamEnum(ctx context.Context, scenario string, head
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ParamEnumHandleResponse(resp)
-	if err != nil {
+	if err := client.ParamEnumHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ParamEnumCreateRequest creates the ParamEnum request.
@@ -500,16 +451,11 @@ func (client *HeaderClient) ParamEnumCreateRequest(ctx context.Context, scenario
 	return req, nil
 }
 
-// ParamEnumHandleResponse handles the ParamEnum response.
-func (client *HeaderClient) ParamEnumHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ParamEnumHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ParamEnumHandleError handles the ParamEnum error response.
 func (client *HeaderClient) ParamEnumHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -527,11 +473,10 @@ func (client *HeaderClient) ParamExistingKey(ctx context.Context, userAgent stri
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ParamExistingKeyHandleResponse(resp)
-	if err != nil {
+	if err := client.ParamExistingKeyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ParamExistingKeyCreateRequest creates the ParamExistingKey request.
@@ -546,16 +491,11 @@ func (client *HeaderClient) ParamExistingKeyCreateRequest(ctx context.Context, u
 	return req, nil
 }
 
-// ParamExistingKeyHandleResponse handles the ParamExistingKey response.
-func (client *HeaderClient) ParamExistingKeyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ParamExistingKeyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ParamExistingKeyHandleError handles the ParamExistingKey error response.
 func (client *HeaderClient) ParamExistingKeyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -573,11 +513,10 @@ func (client *HeaderClient) ParamFloat(ctx context.Context, scenario string, val
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ParamFloatHandleResponse(resp)
-	if err != nil {
+	if err := client.ParamFloatHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ParamFloatCreateRequest creates the ParamFloat request.
@@ -593,16 +532,11 @@ func (client *HeaderClient) ParamFloatCreateRequest(ctx context.Context, scenari
 	return req, nil
 }
 
-// ParamFloatHandleResponse handles the ParamFloat response.
-func (client *HeaderClient) ParamFloatHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ParamFloatHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ParamFloatHandleError handles the ParamFloat error response.
 func (client *HeaderClient) ParamFloatHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -620,11 +554,10 @@ func (client *HeaderClient) ParamInteger(ctx context.Context, scenario string, v
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ParamIntegerHandleResponse(resp)
-	if err != nil {
+	if err := client.ParamIntegerHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ParamIntegerCreateRequest creates the ParamInteger request.
@@ -640,16 +573,11 @@ func (client *HeaderClient) ParamIntegerCreateRequest(ctx context.Context, scena
 	return req, nil
 }
 
-// ParamIntegerHandleResponse handles the ParamInteger response.
-func (client *HeaderClient) ParamIntegerHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ParamIntegerHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ParamIntegerHandleError handles the ParamInteger error response.
 func (client *HeaderClient) ParamIntegerHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -667,11 +595,10 @@ func (client *HeaderClient) ParamLong(ctx context.Context, scenario string, valu
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ParamLongHandleResponse(resp)
-	if err != nil {
+	if err := client.ParamLongHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ParamLongCreateRequest creates the ParamLong request.
@@ -687,16 +614,11 @@ func (client *HeaderClient) ParamLongCreateRequest(ctx context.Context, scenario
 	return req, nil
 }
 
-// ParamLongHandleResponse handles the ParamLong response.
-func (client *HeaderClient) ParamLongHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ParamLongHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ParamLongHandleError handles the ParamLong error response.
 func (client *HeaderClient) ParamLongHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -714,11 +636,10 @@ func (client *HeaderClient) ParamProtectedKey(ctx context.Context, contentType s
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ParamProtectedKeyHandleResponse(resp)
-	if err != nil {
+	if err := client.ParamProtectedKeyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ParamProtectedKeyCreateRequest creates the ParamProtectedKey request.
@@ -733,16 +654,11 @@ func (client *HeaderClient) ParamProtectedKeyCreateRequest(ctx context.Context, 
 	return req, nil
 }
 
-// ParamProtectedKeyHandleResponse handles the ParamProtectedKey response.
-func (client *HeaderClient) ParamProtectedKeyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ParamProtectedKeyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ParamProtectedKeyHandleError handles the ParamProtectedKey error response.
 func (client *HeaderClient) ParamProtectedKeyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -760,11 +676,10 @@ func (client *HeaderClient) ParamString(ctx context.Context, scenario string, he
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ParamStringHandleResponse(resp)
-	if err != nil {
+	if err := client.ParamStringHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ParamStringCreateRequest creates the ParamString request.
@@ -782,16 +697,11 @@ func (client *HeaderClient) ParamStringCreateRequest(ctx context.Context, scenar
 	return req, nil
 }
 
-// ParamStringHandleResponse handles the ParamString response.
-func (client *HeaderClient) ParamStringHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ParamStringHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ParamStringHandleError handles the ParamString error response.
 func (client *HeaderClient) ParamStringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -807,6 +717,9 @@ func (client *HeaderClient) ResponseBool(ctx context.Context, scenario string) (
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResponseBoolHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResponseBoolHandleResponse(resp)
@@ -830,9 +743,6 @@ func (client *HeaderClient) ResponseBoolCreateRequest(ctx context.Context, scena
 
 // ResponseBoolHandleResponse handles the ResponseBool response.
 func (client *HeaderClient) ResponseBoolHandleResponse(resp *azcore.Response) (*HeaderResponseBoolResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ResponseBoolHandleError(resp)
-	}
 	result := HeaderResponseBoolResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
 		value, err := strconv.ParseBool(val)
@@ -846,6 +756,9 @@ func (client *HeaderClient) ResponseBoolHandleResponse(resp *azcore.Response) (*
 
 // ResponseBoolHandleError handles the ResponseBool error response.
 func (client *HeaderClient) ResponseBoolHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -861,6 +774,9 @@ func (client *HeaderClient) ResponseByte(ctx context.Context, scenario string) (
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResponseByteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResponseByteHandleResponse(resp)
@@ -884,9 +800,6 @@ func (client *HeaderClient) ResponseByteCreateRequest(ctx context.Context, scena
 
 // ResponseByteHandleResponse handles the ResponseByte response.
 func (client *HeaderClient) ResponseByteHandleResponse(resp *azcore.Response) (*HeaderResponseByteResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ResponseByteHandleError(resp)
-	}
 	result := HeaderResponseByteResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
 		value, err := base64.StdEncoding.DecodeString(val)
@@ -900,6 +813,9 @@ func (client *HeaderClient) ResponseByteHandleResponse(resp *azcore.Response) (*
 
 // ResponseByteHandleError handles the ResponseByte error response.
 func (client *HeaderClient) ResponseByteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -915,6 +831,9 @@ func (client *HeaderClient) ResponseDate(ctx context.Context, scenario string) (
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResponseDateHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResponseDateHandleResponse(resp)
@@ -938,9 +857,6 @@ func (client *HeaderClient) ResponseDateCreateRequest(ctx context.Context, scena
 
 // ResponseDateHandleResponse handles the ResponseDate response.
 func (client *HeaderClient) ResponseDateHandleResponse(resp *azcore.Response) (*HeaderResponseDateResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ResponseDateHandleError(resp)
-	}
 	result := HeaderResponseDateResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
 		value, err := time.Parse("2006-01-02", val)
@@ -954,6 +870,9 @@ func (client *HeaderClient) ResponseDateHandleResponse(resp *azcore.Response) (*
 
 // ResponseDateHandleError handles the ResponseDate error response.
 func (client *HeaderClient) ResponseDateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -969,6 +888,9 @@ func (client *HeaderClient) ResponseDatetime(ctx context.Context, scenario strin
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResponseDatetimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResponseDatetimeHandleResponse(resp)
@@ -992,9 +914,6 @@ func (client *HeaderClient) ResponseDatetimeCreateRequest(ctx context.Context, s
 
 // ResponseDatetimeHandleResponse handles the ResponseDatetime response.
 func (client *HeaderClient) ResponseDatetimeHandleResponse(resp *azcore.Response) (*HeaderResponseDatetimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ResponseDatetimeHandleError(resp)
-	}
 	result := HeaderResponseDatetimeResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
 		value, err := time.Parse(time.RFC3339Nano, val)
@@ -1008,6 +927,9 @@ func (client *HeaderClient) ResponseDatetimeHandleResponse(resp *azcore.Response
 
 // ResponseDatetimeHandleError handles the ResponseDatetime error response.
 func (client *HeaderClient) ResponseDatetimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1023,6 +945,9 @@ func (client *HeaderClient) ResponseDatetimeRFC1123(ctx context.Context, scenari
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResponseDatetimeRFC1123HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResponseDatetimeRFC1123HandleResponse(resp)
@@ -1046,9 +971,6 @@ func (client *HeaderClient) ResponseDatetimeRFC1123CreateRequest(ctx context.Con
 
 // ResponseDatetimeRFC1123HandleResponse handles the ResponseDatetimeRFC1123 response.
 func (client *HeaderClient) ResponseDatetimeRFC1123HandleResponse(resp *azcore.Response) (*HeaderResponseDatetimeRFC1123Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ResponseDatetimeRFC1123HandleError(resp)
-	}
 	result := HeaderResponseDatetimeRFC1123Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
 		value, err := time.Parse(time.RFC1123, val)
@@ -1062,6 +984,9 @@ func (client *HeaderClient) ResponseDatetimeRFC1123HandleResponse(resp *azcore.R
 
 // ResponseDatetimeRFC1123HandleError handles the ResponseDatetimeRFC1123 error response.
 func (client *HeaderClient) ResponseDatetimeRFC1123HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1077,6 +1002,9 @@ func (client *HeaderClient) ResponseDouble(ctx context.Context, scenario string)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResponseDoubleHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResponseDoubleHandleResponse(resp)
@@ -1100,9 +1028,6 @@ func (client *HeaderClient) ResponseDoubleCreateRequest(ctx context.Context, sce
 
 // ResponseDoubleHandleResponse handles the ResponseDouble response.
 func (client *HeaderClient) ResponseDoubleHandleResponse(resp *azcore.Response) (*HeaderResponseDoubleResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ResponseDoubleHandleError(resp)
-	}
 	result := HeaderResponseDoubleResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
 		value, err := strconv.ParseFloat(val, 64)
@@ -1116,6 +1041,9 @@ func (client *HeaderClient) ResponseDoubleHandleResponse(resp *azcore.Response) 
 
 // ResponseDoubleHandleError handles the ResponseDouble error response.
 func (client *HeaderClient) ResponseDoubleHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1131,6 +1059,9 @@ func (client *HeaderClient) ResponseDuration(ctx context.Context, scenario strin
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResponseDurationHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResponseDurationHandleResponse(resp)
@@ -1154,9 +1085,6 @@ func (client *HeaderClient) ResponseDurationCreateRequest(ctx context.Context, s
 
 // ResponseDurationHandleResponse handles the ResponseDuration response.
 func (client *HeaderClient) ResponseDurationHandleResponse(resp *azcore.Response) (*HeaderResponseDurationResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ResponseDurationHandleError(resp)
-	}
 	result := HeaderResponseDurationResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
 		result.Value = &val
@@ -1166,6 +1094,9 @@ func (client *HeaderClient) ResponseDurationHandleResponse(resp *azcore.Response
 
 // ResponseDurationHandleError handles the ResponseDuration error response.
 func (client *HeaderClient) ResponseDurationHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1181,6 +1112,9 @@ func (client *HeaderClient) ResponseEnum(ctx context.Context, scenario string) (
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResponseEnumHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResponseEnumHandleResponse(resp)
@@ -1204,9 +1138,6 @@ func (client *HeaderClient) ResponseEnumCreateRequest(ctx context.Context, scena
 
 // ResponseEnumHandleResponse handles the ResponseEnum response.
 func (client *HeaderClient) ResponseEnumHandleResponse(resp *azcore.Response) (*HeaderResponseEnumResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ResponseEnumHandleError(resp)
-	}
 	result := HeaderResponseEnumResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
 		result.Value = (*GreyscaleColors)(&val)
@@ -1216,6 +1147,9 @@ func (client *HeaderClient) ResponseEnumHandleResponse(resp *azcore.Response) (*
 
 // ResponseEnumHandleError handles the ResponseEnum error response.
 func (client *HeaderClient) ResponseEnumHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1231,6 +1165,9 @@ func (client *HeaderClient) ResponseExistingKey(ctx context.Context) (*HeaderRes
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResponseExistingKeyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResponseExistingKeyHandleResponse(resp)
@@ -1253,9 +1190,6 @@ func (client *HeaderClient) ResponseExistingKeyCreateRequest(ctx context.Context
 
 // ResponseExistingKeyHandleResponse handles the ResponseExistingKey response.
 func (client *HeaderClient) ResponseExistingKeyHandleResponse(resp *azcore.Response) (*HeaderResponseExistingKeyResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ResponseExistingKeyHandleError(resp)
-	}
 	result := HeaderResponseExistingKeyResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("User-Agent"); val != "" {
 		result.UserAgent = &val
@@ -1265,6 +1199,9 @@ func (client *HeaderClient) ResponseExistingKeyHandleResponse(resp *azcore.Respo
 
 // ResponseExistingKeyHandleError handles the ResponseExistingKey error response.
 func (client *HeaderClient) ResponseExistingKeyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1280,6 +1217,9 @@ func (client *HeaderClient) ResponseFloat(ctx context.Context, scenario string) 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResponseFloatHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResponseFloatHandleResponse(resp)
@@ -1303,9 +1243,6 @@ func (client *HeaderClient) ResponseFloatCreateRequest(ctx context.Context, scen
 
 // ResponseFloatHandleResponse handles the ResponseFloat response.
 func (client *HeaderClient) ResponseFloatHandleResponse(resp *azcore.Response) (*HeaderResponseFloatResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ResponseFloatHandleError(resp)
-	}
 	result := HeaderResponseFloatResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
 		value32, err := strconv.ParseFloat(val, 32)
@@ -1320,6 +1257,9 @@ func (client *HeaderClient) ResponseFloatHandleResponse(resp *azcore.Response) (
 
 // ResponseFloatHandleError handles the ResponseFloat error response.
 func (client *HeaderClient) ResponseFloatHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1335,6 +1275,9 @@ func (client *HeaderClient) ResponseInteger(ctx context.Context, scenario string
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResponseIntegerHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResponseIntegerHandleResponse(resp)
@@ -1358,9 +1301,6 @@ func (client *HeaderClient) ResponseIntegerCreateRequest(ctx context.Context, sc
 
 // ResponseIntegerHandleResponse handles the ResponseInteger response.
 func (client *HeaderClient) ResponseIntegerHandleResponse(resp *azcore.Response) (*HeaderResponseIntegerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ResponseIntegerHandleError(resp)
-	}
 	result := HeaderResponseIntegerResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
 		value32, err := strconv.ParseInt(val, 10, 32)
@@ -1375,6 +1315,9 @@ func (client *HeaderClient) ResponseIntegerHandleResponse(resp *azcore.Response)
 
 // ResponseIntegerHandleError handles the ResponseInteger error response.
 func (client *HeaderClient) ResponseIntegerHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1390,6 +1333,9 @@ func (client *HeaderClient) ResponseLong(ctx context.Context, scenario string) (
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResponseLongHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResponseLongHandleResponse(resp)
@@ -1413,9 +1359,6 @@ func (client *HeaderClient) ResponseLongCreateRequest(ctx context.Context, scena
 
 // ResponseLongHandleResponse handles the ResponseLong response.
 func (client *HeaderClient) ResponseLongHandleResponse(resp *azcore.Response) (*HeaderResponseLongResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ResponseLongHandleError(resp)
-	}
 	result := HeaderResponseLongResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
 		value, err := strconv.ParseInt(val, 10, 64)
@@ -1429,6 +1372,9 @@ func (client *HeaderClient) ResponseLongHandleResponse(resp *azcore.Response) (*
 
 // ResponseLongHandleError handles the ResponseLong error response.
 func (client *HeaderClient) ResponseLongHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1444,6 +1390,9 @@ func (client *HeaderClient) ResponseProtectedKey(ctx context.Context) (*HeaderRe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResponseProtectedKeyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResponseProtectedKeyHandleResponse(resp)
@@ -1466,9 +1415,6 @@ func (client *HeaderClient) ResponseProtectedKeyCreateRequest(ctx context.Contex
 
 // ResponseProtectedKeyHandleResponse handles the ResponseProtectedKey response.
 func (client *HeaderClient) ResponseProtectedKeyHandleResponse(resp *azcore.Response) (*HeaderResponseProtectedKeyResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ResponseProtectedKeyHandleError(resp)
-	}
 	result := HeaderResponseProtectedKeyResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val
@@ -1478,6 +1424,9 @@ func (client *HeaderClient) ResponseProtectedKeyHandleResponse(resp *azcore.Resp
 
 // ResponseProtectedKeyHandleError handles the ResponseProtectedKey error response.
 func (client *HeaderClient) ResponseProtectedKeyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1493,6 +1442,9 @@ func (client *HeaderClient) ResponseString(ctx context.Context, scenario string)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResponseStringHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResponseStringHandleResponse(resp)
@@ -1516,9 +1468,6 @@ func (client *HeaderClient) ResponseStringCreateRequest(ctx context.Context, sce
 
 // ResponseStringHandleResponse handles the ResponseString response.
 func (client *HeaderClient) ResponseStringHandleResponse(resp *azcore.Response) (*HeaderResponseStringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ResponseStringHandleError(resp)
-	}
 	result := HeaderResponseStringResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("value"); val != "" {
 		result.Value = &val
@@ -1528,6 +1477,9 @@ func (client *HeaderClient) ResponseStringHandleResponse(resp *azcore.Response) 
 
 // ResponseStringHandleError handles the ResponseString error response.
 func (client *HeaderClient) ResponseStringHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/headergroup/zz_generated_header.go
+++ b/test/autorest/headergroup/zz_generated_header.go
@@ -102,8 +102,8 @@ func (client *HeaderClient) CustomRequestID(ctx context.Context) (*http.Response
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CustomRequestIDHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.CustomRequestIDHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -121,9 +121,6 @@ func (client *HeaderClient) CustomRequestIDCreateRequest(ctx context.Context) (*
 
 // CustomRequestIDHandleError handles the CustomRequestID error response.
 func (client *HeaderClient) CustomRequestIDHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *HeaderClient) ParamBool(ctx context.Context, scenario string, valu
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ParamBoolHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ParamBoolHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -162,9 +159,6 @@ func (client *HeaderClient) ParamBoolCreateRequest(ctx context.Context, scenario
 
 // ParamBoolHandleError handles the ParamBool error response.
 func (client *HeaderClient) ParamBoolHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -182,8 +176,8 @@ func (client *HeaderClient) ParamByte(ctx context.Context, scenario string, valu
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ParamByteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ParamByteHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -203,9 +197,6 @@ func (client *HeaderClient) ParamByteCreateRequest(ctx context.Context, scenario
 
 // ParamByteHandleError handles the ParamByte error response.
 func (client *HeaderClient) ParamByteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -223,8 +214,8 @@ func (client *HeaderClient) ParamDate(ctx context.Context, scenario string, valu
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ParamDateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ParamDateHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -244,9 +235,6 @@ func (client *HeaderClient) ParamDateCreateRequest(ctx context.Context, scenario
 
 // ParamDateHandleError handles the ParamDate error response.
 func (client *HeaderClient) ParamDateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -264,8 +252,8 @@ func (client *HeaderClient) ParamDatetime(ctx context.Context, scenario string, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ParamDatetimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ParamDatetimeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -285,9 +273,6 @@ func (client *HeaderClient) ParamDatetimeCreateRequest(ctx context.Context, scen
 
 // ParamDatetimeHandleError handles the ParamDatetime error response.
 func (client *HeaderClient) ParamDatetimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -305,8 +290,8 @@ func (client *HeaderClient) ParamDatetimeRFC1123(ctx context.Context, scenario s
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ParamDatetimeRFC1123HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ParamDatetimeRFC1123HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -328,9 +313,6 @@ func (client *HeaderClient) ParamDatetimeRFC1123CreateRequest(ctx context.Contex
 
 // ParamDatetimeRFC1123HandleError handles the ParamDatetimeRFC1123 error response.
 func (client *HeaderClient) ParamDatetimeRFC1123HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -348,8 +330,8 @@ func (client *HeaderClient) ParamDouble(ctx context.Context, scenario string, va
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ParamDoubleHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ParamDoubleHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -369,9 +351,6 @@ func (client *HeaderClient) ParamDoubleCreateRequest(ctx context.Context, scenar
 
 // ParamDoubleHandleError handles the ParamDouble error response.
 func (client *HeaderClient) ParamDoubleHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -389,8 +368,8 @@ func (client *HeaderClient) ParamDuration(ctx context.Context, scenario string, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ParamDurationHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ParamDurationHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -410,9 +389,6 @@ func (client *HeaderClient) ParamDurationCreateRequest(ctx context.Context, scen
 
 // ParamDurationHandleError handles the ParamDuration error response.
 func (client *HeaderClient) ParamDurationHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -430,8 +406,8 @@ func (client *HeaderClient) ParamEnum(ctx context.Context, scenario string, head
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ParamEnumHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ParamEnumHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -453,9 +429,6 @@ func (client *HeaderClient) ParamEnumCreateRequest(ctx context.Context, scenario
 
 // ParamEnumHandleError handles the ParamEnum error response.
 func (client *HeaderClient) ParamEnumHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -473,8 +446,8 @@ func (client *HeaderClient) ParamExistingKey(ctx context.Context, userAgent stri
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ParamExistingKeyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ParamExistingKeyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -493,9 +466,6 @@ func (client *HeaderClient) ParamExistingKeyCreateRequest(ctx context.Context, u
 
 // ParamExistingKeyHandleError handles the ParamExistingKey error response.
 func (client *HeaderClient) ParamExistingKeyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -513,8 +483,8 @@ func (client *HeaderClient) ParamFloat(ctx context.Context, scenario string, val
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ParamFloatHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ParamFloatHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -534,9 +504,6 @@ func (client *HeaderClient) ParamFloatCreateRequest(ctx context.Context, scenari
 
 // ParamFloatHandleError handles the ParamFloat error response.
 func (client *HeaderClient) ParamFloatHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -554,8 +521,8 @@ func (client *HeaderClient) ParamInteger(ctx context.Context, scenario string, v
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ParamIntegerHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ParamIntegerHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -575,9 +542,6 @@ func (client *HeaderClient) ParamIntegerCreateRequest(ctx context.Context, scena
 
 // ParamIntegerHandleError handles the ParamInteger error response.
 func (client *HeaderClient) ParamIntegerHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -595,8 +559,8 @@ func (client *HeaderClient) ParamLong(ctx context.Context, scenario string, valu
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ParamLongHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ParamLongHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -616,9 +580,6 @@ func (client *HeaderClient) ParamLongCreateRequest(ctx context.Context, scenario
 
 // ParamLongHandleError handles the ParamLong error response.
 func (client *HeaderClient) ParamLongHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -636,8 +597,8 @@ func (client *HeaderClient) ParamProtectedKey(ctx context.Context, contentType s
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ParamProtectedKeyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ParamProtectedKeyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -656,9 +617,6 @@ func (client *HeaderClient) ParamProtectedKeyCreateRequest(ctx context.Context, 
 
 // ParamProtectedKeyHandleError handles the ParamProtectedKey error response.
 func (client *HeaderClient) ParamProtectedKeyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -676,8 +634,8 @@ func (client *HeaderClient) ParamString(ctx context.Context, scenario string, he
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ParamStringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ParamStringHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -699,9 +657,6 @@ func (client *HeaderClient) ParamStringCreateRequest(ctx context.Context, scenar
 
 // ParamStringHandleError handles the ParamString error response.
 func (client *HeaderClient) ParamStringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -719,8 +674,8 @@ func (client *HeaderClient) ResponseBool(ctx context.Context, scenario string) (
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResponseBoolHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ResponseBoolHandleError(resp)
 	}
 	result, err := client.ResponseBoolHandleResponse(resp)
 	if err != nil {
@@ -756,9 +711,6 @@ func (client *HeaderClient) ResponseBoolHandleResponse(resp *azcore.Response) (*
 
 // ResponseBoolHandleError handles the ResponseBool error response.
 func (client *HeaderClient) ResponseBoolHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -776,8 +728,8 @@ func (client *HeaderClient) ResponseByte(ctx context.Context, scenario string) (
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResponseByteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ResponseByteHandleError(resp)
 	}
 	result, err := client.ResponseByteHandleResponse(resp)
 	if err != nil {
@@ -813,9 +765,6 @@ func (client *HeaderClient) ResponseByteHandleResponse(resp *azcore.Response) (*
 
 // ResponseByteHandleError handles the ResponseByte error response.
 func (client *HeaderClient) ResponseByteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -833,8 +782,8 @@ func (client *HeaderClient) ResponseDate(ctx context.Context, scenario string) (
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResponseDateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ResponseDateHandleError(resp)
 	}
 	result, err := client.ResponseDateHandleResponse(resp)
 	if err != nil {
@@ -870,9 +819,6 @@ func (client *HeaderClient) ResponseDateHandleResponse(resp *azcore.Response) (*
 
 // ResponseDateHandleError handles the ResponseDate error response.
 func (client *HeaderClient) ResponseDateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -890,8 +836,8 @@ func (client *HeaderClient) ResponseDatetime(ctx context.Context, scenario strin
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResponseDatetimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ResponseDatetimeHandleError(resp)
 	}
 	result, err := client.ResponseDatetimeHandleResponse(resp)
 	if err != nil {
@@ -927,9 +873,6 @@ func (client *HeaderClient) ResponseDatetimeHandleResponse(resp *azcore.Response
 
 // ResponseDatetimeHandleError handles the ResponseDatetime error response.
 func (client *HeaderClient) ResponseDatetimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -947,8 +890,8 @@ func (client *HeaderClient) ResponseDatetimeRFC1123(ctx context.Context, scenari
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResponseDatetimeRFC1123HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ResponseDatetimeRFC1123HandleError(resp)
 	}
 	result, err := client.ResponseDatetimeRFC1123HandleResponse(resp)
 	if err != nil {
@@ -984,9 +927,6 @@ func (client *HeaderClient) ResponseDatetimeRFC1123HandleResponse(resp *azcore.R
 
 // ResponseDatetimeRFC1123HandleError handles the ResponseDatetimeRFC1123 error response.
 func (client *HeaderClient) ResponseDatetimeRFC1123HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1004,8 +944,8 @@ func (client *HeaderClient) ResponseDouble(ctx context.Context, scenario string)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResponseDoubleHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ResponseDoubleHandleError(resp)
 	}
 	result, err := client.ResponseDoubleHandleResponse(resp)
 	if err != nil {
@@ -1041,9 +981,6 @@ func (client *HeaderClient) ResponseDoubleHandleResponse(resp *azcore.Response) 
 
 // ResponseDoubleHandleError handles the ResponseDouble error response.
 func (client *HeaderClient) ResponseDoubleHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1061,8 +998,8 @@ func (client *HeaderClient) ResponseDuration(ctx context.Context, scenario strin
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResponseDurationHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ResponseDurationHandleError(resp)
 	}
 	result, err := client.ResponseDurationHandleResponse(resp)
 	if err != nil {
@@ -1094,9 +1031,6 @@ func (client *HeaderClient) ResponseDurationHandleResponse(resp *azcore.Response
 
 // ResponseDurationHandleError handles the ResponseDuration error response.
 func (client *HeaderClient) ResponseDurationHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1114,8 +1048,8 @@ func (client *HeaderClient) ResponseEnum(ctx context.Context, scenario string) (
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResponseEnumHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ResponseEnumHandleError(resp)
 	}
 	result, err := client.ResponseEnumHandleResponse(resp)
 	if err != nil {
@@ -1147,9 +1081,6 @@ func (client *HeaderClient) ResponseEnumHandleResponse(resp *azcore.Response) (*
 
 // ResponseEnumHandleError handles the ResponseEnum error response.
 func (client *HeaderClient) ResponseEnumHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1167,8 +1098,8 @@ func (client *HeaderClient) ResponseExistingKey(ctx context.Context) (*HeaderRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResponseExistingKeyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ResponseExistingKeyHandleError(resp)
 	}
 	result, err := client.ResponseExistingKeyHandleResponse(resp)
 	if err != nil {
@@ -1199,9 +1130,6 @@ func (client *HeaderClient) ResponseExistingKeyHandleResponse(resp *azcore.Respo
 
 // ResponseExistingKeyHandleError handles the ResponseExistingKey error response.
 func (client *HeaderClient) ResponseExistingKeyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1219,8 +1147,8 @@ func (client *HeaderClient) ResponseFloat(ctx context.Context, scenario string) 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResponseFloatHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ResponseFloatHandleError(resp)
 	}
 	result, err := client.ResponseFloatHandleResponse(resp)
 	if err != nil {
@@ -1257,9 +1185,6 @@ func (client *HeaderClient) ResponseFloatHandleResponse(resp *azcore.Response) (
 
 // ResponseFloatHandleError handles the ResponseFloat error response.
 func (client *HeaderClient) ResponseFloatHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1277,8 +1202,8 @@ func (client *HeaderClient) ResponseInteger(ctx context.Context, scenario string
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResponseIntegerHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ResponseIntegerHandleError(resp)
 	}
 	result, err := client.ResponseIntegerHandleResponse(resp)
 	if err != nil {
@@ -1315,9 +1240,6 @@ func (client *HeaderClient) ResponseIntegerHandleResponse(resp *azcore.Response)
 
 // ResponseIntegerHandleError handles the ResponseInteger error response.
 func (client *HeaderClient) ResponseIntegerHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1335,8 +1257,8 @@ func (client *HeaderClient) ResponseLong(ctx context.Context, scenario string) (
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResponseLongHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ResponseLongHandleError(resp)
 	}
 	result, err := client.ResponseLongHandleResponse(resp)
 	if err != nil {
@@ -1372,9 +1294,6 @@ func (client *HeaderClient) ResponseLongHandleResponse(resp *azcore.Response) (*
 
 // ResponseLongHandleError handles the ResponseLong error response.
 func (client *HeaderClient) ResponseLongHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1392,8 +1311,8 @@ func (client *HeaderClient) ResponseProtectedKey(ctx context.Context) (*HeaderRe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResponseProtectedKeyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ResponseProtectedKeyHandleError(resp)
 	}
 	result, err := client.ResponseProtectedKeyHandleResponse(resp)
 	if err != nil {
@@ -1424,9 +1343,6 @@ func (client *HeaderClient) ResponseProtectedKeyHandleResponse(resp *azcore.Resp
 
 // ResponseProtectedKeyHandleError handles the ResponseProtectedKey error response.
 func (client *HeaderClient) ResponseProtectedKeyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1444,8 +1360,8 @@ func (client *HeaderClient) ResponseString(ctx context.Context, scenario string)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResponseStringHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ResponseStringHandleError(resp)
 	}
 	result, err := client.ResponseStringHandleResponse(resp)
 	if err != nil {
@@ -1477,9 +1393,6 @@ func (client *HeaderClient) ResponseStringHandleResponse(resp *azcore.Response) 
 
 // ResponseStringHandleError handles the ResponseString error response.
 func (client *HeaderClient) ResponseStringHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure.go
@@ -93,11 +93,10 @@ func (client *HTTPClientFailureClient) Delete400(ctx context.Context) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Delete400HandleResponse(resp)
-	if err != nil {
+	if err := client.Delete400HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Delete400CreateRequest creates the Delete400 request.
@@ -111,13 +110,11 @@ func (client *HTTPClientFailureClient) Delete400CreateRequest(ctx context.Contex
 	return req, req.MarshalAsJSON(true)
 }
 
-// Delete400HandleResponse handles the Delete400 response.
-func (client *HTTPClientFailureClient) Delete400HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Delete400HandleError(resp)
-}
-
 // Delete400HandleError handles the Delete400 error response.
 func (client *HTTPClientFailureClient) Delete400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -135,11 +132,10 @@ func (client *HTTPClientFailureClient) Delete407(ctx context.Context) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Delete407HandleResponse(resp)
-	if err != nil {
+	if err := client.Delete407HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Delete407CreateRequest creates the Delete407 request.
@@ -153,13 +149,11 @@ func (client *HTTPClientFailureClient) Delete407CreateRequest(ctx context.Contex
 	return req, req.MarshalAsJSON(true)
 }
 
-// Delete407HandleResponse handles the Delete407 response.
-func (client *HTTPClientFailureClient) Delete407HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Delete407HandleError(resp)
-}
-
 // Delete407HandleError handles the Delete407 error response.
 func (client *HTTPClientFailureClient) Delete407HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -177,11 +171,10 @@ func (client *HTTPClientFailureClient) Delete417(ctx context.Context) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Delete417HandleResponse(resp)
-	if err != nil {
+	if err := client.Delete417HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Delete417CreateRequest creates the Delete417 request.
@@ -195,13 +188,11 @@ func (client *HTTPClientFailureClient) Delete417CreateRequest(ctx context.Contex
 	return req, req.MarshalAsJSON(true)
 }
 
-// Delete417HandleResponse handles the Delete417 response.
-func (client *HTTPClientFailureClient) Delete417HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Delete417HandleError(resp)
-}
-
 // Delete417HandleError handles the Delete417 error response.
 func (client *HTTPClientFailureClient) Delete417HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -219,11 +210,10 @@ func (client *HTTPClientFailureClient) Get400(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get400HandleResponse(resp)
-	if err != nil {
+	if err := client.Get400HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get400CreateRequest creates the Get400 request.
@@ -237,13 +227,11 @@ func (client *HTTPClientFailureClient) Get400CreateRequest(ctx context.Context) 
 	return req, nil
 }
 
-// Get400HandleResponse handles the Get400 response.
-func (client *HTTPClientFailureClient) Get400HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Get400HandleError(resp)
-}
-
 // Get400HandleError handles the Get400 error response.
 func (client *HTTPClientFailureClient) Get400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,11 +249,10 @@ func (client *HTTPClientFailureClient) Get402(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get402HandleResponse(resp)
-	if err != nil {
+	if err := client.Get402HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get402CreateRequest creates the Get402 request.
@@ -279,13 +266,11 @@ func (client *HTTPClientFailureClient) Get402CreateRequest(ctx context.Context) 
 	return req, nil
 }
 
-// Get402HandleResponse handles the Get402 response.
-func (client *HTTPClientFailureClient) Get402HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Get402HandleError(resp)
-}
-
 // Get402HandleError handles the Get402 error response.
 func (client *HTTPClientFailureClient) Get402HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -303,11 +288,10 @@ func (client *HTTPClientFailureClient) Get403(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get403HandleResponse(resp)
-	if err != nil {
+	if err := client.Get403HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get403CreateRequest creates the Get403 request.
@@ -321,13 +305,11 @@ func (client *HTTPClientFailureClient) Get403CreateRequest(ctx context.Context) 
 	return req, nil
 }
 
-// Get403HandleResponse handles the Get403 response.
-func (client *HTTPClientFailureClient) Get403HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Get403HandleError(resp)
-}
-
 // Get403HandleError handles the Get403 error response.
 func (client *HTTPClientFailureClient) Get403HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -345,11 +327,10 @@ func (client *HTTPClientFailureClient) Get411(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get411HandleResponse(resp)
-	if err != nil {
+	if err := client.Get411HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get411CreateRequest creates the Get411 request.
@@ -363,13 +344,11 @@ func (client *HTTPClientFailureClient) Get411CreateRequest(ctx context.Context) 
 	return req, nil
 }
 
-// Get411HandleResponse handles the Get411 response.
-func (client *HTTPClientFailureClient) Get411HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Get411HandleError(resp)
-}
-
 // Get411HandleError handles the Get411 error response.
 func (client *HTTPClientFailureClient) Get411HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -387,11 +366,10 @@ func (client *HTTPClientFailureClient) Get412(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get412HandleResponse(resp)
-	if err != nil {
+	if err := client.Get412HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get412CreateRequest creates the Get412 request.
@@ -405,13 +383,11 @@ func (client *HTTPClientFailureClient) Get412CreateRequest(ctx context.Context) 
 	return req, nil
 }
 
-// Get412HandleResponse handles the Get412 response.
-func (client *HTTPClientFailureClient) Get412HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Get412HandleError(resp)
-}
-
 // Get412HandleError handles the Get412 error response.
 func (client *HTTPClientFailureClient) Get412HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -429,11 +405,10 @@ func (client *HTTPClientFailureClient) Get416(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get416HandleResponse(resp)
-	if err != nil {
+	if err := client.Get416HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get416CreateRequest creates the Get416 request.
@@ -447,13 +422,11 @@ func (client *HTTPClientFailureClient) Get416CreateRequest(ctx context.Context) 
 	return req, nil
 }
 
-// Get416HandleResponse handles the Get416 response.
-func (client *HTTPClientFailureClient) Get416HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Get416HandleError(resp)
-}
-
 // Get416HandleError handles the Get416 error response.
 func (client *HTTPClientFailureClient) Get416HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -471,11 +444,10 @@ func (client *HTTPClientFailureClient) Head400(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Head400HandleResponse(resp)
-	if err != nil {
+	if err := client.Head400HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Head400CreateRequest creates the Head400 request.
@@ -489,13 +461,11 @@ func (client *HTTPClientFailureClient) Head400CreateRequest(ctx context.Context)
 	return req, nil
 }
 
-// Head400HandleResponse handles the Head400 response.
-func (client *HTTPClientFailureClient) Head400HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Head400HandleError(resp)
-}
-
 // Head400HandleError handles the Head400 error response.
 func (client *HTTPClientFailureClient) Head400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -513,11 +483,10 @@ func (client *HTTPClientFailureClient) Head401(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Head401HandleResponse(resp)
-	if err != nil {
+	if err := client.Head401HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Head401CreateRequest creates the Head401 request.
@@ -531,13 +500,11 @@ func (client *HTTPClientFailureClient) Head401CreateRequest(ctx context.Context)
 	return req, nil
 }
 
-// Head401HandleResponse handles the Head401 response.
-func (client *HTTPClientFailureClient) Head401HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Head401HandleError(resp)
-}
-
 // Head401HandleError handles the Head401 error response.
 func (client *HTTPClientFailureClient) Head401HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -555,11 +522,10 @@ func (client *HTTPClientFailureClient) Head410(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Head410HandleResponse(resp)
-	if err != nil {
+	if err := client.Head410HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Head410CreateRequest creates the Head410 request.
@@ -573,13 +539,11 @@ func (client *HTTPClientFailureClient) Head410CreateRequest(ctx context.Context)
 	return req, nil
 }
 
-// Head410HandleResponse handles the Head410 response.
-func (client *HTTPClientFailureClient) Head410HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Head410HandleError(resp)
-}
-
 // Head410HandleError handles the Head410 error response.
 func (client *HTTPClientFailureClient) Head410HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -597,11 +561,10 @@ func (client *HTTPClientFailureClient) Head429(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Head429HandleResponse(resp)
-	if err != nil {
+	if err := client.Head429HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Head429CreateRequest creates the Head429 request.
@@ -615,13 +578,11 @@ func (client *HTTPClientFailureClient) Head429CreateRequest(ctx context.Context)
 	return req, nil
 }
 
-// Head429HandleResponse handles the Head429 response.
-func (client *HTTPClientFailureClient) Head429HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Head429HandleError(resp)
-}
-
 // Head429HandleError handles the Head429 error response.
 func (client *HTTPClientFailureClient) Head429HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -639,11 +600,10 @@ func (client *HTTPClientFailureClient) Options400(ctx context.Context) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Options400HandleResponse(resp)
-	if err != nil {
+	if err := client.Options400HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Options400CreateRequest creates the Options400 request.
@@ -657,13 +617,11 @@ func (client *HTTPClientFailureClient) Options400CreateRequest(ctx context.Conte
 	return req, nil
 }
 
-// Options400HandleResponse handles the Options400 response.
-func (client *HTTPClientFailureClient) Options400HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Options400HandleError(resp)
-}
-
 // Options400HandleError handles the Options400 error response.
 func (client *HTTPClientFailureClient) Options400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -681,11 +639,10 @@ func (client *HTTPClientFailureClient) Options403(ctx context.Context) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Options403HandleResponse(resp)
-	if err != nil {
+	if err := client.Options403HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Options403CreateRequest creates the Options403 request.
@@ -699,13 +656,11 @@ func (client *HTTPClientFailureClient) Options403CreateRequest(ctx context.Conte
 	return req, nil
 }
 
-// Options403HandleResponse handles the Options403 response.
-func (client *HTTPClientFailureClient) Options403HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Options403HandleError(resp)
-}
-
 // Options403HandleError handles the Options403 error response.
 func (client *HTTPClientFailureClient) Options403HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -723,11 +678,10 @@ func (client *HTTPClientFailureClient) Options412(ctx context.Context) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Options412HandleResponse(resp)
-	if err != nil {
+	if err := client.Options412HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Options412CreateRequest creates the Options412 request.
@@ -741,13 +695,11 @@ func (client *HTTPClientFailureClient) Options412CreateRequest(ctx context.Conte
 	return req, nil
 }
 
-// Options412HandleResponse handles the Options412 response.
-func (client *HTTPClientFailureClient) Options412HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Options412HandleError(resp)
-}
-
 // Options412HandleError handles the Options412 error response.
 func (client *HTTPClientFailureClient) Options412HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -765,11 +717,10 @@ func (client *HTTPClientFailureClient) Patch400(ctx context.Context) (*http.Resp
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Patch400HandleResponse(resp)
-	if err != nil {
+	if err := client.Patch400HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Patch400CreateRequest creates the Patch400 request.
@@ -783,13 +734,11 @@ func (client *HTTPClientFailureClient) Patch400CreateRequest(ctx context.Context
 	return req, req.MarshalAsJSON(true)
 }
 
-// Patch400HandleResponse handles the Patch400 response.
-func (client *HTTPClientFailureClient) Patch400HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Patch400HandleError(resp)
-}
-
 // Patch400HandleError handles the Patch400 error response.
 func (client *HTTPClientFailureClient) Patch400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -807,11 +756,10 @@ func (client *HTTPClientFailureClient) Patch405(ctx context.Context) (*http.Resp
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Patch405HandleResponse(resp)
-	if err != nil {
+	if err := client.Patch405HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Patch405CreateRequest creates the Patch405 request.
@@ -825,13 +773,11 @@ func (client *HTTPClientFailureClient) Patch405CreateRequest(ctx context.Context
 	return req, req.MarshalAsJSON(true)
 }
 
-// Patch405HandleResponse handles the Patch405 response.
-func (client *HTTPClientFailureClient) Patch405HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Patch405HandleError(resp)
-}
-
 // Patch405HandleError handles the Patch405 error response.
 func (client *HTTPClientFailureClient) Patch405HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -849,11 +795,10 @@ func (client *HTTPClientFailureClient) Patch414(ctx context.Context) (*http.Resp
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Patch414HandleResponse(resp)
-	if err != nil {
+	if err := client.Patch414HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Patch414CreateRequest creates the Patch414 request.
@@ -867,13 +812,11 @@ func (client *HTTPClientFailureClient) Patch414CreateRequest(ctx context.Context
 	return req, req.MarshalAsJSON(true)
 }
 
-// Patch414HandleResponse handles the Patch414 response.
-func (client *HTTPClientFailureClient) Patch414HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Patch414HandleError(resp)
-}
-
 // Patch414HandleError handles the Patch414 error response.
 func (client *HTTPClientFailureClient) Patch414HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -891,11 +834,10 @@ func (client *HTTPClientFailureClient) Post400(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Post400HandleResponse(resp)
-	if err != nil {
+	if err := client.Post400HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Post400CreateRequest creates the Post400 request.
@@ -909,13 +851,11 @@ func (client *HTTPClientFailureClient) Post400CreateRequest(ctx context.Context)
 	return req, req.MarshalAsJSON(true)
 }
 
-// Post400HandleResponse handles the Post400 response.
-func (client *HTTPClientFailureClient) Post400HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Post400HandleError(resp)
-}
-
 // Post400HandleError handles the Post400 error response.
 func (client *HTTPClientFailureClient) Post400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -933,11 +873,10 @@ func (client *HTTPClientFailureClient) Post406(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Post406HandleResponse(resp)
-	if err != nil {
+	if err := client.Post406HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Post406CreateRequest creates the Post406 request.
@@ -951,13 +890,11 @@ func (client *HTTPClientFailureClient) Post406CreateRequest(ctx context.Context)
 	return req, req.MarshalAsJSON(true)
 }
 
-// Post406HandleResponse handles the Post406 response.
-func (client *HTTPClientFailureClient) Post406HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Post406HandleError(resp)
-}
-
 // Post406HandleError handles the Post406 error response.
 func (client *HTTPClientFailureClient) Post406HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -975,11 +912,10 @@ func (client *HTTPClientFailureClient) Post415(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Post415HandleResponse(resp)
-	if err != nil {
+	if err := client.Post415HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Post415CreateRequest creates the Post415 request.
@@ -993,13 +929,11 @@ func (client *HTTPClientFailureClient) Post415CreateRequest(ctx context.Context)
 	return req, req.MarshalAsJSON(true)
 }
 
-// Post415HandleResponse handles the Post415 response.
-func (client *HTTPClientFailureClient) Post415HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Post415HandleError(resp)
-}
-
 // Post415HandleError handles the Post415 error response.
 func (client *HTTPClientFailureClient) Post415HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1017,11 +951,10 @@ func (client *HTTPClientFailureClient) Put400(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Put400HandleResponse(resp)
-	if err != nil {
+	if err := client.Put400HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Put400CreateRequest creates the Put400 request.
@@ -1035,13 +968,11 @@ func (client *HTTPClientFailureClient) Put400CreateRequest(ctx context.Context) 
 	return req, req.MarshalAsJSON(true)
 }
 
-// Put400HandleResponse handles the Put400 response.
-func (client *HTTPClientFailureClient) Put400HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Put400HandleError(resp)
-}
-
 // Put400HandleError handles the Put400 error response.
 func (client *HTTPClientFailureClient) Put400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1059,11 +990,10 @@ func (client *HTTPClientFailureClient) Put404(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Put404HandleResponse(resp)
-	if err != nil {
+	if err := client.Put404HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Put404CreateRequest creates the Put404 request.
@@ -1077,13 +1007,11 @@ func (client *HTTPClientFailureClient) Put404CreateRequest(ctx context.Context) 
 	return req, req.MarshalAsJSON(true)
 }
 
-// Put404HandleResponse handles the Put404 response.
-func (client *HTTPClientFailureClient) Put404HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Put404HandleError(resp)
-}
-
 // Put404HandleError handles the Put404 error response.
 func (client *HTTPClientFailureClient) Put404HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1101,11 +1029,10 @@ func (client *HTTPClientFailureClient) Put409(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Put409HandleResponse(resp)
-	if err != nil {
+	if err := client.Put409HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Put409CreateRequest creates the Put409 request.
@@ -1119,13 +1046,11 @@ func (client *HTTPClientFailureClient) Put409CreateRequest(ctx context.Context) 
 	return req, req.MarshalAsJSON(true)
 }
 
-// Put409HandleResponse handles the Put409 response.
-func (client *HTTPClientFailureClient) Put409HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Put409HandleError(resp)
-}
-
 // Put409HandleError handles the Put409 error response.
 func (client *HTTPClientFailureClient) Put409HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1143,11 +1068,10 @@ func (client *HTTPClientFailureClient) Put413(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Put413HandleResponse(resp)
-	if err != nil {
+	if err := client.Put413HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Put413CreateRequest creates the Put413 request.
@@ -1161,13 +1085,11 @@ func (client *HTTPClientFailureClient) Put413CreateRequest(ctx context.Context) 
 	return req, req.MarshalAsJSON(true)
 }
 
-// Put413HandleResponse handles the Put413 response.
-func (client *HTTPClientFailureClient) Put413HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Put413HandleError(resp)
-}
-
 // Put413HandleError handles the Put413 error response.
 func (client *HTTPClientFailureClient) Put413HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure.go
@@ -93,8 +93,8 @@ func (client *HTTPClientFailureClient) Delete400(ctx context.Context) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Delete400HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -112,9 +112,6 @@ func (client *HTTPClientFailureClient) Delete400CreateRequest(ctx context.Contex
 
 // Delete400HandleError handles the Delete400 error response.
 func (client *HTTPClientFailureClient) Delete400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -132,8 +129,8 @@ func (client *HTTPClientFailureClient) Delete407(ctx context.Context) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete407HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Delete407HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -151,9 +148,6 @@ func (client *HTTPClientFailureClient) Delete407CreateRequest(ctx context.Contex
 
 // Delete407HandleError handles the Delete407 error response.
 func (client *HTTPClientFailureClient) Delete407HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -171,8 +165,8 @@ func (client *HTTPClientFailureClient) Delete417(ctx context.Context) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete417HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Delete417HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -190,9 +184,6 @@ func (client *HTTPClientFailureClient) Delete417CreateRequest(ctx context.Contex
 
 // Delete417HandleError handles the Delete417 error response.
 func (client *HTTPClientFailureClient) Delete417HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,8 +201,8 @@ func (client *HTTPClientFailureClient) Get400(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Get400HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -229,9 +220,6 @@ func (client *HTTPClientFailureClient) Get400CreateRequest(ctx context.Context) 
 
 // Get400HandleError handles the Get400 error response.
 func (client *HTTPClientFailureClient) Get400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -249,8 +237,8 @@ func (client *HTTPClientFailureClient) Get402(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get402HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Get402HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -268,9 +256,6 @@ func (client *HTTPClientFailureClient) Get402CreateRequest(ctx context.Context) 
 
 // Get402HandleError handles the Get402 error response.
 func (client *HTTPClientFailureClient) Get402HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -288,8 +273,8 @@ func (client *HTTPClientFailureClient) Get403(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get403HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Get403HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -307,9 +292,6 @@ func (client *HTTPClientFailureClient) Get403CreateRequest(ctx context.Context) 
 
 // Get403HandleError handles the Get403 error response.
 func (client *HTTPClientFailureClient) Get403HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -327,8 +309,8 @@ func (client *HTTPClientFailureClient) Get411(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get411HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Get411HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -346,9 +328,6 @@ func (client *HTTPClientFailureClient) Get411CreateRequest(ctx context.Context) 
 
 // Get411HandleError handles the Get411 error response.
 func (client *HTTPClientFailureClient) Get411HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -366,8 +345,8 @@ func (client *HTTPClientFailureClient) Get412(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get412HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Get412HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -385,9 +364,6 @@ func (client *HTTPClientFailureClient) Get412CreateRequest(ctx context.Context) 
 
 // Get412HandleError handles the Get412 error response.
 func (client *HTTPClientFailureClient) Get412HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -405,8 +381,8 @@ func (client *HTTPClientFailureClient) Get416(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get416HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Get416HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -424,9 +400,6 @@ func (client *HTTPClientFailureClient) Get416CreateRequest(ctx context.Context) 
 
 // Get416HandleError handles the Get416 error response.
 func (client *HTTPClientFailureClient) Get416HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -444,8 +417,8 @@ func (client *HTTPClientFailureClient) Head400(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Head400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Head400HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -463,9 +436,6 @@ func (client *HTTPClientFailureClient) Head400CreateRequest(ctx context.Context)
 
 // Head400HandleError handles the Head400 error response.
 func (client *HTTPClientFailureClient) Head400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -483,8 +453,8 @@ func (client *HTTPClientFailureClient) Head401(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Head401HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Head401HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -502,9 +472,6 @@ func (client *HTTPClientFailureClient) Head401CreateRequest(ctx context.Context)
 
 // Head401HandleError handles the Head401 error response.
 func (client *HTTPClientFailureClient) Head401HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -522,8 +489,8 @@ func (client *HTTPClientFailureClient) Head410(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Head410HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Head410HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -541,9 +508,6 @@ func (client *HTTPClientFailureClient) Head410CreateRequest(ctx context.Context)
 
 // Head410HandleError handles the Head410 error response.
 func (client *HTTPClientFailureClient) Head410HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -561,8 +525,8 @@ func (client *HTTPClientFailureClient) Head429(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Head429HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Head429HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -580,9 +544,6 @@ func (client *HTTPClientFailureClient) Head429CreateRequest(ctx context.Context)
 
 // Head429HandleError handles the Head429 error response.
 func (client *HTTPClientFailureClient) Head429HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -600,8 +561,8 @@ func (client *HTTPClientFailureClient) Options400(ctx context.Context) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Options400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Options400HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -619,9 +580,6 @@ func (client *HTTPClientFailureClient) Options400CreateRequest(ctx context.Conte
 
 // Options400HandleError handles the Options400 error response.
 func (client *HTTPClientFailureClient) Options400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -639,8 +597,8 @@ func (client *HTTPClientFailureClient) Options403(ctx context.Context) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Options403HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Options403HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -658,9 +616,6 @@ func (client *HTTPClientFailureClient) Options403CreateRequest(ctx context.Conte
 
 // Options403HandleError handles the Options403 error response.
 func (client *HTTPClientFailureClient) Options403HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -678,8 +633,8 @@ func (client *HTTPClientFailureClient) Options412(ctx context.Context) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Options412HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Options412HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -697,9 +652,6 @@ func (client *HTTPClientFailureClient) Options412CreateRequest(ctx context.Conte
 
 // Options412HandleError handles the Options412 error response.
 func (client *HTTPClientFailureClient) Options412HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -717,8 +669,8 @@ func (client *HTTPClientFailureClient) Patch400(ctx context.Context) (*http.Resp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Patch400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Patch400HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -736,9 +688,6 @@ func (client *HTTPClientFailureClient) Patch400CreateRequest(ctx context.Context
 
 // Patch400HandleError handles the Patch400 error response.
 func (client *HTTPClientFailureClient) Patch400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -756,8 +705,8 @@ func (client *HTTPClientFailureClient) Patch405(ctx context.Context) (*http.Resp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Patch405HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Patch405HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -775,9 +724,6 @@ func (client *HTTPClientFailureClient) Patch405CreateRequest(ctx context.Context
 
 // Patch405HandleError handles the Patch405 error response.
 func (client *HTTPClientFailureClient) Patch405HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -795,8 +741,8 @@ func (client *HTTPClientFailureClient) Patch414(ctx context.Context) (*http.Resp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Patch414HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Patch414HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -814,9 +760,6 @@ func (client *HTTPClientFailureClient) Patch414CreateRequest(ctx context.Context
 
 // Patch414HandleError handles the Patch414 error response.
 func (client *HTTPClientFailureClient) Patch414HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -834,8 +777,8 @@ func (client *HTTPClientFailureClient) Post400(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Post400HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -853,9 +796,6 @@ func (client *HTTPClientFailureClient) Post400CreateRequest(ctx context.Context)
 
 // Post400HandleError handles the Post400 error response.
 func (client *HTTPClientFailureClient) Post400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -873,8 +813,8 @@ func (client *HTTPClientFailureClient) Post406(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post406HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Post406HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -892,9 +832,6 @@ func (client *HTTPClientFailureClient) Post406CreateRequest(ctx context.Context)
 
 // Post406HandleError handles the Post406 error response.
 func (client *HTTPClientFailureClient) Post406HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -912,8 +849,8 @@ func (client *HTTPClientFailureClient) Post415(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post415HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Post415HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -931,9 +868,6 @@ func (client *HTTPClientFailureClient) Post415CreateRequest(ctx context.Context)
 
 // Post415HandleError handles the Post415 error response.
 func (client *HTTPClientFailureClient) Post415HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -951,8 +885,8 @@ func (client *HTTPClientFailureClient) Put400(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Put400HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -970,9 +904,6 @@ func (client *HTTPClientFailureClient) Put400CreateRequest(ctx context.Context) 
 
 // Put400HandleError handles the Put400 error response.
 func (client *HTTPClientFailureClient) Put400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -990,8 +921,8 @@ func (client *HTTPClientFailureClient) Put404(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put404HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Put404HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1009,9 +940,6 @@ func (client *HTTPClientFailureClient) Put404CreateRequest(ctx context.Context) 
 
 // Put404HandleError handles the Put404 error response.
 func (client *HTTPClientFailureClient) Put404HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1029,8 +957,8 @@ func (client *HTTPClientFailureClient) Put409(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put409HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Put409HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1048,9 +976,6 @@ func (client *HTTPClientFailureClient) Put409CreateRequest(ctx context.Context) 
 
 // Put409HandleError handles the Put409 error response.
 func (client *HTTPClientFailureClient) Put409HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1068,8 +993,8 @@ func (client *HTTPClientFailureClient) Put413(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put413HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Put413HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1087,9 +1012,6 @@ func (client *HTTPClientFailureClient) Put413CreateRequest(ctx context.Context) 
 
 // Put413HandleError handles the Put413 error response.
 func (client *HTTPClientFailureClient) Put413HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure.go
@@ -50,8 +50,8 @@ func (client *HTTPFailureClient) GetEmptyError(ctx context.Context) (*BoolRespon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyErrorHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyErrorHandleError(resp)
 	}
 	result, err := client.GetEmptyErrorHandleResponse(resp)
 	if err != nil {
@@ -79,9 +79,6 @@ func (client *HTTPFailureClient) GetEmptyErrorHandleResponse(resp *azcore.Respon
 
 // GetEmptyErrorHandleError handles the GetEmptyError error response.
 func (client *HTTPFailureClient) GetEmptyErrorHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -99,8 +96,8 @@ func (client *HTTPFailureClient) GetNoModelEmpty(ctx context.Context) (*BoolResp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNoModelEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNoModelEmptyHandleError(resp)
 	}
 	result, err := client.GetNoModelEmptyHandleResponse(resp)
 	if err != nil {
@@ -128,9 +125,6 @@ func (client *HTTPFailureClient) GetNoModelEmptyHandleResponse(resp *azcore.Resp
 
 // GetNoModelEmptyHandleError handles the GetNoModelEmpty error response.
 func (client *HTTPFailureClient) GetNoModelEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -151,8 +145,8 @@ func (client *HTTPFailureClient) GetNoModelError(ctx context.Context) (*BoolResp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNoModelErrorHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNoModelErrorHandleError(resp)
 	}
 	result, err := client.GetNoModelErrorHandleResponse(resp)
 	if err != nil {
@@ -180,9 +174,6 @@ func (client *HTTPFailureClient) GetNoModelErrorHandleResponse(resp *azcore.Resp
 
 // GetNoModelErrorHandleError handles the GetNoModelError error response.
 func (client *HTTPFailureClient) GetNoModelErrorHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure.go
@@ -50,6 +50,9 @@ func (client *HTTPFailureClient) GetEmptyError(ctx context.Context) (*BoolRespon
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetEmptyErrorHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetEmptyErrorHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -70,15 +73,15 @@ func (client *HTTPFailureClient) GetEmptyErrorCreateRequest(ctx context.Context)
 
 // GetEmptyErrorHandleResponse handles the GetEmptyError response.
 func (client *HTTPFailureClient) GetEmptyErrorHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyErrorHandleError(resp)
-	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetEmptyErrorHandleError handles the GetEmptyError error response.
 func (client *HTTPFailureClient) GetEmptyErrorHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -94,6 +97,9 @@ func (client *HTTPFailureClient) GetNoModelEmpty(ctx context.Context) (*BoolResp
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNoModelEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNoModelEmptyHandleResponse(resp)
@@ -116,15 +122,15 @@ func (client *HTTPFailureClient) GetNoModelEmptyCreateRequest(ctx context.Contex
 
 // GetNoModelEmptyHandleResponse handles the GetNoModelEmpty response.
 func (client *HTTPFailureClient) GetNoModelEmptyHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNoModelEmptyHandleError(resp)
-	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNoModelEmptyHandleError handles the GetNoModelEmpty error response.
 func (client *HTTPFailureClient) GetNoModelEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -143,6 +149,9 @@ func (client *HTTPFailureClient) GetNoModelError(ctx context.Context) (*BoolResp
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNoModelErrorHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNoModelErrorHandleResponse(resp)
@@ -165,15 +174,15 @@ func (client *HTTPFailureClient) GetNoModelErrorCreateRequest(ctx context.Contex
 
 // GetNoModelErrorHandleResponse handles the GetNoModelError response.
 func (client *HTTPFailureClient) GetNoModelErrorHandleResponse(resp *azcore.Response) (*BoolResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNoModelErrorHandleError(resp)
-	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNoModelErrorHandleError handles the GetNoModelError error response.
 func (client *HTTPFailureClient) GetNoModelErrorHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
@@ -7,6 +7,7 @@ package httpinfrastructuregroup
 
 import (
 	"context"
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
 )
@@ -74,11 +75,10 @@ func (client *HTTPRedirectsClient) Delete307(ctx context.Context) (*http.Respons
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Delete307HandleResponse(resp)
-	if err != nil {
+	if err := client.Delete307HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Delete307CreateRequest creates the Delete307 request.
@@ -92,16 +92,11 @@ func (client *HTTPRedirectsClient) Delete307CreateRequest(ctx context.Context) (
 	return req, req.MarshalAsJSON(true)
 }
 
-// Delete307HandleResponse handles the Delete307 response.
-func (client *HTTPRedirectsClient) Delete307HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Delete307HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Delete307HandleError handles the Delete307 error response.
 func (client *HTTPRedirectsClient) Delete307HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -118,6 +113,9 @@ func (client *HTTPRedirectsClient) Get300(ctx context.Context) (interface{}, err
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get300HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get300HandleResponse(resp)
@@ -154,12 +152,15 @@ func (client *HTTPRedirectsClient) Get300HandleResponse(resp *azcore.Response) (
 		}
 		return &result, resp.UnmarshalAsJSON(&result.StringArray)
 	default:
-		return nil, client.Get300HandleError(resp)
+		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
 }
 
 // Get300HandleError handles the Get300 error response.
 func (client *HTTPRedirectsClient) Get300HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusMultipleChoices) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -177,11 +178,10 @@ func (client *HTTPRedirectsClient) Get301(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get301HandleResponse(resp)
-	if err != nil {
+	if err := client.Get301HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get301CreateRequest creates the Get301 request.
@@ -195,16 +195,11 @@ func (client *HTTPRedirectsClient) Get301CreateRequest(ctx context.Context) (*az
 	return req, nil
 }
 
-// Get301HandleResponse handles the Get301 response.
-func (client *HTTPRedirectsClient) Get301HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Get301HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Get301HandleError handles the Get301 error response.
 func (client *HTTPRedirectsClient) Get301HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -222,11 +217,10 @@ func (client *HTTPRedirectsClient) Get302(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get302HandleResponse(resp)
-	if err != nil {
+	if err := client.Get302HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get302CreateRequest creates the Get302 request.
@@ -240,16 +234,11 @@ func (client *HTTPRedirectsClient) Get302CreateRequest(ctx context.Context) (*az
 	return req, nil
 }
 
-// Get302HandleResponse handles the Get302 response.
-func (client *HTTPRedirectsClient) Get302HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Get302HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Get302HandleError handles the Get302 error response.
 func (client *HTTPRedirectsClient) Get302HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -267,11 +256,10 @@ func (client *HTTPRedirectsClient) Get307(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get307HandleResponse(resp)
-	if err != nil {
+	if err := client.Get307HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get307CreateRequest creates the Get307 request.
@@ -285,16 +273,11 @@ func (client *HTTPRedirectsClient) Get307CreateRequest(ctx context.Context) (*az
 	return req, nil
 }
 
-// Get307HandleResponse handles the Get307 response.
-func (client *HTTPRedirectsClient) Get307HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Get307HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Get307HandleError handles the Get307 error response.
 func (client *HTTPRedirectsClient) Get307HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -310,6 +293,9 @@ func (client *HTTPRedirectsClient) Head300(ctx context.Context) (*HTTPRedirectsH
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Head300HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Head300HandleResponse(resp)
@@ -332,9 +318,6 @@ func (client *HTTPRedirectsClient) Head300CreateRequest(ctx context.Context) (*a
 
 // Head300HandleResponse handles the Head300 response.
 func (client *HTTPRedirectsClient) Head300HandleResponse(resp *azcore.Response) (*HTTPRedirectsHead300Response, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusMultipleChoices) {
-		return nil, client.Head300HandleError(resp)
-	}
 	result := HTTPRedirectsHead300Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
@@ -344,6 +327,9 @@ func (client *HTTPRedirectsClient) Head300HandleResponse(resp *azcore.Response) 
 
 // Head300HandleError handles the Head300 error response.
 func (client *HTTPRedirectsClient) Head300HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusMultipleChoices) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -361,11 +347,10 @@ func (client *HTTPRedirectsClient) Head301(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Head301HandleResponse(resp)
-	if err != nil {
+	if err := client.Head301HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Head301CreateRequest creates the Head301 request.
@@ -379,16 +364,11 @@ func (client *HTTPRedirectsClient) Head301CreateRequest(ctx context.Context) (*a
 	return req, nil
 }
 
-// Head301HandleResponse handles the Head301 response.
-func (client *HTTPRedirectsClient) Head301HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Head301HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Head301HandleError handles the Head301 error response.
 func (client *HTTPRedirectsClient) Head301HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -406,11 +386,10 @@ func (client *HTTPRedirectsClient) Head302(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Head302HandleResponse(resp)
-	if err != nil {
+	if err := client.Head302HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Head302CreateRequest creates the Head302 request.
@@ -424,16 +403,11 @@ func (client *HTTPRedirectsClient) Head302CreateRequest(ctx context.Context) (*a
 	return req, nil
 }
 
-// Head302HandleResponse handles the Head302 response.
-func (client *HTTPRedirectsClient) Head302HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Head302HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Head302HandleError handles the Head302 error response.
 func (client *HTTPRedirectsClient) Head302HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -451,11 +425,10 @@ func (client *HTTPRedirectsClient) Head307(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Head307HandleResponse(resp)
-	if err != nil {
+	if err := client.Head307HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Head307CreateRequest creates the Head307 request.
@@ -469,16 +442,11 @@ func (client *HTTPRedirectsClient) Head307CreateRequest(ctx context.Context) (*a
 	return req, nil
 }
 
-// Head307HandleResponse handles the Head307 response.
-func (client *HTTPRedirectsClient) Head307HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Head307HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Head307HandleError handles the Head307 error response.
 func (client *HTTPRedirectsClient) Head307HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -496,11 +464,10 @@ func (client *HTTPRedirectsClient) Options307(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Options307HandleResponse(resp)
-	if err != nil {
+	if err := client.Options307HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Options307CreateRequest creates the Options307 request.
@@ -514,16 +481,11 @@ func (client *HTTPRedirectsClient) Options307CreateRequest(ctx context.Context) 
 	return req, nil
 }
 
-// Options307HandleResponse handles the Options307 response.
-func (client *HTTPRedirectsClient) Options307HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Options307HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Options307HandleError handles the Options307 error response.
 func (client *HTTPRedirectsClient) Options307HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -539,6 +501,9 @@ func (client *HTTPRedirectsClient) Patch302(ctx context.Context) (*HTTPRedirects
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Patch302HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Patch302HandleResponse(resp)
@@ -561,9 +526,6 @@ func (client *HTTPRedirectsClient) Patch302CreateRequest(ctx context.Context) (*
 
 // Patch302HandleResponse handles the Patch302 response.
 func (client *HTTPRedirectsClient) Patch302HandleResponse(resp *azcore.Response) (*HTTPRedirectsPatch302Response, error) {
-	if !resp.HasStatusCode(http.StatusFound) {
-		return nil, client.Patch302HandleError(resp)
-	}
 	result := HTTPRedirectsPatch302Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
@@ -573,6 +535,9 @@ func (client *HTTPRedirectsClient) Patch302HandleResponse(resp *azcore.Response)
 
 // Patch302HandleError handles the Patch302 error response.
 func (client *HTTPRedirectsClient) Patch302HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusFound) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -590,11 +555,10 @@ func (client *HTTPRedirectsClient) Patch307(ctx context.Context) (*http.Response
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Patch307HandleResponse(resp)
-	if err != nil {
+	if err := client.Patch307HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Patch307CreateRequest creates the Patch307 request.
@@ -608,16 +572,11 @@ func (client *HTTPRedirectsClient) Patch307CreateRequest(ctx context.Context) (*
 	return req, req.MarshalAsJSON(true)
 }
 
-// Patch307HandleResponse handles the Patch307 response.
-func (client *HTTPRedirectsClient) Patch307HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Patch307HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Patch307HandleError handles the Patch307 error response.
 func (client *HTTPRedirectsClient) Patch307HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -633,6 +592,9 @@ func (client *HTTPRedirectsClient) Post303(ctx context.Context) (*HTTPRedirectsP
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Post303HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Post303HandleResponse(resp)
@@ -655,9 +617,6 @@ func (client *HTTPRedirectsClient) Post303CreateRequest(ctx context.Context) (*a
 
 // Post303HandleResponse handles the Post303 response.
 func (client *HTTPRedirectsClient) Post303HandleResponse(resp *azcore.Response) (*HTTPRedirectsPost303Response, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusSeeOther) {
-		return nil, client.Post303HandleError(resp)
-	}
 	result := HTTPRedirectsPost303Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
@@ -667,6 +626,9 @@ func (client *HTTPRedirectsClient) Post303HandleResponse(resp *azcore.Response) 
 
 // Post303HandleError handles the Post303 error response.
 func (client *HTTPRedirectsClient) Post303HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusSeeOther) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -684,11 +646,10 @@ func (client *HTTPRedirectsClient) Post307(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Post307HandleResponse(resp)
-	if err != nil {
+	if err := client.Post307HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Post307CreateRequest creates the Post307 request.
@@ -702,16 +663,11 @@ func (client *HTTPRedirectsClient) Post307CreateRequest(ctx context.Context) (*a
 	return req, req.MarshalAsJSON(true)
 }
 
-// Post307HandleResponse handles the Post307 response.
-func (client *HTTPRedirectsClient) Post307HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Post307HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Post307HandleError handles the Post307 error response.
 func (client *HTTPRedirectsClient) Post307HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -727,6 +683,9 @@ func (client *HTTPRedirectsClient) Put301(ctx context.Context) (*HTTPRedirectsPu
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Put301HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Put301HandleResponse(resp)
@@ -749,9 +708,6 @@ func (client *HTTPRedirectsClient) Put301CreateRequest(ctx context.Context) (*az
 
 // Put301HandleResponse handles the Put301 response.
 func (client *HTTPRedirectsClient) Put301HandleResponse(resp *azcore.Response) (*HTTPRedirectsPut301Response, error) {
-	if !resp.HasStatusCode(http.StatusMovedPermanently) {
-		return nil, client.Put301HandleError(resp)
-	}
 	result := HTTPRedirectsPut301Response{RawResponse: resp.Response}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
@@ -761,6 +717,9 @@ func (client *HTTPRedirectsClient) Put301HandleResponse(resp *azcore.Response) (
 
 // Put301HandleError handles the Put301 error response.
 func (client *HTTPRedirectsClient) Put301HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusMovedPermanently) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -778,11 +737,10 @@ func (client *HTTPRedirectsClient) Put307(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Put307HandleResponse(resp)
-	if err != nil {
+	if err := client.Put307HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Put307CreateRequest creates the Put307 request.
@@ -796,16 +754,11 @@ func (client *HTTPRedirectsClient) Put307CreateRequest(ctx context.Context) (*az
 	return req, req.MarshalAsJSON(true)
 }
 
-// Put307HandleResponse handles the Put307 response.
-func (client *HTTPRedirectsClient) Put307HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Put307HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Put307HandleError handles the Put307 error response.
 func (client *HTTPRedirectsClient) Put307HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
@@ -75,8 +75,8 @@ func (client *HTTPRedirectsClient) Delete307(ctx context.Context) (*http.Respons
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete307HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Delete307HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -94,9 +94,6 @@ func (client *HTTPRedirectsClient) Delete307CreateRequest(ctx context.Context) (
 
 // Delete307HandleError handles the Delete307 error response.
 func (client *HTTPRedirectsClient) Delete307HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -115,8 +112,8 @@ func (client *HTTPRedirectsClient) Get300(ctx context.Context) (interface{}, err
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get300HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusMultipleChoices) {
+		return nil, client.Get300HandleError(resp)
 	}
 	result, err := client.Get300HandleResponse(resp)
 	if err != nil {
@@ -158,9 +155,6 @@ func (client *HTTPRedirectsClient) Get300HandleResponse(resp *azcore.Response) (
 
 // Get300HandleError handles the Get300 error response.
 func (client *HTTPRedirectsClient) Get300HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusMultipleChoices) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -178,8 +172,8 @@ func (client *HTTPRedirectsClient) Get301(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get301HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Get301HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -197,9 +191,6 @@ func (client *HTTPRedirectsClient) Get301CreateRequest(ctx context.Context) (*az
 
 // Get301HandleError handles the Get301 error response.
 func (client *HTTPRedirectsClient) Get301HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -217,8 +208,8 @@ func (client *HTTPRedirectsClient) Get302(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get302HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Get302HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -236,9 +227,6 @@ func (client *HTTPRedirectsClient) Get302CreateRequest(ctx context.Context) (*az
 
 // Get302HandleError handles the Get302 error response.
 func (client *HTTPRedirectsClient) Get302HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -256,8 +244,8 @@ func (client *HTTPRedirectsClient) Get307(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get307HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Get307HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -275,9 +263,6 @@ func (client *HTTPRedirectsClient) Get307CreateRequest(ctx context.Context) (*az
 
 // Get307HandleError handles the Get307 error response.
 func (client *HTTPRedirectsClient) Get307HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -295,8 +280,8 @@ func (client *HTTPRedirectsClient) Head300(ctx context.Context) (*HTTPRedirectsH
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Head300HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusMultipleChoices) {
+		return nil, client.Head300HandleError(resp)
 	}
 	result, err := client.Head300HandleResponse(resp)
 	if err != nil {
@@ -327,9 +312,6 @@ func (client *HTTPRedirectsClient) Head300HandleResponse(resp *azcore.Response) 
 
 // Head300HandleError handles the Head300 error response.
 func (client *HTTPRedirectsClient) Head300HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusMultipleChoices) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -347,8 +329,8 @@ func (client *HTTPRedirectsClient) Head301(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Head301HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Head301HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -366,9 +348,6 @@ func (client *HTTPRedirectsClient) Head301CreateRequest(ctx context.Context) (*a
 
 // Head301HandleError handles the Head301 error response.
 func (client *HTTPRedirectsClient) Head301HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -386,8 +365,8 @@ func (client *HTTPRedirectsClient) Head302(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Head302HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Head302HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -405,9 +384,6 @@ func (client *HTTPRedirectsClient) Head302CreateRequest(ctx context.Context) (*a
 
 // Head302HandleError handles the Head302 error response.
 func (client *HTTPRedirectsClient) Head302HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -425,8 +401,8 @@ func (client *HTTPRedirectsClient) Head307(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Head307HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Head307HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -444,9 +420,6 @@ func (client *HTTPRedirectsClient) Head307CreateRequest(ctx context.Context) (*a
 
 // Head307HandleError handles the Head307 error response.
 func (client *HTTPRedirectsClient) Head307HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -464,8 +437,8 @@ func (client *HTTPRedirectsClient) Options307(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Options307HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Options307HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -483,9 +456,6 @@ func (client *HTTPRedirectsClient) Options307CreateRequest(ctx context.Context) 
 
 // Options307HandleError handles the Options307 error response.
 func (client *HTTPRedirectsClient) Options307HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -503,8 +473,8 @@ func (client *HTTPRedirectsClient) Patch302(ctx context.Context) (*HTTPRedirects
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Patch302HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusFound) {
+		return nil, client.Patch302HandleError(resp)
 	}
 	result, err := client.Patch302HandleResponse(resp)
 	if err != nil {
@@ -535,9 +505,6 @@ func (client *HTTPRedirectsClient) Patch302HandleResponse(resp *azcore.Response)
 
 // Patch302HandleError handles the Patch302 error response.
 func (client *HTTPRedirectsClient) Patch302HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusFound) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -555,8 +522,8 @@ func (client *HTTPRedirectsClient) Patch307(ctx context.Context) (*http.Response
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Patch307HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Patch307HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -574,9 +541,6 @@ func (client *HTTPRedirectsClient) Patch307CreateRequest(ctx context.Context) (*
 
 // Patch307HandleError handles the Patch307 error response.
 func (client *HTTPRedirectsClient) Patch307HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -594,8 +558,8 @@ func (client *HTTPRedirectsClient) Post303(ctx context.Context) (*HTTPRedirectsP
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post303HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusSeeOther) {
+		return nil, client.Post303HandleError(resp)
 	}
 	result, err := client.Post303HandleResponse(resp)
 	if err != nil {
@@ -626,9 +590,6 @@ func (client *HTTPRedirectsClient) Post303HandleResponse(resp *azcore.Response) 
 
 // Post303HandleError handles the Post303 error response.
 func (client *HTTPRedirectsClient) Post303HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusSeeOther) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -646,8 +607,8 @@ func (client *HTTPRedirectsClient) Post307(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post307HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Post307HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -665,9 +626,6 @@ func (client *HTTPRedirectsClient) Post307CreateRequest(ctx context.Context) (*a
 
 // Post307HandleError handles the Post307 error response.
 func (client *HTTPRedirectsClient) Post307HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -685,8 +643,8 @@ func (client *HTTPRedirectsClient) Put301(ctx context.Context) (*HTTPRedirectsPu
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put301HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusMovedPermanently) {
+		return nil, client.Put301HandleError(resp)
 	}
 	result, err := client.Put301HandleResponse(resp)
 	if err != nil {
@@ -717,9 +675,6 @@ func (client *HTTPRedirectsClient) Put301HandleResponse(resp *azcore.Response) (
 
 // Put301HandleError handles the Put301 error response.
 func (client *HTTPRedirectsClient) Put301HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusMovedPermanently) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -737,8 +692,8 @@ func (client *HTTPRedirectsClient) Put307(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put307HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Put307HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -756,9 +711,6 @@ func (client *HTTPRedirectsClient) Put307CreateRequest(ctx context.Context) (*az
 
 // Put307HandleError handles the Put307 error response.
 func (client *HTTPRedirectsClient) Put307HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpretry.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpretry.go
@@ -59,8 +59,8 @@ func (client *HTTPRetryClient) Delete503(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete503HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Delete503HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -78,9 +78,6 @@ func (client *HTTPRetryClient) Delete503CreateRequest(ctx context.Context) (*azc
 
 // Delete503HandleError handles the Delete503 error response.
 func (client *HTTPRetryClient) Delete503HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -98,8 +95,8 @@ func (client *HTTPRetryClient) Get502(ctx context.Context) (*http.Response, erro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get502HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Get502HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -117,9 +114,6 @@ func (client *HTTPRetryClient) Get502CreateRequest(ctx context.Context) (*azcore
 
 // Get502HandleError handles the Get502 error response.
 func (client *HTTPRetryClient) Get502HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -137,8 +131,8 @@ func (client *HTTPRetryClient) Head408(ctx context.Context) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Head408HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Head408HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -156,9 +150,6 @@ func (client *HTTPRetryClient) Head408CreateRequest(ctx context.Context) (*azcor
 
 // Head408HandleError handles the Head408 error response.
 func (client *HTTPRetryClient) Head408HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -176,8 +167,8 @@ func (client *HTTPRetryClient) Options502(ctx context.Context) (*BoolResponse, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Options502HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Options502HandleError(resp)
 	}
 	result, err := client.Options502HandleResponse(resp)
 	if err != nil {
@@ -205,9 +196,6 @@ func (client *HTTPRetryClient) Options502HandleResponse(resp *azcore.Response) (
 
 // Options502HandleError handles the Options502 error response.
 func (client *HTTPRetryClient) Options502HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -225,8 +213,8 @@ func (client *HTTPRetryClient) Patch500(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Patch500HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Patch500HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -244,9 +232,6 @@ func (client *HTTPRetryClient) Patch500CreateRequest(ctx context.Context) (*azco
 
 // Patch500HandleError handles the Patch500 error response.
 func (client *HTTPRetryClient) Patch500HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -264,8 +249,8 @@ func (client *HTTPRetryClient) Patch504(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Patch504HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Patch504HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -283,9 +268,6 @@ func (client *HTTPRetryClient) Patch504CreateRequest(ctx context.Context) (*azco
 
 // Patch504HandleError handles the Patch504 error response.
 func (client *HTTPRetryClient) Patch504HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -303,8 +285,8 @@ func (client *HTTPRetryClient) Post503(ctx context.Context) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post503HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Post503HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -322,9 +304,6 @@ func (client *HTTPRetryClient) Post503CreateRequest(ctx context.Context) (*azcor
 
 // Post503HandleError handles the Post503 error response.
 func (client *HTTPRetryClient) Post503HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -342,8 +321,8 @@ func (client *HTTPRetryClient) Put500(ctx context.Context) (*http.Response, erro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put500HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Put500HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -361,9 +340,6 @@ func (client *HTTPRetryClient) Put500CreateRequest(ctx context.Context) (*azcore
 
 // Put500HandleError handles the Put500 error response.
 func (client *HTTPRetryClient) Put500HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -381,8 +357,8 @@ func (client *HTTPRetryClient) Put504(ctx context.Context) (*http.Response, erro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put504HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Put504HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -400,9 +376,6 @@ func (client *HTTPRetryClient) Put504CreateRequest(ctx context.Context) (*azcore
 
 // Put504HandleError handles the Put504 error response.
 func (client *HTTPRetryClient) Put504HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpretry.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpretry.go
@@ -59,11 +59,10 @@ func (client *HTTPRetryClient) Delete503(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Delete503HandleResponse(resp)
-	if err != nil {
+	if err := client.Delete503HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Delete503CreateRequest creates the Delete503 request.
@@ -77,16 +76,11 @@ func (client *HTTPRetryClient) Delete503CreateRequest(ctx context.Context) (*azc
 	return req, req.MarshalAsJSON(true)
 }
 
-// Delete503HandleResponse handles the Delete503 response.
-func (client *HTTPRetryClient) Delete503HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Delete503HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Delete503HandleError handles the Delete503 error response.
 func (client *HTTPRetryClient) Delete503HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -104,11 +98,10 @@ func (client *HTTPRetryClient) Get502(ctx context.Context) (*http.Response, erro
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get502HandleResponse(resp)
-	if err != nil {
+	if err := client.Get502HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get502CreateRequest creates the Get502 request.
@@ -122,16 +115,11 @@ func (client *HTTPRetryClient) Get502CreateRequest(ctx context.Context) (*azcore
 	return req, nil
 }
 
-// Get502HandleResponse handles the Get502 response.
-func (client *HTTPRetryClient) Get502HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Get502HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Get502HandleError handles the Get502 error response.
 func (client *HTTPRetryClient) Get502HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -149,11 +137,10 @@ func (client *HTTPRetryClient) Head408(ctx context.Context) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Head408HandleResponse(resp)
-	if err != nil {
+	if err := client.Head408HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Head408CreateRequest creates the Head408 request.
@@ -167,16 +154,11 @@ func (client *HTTPRetryClient) Head408CreateRequest(ctx context.Context) (*azcor
 	return req, nil
 }
 
-// Head408HandleResponse handles the Head408 response.
-func (client *HTTPRetryClient) Head408HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Head408HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Head408HandleError handles the Head408 error response.
 func (client *HTTPRetryClient) Head408HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -192,6 +174,9 @@ func (client *HTTPRetryClient) Options502(ctx context.Context) (*BoolResponse, e
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Options502HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Options502HandleResponse(resp)
@@ -214,15 +199,15 @@ func (client *HTTPRetryClient) Options502CreateRequest(ctx context.Context) (*az
 
 // Options502HandleResponse handles the Options502 response.
 func (client *HTTPRetryClient) Options502HandleResponse(resp *azcore.Response) (*BoolResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Options502HandleError(resp)
-	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // Options502HandleError handles the Options502 error response.
 func (client *HTTPRetryClient) Options502HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -240,11 +225,10 @@ func (client *HTTPRetryClient) Patch500(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Patch500HandleResponse(resp)
-	if err != nil {
+	if err := client.Patch500HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Patch500CreateRequest creates the Patch500 request.
@@ -258,16 +242,11 @@ func (client *HTTPRetryClient) Patch500CreateRequest(ctx context.Context) (*azco
 	return req, req.MarshalAsJSON(true)
 }
 
-// Patch500HandleResponse handles the Patch500 response.
-func (client *HTTPRetryClient) Patch500HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Patch500HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Patch500HandleError handles the Patch500 error response.
 func (client *HTTPRetryClient) Patch500HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -285,11 +264,10 @@ func (client *HTTPRetryClient) Patch504(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Patch504HandleResponse(resp)
-	if err != nil {
+	if err := client.Patch504HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Patch504CreateRequest creates the Patch504 request.
@@ -303,16 +281,11 @@ func (client *HTTPRetryClient) Patch504CreateRequest(ctx context.Context) (*azco
 	return req, req.MarshalAsJSON(true)
 }
 
-// Patch504HandleResponse handles the Patch504 response.
-func (client *HTTPRetryClient) Patch504HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Patch504HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Patch504HandleError handles the Patch504 error response.
 func (client *HTTPRetryClient) Patch504HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -330,11 +303,10 @@ func (client *HTTPRetryClient) Post503(ctx context.Context) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Post503HandleResponse(resp)
-	if err != nil {
+	if err := client.Post503HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Post503CreateRequest creates the Post503 request.
@@ -348,16 +320,11 @@ func (client *HTTPRetryClient) Post503CreateRequest(ctx context.Context) (*azcor
 	return req, req.MarshalAsJSON(true)
 }
 
-// Post503HandleResponse handles the Post503 response.
-func (client *HTTPRetryClient) Post503HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Post503HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Post503HandleError handles the Post503 error response.
 func (client *HTTPRetryClient) Post503HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -375,11 +342,10 @@ func (client *HTTPRetryClient) Put500(ctx context.Context) (*http.Response, erro
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Put500HandleResponse(resp)
-	if err != nil {
+	if err := client.Put500HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Put500CreateRequest creates the Put500 request.
@@ -393,16 +359,11 @@ func (client *HTTPRetryClient) Put500CreateRequest(ctx context.Context) (*azcore
 	return req, req.MarshalAsJSON(true)
 }
 
-// Put500HandleResponse handles the Put500 response.
-func (client *HTTPRetryClient) Put500HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Put500HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Put500HandleError handles the Put500 error response.
 func (client *HTTPRetryClient) Put500HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -420,11 +381,10 @@ func (client *HTTPRetryClient) Put504(ctx context.Context) (*http.Response, erro
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Put504HandleResponse(resp)
-	if err != nil {
+	if err := client.Put504HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Put504CreateRequest creates the Put504 request.
@@ -438,16 +398,11 @@ func (client *HTTPRetryClient) Put504CreateRequest(ctx context.Context) (*azcore
 	return req, req.MarshalAsJSON(true)
 }
 
-// Put504HandleResponse handles the Put504 response.
-func (client *HTTPRetryClient) Put504HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Put504HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Put504HandleError handles the Put504 error response.
 func (client *HTTPRetryClient) Put504HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure.go
@@ -49,11 +49,10 @@ func (client *HTTPServerFailureClient) Delete505(ctx context.Context) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Delete505HandleResponse(resp)
-	if err != nil {
+	if err := client.Delete505HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Delete505CreateRequest creates the Delete505 request.
@@ -67,13 +66,11 @@ func (client *HTTPServerFailureClient) Delete505CreateRequest(ctx context.Contex
 	return req, req.MarshalAsJSON(true)
 }
 
-// Delete505HandleResponse handles the Delete505 response.
-func (client *HTTPServerFailureClient) Delete505HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Delete505HandleError(resp)
-}
-
 // Delete505HandleError handles the Delete505 error response.
 func (client *HTTPServerFailureClient) Delete505HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -91,11 +88,10 @@ func (client *HTTPServerFailureClient) Get501(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get501HandleResponse(resp)
-	if err != nil {
+	if err := client.Get501HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get501CreateRequest creates the Get501 request.
@@ -109,13 +105,11 @@ func (client *HTTPServerFailureClient) Get501CreateRequest(ctx context.Context) 
 	return req, nil
 }
 
-// Get501HandleResponse handles the Get501 response.
-func (client *HTTPServerFailureClient) Get501HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Get501HandleError(resp)
-}
-
 // Get501HandleError handles the Get501 error response.
 func (client *HTTPServerFailureClient) Get501HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,11 +127,10 @@ func (client *HTTPServerFailureClient) Head501(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Head501HandleResponse(resp)
-	if err != nil {
+	if err := client.Head501HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Head501CreateRequest creates the Head501 request.
@@ -151,13 +144,11 @@ func (client *HTTPServerFailureClient) Head501CreateRequest(ctx context.Context)
 	return req, nil
 }
 
-// Head501HandleResponse handles the Head501 response.
-func (client *HTTPServerFailureClient) Head501HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Head501HandleError(resp)
-}
-
 // Head501HandleError handles the Head501 error response.
 func (client *HTTPServerFailureClient) Head501HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -175,11 +166,10 @@ func (client *HTTPServerFailureClient) Post505(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Post505HandleResponse(resp)
-	if err != nil {
+	if err := client.Post505HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Post505CreateRequest creates the Post505 request.
@@ -193,13 +183,11 @@ func (client *HTTPServerFailureClient) Post505CreateRequest(ctx context.Context)
 	return req, req.MarshalAsJSON(true)
 }
 
-// Post505HandleResponse handles the Post505 response.
-func (client *HTTPServerFailureClient) Post505HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	return nil, client.Post505HandleError(resp)
-}
-
 // Post505HandleError handles the Post505 error response.
 func (client *HTTPServerFailureClient) Post505HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode() {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure.go
@@ -49,8 +49,8 @@ func (client *HTTPServerFailureClient) Delete505(ctx context.Context) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete505HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Delete505HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -68,9 +68,6 @@ func (client *HTTPServerFailureClient) Delete505CreateRequest(ctx context.Contex
 
 // Delete505HandleError handles the Delete505 error response.
 func (client *HTTPServerFailureClient) Delete505HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -88,8 +85,8 @@ func (client *HTTPServerFailureClient) Get501(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get501HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Get501HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -107,9 +104,6 @@ func (client *HTTPServerFailureClient) Get501CreateRequest(ctx context.Context) 
 
 // Get501HandleError handles the Get501 error response.
 func (client *HTTPServerFailureClient) Get501HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -127,8 +121,8 @@ func (client *HTTPServerFailureClient) Head501(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Head501HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Head501HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -146,9 +140,6 @@ func (client *HTTPServerFailureClient) Head501CreateRequest(ctx context.Context)
 
 // Head501HandleError handles the Head501 error response.
 func (client *HTTPServerFailureClient) Head501HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -166,8 +157,8 @@ func (client *HTTPServerFailureClient) Post505(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post505HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode() {
+		return nil, client.Post505HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -185,9 +176,6 @@ func (client *HTTPServerFailureClient) Post505CreateRequest(ctx context.Context)
 
 // Post505HandleError handles the Post505 error response.
 func (client *HTTPServerFailureClient) Post505HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode() {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess.go
@@ -79,11 +79,10 @@ func (client *HTTPSuccessClient) Delete200(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Delete200HandleResponse(resp)
-	if err != nil {
+	if err := client.Delete200HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Delete200CreateRequest creates the Delete200 request.
@@ -97,16 +96,11 @@ func (client *HTTPSuccessClient) Delete200CreateRequest(ctx context.Context) (*a
 	return req, req.MarshalAsJSON(true)
 }
 
-// Delete200HandleResponse handles the Delete200 response.
-func (client *HTTPSuccessClient) Delete200HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Delete200HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Delete200HandleError handles the Delete200 error response.
 func (client *HTTPSuccessClient) Delete200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -124,11 +118,10 @@ func (client *HTTPSuccessClient) Delete202(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Delete202HandleResponse(resp)
-	if err != nil {
+	if err := client.Delete202HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Delete202CreateRequest creates the Delete202 request.
@@ -142,16 +135,11 @@ func (client *HTTPSuccessClient) Delete202CreateRequest(ctx context.Context) (*a
 	return req, req.MarshalAsJSON(true)
 }
 
-// Delete202HandleResponse handles the Delete202 response.
-func (client *HTTPSuccessClient) Delete202HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, client.Delete202HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Delete202HandleError handles the Delete202 error response.
 func (client *HTTPSuccessClient) Delete202HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -169,11 +157,10 @@ func (client *HTTPSuccessClient) Delete204(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Delete204HandleResponse(resp)
-	if err != nil {
+	if err := client.Delete204HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Delete204CreateRequest creates the Delete204 request.
@@ -187,16 +174,11 @@ func (client *HTTPSuccessClient) Delete204CreateRequest(ctx context.Context) (*a
 	return req, req.MarshalAsJSON(true)
 }
 
-// Delete204HandleResponse handles the Delete204 response.
-func (client *HTTPSuccessClient) Delete204HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusNoContent) {
-		return nil, client.Delete204HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Delete204HandleError handles the Delete204 error response.
 func (client *HTTPSuccessClient) Delete204HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -212,6 +194,9 @@ func (client *HTTPSuccessClient) Get200(ctx context.Context) (*BoolResponse, err
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200HandleResponse(resp)
@@ -234,15 +219,15 @@ func (client *HTTPSuccessClient) Get200CreateRequest(ctx context.Context) (*azco
 
 // Get200HandleResponse handles the Get200 response.
 func (client *HTTPSuccessClient) Get200HandleResponse(resp *azcore.Response) (*BoolResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Get200HandleError(resp)
-	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // Get200HandleError handles the Get200 error response.
 func (client *HTTPSuccessClient) Get200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -260,11 +245,10 @@ func (client *HTTPSuccessClient) Head200(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Head200HandleResponse(resp)
-	if err != nil {
+	if err := client.Head200HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Head200CreateRequest creates the Head200 request.
@@ -278,16 +262,11 @@ func (client *HTTPSuccessClient) Head200CreateRequest(ctx context.Context) (*azc
 	return req, nil
 }
 
-// Head200HandleResponse handles the Head200 response.
-func (client *HTTPSuccessClient) Head200HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Head200HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Head200HandleError handles the Head200 error response.
 func (client *HTTPSuccessClient) Head200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -305,11 +284,10 @@ func (client *HTTPSuccessClient) Head204(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Head204HandleResponse(resp)
-	if err != nil {
+	if err := client.Head204HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Head204CreateRequest creates the Head204 request.
@@ -323,16 +301,11 @@ func (client *HTTPSuccessClient) Head204CreateRequest(ctx context.Context) (*azc
 	return req, nil
 }
 
-// Head204HandleResponse handles the Head204 response.
-func (client *HTTPSuccessClient) Head204HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusNoContent) {
-		return nil, client.Head204HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Head204HandleError handles the Head204 error response.
 func (client *HTTPSuccessClient) Head204HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -350,11 +323,10 @@ func (client *HTTPSuccessClient) Head404(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Head404HandleResponse(resp)
-	if err != nil {
+	if err := client.Head404HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Head404CreateRequest creates the Head404 request.
@@ -368,16 +340,11 @@ func (client *HTTPSuccessClient) Head404CreateRequest(ctx context.Context) (*azc
 	return req, nil
 }
 
-// Head404HandleResponse handles the Head404 response.
-func (client *HTTPSuccessClient) Head404HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusNoContent, http.StatusNotFound) {
-		return nil, client.Head404HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Head404HandleError handles the Head404 error response.
 func (client *HTTPSuccessClient) Head404HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusNoContent, http.StatusNotFound) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -393,6 +360,9 @@ func (client *HTTPSuccessClient) Options200(ctx context.Context) (*BoolResponse,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Options200HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Options200HandleResponse(resp)
@@ -415,15 +385,15 @@ func (client *HTTPSuccessClient) Options200CreateRequest(ctx context.Context) (*
 
 // Options200HandleResponse handles the Options200 response.
 func (client *HTTPSuccessClient) Options200HandleResponse(resp *azcore.Response) (*BoolResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Options200HandleError(resp)
-	}
 	result := BoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // Options200HandleError handles the Options200 error response.
 func (client *HTTPSuccessClient) Options200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -441,11 +411,10 @@ func (client *HTTPSuccessClient) Patch200(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Patch200HandleResponse(resp)
-	if err != nil {
+	if err := client.Patch200HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Patch200CreateRequest creates the Patch200 request.
@@ -459,16 +428,11 @@ func (client *HTTPSuccessClient) Patch200CreateRequest(ctx context.Context) (*az
 	return req, req.MarshalAsJSON(true)
 }
 
-// Patch200HandleResponse handles the Patch200 response.
-func (client *HTTPSuccessClient) Patch200HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Patch200HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Patch200HandleError handles the Patch200 error response.
 func (client *HTTPSuccessClient) Patch200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -486,11 +450,10 @@ func (client *HTTPSuccessClient) Patch202(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Patch202HandleResponse(resp)
-	if err != nil {
+	if err := client.Patch202HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Patch202CreateRequest creates the Patch202 request.
@@ -504,16 +467,11 @@ func (client *HTTPSuccessClient) Patch202CreateRequest(ctx context.Context) (*az
 	return req, req.MarshalAsJSON(true)
 }
 
-// Patch202HandleResponse handles the Patch202 response.
-func (client *HTTPSuccessClient) Patch202HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, client.Patch202HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Patch202HandleError handles the Patch202 error response.
 func (client *HTTPSuccessClient) Patch202HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -531,11 +489,10 @@ func (client *HTTPSuccessClient) Patch204(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Patch204HandleResponse(resp)
-	if err != nil {
+	if err := client.Patch204HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Patch204CreateRequest creates the Patch204 request.
@@ -549,16 +506,11 @@ func (client *HTTPSuccessClient) Patch204CreateRequest(ctx context.Context) (*az
 	return req, req.MarshalAsJSON(true)
 }
 
-// Patch204HandleResponse handles the Patch204 response.
-func (client *HTTPSuccessClient) Patch204HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusNoContent) {
-		return nil, client.Patch204HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Patch204HandleError handles the Patch204 error response.
 func (client *HTTPSuccessClient) Patch204HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -576,11 +528,10 @@ func (client *HTTPSuccessClient) Post200(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Post200HandleResponse(resp)
-	if err != nil {
+	if err := client.Post200HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Post200CreateRequest creates the Post200 request.
@@ -594,16 +545,11 @@ func (client *HTTPSuccessClient) Post200CreateRequest(ctx context.Context) (*azc
 	return req, req.MarshalAsJSON(true)
 }
 
-// Post200HandleResponse handles the Post200 response.
-func (client *HTTPSuccessClient) Post200HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Post200HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Post200HandleError handles the Post200 error response.
 func (client *HTTPSuccessClient) Post200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -621,11 +567,10 @@ func (client *HTTPSuccessClient) Post201(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Post201HandleResponse(resp)
-	if err != nil {
+	if err := client.Post201HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Post201CreateRequest creates the Post201 request.
@@ -639,16 +584,11 @@ func (client *HTTPSuccessClient) Post201CreateRequest(ctx context.Context) (*azc
 	return req, req.MarshalAsJSON(true)
 }
 
-// Post201HandleResponse handles the Post201 response.
-func (client *HTTPSuccessClient) Post201HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.Post201HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Post201HandleError handles the Post201 error response.
 func (client *HTTPSuccessClient) Post201HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -666,11 +606,10 @@ func (client *HTTPSuccessClient) Post202(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Post202HandleResponse(resp)
-	if err != nil {
+	if err := client.Post202HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Post202CreateRequest creates the Post202 request.
@@ -684,16 +623,11 @@ func (client *HTTPSuccessClient) Post202CreateRequest(ctx context.Context) (*azc
 	return req, req.MarshalAsJSON(true)
 }
 
-// Post202HandleResponse handles the Post202 response.
-func (client *HTTPSuccessClient) Post202HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, client.Post202HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Post202HandleError handles the Post202 error response.
 func (client *HTTPSuccessClient) Post202HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -711,11 +645,10 @@ func (client *HTTPSuccessClient) Post204(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Post204HandleResponse(resp)
-	if err != nil {
+	if err := client.Post204HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Post204CreateRequest creates the Post204 request.
@@ -729,16 +662,11 @@ func (client *HTTPSuccessClient) Post204CreateRequest(ctx context.Context) (*azc
 	return req, req.MarshalAsJSON(true)
 }
 
-// Post204HandleResponse handles the Post204 response.
-func (client *HTTPSuccessClient) Post204HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusNoContent) {
-		return nil, client.Post204HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Post204HandleError handles the Post204 error response.
 func (client *HTTPSuccessClient) Post204HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -756,11 +684,10 @@ func (client *HTTPSuccessClient) Put200(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Put200HandleResponse(resp)
-	if err != nil {
+	if err := client.Put200HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Put200CreateRequest creates the Put200 request.
@@ -774,16 +701,11 @@ func (client *HTTPSuccessClient) Put200CreateRequest(ctx context.Context) (*azco
 	return req, req.MarshalAsJSON(true)
 }
 
-// Put200HandleResponse handles the Put200 response.
-func (client *HTTPSuccessClient) Put200HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Put200HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Put200HandleError handles the Put200 error response.
 func (client *HTTPSuccessClient) Put200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -801,11 +723,10 @@ func (client *HTTPSuccessClient) Put201(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Put201HandleResponse(resp)
-	if err != nil {
+	if err := client.Put201HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Put201CreateRequest creates the Put201 request.
@@ -819,16 +740,11 @@ func (client *HTTPSuccessClient) Put201CreateRequest(ctx context.Context) (*azco
 	return req, req.MarshalAsJSON(true)
 }
 
-// Put201HandleResponse handles the Put201 response.
-func (client *HTTPSuccessClient) Put201HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.Put201HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Put201HandleError handles the Put201 error response.
 func (client *HTTPSuccessClient) Put201HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -846,11 +762,10 @@ func (client *HTTPSuccessClient) Put202(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Put202HandleResponse(resp)
-	if err != nil {
+	if err := client.Put202HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Put202CreateRequest creates the Put202 request.
@@ -864,16 +779,11 @@ func (client *HTTPSuccessClient) Put202CreateRequest(ctx context.Context) (*azco
 	return req, req.MarshalAsJSON(true)
 }
 
-// Put202HandleResponse handles the Put202 response.
-func (client *HTTPSuccessClient) Put202HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, client.Put202HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Put202HandleError handles the Put202 error response.
 func (client *HTTPSuccessClient) Put202HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -891,11 +801,10 @@ func (client *HTTPSuccessClient) Put204(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Put204HandleResponse(resp)
-	if err != nil {
+	if err := client.Put204HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Put204CreateRequest creates the Put204 request.
@@ -909,16 +818,11 @@ func (client *HTTPSuccessClient) Put204CreateRequest(ctx context.Context) (*azco
 	return req, req.MarshalAsJSON(true)
 }
 
-// Put204HandleResponse handles the Put204 response.
-func (client *HTTPSuccessClient) Put204HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusNoContent) {
-		return nil, client.Put204HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Put204HandleError handles the Put204 error response.
 func (client *HTTPSuccessClient) Put204HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess.go
@@ -79,8 +79,8 @@ func (client *HTTPSuccessClient) Delete200(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Delete200HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -98,9 +98,6 @@ func (client *HTTPSuccessClient) Delete200CreateRequest(ctx context.Context) (*a
 
 // Delete200HandleError handles the Delete200 error response.
 func (client *HTTPSuccessClient) Delete200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -118,8 +115,8 @@ func (client *HTTPSuccessClient) Delete202(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete202HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.Delete202HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -137,9 +134,6 @@ func (client *HTTPSuccessClient) Delete202CreateRequest(ctx context.Context) (*a
 
 // Delete202HandleError handles the Delete202 error response.
 func (client *HTTPSuccessClient) Delete202HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -157,8 +151,8 @@ func (client *HTTPSuccessClient) Delete204(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete204HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusNoContent) {
+		return nil, client.Delete204HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -176,9 +170,6 @@ func (client *HTTPSuccessClient) Delete204CreateRequest(ctx context.Context) (*a
 
 // Delete204HandleError handles the Delete204 error response.
 func (client *HTTPSuccessClient) Delete204HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -196,8 +187,8 @@ func (client *HTTPSuccessClient) Get200(ctx context.Context) (*BoolResponse, err
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Get200HandleError(resp)
 	}
 	result, err := client.Get200HandleResponse(resp)
 	if err != nil {
@@ -225,9 +216,6 @@ func (client *HTTPSuccessClient) Get200HandleResponse(resp *azcore.Response) (*B
 
 // Get200HandleError handles the Get200 error response.
 func (client *HTTPSuccessClient) Get200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -245,8 +233,8 @@ func (client *HTTPSuccessClient) Head200(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Head200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Head200HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -264,9 +252,6 @@ func (client *HTTPSuccessClient) Head200CreateRequest(ctx context.Context) (*azc
 
 // Head200HandleError handles the Head200 error response.
 func (client *HTTPSuccessClient) Head200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -284,8 +269,8 @@ func (client *HTTPSuccessClient) Head204(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Head204HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusNoContent) {
+		return nil, client.Head204HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -303,9 +288,6 @@ func (client *HTTPSuccessClient) Head204CreateRequest(ctx context.Context) (*azc
 
 // Head204HandleError handles the Head204 error response.
 func (client *HTTPSuccessClient) Head204HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -323,8 +305,8 @@ func (client *HTTPSuccessClient) Head404(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Head404HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusNoContent, http.StatusNotFound) {
+		return nil, client.Head404HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -342,9 +324,6 @@ func (client *HTTPSuccessClient) Head404CreateRequest(ctx context.Context) (*azc
 
 // Head404HandleError handles the Head404 error response.
 func (client *HTTPSuccessClient) Head404HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusNoContent, http.StatusNotFound) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -362,8 +341,8 @@ func (client *HTTPSuccessClient) Options200(ctx context.Context) (*BoolResponse,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Options200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Options200HandleError(resp)
 	}
 	result, err := client.Options200HandleResponse(resp)
 	if err != nil {
@@ -391,9 +370,6 @@ func (client *HTTPSuccessClient) Options200HandleResponse(resp *azcore.Response)
 
 // Options200HandleError handles the Options200 error response.
 func (client *HTTPSuccessClient) Options200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -411,8 +387,8 @@ func (client *HTTPSuccessClient) Patch200(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Patch200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Patch200HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -430,9 +406,6 @@ func (client *HTTPSuccessClient) Patch200CreateRequest(ctx context.Context) (*az
 
 // Patch200HandleError handles the Patch200 error response.
 func (client *HTTPSuccessClient) Patch200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -450,8 +423,8 @@ func (client *HTTPSuccessClient) Patch202(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Patch202HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.Patch202HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -469,9 +442,6 @@ func (client *HTTPSuccessClient) Patch202CreateRequest(ctx context.Context) (*az
 
 // Patch202HandleError handles the Patch202 error response.
 func (client *HTTPSuccessClient) Patch202HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -489,8 +459,8 @@ func (client *HTTPSuccessClient) Patch204(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Patch204HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusNoContent) {
+		return nil, client.Patch204HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -508,9 +478,6 @@ func (client *HTTPSuccessClient) Patch204CreateRequest(ctx context.Context) (*az
 
 // Patch204HandleError handles the Patch204 error response.
 func (client *HTTPSuccessClient) Patch204HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -528,8 +495,8 @@ func (client *HTTPSuccessClient) Post200(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Post200HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -547,9 +514,6 @@ func (client *HTTPSuccessClient) Post200CreateRequest(ctx context.Context) (*azc
 
 // Post200HandleError handles the Post200 error response.
 func (client *HTTPSuccessClient) Post200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -567,8 +531,8 @@ func (client *HTTPSuccessClient) Post201(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post201HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.Post201HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -586,9 +550,6 @@ func (client *HTTPSuccessClient) Post201CreateRequest(ctx context.Context) (*azc
 
 // Post201HandleError handles the Post201 error response.
 func (client *HTTPSuccessClient) Post201HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -606,8 +567,8 @@ func (client *HTTPSuccessClient) Post202(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post202HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.Post202HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -625,9 +586,6 @@ func (client *HTTPSuccessClient) Post202CreateRequest(ctx context.Context) (*azc
 
 // Post202HandleError handles the Post202 error response.
 func (client *HTTPSuccessClient) Post202HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -645,8 +603,8 @@ func (client *HTTPSuccessClient) Post204(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post204HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusNoContent) {
+		return nil, client.Post204HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -664,9 +622,6 @@ func (client *HTTPSuccessClient) Post204CreateRequest(ctx context.Context) (*azc
 
 // Post204HandleError handles the Post204 error response.
 func (client *HTTPSuccessClient) Post204HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -684,8 +639,8 @@ func (client *HTTPSuccessClient) Put200(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Put200HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -703,9 +658,6 @@ func (client *HTTPSuccessClient) Put200CreateRequest(ctx context.Context) (*azco
 
 // Put200HandleError handles the Put200 error response.
 func (client *HTTPSuccessClient) Put200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -723,8 +675,8 @@ func (client *HTTPSuccessClient) Put201(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put201HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.Put201HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -742,9 +694,6 @@ func (client *HTTPSuccessClient) Put201CreateRequest(ctx context.Context) (*azco
 
 // Put201HandleError handles the Put201 error response.
 func (client *HTTPSuccessClient) Put201HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -762,8 +711,8 @@ func (client *HTTPSuccessClient) Put202(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put202HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.Put202HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -781,9 +730,6 @@ func (client *HTTPSuccessClient) Put202CreateRequest(ctx context.Context) (*azco
 
 // Put202HandleError handles the Put202 error response.
 func (client *HTTPSuccessClient) Put202HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -801,8 +747,8 @@ func (client *HTTPSuccessClient) Put204(ctx context.Context) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put204HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusNoContent) {
+		return nil, client.Put204HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -820,9 +766,6 @@ func (client *HTTPSuccessClient) Put204CreateRequest(ctx context.Context) (*azco
 
 // Put204HandleError handles the Put204 error response.
 func (client *HTTPSuccessClient) Put204HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses.go
@@ -120,6 +120,9 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError200Valid(c
 	if err != nil {
 		return nil, err
 	}
+	if err := client.Get200Model201ModelDefaultError200ValidHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.Get200Model201ModelDefaultError200ValidHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -148,12 +151,15 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError200ValidHa
 		result := BResponse{RawResponse: resp.Response}
 		return &result, resp.UnmarshalAsJSON(&result.B)
 	default:
-		return nil, client.Get200Model201ModelDefaultError200ValidHandleError(resp)
+		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
 }
 
 // Get200Model201ModelDefaultError200ValidHandleError handles the Get200Model201ModelDefaultError200Valid error response.
 func (client *MultipleResponsesClient) Get200Model201ModelDefaultError200ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -170,6 +176,9 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError201Valid(c
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200Model201ModelDefaultError201ValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200Model201ModelDefaultError201ValidHandleResponse(resp)
@@ -200,12 +209,15 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError201ValidHa
 		result := BResponse{RawResponse: resp.Response}
 		return &result, resp.UnmarshalAsJSON(&result.B)
 	default:
-		return nil, client.Get200Model201ModelDefaultError201ValidHandleError(resp)
+		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
 }
 
 // Get200Model201ModelDefaultError201ValidHandleError handles the Get200Model201ModelDefaultError201Valid error response.
 func (client *MultipleResponsesClient) Get200Model201ModelDefaultError201ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -222,6 +234,9 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError400Valid(c
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200Model201ModelDefaultError400ValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200Model201ModelDefaultError400ValidHandleResponse(resp)
@@ -252,12 +267,15 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError400ValidHa
 		result := BResponse{RawResponse: resp.Response}
 		return &result, resp.UnmarshalAsJSON(&result.B)
 	default:
-		return nil, client.Get200Model201ModelDefaultError400ValidHandleError(resp)
+		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
 }
 
 // Get200Model201ModelDefaultError400ValidHandleError handles the Get200Model201ModelDefaultError400Valid error response.
 func (client *MultipleResponsesClient) Get200Model201ModelDefaultError400ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -273,6 +291,9 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200Valid
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200Model204NoModelDefaultError200ValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200Model204NoModelDefaultError200ValidHandleResponse(resp)
@@ -295,15 +316,15 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200Valid
 
 // Get200Model204NoModelDefaultError200ValidHandleResponse handles the Get200Model204NoModelDefaultError200Valid response.
 func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.Get200Model204NoModelDefaultError200ValidHandleError(resp)
-	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // Get200Model204NoModelDefaultError200ValidHandleError handles the Get200Model204NoModelDefaultError200Valid error response.
 func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -319,6 +340,9 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201Inval
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200Model204NoModelDefaultError201InvalidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200Model204NoModelDefaultError201InvalidHandleResponse(resp)
@@ -341,15 +365,15 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201Inval
 
 // Get200Model204NoModelDefaultError201InvalidHandleResponse handles the Get200Model204NoModelDefaultError201Invalid response.
 func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201InvalidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.Get200Model204NoModelDefaultError201InvalidHandleError(resp)
-	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // Get200Model204NoModelDefaultError201InvalidHandleError handles the Get200Model204NoModelDefaultError201Invalid error response.
 func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201InvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -365,6 +389,9 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202None(
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200Model204NoModelDefaultError202NoneHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200Model204NoModelDefaultError202NoneHandleResponse(resp)
@@ -387,15 +414,15 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202NoneC
 
 // Get200Model204NoModelDefaultError202NoneHandleResponse handles the Get200Model204NoModelDefaultError202None response.
 func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202NoneHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.Get200Model204NoModelDefaultError202NoneHandleError(resp)
-	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // Get200Model204NoModelDefaultError202NoneHandleError handles the Get200Model204NoModelDefaultError202None error response.
 func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202NoneHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -411,6 +438,9 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204Valid
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200Model204NoModelDefaultError204ValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200Model204NoModelDefaultError204ValidHandleResponse(resp)
@@ -433,15 +463,15 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204Valid
 
 // Get200Model204NoModelDefaultError204ValidHandleResponse handles the Get200Model204NoModelDefaultError204Valid response.
 func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.Get200Model204NoModelDefaultError204ValidHandleError(resp)
-	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // Get200Model204NoModelDefaultError204ValidHandleError handles the Get200Model204NoModelDefaultError204Valid error response.
 func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -457,6 +487,9 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400Valid
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200Model204NoModelDefaultError400ValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200Model204NoModelDefaultError400ValidHandleResponse(resp)
@@ -479,15 +512,15 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400Valid
 
 // Get200Model204NoModelDefaultError400ValidHandleResponse handles the Get200Model204NoModelDefaultError400Valid response.
 func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.Get200Model204NoModelDefaultError400ValidHandleError(resp)
-	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // Get200Model204NoModelDefaultError400ValidHandleError handles the Get200Model204NoModelDefaultError400Valid error response.
 func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -503,6 +536,9 @@ func (client *MultipleResponsesClient) Get200ModelA200Invalid(ctx context.Contex
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200ModelA200InvalidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200ModelA200InvalidHandleResponse(resp)
@@ -525,15 +561,15 @@ func (client *MultipleResponsesClient) Get200ModelA200InvalidCreateRequest(ctx c
 
 // Get200ModelA200InvalidHandleResponse handles the Get200ModelA200Invalid response.
 func (client *MultipleResponsesClient) Get200ModelA200InvalidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Get200ModelA200InvalidHandleError(resp)
-	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // Get200ModelA200InvalidHandleError handles the Get200ModelA200Invalid error response.
 func (client *MultipleResponsesClient) Get200ModelA200InvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -552,6 +588,9 @@ func (client *MultipleResponsesClient) Get200ModelA200None(ctx context.Context) 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200ModelA200NoneHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200ModelA200NoneHandleResponse(resp)
@@ -574,15 +613,15 @@ func (client *MultipleResponsesClient) Get200ModelA200NoneCreateRequest(ctx cont
 
 // Get200ModelA200NoneHandleResponse handles the Get200ModelA200None response.
 func (client *MultipleResponsesClient) Get200ModelA200NoneHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Get200ModelA200NoneHandleError(resp)
-	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // Get200ModelA200NoneHandleError handles the Get200ModelA200None error response.
 func (client *MultipleResponsesClient) Get200ModelA200NoneHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -601,6 +640,9 @@ func (client *MultipleResponsesClient) Get200ModelA200Valid(ctx context.Context)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200ModelA200ValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200ModelA200ValidHandleResponse(resp)
@@ -623,15 +665,15 @@ func (client *MultipleResponsesClient) Get200ModelA200ValidCreateRequest(ctx con
 
 // Get200ModelA200ValidHandleResponse handles the Get200ModelA200Valid response.
 func (client *MultipleResponsesClient) Get200ModelA200ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Get200ModelA200ValidHandleError(resp)
-	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // Get200ModelA200ValidHandleError handles the Get200ModelA200Valid error response.
 func (client *MultipleResponsesClient) Get200ModelA200ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -651,6 +693,9 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200ModelA201ModelC404ModelDDefaultError200ValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError200ValidHandleResponse(resp)
@@ -684,12 +729,15 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 		result := DResponse{RawResponse: resp.Response}
 		return &result, resp.UnmarshalAsJSON(&result.D)
 	default:
-		return nil, client.Get200ModelA201ModelC404ModelDDefaultError200ValidHandleError(resp)
+		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError200ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError200Valid error response.
 func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError200ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -706,6 +754,9 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200ModelA201ModelC404ModelDDefaultError201ValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError201ValidHandleResponse(resp)
@@ -739,12 +790,15 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 		result := DResponse{RawResponse: resp.Response}
 		return &result, resp.UnmarshalAsJSON(&result.D)
 	default:
-		return nil, client.Get200ModelA201ModelC404ModelDDefaultError201ValidHandleError(resp)
+		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError201ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError201Valid error response.
 func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError201ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -761,6 +815,9 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200ModelA201ModelC404ModelDDefaultError400ValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError400ValidHandleResponse(resp)
@@ -794,12 +851,15 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 		result := DResponse{RawResponse: resp.Response}
 		return &result, resp.UnmarshalAsJSON(&result.D)
 	default:
-		return nil, client.Get200ModelA201ModelC404ModelDDefaultError400ValidHandleError(resp)
+		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError400ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError400Valid error response.
 func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError400ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -816,6 +876,9 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200ModelA201ModelC404ModelDDefaultError404ValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError404ValidHandleResponse(resp)
@@ -849,12 +912,15 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 		result := DResponse{RawResponse: resp.Response}
 		return &result, resp.UnmarshalAsJSON(&result.D)
 	default:
-		return nil, client.Get200ModelA201ModelC404ModelDDefaultError404ValidHandleError(resp)
+		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError404ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError404Valid error response.
 func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError404ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -870,6 +936,9 @@ func (client *MultipleResponsesClient) Get200ModelA202Valid(ctx context.Context)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200ModelA202ValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200ModelA202ValidHandleResponse(resp)
@@ -892,15 +961,15 @@ func (client *MultipleResponsesClient) Get200ModelA202ValidCreateRequest(ctx con
 
 // Get200ModelA202ValidHandleResponse handles the Get200ModelA202Valid response.
 func (client *MultipleResponsesClient) Get200ModelA202ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Get200ModelA202ValidHandleError(resp)
-	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // Get200ModelA202ValidHandleError handles the Get200ModelA202Valid error response.
 func (client *MultipleResponsesClient) Get200ModelA202ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -919,6 +988,9 @@ func (client *MultipleResponsesClient) Get200ModelA400Invalid(ctx context.Contex
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200ModelA400InvalidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200ModelA400InvalidHandleResponse(resp)
@@ -941,15 +1013,15 @@ func (client *MultipleResponsesClient) Get200ModelA400InvalidCreateRequest(ctx c
 
 // Get200ModelA400InvalidHandleResponse handles the Get200ModelA400Invalid response.
 func (client *MultipleResponsesClient) Get200ModelA400InvalidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Get200ModelA400InvalidHandleError(resp)
-	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // Get200ModelA400InvalidHandleError handles the Get200ModelA400Invalid error response.
 func (client *MultipleResponsesClient) Get200ModelA400InvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -968,6 +1040,9 @@ func (client *MultipleResponsesClient) Get200ModelA400None(ctx context.Context) 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200ModelA400NoneHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200ModelA400NoneHandleResponse(resp)
@@ -990,15 +1065,15 @@ func (client *MultipleResponsesClient) Get200ModelA400NoneCreateRequest(ctx cont
 
 // Get200ModelA400NoneHandleResponse handles the Get200ModelA400None response.
 func (client *MultipleResponsesClient) Get200ModelA400NoneHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Get200ModelA400NoneHandleError(resp)
-	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // Get200ModelA400NoneHandleError handles the Get200ModelA400None error response.
 func (client *MultipleResponsesClient) Get200ModelA400NoneHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1017,6 +1092,9 @@ func (client *MultipleResponsesClient) Get200ModelA400Valid(ctx context.Context)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Get200ModelA400ValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Get200ModelA400ValidHandleResponse(resp)
@@ -1039,15 +1117,15 @@ func (client *MultipleResponsesClient) Get200ModelA400ValidCreateRequest(ctx con
 
 // Get200ModelA400ValidHandleResponse handles the Get200ModelA400Valid response.
 func (client *MultipleResponsesClient) Get200ModelA400ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Get200ModelA400ValidHandleError(resp)
-	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // Get200ModelA400ValidHandleError handles the Get200ModelA400Valid error response.
 func (client *MultipleResponsesClient) Get200ModelA400ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1068,11 +1146,10 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError202None(ctx 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get202None204NoneDefaultError202NoneHandleResponse(resp)
-	if err != nil {
+	if err := client.Get202None204NoneDefaultError202NoneHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get202None204NoneDefaultError202NoneCreateRequest creates the Get202None204NoneDefaultError202None request.
@@ -1086,16 +1163,11 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError202NoneCreat
 	return req, nil
 }
 
-// Get202None204NoneDefaultError202NoneHandleResponse handles the Get202None204NoneDefaultError202None response.
-func (client *MultipleResponsesClient) Get202None204NoneDefaultError202NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Get202None204NoneDefaultError202NoneHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Get202None204NoneDefaultError202NoneHandleError handles the Get202None204NoneDefaultError202None error response.
 func (client *MultipleResponsesClient) Get202None204NoneDefaultError202NoneHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1113,11 +1185,10 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError204None(ctx 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get202None204NoneDefaultError204NoneHandleResponse(resp)
-	if err != nil {
+	if err := client.Get202None204NoneDefaultError204NoneHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get202None204NoneDefaultError204NoneCreateRequest creates the Get202None204NoneDefaultError204None request.
@@ -1131,16 +1202,11 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError204NoneCreat
 	return req, nil
 }
 
-// Get202None204NoneDefaultError204NoneHandleResponse handles the Get202None204NoneDefaultError204None response.
-func (client *MultipleResponsesClient) Get202None204NoneDefaultError204NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Get202None204NoneDefaultError204NoneHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Get202None204NoneDefaultError204NoneHandleError handles the Get202None204NoneDefaultError204None error response.
 func (client *MultipleResponsesClient) Get202None204NoneDefaultError204NoneHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1158,11 +1224,10 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError400Valid(ctx
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get202None204NoneDefaultError400ValidHandleResponse(resp)
-	if err != nil {
+	if err := client.Get202None204NoneDefaultError400ValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get202None204NoneDefaultError400ValidCreateRequest creates the Get202None204NoneDefaultError400Valid request.
@@ -1176,16 +1241,11 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError400ValidCrea
 	return req, nil
 }
 
-// Get202None204NoneDefaultError400ValidHandleResponse handles the Get202None204NoneDefaultError400Valid response.
-func (client *MultipleResponsesClient) Get202None204NoneDefaultError400ValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Get202None204NoneDefaultError400ValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Get202None204NoneDefaultError400ValidHandleError handles the Get202None204NoneDefaultError400Valid error response.
 func (client *MultipleResponsesClient) Get202None204NoneDefaultError400ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1203,11 +1263,10 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202Invalid(ct
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get202None204NoneDefaultNone202InvalidHandleResponse(resp)
-	if err != nil {
+	if err := client.Get202None204NoneDefaultNone202InvalidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get202None204NoneDefaultNone202InvalidCreateRequest creates the Get202None204NoneDefaultNone202Invalid request.
@@ -1220,16 +1279,11 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202InvalidCre
 	return req, nil
 }
 
-// Get202None204NoneDefaultNone202InvalidHandleResponse handles the Get202None204NoneDefaultNone202Invalid response.
-func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202InvalidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Get202None204NoneDefaultNone202InvalidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Get202None204NoneDefaultNone202InvalidHandleError handles the Get202None204NoneDefaultNone202Invalid error response.
 func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202InvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1250,11 +1304,10 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204None(ctx c
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get202None204NoneDefaultNone204NoneHandleResponse(resp)
-	if err != nil {
+	if err := client.Get202None204NoneDefaultNone204NoneHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get202None204NoneDefaultNone204NoneCreateRequest creates the Get202None204NoneDefaultNone204None request.
@@ -1267,16 +1320,11 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204NoneCreate
 	return req, nil
 }
 
-// Get202None204NoneDefaultNone204NoneHandleResponse handles the Get202None204NoneDefaultNone204None response.
-func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Get202None204NoneDefaultNone204NoneHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Get202None204NoneDefaultNone204NoneHandleError handles the Get202None204NoneDefaultNone204None error response.
 func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204NoneHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1297,11 +1345,10 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400Invalid(ct
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get202None204NoneDefaultNone400InvalidHandleResponse(resp)
-	if err != nil {
+	if err := client.Get202None204NoneDefaultNone400InvalidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get202None204NoneDefaultNone400InvalidCreateRequest creates the Get202None204NoneDefaultNone400Invalid request.
@@ -1314,16 +1361,11 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400InvalidCre
 	return req, nil
 }
 
-// Get202None204NoneDefaultNone400InvalidHandleResponse handles the Get202None204NoneDefaultNone400Invalid response.
-func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400InvalidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Get202None204NoneDefaultNone400InvalidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Get202None204NoneDefaultNone400InvalidHandleError handles the Get202None204NoneDefaultNone400Invalid error response.
 func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400InvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1344,11 +1386,10 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400None(ctx c
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Get202None204NoneDefaultNone400NoneHandleResponse(resp)
-	if err != nil {
+	if err := client.Get202None204NoneDefaultNone400NoneHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Get202None204NoneDefaultNone400NoneCreateRequest creates the Get202None204NoneDefaultNone400None request.
@@ -1361,16 +1402,11 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400NoneCreate
 	return req, nil
 }
 
-// Get202None204NoneDefaultNone400NoneHandleResponse handles the Get202None204NoneDefaultNone400None response.
-func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Get202None204NoneDefaultNone400NoneHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Get202None204NoneDefaultNone400NoneHandleError handles the Get202None204NoneDefaultNone400None error response.
 func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400NoneHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1389,6 +1425,9 @@ func (client *MultipleResponsesClient) GetDefaultModelA200None(ctx context.Conte
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDefaultModelA200NoneHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDefaultModelA200NoneHandleResponse(resp)
@@ -1411,15 +1450,15 @@ func (client *MultipleResponsesClient) GetDefaultModelA200NoneCreateRequest(ctx 
 
 // GetDefaultModelA200NoneHandleResponse handles the GetDefaultModelA200None response.
 func (client *MultipleResponsesClient) GetDefaultModelA200NoneHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDefaultModelA200NoneHandleError(resp)
-	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // GetDefaultModelA200NoneHandleError handles the GetDefaultModelA200None error response.
 func (client *MultipleResponsesClient) GetDefaultModelA200NoneHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1438,6 +1477,9 @@ func (client *MultipleResponsesClient) GetDefaultModelA200Valid(ctx context.Cont
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetDefaultModelA200ValidHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetDefaultModelA200ValidHandleResponse(resp)
@@ -1460,15 +1502,15 @@ func (client *MultipleResponsesClient) GetDefaultModelA200ValidCreateRequest(ctx
 
 // GetDefaultModelA200ValidHandleResponse handles the GetDefaultModelA200Valid response.
 func (client *MultipleResponsesClient) GetDefaultModelA200ValidHandleResponse(resp *azcore.Response) (*MyExceptionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDefaultModelA200ValidHandleError(resp)
-	}
 	result := MyExceptionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.MyException)
 }
 
 // GetDefaultModelA200ValidHandleError handles the GetDefaultModelA200Valid error response.
 func (client *MultipleResponsesClient) GetDefaultModelA200ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1489,11 +1531,10 @@ func (client *MultipleResponsesClient) GetDefaultModelA400None(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetDefaultModelA400NoneHandleResponse(resp)
-	if err != nil {
+	if err := client.GetDefaultModelA400NoneHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetDefaultModelA400NoneCreateRequest creates the GetDefaultModelA400None request.
@@ -1507,16 +1548,11 @@ func (client *MultipleResponsesClient) GetDefaultModelA400NoneCreateRequest(ctx 
 	return req, nil
 }
 
-// GetDefaultModelA400NoneHandleResponse handles the GetDefaultModelA400None response.
-func (client *MultipleResponsesClient) GetDefaultModelA400NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDefaultModelA400NoneHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetDefaultModelA400NoneHandleError handles the GetDefaultModelA400None error response.
 func (client *MultipleResponsesClient) GetDefaultModelA400NoneHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err MyException
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1534,11 +1570,10 @@ func (client *MultipleResponsesClient) GetDefaultModelA400Valid(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetDefaultModelA400ValidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetDefaultModelA400ValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetDefaultModelA400ValidCreateRequest creates the GetDefaultModelA400Valid request.
@@ -1552,16 +1587,11 @@ func (client *MultipleResponsesClient) GetDefaultModelA400ValidCreateRequest(ctx
 	return req, nil
 }
 
-// GetDefaultModelA400ValidHandleResponse handles the GetDefaultModelA400Valid response.
-func (client *MultipleResponsesClient) GetDefaultModelA400ValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDefaultModelA400ValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetDefaultModelA400ValidHandleError handles the GetDefaultModelA400Valid error response.
 func (client *MultipleResponsesClient) GetDefaultModelA400ValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err MyException
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1579,11 +1609,10 @@ func (client *MultipleResponsesClient) GetDefaultNone200Invalid(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetDefaultNone200InvalidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetDefaultNone200InvalidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetDefaultNone200InvalidCreateRequest creates the GetDefaultNone200Invalid request.
@@ -1596,16 +1625,11 @@ func (client *MultipleResponsesClient) GetDefaultNone200InvalidCreateRequest(ctx
 	return req, nil
 }
 
-// GetDefaultNone200InvalidHandleResponse handles the GetDefaultNone200Invalid response.
-func (client *MultipleResponsesClient) GetDefaultNone200InvalidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDefaultNone200InvalidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetDefaultNone200InvalidHandleError handles the GetDefaultNone200Invalid error response.
 func (client *MultipleResponsesClient) GetDefaultNone200InvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1626,11 +1650,10 @@ func (client *MultipleResponsesClient) GetDefaultNone200None(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetDefaultNone200NoneHandleResponse(resp)
-	if err != nil {
+	if err := client.GetDefaultNone200NoneHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetDefaultNone200NoneCreateRequest creates the GetDefaultNone200None request.
@@ -1643,16 +1666,11 @@ func (client *MultipleResponsesClient) GetDefaultNone200NoneCreateRequest(ctx co
 	return req, nil
 }
 
-// GetDefaultNone200NoneHandleResponse handles the GetDefaultNone200None response.
-func (client *MultipleResponsesClient) GetDefaultNone200NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDefaultNone200NoneHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetDefaultNone200NoneHandleError handles the GetDefaultNone200None error response.
 func (client *MultipleResponsesClient) GetDefaultNone200NoneHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1673,11 +1691,10 @@ func (client *MultipleResponsesClient) GetDefaultNone400Invalid(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetDefaultNone400InvalidHandleResponse(resp)
-	if err != nil {
+	if err := client.GetDefaultNone400InvalidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetDefaultNone400InvalidCreateRequest creates the GetDefaultNone400Invalid request.
@@ -1690,16 +1707,11 @@ func (client *MultipleResponsesClient) GetDefaultNone400InvalidCreateRequest(ctx
 	return req, nil
 }
 
-// GetDefaultNone400InvalidHandleResponse handles the GetDefaultNone400Invalid response.
-func (client *MultipleResponsesClient) GetDefaultNone400InvalidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDefaultNone400InvalidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetDefaultNone400InvalidHandleError handles the GetDefaultNone400Invalid error response.
 func (client *MultipleResponsesClient) GetDefaultNone400InvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1720,11 +1732,10 @@ func (client *MultipleResponsesClient) GetDefaultNone400None(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetDefaultNone400NoneHandleResponse(resp)
-	if err != nil {
+	if err := client.GetDefaultNone400NoneHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetDefaultNone400NoneCreateRequest creates the GetDefaultNone400None request.
@@ -1737,16 +1748,11 @@ func (client *MultipleResponsesClient) GetDefaultNone400NoneCreateRequest(ctx co
 	return req, nil
 }
 
-// GetDefaultNone400NoneHandleResponse handles the GetDefaultNone400None response.
-func (client *MultipleResponsesClient) GetDefaultNone400NoneHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetDefaultNone400NoneHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetDefaultNone400NoneHandleError handles the GetDefaultNone400None error response.
 func (client *MultipleResponsesClient) GetDefaultNone400NoneHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses.go
@@ -120,8 +120,8 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError200Valid(c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200Model201ModelDefaultError200ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.Get200Model201ModelDefaultError200ValidHandleError(resp)
 	}
 	result, err := client.Get200Model201ModelDefaultError200ValidHandleResponse(resp)
 	if err != nil {
@@ -157,9 +157,6 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError200ValidHa
 
 // Get200Model201ModelDefaultError200ValidHandleError handles the Get200Model201ModelDefaultError200Valid error response.
 func (client *MultipleResponsesClient) Get200Model201ModelDefaultError200ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -178,8 +175,8 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError201Valid(c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200Model201ModelDefaultError201ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.Get200Model201ModelDefaultError201ValidHandleError(resp)
 	}
 	result, err := client.Get200Model201ModelDefaultError201ValidHandleResponse(resp)
 	if err != nil {
@@ -215,9 +212,6 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError201ValidHa
 
 // Get200Model201ModelDefaultError201ValidHandleError handles the Get200Model201ModelDefaultError201Valid error response.
 func (client *MultipleResponsesClient) Get200Model201ModelDefaultError201ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -236,8 +230,8 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError400Valid(c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200Model201ModelDefaultError400ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.Get200Model201ModelDefaultError400ValidHandleError(resp)
 	}
 	result, err := client.Get200Model201ModelDefaultError400ValidHandleResponse(resp)
 	if err != nil {
@@ -273,9 +267,6 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError400ValidHa
 
 // Get200Model201ModelDefaultError400ValidHandleError handles the Get200Model201ModelDefaultError400Valid error response.
 func (client *MultipleResponsesClient) Get200Model201ModelDefaultError400ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -293,8 +284,8 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200Valid
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200Model204NoModelDefaultError200ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil, client.Get200Model204NoModelDefaultError200ValidHandleError(resp)
 	}
 	result, err := client.Get200Model204NoModelDefaultError200ValidHandleResponse(resp)
 	if err != nil {
@@ -322,9 +313,6 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200Valid
 
 // Get200Model204NoModelDefaultError200ValidHandleError handles the Get200Model204NoModelDefaultError200Valid error response.
 func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -342,8 +330,8 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201Inval
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200Model204NoModelDefaultError201InvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil, client.Get200Model204NoModelDefaultError201InvalidHandleError(resp)
 	}
 	result, err := client.Get200Model204NoModelDefaultError201InvalidHandleResponse(resp)
 	if err != nil {
@@ -371,9 +359,6 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201Inval
 
 // Get200Model204NoModelDefaultError201InvalidHandleError handles the Get200Model204NoModelDefaultError201Invalid error response.
 func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201InvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -391,8 +376,8 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202None(
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200Model204NoModelDefaultError202NoneHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil, client.Get200Model204NoModelDefaultError202NoneHandleError(resp)
 	}
 	result, err := client.Get200Model204NoModelDefaultError202NoneHandleResponse(resp)
 	if err != nil {
@@ -420,9 +405,6 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202NoneH
 
 // Get200Model204NoModelDefaultError202NoneHandleError handles the Get200Model204NoModelDefaultError202None error response.
 func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202NoneHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -440,8 +422,8 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204Valid
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200Model204NoModelDefaultError204ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil, client.Get200Model204NoModelDefaultError204ValidHandleError(resp)
 	}
 	result, err := client.Get200Model204NoModelDefaultError204ValidHandleResponse(resp)
 	if err != nil {
@@ -469,9 +451,6 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204Valid
 
 // Get200Model204NoModelDefaultError204ValidHandleError handles the Get200Model204NoModelDefaultError204Valid error response.
 func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -489,8 +468,8 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400Valid
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200Model204NoModelDefaultError400ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil, client.Get200Model204NoModelDefaultError400ValidHandleError(resp)
 	}
 	result, err := client.Get200Model204NoModelDefaultError400ValidHandleResponse(resp)
 	if err != nil {
@@ -518,9 +497,6 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400Valid
 
 // Get200Model204NoModelDefaultError400ValidHandleError handles the Get200Model204NoModelDefaultError400Valid error response.
 func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -538,8 +514,8 @@ func (client *MultipleResponsesClient) Get200ModelA200Invalid(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200ModelA200InvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Get200ModelA200InvalidHandleError(resp)
 	}
 	result, err := client.Get200ModelA200InvalidHandleResponse(resp)
 	if err != nil {
@@ -567,9 +543,6 @@ func (client *MultipleResponsesClient) Get200ModelA200InvalidHandleResponse(resp
 
 // Get200ModelA200InvalidHandleError handles the Get200ModelA200Invalid error response.
 func (client *MultipleResponsesClient) Get200ModelA200InvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -590,8 +563,8 @@ func (client *MultipleResponsesClient) Get200ModelA200None(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200ModelA200NoneHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Get200ModelA200NoneHandleError(resp)
 	}
 	result, err := client.Get200ModelA200NoneHandleResponse(resp)
 	if err != nil {
@@ -619,9 +592,6 @@ func (client *MultipleResponsesClient) Get200ModelA200NoneHandleResponse(resp *a
 
 // Get200ModelA200NoneHandleError handles the Get200ModelA200None error response.
 func (client *MultipleResponsesClient) Get200ModelA200NoneHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -642,8 +612,8 @@ func (client *MultipleResponsesClient) Get200ModelA200Valid(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200ModelA200ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Get200ModelA200ValidHandleError(resp)
 	}
 	result, err := client.Get200ModelA200ValidHandleResponse(resp)
 	if err != nil {
@@ -671,9 +641,6 @@ func (client *MultipleResponsesClient) Get200ModelA200ValidHandleResponse(resp *
 
 // Get200ModelA200ValidHandleError handles the Get200ModelA200Valid error response.
 func (client *MultipleResponsesClient) Get200ModelA200ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -695,8 +662,8 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200ModelA201ModelC404ModelDDefaultError200ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
+		return nil, client.Get200ModelA201ModelC404ModelDDefaultError200ValidHandleError(resp)
 	}
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError200ValidHandleResponse(resp)
 	if err != nil {
@@ -735,9 +702,6 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 
 // Get200ModelA201ModelC404ModelDDefaultError200ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError200Valid error response.
 func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError200ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -756,8 +720,8 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200ModelA201ModelC404ModelDDefaultError201ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
+		return nil, client.Get200ModelA201ModelC404ModelDDefaultError201ValidHandleError(resp)
 	}
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError201ValidHandleResponse(resp)
 	if err != nil {
@@ -796,9 +760,6 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 
 // Get200ModelA201ModelC404ModelDDefaultError201ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError201Valid error response.
 func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError201ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -817,8 +778,8 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200ModelA201ModelC404ModelDDefaultError400ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
+		return nil, client.Get200ModelA201ModelC404ModelDDefaultError400ValidHandleError(resp)
 	}
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError400ValidHandleResponse(resp)
 	if err != nil {
@@ -857,9 +818,6 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 
 // Get200ModelA201ModelC404ModelDDefaultError400ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError400Valid error response.
 func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError400ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -878,8 +836,8 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200ModelA201ModelC404ModelDDefaultError404ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
+		return nil, client.Get200ModelA201ModelC404ModelDDefaultError404ValidHandleError(resp)
 	}
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError404ValidHandleResponse(resp)
 	if err != nil {
@@ -918,9 +876,6 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 
 // Get200ModelA201ModelC404ModelDDefaultError404ValidHandleError handles the Get200ModelA201ModelC404ModelDDefaultError404Valid error response.
 func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError404ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -938,8 +893,8 @@ func (client *MultipleResponsesClient) Get200ModelA202Valid(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200ModelA202ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Get200ModelA202ValidHandleError(resp)
 	}
 	result, err := client.Get200ModelA202ValidHandleResponse(resp)
 	if err != nil {
@@ -967,9 +922,6 @@ func (client *MultipleResponsesClient) Get200ModelA202ValidHandleResponse(resp *
 
 // Get200ModelA202ValidHandleError handles the Get200ModelA202Valid error response.
 func (client *MultipleResponsesClient) Get200ModelA202ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -990,8 +942,8 @@ func (client *MultipleResponsesClient) Get200ModelA400Invalid(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200ModelA400InvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Get200ModelA400InvalidHandleError(resp)
 	}
 	result, err := client.Get200ModelA400InvalidHandleResponse(resp)
 	if err != nil {
@@ -1019,9 +971,6 @@ func (client *MultipleResponsesClient) Get200ModelA400InvalidHandleResponse(resp
 
 // Get200ModelA400InvalidHandleError handles the Get200ModelA400Invalid error response.
 func (client *MultipleResponsesClient) Get200ModelA400InvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1042,8 +991,8 @@ func (client *MultipleResponsesClient) Get200ModelA400None(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200ModelA400NoneHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Get200ModelA400NoneHandleError(resp)
 	}
 	result, err := client.Get200ModelA400NoneHandleResponse(resp)
 	if err != nil {
@@ -1071,9 +1020,6 @@ func (client *MultipleResponsesClient) Get200ModelA400NoneHandleResponse(resp *a
 
 // Get200ModelA400NoneHandleError handles the Get200ModelA400None error response.
 func (client *MultipleResponsesClient) Get200ModelA400NoneHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1094,8 +1040,8 @@ func (client *MultipleResponsesClient) Get200ModelA400Valid(ctx context.Context)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get200ModelA400ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Get200ModelA400ValidHandleError(resp)
 	}
 	result, err := client.Get200ModelA400ValidHandleResponse(resp)
 	if err != nil {
@@ -1123,9 +1069,6 @@ func (client *MultipleResponsesClient) Get200ModelA400ValidHandleResponse(resp *
 
 // Get200ModelA400ValidHandleError handles the Get200ModelA400Valid error response.
 func (client *MultipleResponsesClient) Get200ModelA400ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1146,8 +1089,8 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError202None(ctx 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get202None204NoneDefaultError202NoneHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.Get202None204NoneDefaultError202NoneHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1165,9 +1108,6 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError202NoneCreat
 
 // Get202None204NoneDefaultError202NoneHandleError handles the Get202None204NoneDefaultError202None error response.
 func (client *MultipleResponsesClient) Get202None204NoneDefaultError202NoneHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1185,8 +1125,8 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError204None(ctx 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get202None204NoneDefaultError204NoneHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.Get202None204NoneDefaultError204NoneHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1204,9 +1144,6 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError204NoneCreat
 
 // Get202None204NoneDefaultError204NoneHandleError handles the Get202None204NoneDefaultError204None error response.
 func (client *MultipleResponsesClient) Get202None204NoneDefaultError204NoneHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1224,8 +1161,8 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError400Valid(ctx
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get202None204NoneDefaultError400ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.Get202None204NoneDefaultError400ValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1243,9 +1180,6 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError400ValidCrea
 
 // Get202None204NoneDefaultError400ValidHandleError handles the Get202None204NoneDefaultError400Valid error response.
 func (client *MultipleResponsesClient) Get202None204NoneDefaultError400ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1263,8 +1197,8 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202Invalid(ct
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get202None204NoneDefaultNone202InvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.Get202None204NoneDefaultNone202InvalidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1281,9 +1215,6 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202InvalidCre
 
 // Get202None204NoneDefaultNone202InvalidHandleError handles the Get202None204NoneDefaultNone202Invalid error response.
 func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202InvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1304,8 +1235,8 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204None(ctx c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get202None204NoneDefaultNone204NoneHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.Get202None204NoneDefaultNone204NoneHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1322,9 +1253,6 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204NoneCreate
 
 // Get202None204NoneDefaultNone204NoneHandleError handles the Get202None204NoneDefaultNone204None error response.
 func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204NoneHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1345,8 +1273,8 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400Invalid(ct
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get202None204NoneDefaultNone400InvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.Get202None204NoneDefaultNone400InvalidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1363,9 +1291,6 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400InvalidCre
 
 // Get202None204NoneDefaultNone400InvalidHandleError handles the Get202None204NoneDefaultNone400Invalid error response.
 func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400InvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1386,8 +1311,8 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400None(ctx c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Get202None204NoneDefaultNone400NoneHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.Get202None204NoneDefaultNone400NoneHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1404,9 +1329,6 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400NoneCreate
 
 // Get202None204NoneDefaultNone400NoneHandleError handles the Get202None204NoneDefaultNone400None error response.
 func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400NoneHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1427,8 +1349,8 @@ func (client *MultipleResponsesClient) GetDefaultModelA200None(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDefaultModelA200NoneHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDefaultModelA200NoneHandleError(resp)
 	}
 	result, err := client.GetDefaultModelA200NoneHandleResponse(resp)
 	if err != nil {
@@ -1456,9 +1378,6 @@ func (client *MultipleResponsesClient) GetDefaultModelA200NoneHandleResponse(res
 
 // GetDefaultModelA200NoneHandleError handles the GetDefaultModelA200None error response.
 func (client *MultipleResponsesClient) GetDefaultModelA200NoneHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1479,8 +1398,8 @@ func (client *MultipleResponsesClient) GetDefaultModelA200Valid(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDefaultModelA200ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDefaultModelA200ValidHandleError(resp)
 	}
 	result, err := client.GetDefaultModelA200ValidHandleResponse(resp)
 	if err != nil {
@@ -1508,9 +1427,6 @@ func (client *MultipleResponsesClient) GetDefaultModelA200ValidHandleResponse(re
 
 // GetDefaultModelA200ValidHandleError handles the GetDefaultModelA200Valid error response.
 func (client *MultipleResponsesClient) GetDefaultModelA200ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1531,8 +1447,8 @@ func (client *MultipleResponsesClient) GetDefaultModelA400None(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDefaultModelA400NoneHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDefaultModelA400NoneHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1550,9 +1466,6 @@ func (client *MultipleResponsesClient) GetDefaultModelA400NoneCreateRequest(ctx 
 
 // GetDefaultModelA400NoneHandleError handles the GetDefaultModelA400None error response.
 func (client *MultipleResponsesClient) GetDefaultModelA400NoneHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err MyException
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1570,8 +1483,8 @@ func (client *MultipleResponsesClient) GetDefaultModelA400Valid(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDefaultModelA400ValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDefaultModelA400ValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1589,9 +1502,6 @@ func (client *MultipleResponsesClient) GetDefaultModelA400ValidCreateRequest(ctx
 
 // GetDefaultModelA400ValidHandleError handles the GetDefaultModelA400Valid error response.
 func (client *MultipleResponsesClient) GetDefaultModelA400ValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err MyException
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1609,8 +1519,8 @@ func (client *MultipleResponsesClient) GetDefaultNone200Invalid(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDefaultNone200InvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDefaultNone200InvalidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1627,9 +1537,6 @@ func (client *MultipleResponsesClient) GetDefaultNone200InvalidCreateRequest(ctx
 
 // GetDefaultNone200InvalidHandleError handles the GetDefaultNone200Invalid error response.
 func (client *MultipleResponsesClient) GetDefaultNone200InvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1650,8 +1557,8 @@ func (client *MultipleResponsesClient) GetDefaultNone200None(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDefaultNone200NoneHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDefaultNone200NoneHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1668,9 +1575,6 @@ func (client *MultipleResponsesClient) GetDefaultNone200NoneCreateRequest(ctx co
 
 // GetDefaultNone200NoneHandleError handles the GetDefaultNone200None error response.
 func (client *MultipleResponsesClient) GetDefaultNone200NoneHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1691,8 +1595,8 @@ func (client *MultipleResponsesClient) GetDefaultNone400Invalid(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDefaultNone400InvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDefaultNone400InvalidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1709,9 +1613,6 @@ func (client *MultipleResponsesClient) GetDefaultNone400InvalidCreateRequest(ctx
 
 // GetDefaultNone400InvalidHandleError handles the GetDefaultNone400Invalid error response.
 func (client *MultipleResponsesClient) GetDefaultNone400InvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1732,8 +1633,8 @@ func (client *MultipleResponsesClient) GetDefaultNone400None(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetDefaultNone400NoneHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetDefaultNone400NoneHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1750,9 +1651,6 @@ func (client *MultipleResponsesClient) GetDefaultNone400NoneCreateRequest(ctx co
 
 // GetDefaultNone400NoneHandleError handles the GetDefaultNone400None error response.
 func (client *MultipleResponsesClient) GetDefaultNone400NoneHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/integergroup/zz_generated_int.go
+++ b/test/autorest/integergroup/zz_generated_int.go
@@ -70,6 +70,9 @@ func (client *IntClient) GetInvalid(ctx context.Context) (*Int32Response, error)
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetInvalidHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetInvalidHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -90,15 +93,15 @@ func (client *IntClient) GetInvalidCreateRequest(ctx context.Context) (*azcore.R
 
 // GetInvalidHandleResponse handles the GetInvalid response.
 func (client *IntClient) GetInvalidHandleResponse(resp *azcore.Response) (*Int32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetInvalidHandleError(resp)
-	}
 	result := Int32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *IntClient) GetInvalidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -114,6 +117,9 @@ func (client *IntClient) GetInvalidUnixTime(ctx context.Context) (*TimeResponse,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetInvalidUnixTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetInvalidUnixTimeHandleResponse(resp)
@@ -136,9 +142,6 @@ func (client *IntClient) GetInvalidUnixTimeCreateRequest(ctx context.Context) (*
 
 // GetInvalidUnixTimeHandleResponse handles the GetInvalidUnixTime response.
 func (client *IntClient) GetInvalidUnixTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetInvalidUnixTimeHandleError(resp)
-	}
 	var aux *timeUnix
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -146,6 +149,9 @@ func (client *IntClient) GetInvalidUnixTimeHandleResponse(resp *azcore.Response)
 
 // GetInvalidUnixTimeHandleError handles the GetInvalidUnixTime error response.
 func (client *IntClient) GetInvalidUnixTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -161,6 +167,9 @@ func (client *IntClient) GetNull(ctx context.Context) (*Int32Response, error) {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullHandleResponse(resp)
@@ -183,15 +192,15 @@ func (client *IntClient) GetNullCreateRequest(ctx context.Context) (*azcore.Requ
 
 // GetNullHandleResponse handles the GetNull response.
 func (client *IntClient) GetNullHandleResponse(resp *azcore.Response) (*Int32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullHandleError(resp)
-	}
 	result := Int32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNullHandleError handles the GetNull error response.
 func (client *IntClient) GetNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -207,6 +216,9 @@ func (client *IntClient) GetNullUnixTime(ctx context.Context) (*TimeResponse, er
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullUnixTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullUnixTimeHandleResponse(resp)
@@ -229,9 +241,6 @@ func (client *IntClient) GetNullUnixTimeCreateRequest(ctx context.Context) (*azc
 
 // GetNullUnixTimeHandleResponse handles the GetNullUnixTime response.
 func (client *IntClient) GetNullUnixTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullUnixTimeHandleError(resp)
-	}
 	var aux *timeUnix
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -239,6 +248,9 @@ func (client *IntClient) GetNullUnixTimeHandleResponse(resp *azcore.Response) (*
 
 // GetNullUnixTimeHandleError handles the GetNullUnixTime error response.
 func (client *IntClient) GetNullUnixTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -254,6 +266,9 @@ func (client *IntClient) GetOverflowInt32(ctx context.Context) (*Int32Response, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetOverflowInt32HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetOverflowInt32HandleResponse(resp)
@@ -276,15 +291,15 @@ func (client *IntClient) GetOverflowInt32CreateRequest(ctx context.Context) (*az
 
 // GetOverflowInt32HandleResponse handles the GetOverflowInt32 response.
 func (client *IntClient) GetOverflowInt32HandleResponse(resp *azcore.Response) (*Int32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetOverflowInt32HandleError(resp)
-	}
 	result := Int32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetOverflowInt32HandleError handles the GetOverflowInt32 error response.
 func (client *IntClient) GetOverflowInt32HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -300,6 +315,9 @@ func (client *IntClient) GetOverflowInt64(ctx context.Context) (*Int64Response, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetOverflowInt64HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetOverflowInt64HandleResponse(resp)
@@ -322,15 +340,15 @@ func (client *IntClient) GetOverflowInt64CreateRequest(ctx context.Context) (*az
 
 // GetOverflowInt64HandleResponse handles the GetOverflowInt64 response.
 func (client *IntClient) GetOverflowInt64HandleResponse(resp *azcore.Response) (*Int64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetOverflowInt64HandleError(resp)
-	}
 	result := Int64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetOverflowInt64HandleError handles the GetOverflowInt64 error response.
 func (client *IntClient) GetOverflowInt64HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -346,6 +364,9 @@ func (client *IntClient) GetUnderflowInt32(ctx context.Context) (*Int32Response,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetUnderflowInt32HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetUnderflowInt32HandleResponse(resp)
@@ -368,15 +389,15 @@ func (client *IntClient) GetUnderflowInt32CreateRequest(ctx context.Context) (*a
 
 // GetUnderflowInt32HandleResponse handles the GetUnderflowInt32 response.
 func (client *IntClient) GetUnderflowInt32HandleResponse(resp *azcore.Response) (*Int32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetUnderflowInt32HandleError(resp)
-	}
 	result := Int32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetUnderflowInt32HandleError handles the GetUnderflowInt32 error response.
 func (client *IntClient) GetUnderflowInt32HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -392,6 +413,9 @@ func (client *IntClient) GetUnderflowInt64(ctx context.Context) (*Int64Response,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetUnderflowInt64HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetUnderflowInt64HandleResponse(resp)
@@ -414,15 +438,15 @@ func (client *IntClient) GetUnderflowInt64CreateRequest(ctx context.Context) (*a
 
 // GetUnderflowInt64HandleResponse handles the GetUnderflowInt64 response.
 func (client *IntClient) GetUnderflowInt64HandleResponse(resp *azcore.Response) (*Int64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetUnderflowInt64HandleError(resp)
-	}
 	result := Int64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetUnderflowInt64HandleError handles the GetUnderflowInt64 error response.
 func (client *IntClient) GetUnderflowInt64HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -438,6 +462,9 @@ func (client *IntClient) GetUnixTime(ctx context.Context) (*TimeResponse, error)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetUnixTimeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetUnixTimeHandleResponse(resp)
@@ -460,9 +487,6 @@ func (client *IntClient) GetUnixTimeCreateRequest(ctx context.Context) (*azcore.
 
 // GetUnixTimeHandleResponse handles the GetUnixTime response.
 func (client *IntClient) GetUnixTimeHandleResponse(resp *azcore.Response) (*TimeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetUnixTimeHandleError(resp)
-	}
 	var aux *timeUnix
 	err := resp.UnmarshalAsJSON(&aux)
 	return &TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
@@ -470,6 +494,9 @@ func (client *IntClient) GetUnixTimeHandleResponse(resp *azcore.Response) (*Time
 
 // GetUnixTimeHandleError handles the GetUnixTime error response.
 func (client *IntClient) GetUnixTimeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -487,11 +514,10 @@ func (client *IntClient) PutMax32(ctx context.Context, intBody int32) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutMax32HandleResponse(resp)
-	if err != nil {
+	if err := client.PutMax32HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutMax32CreateRequest creates the PutMax32 request.
@@ -505,16 +531,11 @@ func (client *IntClient) PutMax32CreateRequest(ctx context.Context, intBody int3
 	return req, req.MarshalAsJSON(intBody)
 }
 
-// PutMax32HandleResponse handles the PutMax32 response.
-func (client *IntClient) PutMax32HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutMax32HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutMax32HandleError handles the PutMax32 error response.
 func (client *IntClient) PutMax32HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -532,11 +553,10 @@ func (client *IntClient) PutMax64(ctx context.Context, intBody int64) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutMax64HandleResponse(resp)
-	if err != nil {
+	if err := client.PutMax64HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutMax64CreateRequest creates the PutMax64 request.
@@ -550,16 +570,11 @@ func (client *IntClient) PutMax64CreateRequest(ctx context.Context, intBody int6
 	return req, req.MarshalAsJSON(intBody)
 }
 
-// PutMax64HandleResponse handles the PutMax64 response.
-func (client *IntClient) PutMax64HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutMax64HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutMax64HandleError handles the PutMax64 error response.
 func (client *IntClient) PutMax64HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -577,11 +592,10 @@ func (client *IntClient) PutMin32(ctx context.Context, intBody int32) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutMin32HandleResponse(resp)
-	if err != nil {
+	if err := client.PutMin32HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutMin32CreateRequest creates the PutMin32 request.
@@ -595,16 +609,11 @@ func (client *IntClient) PutMin32CreateRequest(ctx context.Context, intBody int3
 	return req, req.MarshalAsJSON(intBody)
 }
 
-// PutMin32HandleResponse handles the PutMin32 response.
-func (client *IntClient) PutMin32HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutMin32HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutMin32HandleError handles the PutMin32 error response.
 func (client *IntClient) PutMin32HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -622,11 +631,10 @@ func (client *IntClient) PutMin64(ctx context.Context, intBody int64) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutMin64HandleResponse(resp)
-	if err != nil {
+	if err := client.PutMin64HandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutMin64CreateRequest creates the PutMin64 request.
@@ -640,16 +648,11 @@ func (client *IntClient) PutMin64CreateRequest(ctx context.Context, intBody int6
 	return req, req.MarshalAsJSON(intBody)
 }
 
-// PutMin64HandleResponse handles the PutMin64 response.
-func (client *IntClient) PutMin64HandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutMin64HandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutMin64HandleError handles the PutMin64 error response.
 func (client *IntClient) PutMin64HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -667,11 +670,10 @@ func (client *IntClient) PutUnixTimeDate(ctx context.Context, intBody time.Time)
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutUnixTimeDateHandleResponse(resp)
-	if err != nil {
+	if err := client.PutUnixTimeDateHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutUnixTimeDateCreateRequest creates the PutUnixTimeDate request.
@@ -686,16 +688,11 @@ func (client *IntClient) PutUnixTimeDateCreateRequest(ctx context.Context, intBo
 	return req, req.MarshalAsJSON(aux)
 }
 
-// PutUnixTimeDateHandleResponse handles the PutUnixTimeDate response.
-func (client *IntClient) PutUnixTimeDateHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutUnixTimeDateHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutUnixTimeDateHandleError handles the PutUnixTimeDate error response.
 func (client *IntClient) PutUnixTimeDateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/integergroup/zz_generated_int.go
+++ b/test/autorest/integergroup/zz_generated_int.go
@@ -70,8 +70,8 @@ func (client *IntClient) GetInvalid(ctx context.Context) (*Int32Response, error)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetInvalidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetInvalidHandleError(resp)
 	}
 	result, err := client.GetInvalidHandleResponse(resp)
 	if err != nil {
@@ -99,9 +99,6 @@ func (client *IntClient) GetInvalidHandleResponse(resp *azcore.Response) (*Int32
 
 // GetInvalidHandleError handles the GetInvalid error response.
 func (client *IntClient) GetInvalidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -119,8 +116,8 @@ func (client *IntClient) GetInvalidUnixTime(ctx context.Context) (*TimeResponse,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetInvalidUnixTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetInvalidUnixTimeHandleError(resp)
 	}
 	result, err := client.GetInvalidUnixTimeHandleResponse(resp)
 	if err != nil {
@@ -149,9 +146,6 @@ func (client *IntClient) GetInvalidUnixTimeHandleResponse(resp *azcore.Response)
 
 // GetInvalidUnixTimeHandleError handles the GetInvalidUnixTime error response.
 func (client *IntClient) GetInvalidUnixTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -169,8 +163,8 @@ func (client *IntClient) GetNull(ctx context.Context) (*Int32Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullHandleError(resp)
 	}
 	result, err := client.GetNullHandleResponse(resp)
 	if err != nil {
@@ -198,9 +192,6 @@ func (client *IntClient) GetNullHandleResponse(resp *azcore.Response) (*Int32Res
 
 // GetNullHandleError handles the GetNull error response.
 func (client *IntClient) GetNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +209,8 @@ func (client *IntClient) GetNullUnixTime(ctx context.Context) (*TimeResponse, er
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullUnixTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullUnixTimeHandleError(resp)
 	}
 	result, err := client.GetNullUnixTimeHandleResponse(resp)
 	if err != nil {
@@ -248,9 +239,6 @@ func (client *IntClient) GetNullUnixTimeHandleResponse(resp *azcore.Response) (*
 
 // GetNullUnixTimeHandleError handles the GetNullUnixTime error response.
 func (client *IntClient) GetNullUnixTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -268,8 +256,8 @@ func (client *IntClient) GetOverflowInt32(ctx context.Context) (*Int32Response, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetOverflowInt32HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetOverflowInt32HandleError(resp)
 	}
 	result, err := client.GetOverflowInt32HandleResponse(resp)
 	if err != nil {
@@ -297,9 +285,6 @@ func (client *IntClient) GetOverflowInt32HandleResponse(resp *azcore.Response) (
 
 // GetOverflowInt32HandleError handles the GetOverflowInt32 error response.
 func (client *IntClient) GetOverflowInt32HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -317,8 +302,8 @@ func (client *IntClient) GetOverflowInt64(ctx context.Context) (*Int64Response, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetOverflowInt64HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetOverflowInt64HandleError(resp)
 	}
 	result, err := client.GetOverflowInt64HandleResponse(resp)
 	if err != nil {
@@ -346,9 +331,6 @@ func (client *IntClient) GetOverflowInt64HandleResponse(resp *azcore.Response) (
 
 // GetOverflowInt64HandleError handles the GetOverflowInt64 error response.
 func (client *IntClient) GetOverflowInt64HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -366,8 +348,8 @@ func (client *IntClient) GetUnderflowInt32(ctx context.Context) (*Int32Response,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetUnderflowInt32HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetUnderflowInt32HandleError(resp)
 	}
 	result, err := client.GetUnderflowInt32HandleResponse(resp)
 	if err != nil {
@@ -395,9 +377,6 @@ func (client *IntClient) GetUnderflowInt32HandleResponse(resp *azcore.Response) 
 
 // GetUnderflowInt32HandleError handles the GetUnderflowInt32 error response.
 func (client *IntClient) GetUnderflowInt32HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -415,8 +394,8 @@ func (client *IntClient) GetUnderflowInt64(ctx context.Context) (*Int64Response,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetUnderflowInt64HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetUnderflowInt64HandleError(resp)
 	}
 	result, err := client.GetUnderflowInt64HandleResponse(resp)
 	if err != nil {
@@ -444,9 +423,6 @@ func (client *IntClient) GetUnderflowInt64HandleResponse(resp *azcore.Response) 
 
 // GetUnderflowInt64HandleError handles the GetUnderflowInt64 error response.
 func (client *IntClient) GetUnderflowInt64HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -464,8 +440,8 @@ func (client *IntClient) GetUnixTime(ctx context.Context) (*TimeResponse, error)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetUnixTimeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetUnixTimeHandleError(resp)
 	}
 	result, err := client.GetUnixTimeHandleResponse(resp)
 	if err != nil {
@@ -494,9 +470,6 @@ func (client *IntClient) GetUnixTimeHandleResponse(resp *azcore.Response) (*Time
 
 // GetUnixTimeHandleError handles the GetUnixTime error response.
 func (client *IntClient) GetUnixTimeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -514,8 +487,8 @@ func (client *IntClient) PutMax32(ctx context.Context, intBody int32) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutMax32HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutMax32HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -533,9 +506,6 @@ func (client *IntClient) PutMax32CreateRequest(ctx context.Context, intBody int3
 
 // PutMax32HandleError handles the PutMax32 error response.
 func (client *IntClient) PutMax32HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -553,8 +523,8 @@ func (client *IntClient) PutMax64(ctx context.Context, intBody int64) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutMax64HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutMax64HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -572,9 +542,6 @@ func (client *IntClient) PutMax64CreateRequest(ctx context.Context, intBody int6
 
 // PutMax64HandleError handles the PutMax64 error response.
 func (client *IntClient) PutMax64HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -592,8 +559,8 @@ func (client *IntClient) PutMin32(ctx context.Context, intBody int32) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutMin32HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutMin32HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -611,9 +578,6 @@ func (client *IntClient) PutMin32CreateRequest(ctx context.Context, intBody int3
 
 // PutMin32HandleError handles the PutMin32 error response.
 func (client *IntClient) PutMin32HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -631,8 +595,8 @@ func (client *IntClient) PutMin64(ctx context.Context, intBody int64) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutMin64HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutMin64HandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -650,9 +614,6 @@ func (client *IntClient) PutMin64CreateRequest(ctx context.Context, intBody int6
 
 // PutMin64HandleError handles the PutMin64 error response.
 func (client *IntClient) PutMin64HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -670,8 +631,8 @@ func (client *IntClient) PutUnixTimeDate(ctx context.Context, intBody time.Time)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutUnixTimeDateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutUnixTimeDateHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -690,9 +651,6 @@ func (client *IntClient) PutUnixTimeDateCreateRequest(ctx context.Context, intBo
 
 // PutUnixTimeDateHandleError handles the PutUnixTimeDate error response.
 func (client *IntClient) PutUnixTimeDateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/lrogroup/zz_generated_lroretrys.go
+++ b/test/autorest/lrogroup/zz_generated_lroretrys.go
@@ -72,8 +72,8 @@ func (client *LroRetrysClient) BeginDelete202Retry200(ctx context.Context) (*HTT
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete202Retry200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.Delete202Retry200HandleError(resp)
 	}
 	result, err := client.Delete202Retry200HandleResponse(resp)
 	if err != nil {
@@ -123,9 +123,6 @@ func (client *LroRetrysClient) Delete202Retry200HandleResponse(resp *azcore.Resp
 
 // Delete202Retry200HandleError handles the Delete202Retry200 error response.
 func (client *LroRetrysClient) Delete202Retry200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -144,8 +141,8 @@ func (client *LroRetrysClient) BeginDeleteAsyncRelativeRetrySucceeded(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteAsyncRelativeRetrySucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.DeleteAsyncRelativeRetrySucceededHandleError(resp)
 	}
 	result, err := client.DeleteAsyncRelativeRetrySucceededHandleResponse(resp)
 	if err != nil {
@@ -195,9 +192,6 @@ func (client *LroRetrysClient) DeleteAsyncRelativeRetrySucceededHandleResponse(r
 
 // DeleteAsyncRelativeRetrySucceededHandleError handles the DeleteAsyncRelativeRetrySucceeded error response.
 func (client *LroRetrysClient) DeleteAsyncRelativeRetrySucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *LroRetrysClient) BeginDeleteProvisioning202Accepted200Succeeded(ct
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteProvisioning202Accepted200SucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.DeleteProvisioning202Accepted200SucceededHandleError(resp)
 	}
 	result, err := client.DeleteProvisioning202Accepted200SucceededHandleResponse(resp)
 	if err != nil {
@@ -267,9 +261,6 @@ func (client *LroRetrysClient) DeleteProvisioning202Accepted200SucceededHandleRe
 
 // DeleteProvisioning202Accepted200SucceededHandleError handles the DeleteProvisioning202Accepted200Succeeded error response.
 func (client *LroRetrysClient) DeleteProvisioning202Accepted200SucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -288,8 +279,8 @@ func (client *LroRetrysClient) BeginPost202Retry200(ctx context.Context, lroRetr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post202Retry200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.Post202Retry200HandleError(resp)
 	}
 	result, err := client.Post202Retry200HandleResponse(resp)
 	if err != nil {
@@ -342,9 +333,6 @@ func (client *LroRetrysClient) Post202Retry200HandleResponse(resp *azcore.Respon
 
 // Post202Retry200HandleError handles the Post202Retry200 error response.
 func (client *LroRetrysClient) Post202Retry200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -363,8 +351,8 @@ func (client *LroRetrysClient) BeginPostAsyncRelativeRetrySucceeded(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostAsyncRelativeRetrySucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PostAsyncRelativeRetrySucceededHandleError(resp)
 	}
 	result, err := client.PostAsyncRelativeRetrySucceededHandleResponse(resp)
 	if err != nil {
@@ -417,9 +405,6 @@ func (client *LroRetrysClient) PostAsyncRelativeRetrySucceededHandleResponse(res
 
 // PostAsyncRelativeRetrySucceededHandleError handles the PostAsyncRelativeRetrySucceeded error response.
 func (client *LroRetrysClient) PostAsyncRelativeRetrySucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -438,8 +423,8 @@ func (client *LroRetrysClient) BeginPut201CreatingSucceeded200(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put201CreatingSucceeded200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.Put201CreatingSucceeded200HandleError(resp)
 	}
 	result, err := client.Put201CreatingSucceeded200HandleResponse(resp)
 	if err != nil {
@@ -492,9 +477,6 @@ func (client *LroRetrysClient) Put201CreatingSucceeded200HandleResponse(resp *az
 
 // Put201CreatingSucceeded200HandleError handles the Put201CreatingSucceeded200 error response.
 func (client *LroRetrysClient) Put201CreatingSucceeded200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -513,8 +495,8 @@ func (client *LroRetrysClient) BeginPutAsyncRelativeRetrySucceeded(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutAsyncRelativeRetrySucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutAsyncRelativeRetrySucceededHandleError(resp)
 	}
 	result, err := client.PutAsyncRelativeRetrySucceededHandleResponse(resp)
 	if err != nil {
@@ -567,9 +549,6 @@ func (client *LroRetrysClient) PutAsyncRelativeRetrySucceededHandleResponse(resp
 
 // PutAsyncRelativeRetrySucceededHandleError handles the PutAsyncRelativeRetrySucceeded error response.
 func (client *LroRetrysClient) PutAsyncRelativeRetrySucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/lrogroup/zz_generated_lroretrys.go
+++ b/test/autorest/lrogroup/zz_generated_lroretrys.go
@@ -72,6 +72,9 @@ func (client *LroRetrysClient) BeginDelete202Retry200(ctx context.Context) (*HTT
 	if err != nil {
 		return nil, err
 	}
+	if err := client.Delete202Retry200HandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.Delete202Retry200HandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -115,14 +118,14 @@ func (client *LroRetrysClient) Delete202Retry200CreateRequest(ctx context.Contex
 
 // Delete202Retry200HandleResponse handles the Delete202Retry200 response.
 func (client *LroRetrysClient) Delete202Retry200HandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Delete202Retry200HandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Delete202Retry200HandleError handles the Delete202Retry200 error response.
 func (client *LroRetrysClient) Delete202Retry200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -139,6 +142,9 @@ func (client *LroRetrysClient) BeginDeleteAsyncRelativeRetrySucceeded(ctx contex
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteAsyncRelativeRetrySucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteAsyncRelativeRetrySucceededHandleResponse(resp)
@@ -184,14 +190,14 @@ func (client *LroRetrysClient) DeleteAsyncRelativeRetrySucceededCreateRequest(ct
 
 // DeleteAsyncRelativeRetrySucceededHandleResponse handles the DeleteAsyncRelativeRetrySucceeded response.
 func (client *LroRetrysClient) DeleteAsyncRelativeRetrySucceededHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteAsyncRelativeRetrySucceededHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteAsyncRelativeRetrySucceededHandleError handles the DeleteAsyncRelativeRetrySucceeded error response.
 func (client *LroRetrysClient) DeleteAsyncRelativeRetrySucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *LroRetrysClient) BeginDeleteProvisioning202Accepted200Succeeded(ct
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteProvisioning202Accepted200SucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteProvisioning202Accepted200SucceededHandleResponse(resp)
@@ -253,14 +262,14 @@ func (client *LroRetrysClient) DeleteProvisioning202Accepted200SucceededCreateRe
 
 // DeleteProvisioning202Accepted200SucceededHandleResponse handles the DeleteProvisioning202Accepted200Succeeded response.
 func (client *LroRetrysClient) DeleteProvisioning202Accepted200SucceededHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteProvisioning202Accepted200SucceededHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteProvisioning202Accepted200SucceededHandleError handles the DeleteProvisioning202Accepted200Succeeded error response.
 func (client *LroRetrysClient) DeleteProvisioning202Accepted200SucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -277,6 +286,9 @@ func (client *LroRetrysClient) BeginPost202Retry200(ctx context.Context, lroRetr
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Post202Retry200HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Post202Retry200HandleResponse(resp)
@@ -325,14 +337,14 @@ func (client *LroRetrysClient) Post202Retry200CreateRequest(ctx context.Context,
 
 // Post202Retry200HandleResponse handles the Post202Retry200 response.
 func (client *LroRetrysClient) Post202Retry200HandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Post202Retry200HandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Post202Retry200HandleError handles the Post202Retry200 error response.
 func (client *LroRetrysClient) Post202Retry200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -349,6 +361,9 @@ func (client *LroRetrysClient) BeginPostAsyncRelativeRetrySucceeded(ctx context.
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PostAsyncRelativeRetrySucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PostAsyncRelativeRetrySucceededHandleResponse(resp)
@@ -397,14 +412,14 @@ func (client *LroRetrysClient) PostAsyncRelativeRetrySucceededCreateRequest(ctx 
 
 // PostAsyncRelativeRetrySucceededHandleResponse handles the PostAsyncRelativeRetrySucceeded response.
 func (client *LroRetrysClient) PostAsyncRelativeRetrySucceededHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PostAsyncRelativeRetrySucceededHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PostAsyncRelativeRetrySucceededHandleError handles the PostAsyncRelativeRetrySucceeded error response.
 func (client *LroRetrysClient) PostAsyncRelativeRetrySucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -421,6 +436,9 @@ func (client *LroRetrysClient) BeginPut201CreatingSucceeded200(ctx context.Conte
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Put201CreatingSucceeded200HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Put201CreatingSucceeded200HandleResponse(resp)
@@ -469,14 +487,14 @@ func (client *LroRetrysClient) Put201CreatingSucceeded200CreateRequest(ctx conte
 
 // Put201CreatingSucceeded200HandleResponse handles the Put201CreatingSucceeded200 response.
 func (client *LroRetrysClient) Put201CreatingSucceeded200HandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.Put201CreatingSucceeded200HandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Put201CreatingSucceeded200HandleError handles the Put201CreatingSucceeded200 error response.
 func (client *LroRetrysClient) Put201CreatingSucceeded200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -493,6 +511,9 @@ func (client *LroRetrysClient) BeginPutAsyncRelativeRetrySucceeded(ctx context.C
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutAsyncRelativeRetrySucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutAsyncRelativeRetrySucceededHandleResponse(resp)
@@ -541,14 +562,14 @@ func (client *LroRetrysClient) PutAsyncRelativeRetrySucceededCreateRequest(ctx c
 
 // PutAsyncRelativeRetrySucceededHandleResponse handles the PutAsyncRelativeRetrySucceeded response.
 func (client *LroRetrysClient) PutAsyncRelativeRetrySucceededHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.PutAsyncRelativeRetrySucceededHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutAsyncRelativeRetrySucceededHandleError handles the PutAsyncRelativeRetrySucceeded error response.
 func (client *LroRetrysClient) PutAsyncRelativeRetrySucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/lrogroup/zz_generated_lros.go
+++ b/test/autorest/lrogroup/zz_generated_lros.go
@@ -208,6 +208,9 @@ func (client *LrOSClient) BeginDelete202NoRetry204(ctx context.Context) (*Produc
 	if err != nil {
 		return nil, err
 	}
+	if err := client.Delete202NoRetry204HandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.Delete202NoRetry204HandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -251,14 +254,14 @@ func (client *LrOSClient) Delete202NoRetry204CreateRequest(ctx context.Context) 
 
 // Delete202NoRetry204HandleResponse handles the Delete202NoRetry204 response.
 func (client *LrOSClient) Delete202NoRetry204HandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Delete202NoRetry204HandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Delete202NoRetry204HandleError handles the Delete202NoRetry204 error response.
 func (client *LrOSClient) Delete202NoRetry204HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -275,6 +278,9 @@ func (client *LrOSClient) BeginDelete202Retry200(ctx context.Context) (*ProductP
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Delete202Retry200HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Delete202Retry200HandleResponse(resp)
@@ -320,14 +326,14 @@ func (client *LrOSClient) Delete202Retry200CreateRequest(ctx context.Context) (*
 
 // Delete202Retry200HandleResponse handles the Delete202Retry200 response.
 func (client *LrOSClient) Delete202Retry200HandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Delete202Retry200HandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Delete202Retry200HandleError handles the Delete202Retry200 error response.
 func (client *LrOSClient) Delete202Retry200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -344,6 +350,9 @@ func (client *LrOSClient) BeginDelete204Succeeded(ctx context.Context) (*HTTPPol
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Delete204SucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Delete204SucceededHandleResponse(resp)
@@ -389,14 +398,14 @@ func (client *LrOSClient) Delete204SucceededCreateRequest(ctx context.Context) (
 
 // Delete204SucceededHandleResponse handles the Delete204Succeeded response.
 func (client *LrOSClient) Delete204SucceededHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusNoContent) {
-		return nil, client.Delete204SucceededHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Delete204SucceededHandleError handles the Delete204Succeeded error response.
 func (client *LrOSClient) Delete204SucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -413,6 +422,9 @@ func (client *LrOSClient) BeginDeleteAsyncNoHeaderInRetry(ctx context.Context) (
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteAsyncNoHeaderInRetryHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteAsyncNoHeaderInRetryHandleResponse(resp)
@@ -458,14 +470,14 @@ func (client *LrOSClient) DeleteAsyncNoHeaderInRetryCreateRequest(ctx context.Co
 
 // DeleteAsyncNoHeaderInRetryHandleResponse handles the DeleteAsyncNoHeaderInRetry response.
 func (client *LrOSClient) DeleteAsyncNoHeaderInRetryHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteAsyncNoHeaderInRetryHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteAsyncNoHeaderInRetryHandleError handles the DeleteAsyncNoHeaderInRetry error response.
 func (client *LrOSClient) DeleteAsyncNoHeaderInRetryHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -482,6 +494,9 @@ func (client *LrOSClient) BeginDeleteAsyncNoRetrySucceeded(ctx context.Context) 
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteAsyncNoRetrySucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteAsyncNoRetrySucceededHandleResponse(resp)
@@ -527,14 +542,14 @@ func (client *LrOSClient) DeleteAsyncNoRetrySucceededCreateRequest(ctx context.C
 
 // DeleteAsyncNoRetrySucceededHandleResponse handles the DeleteAsyncNoRetrySucceeded response.
 func (client *LrOSClient) DeleteAsyncNoRetrySucceededHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteAsyncNoRetrySucceededHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteAsyncNoRetrySucceededHandleError handles the DeleteAsyncNoRetrySucceeded error response.
 func (client *LrOSClient) DeleteAsyncNoRetrySucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -551,6 +566,9 @@ func (client *LrOSClient) BeginDeleteAsyncRetryFailed(ctx context.Context) (*HTT
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteAsyncRetryFailedHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteAsyncRetryFailedHandleResponse(resp)
@@ -596,14 +614,14 @@ func (client *LrOSClient) DeleteAsyncRetryFailedCreateRequest(ctx context.Contex
 
 // DeleteAsyncRetryFailedHandleResponse handles the DeleteAsyncRetryFailed response.
 func (client *LrOSClient) DeleteAsyncRetryFailedHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteAsyncRetryFailedHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteAsyncRetryFailedHandleError handles the DeleteAsyncRetryFailed error response.
 func (client *LrOSClient) DeleteAsyncRetryFailedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -620,6 +638,9 @@ func (client *LrOSClient) BeginDeleteAsyncRetrySucceeded(ctx context.Context) (*
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteAsyncRetrySucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteAsyncRetrySucceededHandleResponse(resp)
@@ -665,14 +686,14 @@ func (client *LrOSClient) DeleteAsyncRetrySucceededCreateRequest(ctx context.Con
 
 // DeleteAsyncRetrySucceededHandleResponse handles the DeleteAsyncRetrySucceeded response.
 func (client *LrOSClient) DeleteAsyncRetrySucceededHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteAsyncRetrySucceededHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteAsyncRetrySucceededHandleError handles the DeleteAsyncRetrySucceeded error response.
 func (client *LrOSClient) DeleteAsyncRetrySucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -689,6 +710,9 @@ func (client *LrOSClient) BeginDeleteAsyncRetrycanceled(ctx context.Context) (*H
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteAsyncRetrycanceledHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteAsyncRetrycanceledHandleResponse(resp)
@@ -734,14 +758,14 @@ func (client *LrOSClient) DeleteAsyncRetrycanceledCreateRequest(ctx context.Cont
 
 // DeleteAsyncRetrycanceledHandleResponse handles the DeleteAsyncRetrycanceled response.
 func (client *LrOSClient) DeleteAsyncRetrycanceledHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteAsyncRetrycanceledHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteAsyncRetrycanceledHandleError handles the DeleteAsyncRetrycanceled error response.
 func (client *LrOSClient) DeleteAsyncRetrycanceledHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -758,6 +782,9 @@ func (client *LrOSClient) BeginDeleteNoHeaderInRetry(ctx context.Context) (*HTTP
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteNoHeaderInRetryHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteNoHeaderInRetryHandleResponse(resp)
@@ -803,14 +830,14 @@ func (client *LrOSClient) DeleteNoHeaderInRetryCreateRequest(ctx context.Context
 
 // DeleteNoHeaderInRetryHandleResponse handles the DeleteNoHeaderInRetry response.
 func (client *LrOSClient) DeleteNoHeaderInRetryHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteNoHeaderInRetryHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteNoHeaderInRetryHandleError handles the DeleteNoHeaderInRetry error response.
 func (client *LrOSClient) DeleteNoHeaderInRetryHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -827,6 +854,9 @@ func (client *LrOSClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx con
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteProvisioning202Accepted200SucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteProvisioning202Accepted200SucceededHandleResponse(resp)
@@ -872,14 +902,14 @@ func (client *LrOSClient) DeleteProvisioning202Accepted200SucceededCreateRequest
 
 // DeleteProvisioning202Accepted200SucceededHandleResponse handles the DeleteProvisioning202Accepted200Succeeded response.
 func (client *LrOSClient) DeleteProvisioning202Accepted200SucceededHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteProvisioning202Accepted200SucceededHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteProvisioning202Accepted200SucceededHandleError handles the DeleteProvisioning202Accepted200Succeeded error response.
 func (client *LrOSClient) DeleteProvisioning202Accepted200SucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -896,6 +926,9 @@ func (client *LrOSClient) BeginDeleteProvisioning202DeletingFailed200(ctx contex
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteProvisioning202DeletingFailed200HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteProvisioning202DeletingFailed200HandleResponse(resp)
@@ -941,14 +974,14 @@ func (client *LrOSClient) DeleteProvisioning202DeletingFailed200CreateRequest(ct
 
 // DeleteProvisioning202DeletingFailed200HandleResponse handles the DeleteProvisioning202DeletingFailed200 response.
 func (client *LrOSClient) DeleteProvisioning202DeletingFailed200HandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteProvisioning202DeletingFailed200HandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteProvisioning202DeletingFailed200HandleError handles the DeleteProvisioning202DeletingFailed200 error response.
 func (client *LrOSClient) DeleteProvisioning202DeletingFailed200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -965,6 +998,9 @@ func (client *LrOSClient) BeginDeleteProvisioning202Deletingcanceled200(ctx cont
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteProvisioning202Deletingcanceled200HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteProvisioning202Deletingcanceled200HandleResponse(resp)
@@ -1010,14 +1046,14 @@ func (client *LrOSClient) DeleteProvisioning202Deletingcanceled200CreateRequest(
 
 // DeleteProvisioning202Deletingcanceled200HandleResponse handles the DeleteProvisioning202Deletingcanceled200 response.
 func (client *LrOSClient) DeleteProvisioning202Deletingcanceled200HandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteProvisioning202Deletingcanceled200HandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteProvisioning202Deletingcanceled200HandleError handles the DeleteProvisioning202Deletingcanceled200 error response.
 func (client *LrOSClient) DeleteProvisioning202Deletingcanceled200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1034,6 +1070,9 @@ func (client *LrOSClient) BeginPost200WithPayload(ctx context.Context) (*SKUPoll
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Post200WithPayloadHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Post200WithPayloadHandleResponse(resp)
@@ -1079,14 +1118,14 @@ func (client *LrOSClient) Post200WithPayloadCreateRequest(ctx context.Context) (
 
 // Post200WithPayloadHandleResponse handles the Post200WithPayload response.
 func (client *LrOSClient) Post200WithPayloadHandleResponse(resp *azcore.Response) (*SKUPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Post200WithPayloadHandleError(resp)
-	}
 	return &SKUPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Post200WithPayloadHandleError handles the Post200WithPayload error response.
 func (client *LrOSClient) Post200WithPayloadHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1103,6 +1142,9 @@ func (client *LrOSClient) BeginPost202List(ctx context.Context) (*ProductArrayPo
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Post202ListHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Post202ListHandleResponse(resp)
@@ -1148,14 +1190,14 @@ func (client *LrOSClient) Post202ListCreateRequest(ctx context.Context) (*azcore
 
 // Post202ListHandleResponse handles the Post202List response.
 func (client *LrOSClient) Post202ListHandleResponse(resp *azcore.Response) (*ProductArrayPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Post202ListHandleError(resp)
-	}
 	return &ProductArrayPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Post202ListHandleError handles the Post202List error response.
 func (client *LrOSClient) Post202ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1172,6 +1214,9 @@ func (client *LrOSClient) BeginPost202NoRetry204(ctx context.Context, lrOSPost20
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Post202NoRetry204HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Post202NoRetry204HandleResponse(resp)
@@ -1220,14 +1265,14 @@ func (client *LrOSClient) Post202NoRetry204CreateRequest(ctx context.Context, lr
 
 // Post202NoRetry204HandleResponse handles the Post202NoRetry204 response.
 func (client *LrOSClient) Post202NoRetry204HandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Post202NoRetry204HandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Post202NoRetry204HandleError handles the Post202NoRetry204 error response.
 func (client *LrOSClient) Post202NoRetry204HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1244,6 +1289,9 @@ func (client *LrOSClient) BeginPost202Retry200(ctx context.Context, lrOSPost202R
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Post202Retry200HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Post202Retry200HandleResponse(resp)
@@ -1292,14 +1340,14 @@ func (client *LrOSClient) Post202Retry200CreateRequest(ctx context.Context, lrOS
 
 // Post202Retry200HandleResponse handles the Post202Retry200 response.
 func (client *LrOSClient) Post202Retry200HandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Post202Retry200HandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Post202Retry200HandleError handles the Post202Retry200 error response.
 func (client *LrOSClient) Post202Retry200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1316,6 +1364,9 @@ func (client *LrOSClient) BeginPostAsyncNoRetrySucceeded(ctx context.Context, lr
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PostAsyncNoRetrySucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PostAsyncNoRetrySucceededHandleResponse(resp)
@@ -1364,14 +1415,14 @@ func (client *LrOSClient) PostAsyncNoRetrySucceededCreateRequest(ctx context.Con
 
 // PostAsyncNoRetrySucceededHandleResponse handles the PostAsyncNoRetrySucceeded response.
 func (client *LrOSClient) PostAsyncNoRetrySucceededHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PostAsyncNoRetrySucceededHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PostAsyncNoRetrySucceededHandleError handles the PostAsyncNoRetrySucceeded error response.
 func (client *LrOSClient) PostAsyncNoRetrySucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1388,6 +1439,9 @@ func (client *LrOSClient) BeginPostAsyncRetryFailed(ctx context.Context, lrOSPos
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PostAsyncRetryFailedHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PostAsyncRetryFailedHandleResponse(resp)
@@ -1436,14 +1490,14 @@ func (client *LrOSClient) PostAsyncRetryFailedCreateRequest(ctx context.Context,
 
 // PostAsyncRetryFailedHandleResponse handles the PostAsyncRetryFailed response.
 func (client *LrOSClient) PostAsyncRetryFailedHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PostAsyncRetryFailedHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PostAsyncRetryFailedHandleError handles the PostAsyncRetryFailed error response.
 func (client *LrOSClient) PostAsyncRetryFailedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1460,6 +1514,9 @@ func (client *LrOSClient) BeginPostAsyncRetrySucceeded(ctx context.Context, lrOS
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PostAsyncRetrySucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PostAsyncRetrySucceededHandleResponse(resp)
@@ -1508,14 +1565,14 @@ func (client *LrOSClient) PostAsyncRetrySucceededCreateRequest(ctx context.Conte
 
 // PostAsyncRetrySucceededHandleResponse handles the PostAsyncRetrySucceeded response.
 func (client *LrOSClient) PostAsyncRetrySucceededHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PostAsyncRetrySucceededHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PostAsyncRetrySucceededHandleError handles the PostAsyncRetrySucceeded error response.
 func (client *LrOSClient) PostAsyncRetrySucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1532,6 +1589,9 @@ func (client *LrOSClient) BeginPostAsyncRetrycanceled(ctx context.Context, lrOSP
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PostAsyncRetrycanceledHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PostAsyncRetrycanceledHandleResponse(resp)
@@ -1580,14 +1640,14 @@ func (client *LrOSClient) PostAsyncRetrycanceledCreateRequest(ctx context.Contex
 
 // PostAsyncRetrycanceledHandleResponse handles the PostAsyncRetrycanceled response.
 func (client *LrOSClient) PostAsyncRetrycanceledHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PostAsyncRetrycanceledHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PostAsyncRetrycanceledHandleError handles the PostAsyncRetrycanceled error response.
 func (client *LrOSClient) PostAsyncRetrycanceledHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1604,6 +1664,9 @@ func (client *LrOSClient) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx context.
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PostDoubleHeadersFinalAzureHeaderGetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PostDoubleHeadersFinalAzureHeaderGetHandleResponse(resp)
@@ -1649,14 +1712,14 @@ func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetCreateRequest(ctx 
 
 // PostDoubleHeadersFinalAzureHeaderGetHandleResponse handles the PostDoubleHeadersFinalAzureHeaderGet response.
 func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PostDoubleHeadersFinalAzureHeaderGetHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PostDoubleHeadersFinalAzureHeaderGetHandleError handles the PostDoubleHeadersFinalAzureHeaderGet error response.
 func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1673,6 +1736,9 @@ func (client *LrOSClient) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(ctx c
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PostDoubleHeadersFinalAzureHeaderGetDefaultHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PostDoubleHeadersFinalAzureHeaderGetDefaultHandleResponse(resp)
@@ -1718,14 +1784,14 @@ func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetDefaultCreateReque
 
 // PostDoubleHeadersFinalAzureHeaderGetDefaultHandleResponse handles the PostDoubleHeadersFinalAzureHeaderGetDefault response.
 func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetDefaultHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PostDoubleHeadersFinalAzureHeaderGetDefaultHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PostDoubleHeadersFinalAzureHeaderGetDefaultHandleError handles the PostDoubleHeadersFinalAzureHeaderGetDefault error response.
 func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetDefaultHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1742,6 +1808,9 @@ func (client *LrOSClient) BeginPostDoubleHeadersFinalLocationGet(ctx context.Con
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PostDoubleHeadersFinalLocationGetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PostDoubleHeadersFinalLocationGetHandleResponse(resp)
@@ -1787,14 +1856,14 @@ func (client *LrOSClient) PostDoubleHeadersFinalLocationGetCreateRequest(ctx con
 
 // PostDoubleHeadersFinalLocationGetHandleResponse handles the PostDoubleHeadersFinalLocationGet response.
 func (client *LrOSClient) PostDoubleHeadersFinalLocationGetHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PostDoubleHeadersFinalLocationGetHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PostDoubleHeadersFinalLocationGetHandleError handles the PostDoubleHeadersFinalLocationGet error response.
 func (client *LrOSClient) PostDoubleHeadersFinalLocationGetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1811,6 +1880,9 @@ func (client *LrOSClient) BeginPut200Acceptedcanceled200(ctx context.Context, lr
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Put200Acceptedcanceled200HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Put200Acceptedcanceled200HandleResponse(resp)
@@ -1859,14 +1931,14 @@ func (client *LrOSClient) Put200Acceptedcanceled200CreateRequest(ctx context.Con
 
 // Put200Acceptedcanceled200HandleResponse handles the Put200Acceptedcanceled200 response.
 func (client *LrOSClient) Put200Acceptedcanceled200HandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.Put200Acceptedcanceled200HandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Put200Acceptedcanceled200HandleError handles the Put200Acceptedcanceled200 error response.
 func (client *LrOSClient) Put200Acceptedcanceled200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1883,6 +1955,9 @@ func (client *LrOSClient) BeginPut200Succeeded(ctx context.Context, lrOSPut200Su
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Put200SucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Put200SucceededHandleResponse(resp)
@@ -1931,14 +2006,14 @@ func (client *LrOSClient) Put200SucceededCreateRequest(ctx context.Context, lrOS
 
 // Put200SucceededHandleResponse handles the Put200Succeeded response.
 func (client *LrOSClient) Put200SucceededHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.Put200SucceededHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Put200SucceededHandleError handles the Put200Succeeded error response.
 func (client *LrOSClient) Put200SucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1955,6 +2030,9 @@ func (client *LrOSClient) BeginPut200SucceededNoState(ctx context.Context, lrOSP
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Put200SucceededNoStateHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Put200SucceededNoStateHandleResponse(resp)
@@ -2003,14 +2081,14 @@ func (client *LrOSClient) Put200SucceededNoStateCreateRequest(ctx context.Contex
 
 // Put200SucceededNoStateHandleResponse handles the Put200SucceededNoState response.
 func (client *LrOSClient) Put200SucceededNoStateHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.Put200SucceededNoStateHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Put200SucceededNoStateHandleError handles the Put200SucceededNoState error response.
 func (client *LrOSClient) Put200SucceededNoStateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2027,6 +2105,9 @@ func (client *LrOSClient) BeginPut200UpdatingSucceeded204(ctx context.Context, l
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Put200UpdatingSucceeded204HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Put200UpdatingSucceeded204HandleResponse(resp)
@@ -2075,14 +2156,14 @@ func (client *LrOSClient) Put200UpdatingSucceeded204CreateRequest(ctx context.Co
 
 // Put200UpdatingSucceeded204HandleResponse handles the Put200UpdatingSucceeded204 response.
 func (client *LrOSClient) Put200UpdatingSucceeded204HandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.Put200UpdatingSucceeded204HandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Put200UpdatingSucceeded204HandleError handles the Put200UpdatingSucceeded204 error response.
 func (client *LrOSClient) Put200UpdatingSucceeded204HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2099,6 +2180,9 @@ func (client *LrOSClient) BeginPut201CreatingFailed200(ctx context.Context, lrOS
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Put201CreatingFailed200HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Put201CreatingFailed200HandleResponse(resp)
@@ -2147,14 +2231,14 @@ func (client *LrOSClient) Put201CreatingFailed200CreateRequest(ctx context.Conte
 
 // Put201CreatingFailed200HandleResponse handles the Put201CreatingFailed200 response.
 func (client *LrOSClient) Put201CreatingFailed200HandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.Put201CreatingFailed200HandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Put201CreatingFailed200HandleError handles the Put201CreatingFailed200 error response.
 func (client *LrOSClient) Put201CreatingFailed200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2171,6 +2255,9 @@ func (client *LrOSClient) BeginPut201CreatingSucceeded200(ctx context.Context, l
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Put201CreatingSucceeded200HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Put201CreatingSucceeded200HandleResponse(resp)
@@ -2219,14 +2306,14 @@ func (client *LrOSClient) Put201CreatingSucceeded200CreateRequest(ctx context.Co
 
 // Put201CreatingSucceeded200HandleResponse handles the Put201CreatingSucceeded200 response.
 func (client *LrOSClient) Put201CreatingSucceeded200HandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.Put201CreatingSucceeded200HandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Put201CreatingSucceeded200HandleError handles the Put201CreatingSucceeded200 error response.
 func (client *LrOSClient) Put201CreatingSucceeded200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2243,6 +2330,9 @@ func (client *LrOSClient) BeginPut201Succeeded(ctx context.Context, lrOSPut201Su
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Put201SucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Put201SucceededHandleResponse(resp)
@@ -2291,14 +2381,14 @@ func (client *LrOSClient) Put201SucceededCreateRequest(ctx context.Context, lrOS
 
 // Put201SucceededHandleResponse handles the Put201Succeeded response.
 func (client *LrOSClient) Put201SucceededHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated, http.StatusNoContent) {
-		return nil, client.Put201SucceededHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Put201SucceededHandleError handles the Put201Succeeded error response.
 func (client *LrOSClient) Put201SucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2315,6 +2405,9 @@ func (client *LrOSClient) BeginPut202Retry200(ctx context.Context, lrOSPut202Ret
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Put202Retry200HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Put202Retry200HandleResponse(resp)
@@ -2363,14 +2456,14 @@ func (client *LrOSClient) Put202Retry200CreateRequest(ctx context.Context, lrOSP
 
 // Put202Retry200HandleResponse handles the Put202Retry200 response.
 func (client *LrOSClient) Put202Retry200HandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Put202Retry200HandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Put202Retry200HandleError handles the Put202Retry200 error response.
 func (client *LrOSClient) Put202Retry200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2387,6 +2480,9 @@ func (client *LrOSClient) BeginPutAsyncNoHeaderInRetry(ctx context.Context, lrOS
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutAsyncNoHeaderInRetryHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutAsyncNoHeaderInRetryHandleResponse(resp)
@@ -2435,14 +2531,14 @@ func (client *LrOSClient) PutAsyncNoHeaderInRetryCreateRequest(ctx context.Conte
 
 // PutAsyncNoHeaderInRetryHandleResponse handles the PutAsyncNoHeaderInRetry response.
 func (client *LrOSClient) PutAsyncNoHeaderInRetryHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated, http.StatusNoContent) {
-		return nil, client.PutAsyncNoHeaderInRetryHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutAsyncNoHeaderInRetryHandleError handles the PutAsyncNoHeaderInRetry error response.
 func (client *LrOSClient) PutAsyncNoHeaderInRetryHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2459,6 +2555,9 @@ func (client *LrOSClient) BeginPutAsyncNoRetrySucceeded(ctx context.Context, lrO
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutAsyncNoRetrySucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutAsyncNoRetrySucceededHandleResponse(resp)
@@ -2507,14 +2606,14 @@ func (client *LrOSClient) PutAsyncNoRetrySucceededCreateRequest(ctx context.Cont
 
 // PutAsyncNoRetrySucceededHandleResponse handles the PutAsyncNoRetrySucceeded response.
 func (client *LrOSClient) PutAsyncNoRetrySucceededHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.PutAsyncNoRetrySucceededHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutAsyncNoRetrySucceededHandleError handles the PutAsyncNoRetrySucceeded error response.
 func (client *LrOSClient) PutAsyncNoRetrySucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2531,6 +2630,9 @@ func (client *LrOSClient) BeginPutAsyncNoRetrycanceled(ctx context.Context, lrOS
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutAsyncNoRetrycanceledHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutAsyncNoRetrycanceledHandleResponse(resp)
@@ -2579,14 +2681,14 @@ func (client *LrOSClient) PutAsyncNoRetrycanceledCreateRequest(ctx context.Conte
 
 // PutAsyncNoRetrycanceledHandleResponse handles the PutAsyncNoRetrycanceled response.
 func (client *LrOSClient) PutAsyncNoRetrycanceledHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.PutAsyncNoRetrycanceledHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutAsyncNoRetrycanceledHandleError handles the PutAsyncNoRetrycanceled error response.
 func (client *LrOSClient) PutAsyncNoRetrycanceledHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2603,6 +2705,9 @@ func (client *LrOSClient) BeginPutAsyncNonResource(ctx context.Context, lrOSPutA
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutAsyncNonResourceHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutAsyncNonResourceHandleResponse(resp)
@@ -2651,14 +2756,14 @@ func (client *LrOSClient) PutAsyncNonResourceCreateRequest(ctx context.Context, 
 
 // PutAsyncNonResourceHandleResponse handles the PutAsyncNonResource response.
 func (client *LrOSClient) PutAsyncNonResourceHandleResponse(resp *azcore.Response) (*SKUPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PutAsyncNonResourceHandleError(resp)
-	}
 	return &SKUPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutAsyncNonResourceHandleError handles the PutAsyncNonResource error response.
 func (client *LrOSClient) PutAsyncNonResourceHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2675,6 +2780,9 @@ func (client *LrOSClient) BeginPutAsyncRetryFailed(ctx context.Context, lrOSPutA
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutAsyncRetryFailedHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutAsyncRetryFailedHandleResponse(resp)
@@ -2723,14 +2831,14 @@ func (client *LrOSClient) PutAsyncRetryFailedCreateRequest(ctx context.Context, 
 
 // PutAsyncRetryFailedHandleResponse handles the PutAsyncRetryFailed response.
 func (client *LrOSClient) PutAsyncRetryFailedHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.PutAsyncRetryFailedHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutAsyncRetryFailedHandleError handles the PutAsyncRetryFailed error response.
 func (client *LrOSClient) PutAsyncRetryFailedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2747,6 +2855,9 @@ func (client *LrOSClient) BeginPutAsyncRetrySucceeded(ctx context.Context, lrOSP
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutAsyncRetrySucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutAsyncRetrySucceededHandleResponse(resp)
@@ -2795,14 +2906,14 @@ func (client *LrOSClient) PutAsyncRetrySucceededCreateRequest(ctx context.Contex
 
 // PutAsyncRetrySucceededHandleResponse handles the PutAsyncRetrySucceeded response.
 func (client *LrOSClient) PutAsyncRetrySucceededHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.PutAsyncRetrySucceededHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutAsyncRetrySucceededHandleError handles the PutAsyncRetrySucceeded error response.
 func (client *LrOSClient) PutAsyncRetrySucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2819,6 +2930,9 @@ func (client *LrOSClient) BeginPutAsyncSubResource(ctx context.Context, lrOSPutA
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutAsyncSubResourceHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutAsyncSubResourceHandleResponse(resp)
@@ -2867,14 +2981,14 @@ func (client *LrOSClient) PutAsyncSubResourceCreateRequest(ctx context.Context, 
 
 // PutAsyncSubResourceHandleResponse handles the PutAsyncSubResource response.
 func (client *LrOSClient) PutAsyncSubResourceHandleResponse(resp *azcore.Response) (*SubProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PutAsyncSubResourceHandleError(resp)
-	}
 	return &SubProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutAsyncSubResourceHandleError handles the PutAsyncSubResource error response.
 func (client *LrOSClient) PutAsyncSubResourceHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2891,6 +3005,9 @@ func (client *LrOSClient) BeginPutNoHeaderInRetry(ctx context.Context, lrOSPutNo
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutNoHeaderInRetryHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutNoHeaderInRetryHandleResponse(resp)
@@ -2939,14 +3056,14 @@ func (client *LrOSClient) PutNoHeaderInRetryCreateRequest(ctx context.Context, l
 
 // PutNoHeaderInRetryHandleResponse handles the PutNoHeaderInRetry response.
 func (client *LrOSClient) PutNoHeaderInRetryHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PutNoHeaderInRetryHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutNoHeaderInRetryHandleError handles the PutNoHeaderInRetry error response.
 func (client *LrOSClient) PutNoHeaderInRetryHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2963,6 +3080,9 @@ func (client *LrOSClient) BeginPutNonResource(ctx context.Context, lrOSPutNonRes
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutNonResourceHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutNonResourceHandleResponse(resp)
@@ -3011,14 +3131,14 @@ func (client *LrOSClient) PutNonResourceCreateRequest(ctx context.Context, lrOSP
 
 // PutNonResourceHandleResponse handles the PutNonResource response.
 func (client *LrOSClient) PutNonResourceHandleResponse(resp *azcore.Response) (*SKUPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PutNonResourceHandleError(resp)
-	}
 	return &SKUPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutNonResourceHandleError handles the PutNonResource error response.
 func (client *LrOSClient) PutNonResourceHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3035,6 +3155,9 @@ func (client *LrOSClient) BeginPutSubResource(ctx context.Context, lrOSPutSubRes
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutSubResourceHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutSubResourceHandleResponse(resp)
@@ -3083,14 +3206,14 @@ func (client *LrOSClient) PutSubResourceCreateRequest(ctx context.Context, lrOSP
 
 // PutSubResourceHandleResponse handles the PutSubResource response.
 func (client *LrOSClient) PutSubResourceHandleResponse(resp *azcore.Response) (*SubProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PutSubResourceHandleError(resp)
-	}
 	return &SubProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutSubResourceHandleError handles the PutSubResource error response.
 func (client *LrOSClient) PutSubResourceHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/lrogroup/zz_generated_lros.go
+++ b/test/autorest/lrogroup/zz_generated_lros.go
@@ -208,8 +208,8 @@ func (client *LrOSClient) BeginDelete202NoRetry204(ctx context.Context) (*Produc
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete202NoRetry204HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.Delete202NoRetry204HandleError(resp)
 	}
 	result, err := client.Delete202NoRetry204HandleResponse(resp)
 	if err != nil {
@@ -259,9 +259,6 @@ func (client *LrOSClient) Delete202NoRetry204HandleResponse(resp *azcore.Respons
 
 // Delete202NoRetry204HandleError handles the Delete202NoRetry204 error response.
 func (client *LrOSClient) Delete202NoRetry204HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -280,8 +277,8 @@ func (client *LrOSClient) BeginDelete202Retry200(ctx context.Context) (*ProductP
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete202Retry200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.Delete202Retry200HandleError(resp)
 	}
 	result, err := client.Delete202Retry200HandleResponse(resp)
 	if err != nil {
@@ -331,9 +328,6 @@ func (client *LrOSClient) Delete202Retry200HandleResponse(resp *azcore.Response)
 
 // Delete202Retry200HandleError handles the Delete202Retry200 error response.
 func (client *LrOSClient) Delete202Retry200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -352,8 +346,8 @@ func (client *LrOSClient) BeginDelete204Succeeded(ctx context.Context) (*HTTPPol
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete204SucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusNoContent) {
+		return nil, client.Delete204SucceededHandleError(resp)
 	}
 	result, err := client.Delete204SucceededHandleResponse(resp)
 	if err != nil {
@@ -403,9 +397,6 @@ func (client *LrOSClient) Delete204SucceededHandleResponse(resp *azcore.Response
 
 // Delete204SucceededHandleError handles the Delete204Succeeded error response.
 func (client *LrOSClient) Delete204SucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -424,8 +415,8 @@ func (client *LrOSClient) BeginDeleteAsyncNoHeaderInRetry(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteAsyncNoHeaderInRetryHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteAsyncNoHeaderInRetryHandleError(resp)
 	}
 	result, err := client.DeleteAsyncNoHeaderInRetryHandleResponse(resp)
 	if err != nil {
@@ -475,9 +466,6 @@ func (client *LrOSClient) DeleteAsyncNoHeaderInRetryHandleResponse(resp *azcore.
 
 // DeleteAsyncNoHeaderInRetryHandleError handles the DeleteAsyncNoHeaderInRetry error response.
 func (client *LrOSClient) DeleteAsyncNoHeaderInRetryHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -496,8 +484,8 @@ func (client *LrOSClient) BeginDeleteAsyncNoRetrySucceeded(ctx context.Context) 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteAsyncNoRetrySucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.DeleteAsyncNoRetrySucceededHandleError(resp)
 	}
 	result, err := client.DeleteAsyncNoRetrySucceededHandleResponse(resp)
 	if err != nil {
@@ -547,9 +535,6 @@ func (client *LrOSClient) DeleteAsyncNoRetrySucceededHandleResponse(resp *azcore
 
 // DeleteAsyncNoRetrySucceededHandleError handles the DeleteAsyncNoRetrySucceeded error response.
 func (client *LrOSClient) DeleteAsyncNoRetrySucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -568,8 +553,8 @@ func (client *LrOSClient) BeginDeleteAsyncRetryFailed(ctx context.Context) (*HTT
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteAsyncRetryFailedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.DeleteAsyncRetryFailedHandleError(resp)
 	}
 	result, err := client.DeleteAsyncRetryFailedHandleResponse(resp)
 	if err != nil {
@@ -619,9 +604,6 @@ func (client *LrOSClient) DeleteAsyncRetryFailedHandleResponse(resp *azcore.Resp
 
 // DeleteAsyncRetryFailedHandleError handles the DeleteAsyncRetryFailed error response.
 func (client *LrOSClient) DeleteAsyncRetryFailedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -640,8 +622,8 @@ func (client *LrOSClient) BeginDeleteAsyncRetrySucceeded(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteAsyncRetrySucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.DeleteAsyncRetrySucceededHandleError(resp)
 	}
 	result, err := client.DeleteAsyncRetrySucceededHandleResponse(resp)
 	if err != nil {
@@ -691,9 +673,6 @@ func (client *LrOSClient) DeleteAsyncRetrySucceededHandleResponse(resp *azcore.R
 
 // DeleteAsyncRetrySucceededHandleError handles the DeleteAsyncRetrySucceeded error response.
 func (client *LrOSClient) DeleteAsyncRetrySucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -712,8 +691,8 @@ func (client *LrOSClient) BeginDeleteAsyncRetrycanceled(ctx context.Context) (*H
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteAsyncRetrycanceledHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.DeleteAsyncRetrycanceledHandleError(resp)
 	}
 	result, err := client.DeleteAsyncRetrycanceledHandleResponse(resp)
 	if err != nil {
@@ -763,9 +742,6 @@ func (client *LrOSClient) DeleteAsyncRetrycanceledHandleResponse(resp *azcore.Re
 
 // DeleteAsyncRetrycanceledHandleError handles the DeleteAsyncRetrycanceled error response.
 func (client *LrOSClient) DeleteAsyncRetrycanceledHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -784,8 +760,8 @@ func (client *LrOSClient) BeginDeleteNoHeaderInRetry(ctx context.Context) (*HTTP
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteNoHeaderInRetryHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteNoHeaderInRetryHandleError(resp)
 	}
 	result, err := client.DeleteNoHeaderInRetryHandleResponse(resp)
 	if err != nil {
@@ -835,9 +811,6 @@ func (client *LrOSClient) DeleteNoHeaderInRetryHandleResponse(resp *azcore.Respo
 
 // DeleteNoHeaderInRetryHandleError handles the DeleteNoHeaderInRetry error response.
 func (client *LrOSClient) DeleteNoHeaderInRetryHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -856,8 +829,8 @@ func (client *LrOSClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteProvisioning202Accepted200SucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.DeleteProvisioning202Accepted200SucceededHandleError(resp)
 	}
 	result, err := client.DeleteProvisioning202Accepted200SucceededHandleResponse(resp)
 	if err != nil {
@@ -907,9 +880,6 @@ func (client *LrOSClient) DeleteProvisioning202Accepted200SucceededHandleRespons
 
 // DeleteProvisioning202Accepted200SucceededHandleError handles the DeleteProvisioning202Accepted200Succeeded error response.
 func (client *LrOSClient) DeleteProvisioning202Accepted200SucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -928,8 +898,8 @@ func (client *LrOSClient) BeginDeleteProvisioning202DeletingFailed200(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteProvisioning202DeletingFailed200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.DeleteProvisioning202DeletingFailed200HandleError(resp)
 	}
 	result, err := client.DeleteProvisioning202DeletingFailed200HandleResponse(resp)
 	if err != nil {
@@ -979,9 +949,6 @@ func (client *LrOSClient) DeleteProvisioning202DeletingFailed200HandleResponse(r
 
 // DeleteProvisioning202DeletingFailed200HandleError handles the DeleteProvisioning202DeletingFailed200 error response.
 func (client *LrOSClient) DeleteProvisioning202DeletingFailed200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1000,8 +967,8 @@ func (client *LrOSClient) BeginDeleteProvisioning202Deletingcanceled200(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteProvisioning202Deletingcanceled200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.DeleteProvisioning202Deletingcanceled200HandleError(resp)
 	}
 	result, err := client.DeleteProvisioning202Deletingcanceled200HandleResponse(resp)
 	if err != nil {
@@ -1051,9 +1018,6 @@ func (client *LrOSClient) DeleteProvisioning202Deletingcanceled200HandleResponse
 
 // DeleteProvisioning202Deletingcanceled200HandleError handles the DeleteProvisioning202Deletingcanceled200 error response.
 func (client *LrOSClient) DeleteProvisioning202Deletingcanceled200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1072,8 +1036,8 @@ func (client *LrOSClient) BeginPost200WithPayload(ctx context.Context) (*SKUPoll
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post200WithPayloadHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.Post200WithPayloadHandleError(resp)
 	}
 	result, err := client.Post200WithPayloadHandleResponse(resp)
 	if err != nil {
@@ -1123,9 +1087,6 @@ func (client *LrOSClient) Post200WithPayloadHandleResponse(resp *azcore.Response
 
 // Post200WithPayloadHandleError handles the Post200WithPayload error response.
 func (client *LrOSClient) Post200WithPayloadHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1144,8 +1105,8 @@ func (client *LrOSClient) BeginPost202List(ctx context.Context) (*ProductArrayPo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post202ListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.Post202ListHandleError(resp)
 	}
 	result, err := client.Post202ListHandleResponse(resp)
 	if err != nil {
@@ -1195,9 +1156,6 @@ func (client *LrOSClient) Post202ListHandleResponse(resp *azcore.Response) (*Pro
 
 // Post202ListHandleError handles the Post202List error response.
 func (client *LrOSClient) Post202ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1216,8 +1174,8 @@ func (client *LrOSClient) BeginPost202NoRetry204(ctx context.Context, lrOSPost20
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post202NoRetry204HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.Post202NoRetry204HandleError(resp)
 	}
 	result, err := client.Post202NoRetry204HandleResponse(resp)
 	if err != nil {
@@ -1270,9 +1228,6 @@ func (client *LrOSClient) Post202NoRetry204HandleResponse(resp *azcore.Response)
 
 // Post202NoRetry204HandleError handles the Post202NoRetry204 error response.
 func (client *LrOSClient) Post202NoRetry204HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1291,8 +1246,8 @@ func (client *LrOSClient) BeginPost202Retry200(ctx context.Context, lrOSPost202R
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post202Retry200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.Post202Retry200HandleError(resp)
 	}
 	result, err := client.Post202Retry200HandleResponse(resp)
 	if err != nil {
@@ -1345,9 +1300,6 @@ func (client *LrOSClient) Post202Retry200HandleResponse(resp *azcore.Response) (
 
 // Post202Retry200HandleError handles the Post202Retry200 error response.
 func (client *LrOSClient) Post202Retry200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1366,8 +1318,8 @@ func (client *LrOSClient) BeginPostAsyncNoRetrySucceeded(ctx context.Context, lr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostAsyncNoRetrySucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.PostAsyncNoRetrySucceededHandleError(resp)
 	}
 	result, err := client.PostAsyncNoRetrySucceededHandleResponse(resp)
 	if err != nil {
@@ -1420,9 +1372,6 @@ func (client *LrOSClient) PostAsyncNoRetrySucceededHandleResponse(resp *azcore.R
 
 // PostAsyncNoRetrySucceededHandleError handles the PostAsyncNoRetrySucceeded error response.
 func (client *LrOSClient) PostAsyncNoRetrySucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1441,8 +1390,8 @@ func (client *LrOSClient) BeginPostAsyncRetryFailed(ctx context.Context, lrOSPos
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostAsyncRetryFailedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PostAsyncRetryFailedHandleError(resp)
 	}
 	result, err := client.PostAsyncRetryFailedHandleResponse(resp)
 	if err != nil {
@@ -1495,9 +1444,6 @@ func (client *LrOSClient) PostAsyncRetryFailedHandleResponse(resp *azcore.Respon
 
 // PostAsyncRetryFailedHandleError handles the PostAsyncRetryFailed error response.
 func (client *LrOSClient) PostAsyncRetryFailedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1516,8 +1462,8 @@ func (client *LrOSClient) BeginPostAsyncRetrySucceeded(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostAsyncRetrySucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.PostAsyncRetrySucceededHandleError(resp)
 	}
 	result, err := client.PostAsyncRetrySucceededHandleResponse(resp)
 	if err != nil {
@@ -1570,9 +1516,6 @@ func (client *LrOSClient) PostAsyncRetrySucceededHandleResponse(resp *azcore.Res
 
 // PostAsyncRetrySucceededHandleError handles the PostAsyncRetrySucceeded error response.
 func (client *LrOSClient) PostAsyncRetrySucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1591,8 +1534,8 @@ func (client *LrOSClient) BeginPostAsyncRetrycanceled(ctx context.Context, lrOSP
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostAsyncRetrycanceledHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PostAsyncRetrycanceledHandleError(resp)
 	}
 	result, err := client.PostAsyncRetrycanceledHandleResponse(resp)
 	if err != nil {
@@ -1645,9 +1588,6 @@ func (client *LrOSClient) PostAsyncRetrycanceledHandleResponse(resp *azcore.Resp
 
 // PostAsyncRetrycanceledHandleError handles the PostAsyncRetrycanceled error response.
 func (client *LrOSClient) PostAsyncRetrycanceledHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1666,8 +1606,8 @@ func (client *LrOSClient) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostDoubleHeadersFinalAzureHeaderGetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PostDoubleHeadersFinalAzureHeaderGetHandleError(resp)
 	}
 	result, err := client.PostDoubleHeadersFinalAzureHeaderGetHandleResponse(resp)
 	if err != nil {
@@ -1717,9 +1657,6 @@ func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetHandleResponse(res
 
 // PostDoubleHeadersFinalAzureHeaderGetHandleError handles the PostDoubleHeadersFinalAzureHeaderGet error response.
 func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1738,8 +1675,8 @@ func (client *LrOSClient) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(ctx c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostDoubleHeadersFinalAzureHeaderGetDefaultHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PostDoubleHeadersFinalAzureHeaderGetDefaultHandleError(resp)
 	}
 	result, err := client.PostDoubleHeadersFinalAzureHeaderGetDefaultHandleResponse(resp)
 	if err != nil {
@@ -1789,9 +1726,6 @@ func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetDefaultHandleRespo
 
 // PostDoubleHeadersFinalAzureHeaderGetDefaultHandleError handles the PostDoubleHeadersFinalAzureHeaderGetDefault error response.
 func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetDefaultHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1810,8 +1744,8 @@ func (client *LrOSClient) BeginPostDoubleHeadersFinalLocationGet(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostDoubleHeadersFinalLocationGetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PostDoubleHeadersFinalLocationGetHandleError(resp)
 	}
 	result, err := client.PostDoubleHeadersFinalLocationGetHandleResponse(resp)
 	if err != nil {
@@ -1861,9 +1795,6 @@ func (client *LrOSClient) PostDoubleHeadersFinalLocationGetHandleResponse(resp *
 
 // PostDoubleHeadersFinalLocationGetHandleError handles the PostDoubleHeadersFinalLocationGet error response.
 func (client *LrOSClient) PostDoubleHeadersFinalLocationGetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1882,8 +1813,8 @@ func (client *LrOSClient) BeginPut200Acceptedcanceled200(ctx context.Context, lr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put200Acceptedcanceled200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Put200Acceptedcanceled200HandleError(resp)
 	}
 	result, err := client.Put200Acceptedcanceled200HandleResponse(resp)
 	if err != nil {
@@ -1936,9 +1867,6 @@ func (client *LrOSClient) Put200Acceptedcanceled200HandleResponse(resp *azcore.R
 
 // Put200Acceptedcanceled200HandleError handles the Put200Acceptedcanceled200 error response.
 func (client *LrOSClient) Put200Acceptedcanceled200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1957,8 +1885,8 @@ func (client *LrOSClient) BeginPut200Succeeded(ctx context.Context, lrOSPut200Su
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put200SucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil, client.Put200SucceededHandleError(resp)
 	}
 	result, err := client.Put200SucceededHandleResponse(resp)
 	if err != nil {
@@ -2011,9 +1939,6 @@ func (client *LrOSClient) Put200SucceededHandleResponse(resp *azcore.Response) (
 
 // Put200SucceededHandleError handles the Put200Succeeded error response.
 func (client *LrOSClient) Put200SucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2032,8 +1957,8 @@ func (client *LrOSClient) BeginPut200SucceededNoState(ctx context.Context, lrOSP
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put200SucceededNoStateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Put200SucceededNoStateHandleError(resp)
 	}
 	result, err := client.Put200SucceededNoStateHandleResponse(resp)
 	if err != nil {
@@ -2086,9 +2011,6 @@ func (client *LrOSClient) Put200SucceededNoStateHandleResponse(resp *azcore.Resp
 
 // Put200SucceededNoStateHandleError handles the Put200SucceededNoState error response.
 func (client *LrOSClient) Put200SucceededNoStateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2107,8 +2029,8 @@ func (client *LrOSClient) BeginPut200UpdatingSucceeded204(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put200UpdatingSucceeded204HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Put200UpdatingSucceeded204HandleError(resp)
 	}
 	result, err := client.Put200UpdatingSucceeded204HandleResponse(resp)
 	if err != nil {
@@ -2161,9 +2083,6 @@ func (client *LrOSClient) Put200UpdatingSucceeded204HandleResponse(resp *azcore.
 
 // Put200UpdatingSucceeded204HandleError handles the Put200UpdatingSucceeded204 error response.
 func (client *LrOSClient) Put200UpdatingSucceeded204HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2182,8 +2101,8 @@ func (client *LrOSClient) BeginPut201CreatingFailed200(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put201CreatingFailed200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.Put201CreatingFailed200HandleError(resp)
 	}
 	result, err := client.Put201CreatingFailed200HandleResponse(resp)
 	if err != nil {
@@ -2236,9 +2155,6 @@ func (client *LrOSClient) Put201CreatingFailed200HandleResponse(resp *azcore.Res
 
 // Put201CreatingFailed200HandleError handles the Put201CreatingFailed200 error response.
 func (client *LrOSClient) Put201CreatingFailed200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2257,8 +2173,8 @@ func (client *LrOSClient) BeginPut201CreatingSucceeded200(ctx context.Context, l
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put201CreatingSucceeded200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.Put201CreatingSucceeded200HandleError(resp)
 	}
 	result, err := client.Put201CreatingSucceeded200HandleResponse(resp)
 	if err != nil {
@@ -2311,9 +2227,6 @@ func (client *LrOSClient) Put201CreatingSucceeded200HandleResponse(resp *azcore.
 
 // Put201CreatingSucceeded200HandleError handles the Put201CreatingSucceeded200 error response.
 func (client *LrOSClient) Put201CreatingSucceeded200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2332,8 +2245,8 @@ func (client *LrOSClient) BeginPut201Succeeded(ctx context.Context, lrOSPut201Su
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put201SucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.Put201SucceededHandleError(resp)
 	}
 	result, err := client.Put201SucceededHandleResponse(resp)
 	if err != nil {
@@ -2386,9 +2299,6 @@ func (client *LrOSClient) Put201SucceededHandleResponse(resp *azcore.Response) (
 
 // Put201SucceededHandleError handles the Put201Succeeded error response.
 func (client *LrOSClient) Put201SucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2407,8 +2317,8 @@ func (client *LrOSClient) BeginPut202Retry200(ctx context.Context, lrOSPut202Ret
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put202Retry200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.Put202Retry200HandleError(resp)
 	}
 	result, err := client.Put202Retry200HandleResponse(resp)
 	if err != nil {
@@ -2461,9 +2371,6 @@ func (client *LrOSClient) Put202Retry200HandleResponse(resp *azcore.Response) (*
 
 // Put202Retry200HandleError handles the Put202Retry200 error response.
 func (client *LrOSClient) Put202Retry200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2482,8 +2389,8 @@ func (client *LrOSClient) BeginPutAsyncNoHeaderInRetry(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutAsyncNoHeaderInRetryHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.PutAsyncNoHeaderInRetryHandleError(resp)
 	}
 	result, err := client.PutAsyncNoHeaderInRetryHandleResponse(resp)
 	if err != nil {
@@ -2536,9 +2443,6 @@ func (client *LrOSClient) PutAsyncNoHeaderInRetryHandleResponse(resp *azcore.Res
 
 // PutAsyncNoHeaderInRetryHandleError handles the PutAsyncNoHeaderInRetry error response.
 func (client *LrOSClient) PutAsyncNoHeaderInRetryHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2557,8 +2461,8 @@ func (client *LrOSClient) BeginPutAsyncNoRetrySucceeded(ctx context.Context, lrO
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutAsyncNoRetrySucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutAsyncNoRetrySucceededHandleError(resp)
 	}
 	result, err := client.PutAsyncNoRetrySucceededHandleResponse(resp)
 	if err != nil {
@@ -2611,9 +2515,6 @@ func (client *LrOSClient) PutAsyncNoRetrySucceededHandleResponse(resp *azcore.Re
 
 // PutAsyncNoRetrySucceededHandleError handles the PutAsyncNoRetrySucceeded error response.
 func (client *LrOSClient) PutAsyncNoRetrySucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2632,8 +2533,8 @@ func (client *LrOSClient) BeginPutAsyncNoRetrycanceled(ctx context.Context, lrOS
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutAsyncNoRetrycanceledHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutAsyncNoRetrycanceledHandleError(resp)
 	}
 	result, err := client.PutAsyncNoRetrycanceledHandleResponse(resp)
 	if err != nil {
@@ -2686,9 +2587,6 @@ func (client *LrOSClient) PutAsyncNoRetrycanceledHandleResponse(resp *azcore.Res
 
 // PutAsyncNoRetrycanceledHandleError handles the PutAsyncNoRetrycanceled error response.
 func (client *LrOSClient) PutAsyncNoRetrycanceledHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2707,8 +2605,8 @@ func (client *LrOSClient) BeginPutAsyncNonResource(ctx context.Context, lrOSPutA
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutAsyncNonResourceHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PutAsyncNonResourceHandleError(resp)
 	}
 	result, err := client.PutAsyncNonResourceHandleResponse(resp)
 	if err != nil {
@@ -2761,9 +2659,6 @@ func (client *LrOSClient) PutAsyncNonResourceHandleResponse(resp *azcore.Respons
 
 // PutAsyncNonResourceHandleError handles the PutAsyncNonResource error response.
 func (client *LrOSClient) PutAsyncNonResourceHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2782,8 +2677,8 @@ func (client *LrOSClient) BeginPutAsyncRetryFailed(ctx context.Context, lrOSPutA
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutAsyncRetryFailedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutAsyncRetryFailedHandleError(resp)
 	}
 	result, err := client.PutAsyncRetryFailedHandleResponse(resp)
 	if err != nil {
@@ -2836,9 +2731,6 @@ func (client *LrOSClient) PutAsyncRetryFailedHandleResponse(resp *azcore.Respons
 
 // PutAsyncRetryFailedHandleError handles the PutAsyncRetryFailed error response.
 func (client *LrOSClient) PutAsyncRetryFailedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2857,8 +2749,8 @@ func (client *LrOSClient) BeginPutAsyncRetrySucceeded(ctx context.Context, lrOSP
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutAsyncRetrySucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutAsyncRetrySucceededHandleError(resp)
 	}
 	result, err := client.PutAsyncRetrySucceededHandleResponse(resp)
 	if err != nil {
@@ -2911,9 +2803,6 @@ func (client *LrOSClient) PutAsyncRetrySucceededHandleResponse(resp *azcore.Resp
 
 // PutAsyncRetrySucceededHandleError handles the PutAsyncRetrySucceeded error response.
 func (client *LrOSClient) PutAsyncRetrySucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -2932,8 +2821,8 @@ func (client *LrOSClient) BeginPutAsyncSubResource(ctx context.Context, lrOSPutA
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutAsyncSubResourceHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PutAsyncSubResourceHandleError(resp)
 	}
 	result, err := client.PutAsyncSubResourceHandleResponse(resp)
 	if err != nil {
@@ -2986,9 +2875,6 @@ func (client *LrOSClient) PutAsyncSubResourceHandleResponse(resp *azcore.Respons
 
 // PutAsyncSubResourceHandleError handles the PutAsyncSubResource error response.
 func (client *LrOSClient) PutAsyncSubResourceHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3007,8 +2893,8 @@ func (client *LrOSClient) BeginPutNoHeaderInRetry(ctx context.Context, lrOSPutNo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutNoHeaderInRetryHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PutNoHeaderInRetryHandleError(resp)
 	}
 	result, err := client.PutNoHeaderInRetryHandleResponse(resp)
 	if err != nil {
@@ -3061,9 +2947,6 @@ func (client *LrOSClient) PutNoHeaderInRetryHandleResponse(resp *azcore.Response
 
 // PutNoHeaderInRetryHandleError handles the PutNoHeaderInRetry error response.
 func (client *LrOSClient) PutNoHeaderInRetryHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3082,8 +2965,8 @@ func (client *LrOSClient) BeginPutNonResource(ctx context.Context, lrOSPutNonRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutNonResourceHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PutNonResourceHandleError(resp)
 	}
 	result, err := client.PutNonResourceHandleResponse(resp)
 	if err != nil {
@@ -3136,9 +3019,6 @@ func (client *LrOSClient) PutNonResourceHandleResponse(resp *azcore.Response) (*
 
 // PutNonResourceHandleError handles the PutNonResource error response.
 func (client *LrOSClient) PutNonResourceHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -3157,8 +3037,8 @@ func (client *LrOSClient) BeginPutSubResource(ctx context.Context, lrOSPutSubRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutSubResourceHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PutSubResourceHandleError(resp)
 	}
 	result, err := client.PutSubResourceHandleResponse(resp)
 	if err != nil {
@@ -3211,9 +3091,6 @@ func (client *LrOSClient) PutSubResourceHandleResponse(resp *azcore.Response) (*
 
 // PutSubResourceHandleError handles the PutSubResource error response.
 func (client *LrOSClient) PutSubResourceHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/lrogroup/zz_generated_lrosads.go
+++ b/test/autorest/lrogroup/zz_generated_lrosads.go
@@ -148,6 +148,9 @@ func (client *LrosaDsClient) BeginDelete202NonRetry400(ctx context.Context) (*HT
 	if err != nil {
 		return nil, err
 	}
+	if err := client.Delete202NonRetry400HandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.Delete202NonRetry400HandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -191,14 +194,14 @@ func (client *LrosaDsClient) Delete202NonRetry400CreateRequest(ctx context.Conte
 
 // Delete202NonRetry400HandleResponse handles the Delete202NonRetry400 response.
 func (client *LrosaDsClient) Delete202NonRetry400HandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Delete202NonRetry400HandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Delete202NonRetry400HandleError handles the Delete202NonRetry400 error response.
 func (client *LrosaDsClient) Delete202NonRetry400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -215,6 +218,9 @@ func (client *LrosaDsClient) BeginDelete202RetryInvalidHeader(ctx context.Contex
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Delete202RetryInvalidHeaderHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Delete202RetryInvalidHeaderHandleResponse(resp)
@@ -260,14 +266,14 @@ func (client *LrosaDsClient) Delete202RetryInvalidHeaderCreateRequest(ctx contex
 
 // Delete202RetryInvalidHeaderHandleResponse handles the Delete202RetryInvalidHeader response.
 func (client *LrosaDsClient) Delete202RetryInvalidHeaderHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Delete202RetryInvalidHeaderHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Delete202RetryInvalidHeaderHandleError handles the Delete202RetryInvalidHeader error response.
 func (client *LrosaDsClient) Delete202RetryInvalidHeaderHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -284,6 +290,9 @@ func (client *LrosaDsClient) BeginDelete204Succeeded(ctx context.Context) (*HTTP
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Delete204SucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Delete204SucceededHandleResponse(resp)
@@ -329,14 +338,14 @@ func (client *LrosaDsClient) Delete204SucceededCreateRequest(ctx context.Context
 
 // Delete204SucceededHandleResponse handles the Delete204Succeeded response.
 func (client *LrosaDsClient) Delete204SucceededHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusNoContent) {
-		return nil, client.Delete204SucceededHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Delete204SucceededHandleError handles the Delete204Succeeded error response.
 func (client *LrosaDsClient) Delete204SucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -353,6 +362,9 @@ func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetry400(ctx context.Contex
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteAsyncRelativeRetry400HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteAsyncRelativeRetry400HandleResponse(resp)
@@ -398,14 +410,14 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetry400CreateRequest(ctx contex
 
 // DeleteAsyncRelativeRetry400HandleResponse handles the DeleteAsyncRelativeRetry400 response.
 func (client *LrosaDsClient) DeleteAsyncRelativeRetry400HandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteAsyncRelativeRetry400HandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteAsyncRelativeRetry400HandleError handles the DeleteAsyncRelativeRetry400 error response.
 func (client *LrosaDsClient) DeleteAsyncRelativeRetry400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -422,6 +434,9 @@ func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx cont
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteAsyncRelativeRetryInvalidHeaderHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteAsyncRelativeRetryInvalidHeaderHandleResponse(resp)
@@ -467,14 +482,14 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidHeaderCreateRequest(
 
 // DeleteAsyncRelativeRetryInvalidHeaderHandleResponse handles the DeleteAsyncRelativeRetryInvalidHeader response.
 func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidHeaderHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteAsyncRelativeRetryInvalidHeaderHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteAsyncRelativeRetryInvalidHeaderHandleError handles the DeleteAsyncRelativeRetryInvalidHeader error response.
 func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidHeaderHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -491,6 +506,9 @@ func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetryInvalidJSONPolling(ctx
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteAsyncRelativeRetryInvalidJSONPollingHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteAsyncRelativeRetryInvalidJSONPollingHandleResponse(resp)
@@ -536,14 +554,14 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidJSONPollingCreateReq
 
 // DeleteAsyncRelativeRetryInvalidJSONPollingHandleResponse handles the DeleteAsyncRelativeRetryInvalidJSONPolling response.
 func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidJSONPollingHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteAsyncRelativeRetryInvalidJSONPollingHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteAsyncRelativeRetryInvalidJSONPollingHandleError handles the DeleteAsyncRelativeRetryInvalidJSONPolling error response.
 func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidJSONPollingHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -560,6 +578,9 @@ func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetryNoStatus(ctx context.C
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteAsyncRelativeRetryNoStatusHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteAsyncRelativeRetryNoStatusHandleResponse(resp)
@@ -605,14 +626,14 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryNoStatusCreateRequest(ctx c
 
 // DeleteAsyncRelativeRetryNoStatusHandleResponse handles the DeleteAsyncRelativeRetryNoStatus response.
 func (client *LrosaDsClient) DeleteAsyncRelativeRetryNoStatusHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteAsyncRelativeRetryNoStatusHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteAsyncRelativeRetryNoStatusHandleError handles the DeleteAsyncRelativeRetryNoStatus error response.
 func (client *LrosaDsClient) DeleteAsyncRelativeRetryNoStatusHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -629,6 +650,9 @@ func (client *LrosaDsClient) BeginDeleteNonRetry400(ctx context.Context) (*HTTPP
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteNonRetry400HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteNonRetry400HandleResponse(resp)
@@ -674,14 +698,14 @@ func (client *LrosaDsClient) DeleteNonRetry400CreateRequest(ctx context.Context)
 
 // DeleteNonRetry400HandleResponse handles the DeleteNonRetry400 response.
 func (client *LrosaDsClient) DeleteNonRetry400HandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteNonRetry400HandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteNonRetry400HandleError handles the DeleteNonRetry400 error response.
 func (client *LrosaDsClient) DeleteNonRetry400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -698,6 +722,9 @@ func (client *LrosaDsClient) BeginPost202NoLocation(ctx context.Context, lrosaDs
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Post202NoLocationHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Post202NoLocationHandleResponse(resp)
@@ -746,14 +773,14 @@ func (client *LrosaDsClient) Post202NoLocationCreateRequest(ctx context.Context,
 
 // Post202NoLocationHandleResponse handles the Post202NoLocation response.
 func (client *LrosaDsClient) Post202NoLocationHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Post202NoLocationHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Post202NoLocationHandleError handles the Post202NoLocation error response.
 func (client *LrosaDsClient) Post202NoLocationHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -770,6 +797,9 @@ func (client *LrosaDsClient) BeginPost202NonRetry400(ctx context.Context, lrosaD
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Post202NonRetry400HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Post202NonRetry400HandleResponse(resp)
@@ -818,14 +848,14 @@ func (client *LrosaDsClient) Post202NonRetry400CreateRequest(ctx context.Context
 
 // Post202NonRetry400HandleResponse handles the Post202NonRetry400 response.
 func (client *LrosaDsClient) Post202NonRetry400HandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Post202NonRetry400HandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Post202NonRetry400HandleError handles the Post202NonRetry400 error response.
 func (client *LrosaDsClient) Post202NonRetry400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -842,6 +872,9 @@ func (client *LrosaDsClient) BeginPost202RetryInvalidHeader(ctx context.Context,
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Post202RetryInvalidHeaderHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Post202RetryInvalidHeaderHandleResponse(resp)
@@ -890,14 +923,14 @@ func (client *LrosaDsClient) Post202RetryInvalidHeaderCreateRequest(ctx context.
 
 // Post202RetryInvalidHeaderHandleResponse handles the Post202RetryInvalidHeader response.
 func (client *LrosaDsClient) Post202RetryInvalidHeaderHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Post202RetryInvalidHeaderHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Post202RetryInvalidHeaderHandleError handles the Post202RetryInvalidHeader error response.
 func (client *LrosaDsClient) Post202RetryInvalidHeaderHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -914,6 +947,9 @@ func (client *LrosaDsClient) BeginPostAsyncRelativeRetry400(ctx context.Context,
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PostAsyncRelativeRetry400HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PostAsyncRelativeRetry400HandleResponse(resp)
@@ -962,14 +998,14 @@ func (client *LrosaDsClient) PostAsyncRelativeRetry400CreateRequest(ctx context.
 
 // PostAsyncRelativeRetry400HandleResponse handles the PostAsyncRelativeRetry400 response.
 func (client *LrosaDsClient) PostAsyncRelativeRetry400HandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PostAsyncRelativeRetry400HandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PostAsyncRelativeRetry400HandleError handles the PostAsyncRelativeRetry400 error response.
 func (client *LrosaDsClient) PostAsyncRelativeRetry400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -986,6 +1022,9 @@ func (client *LrosaDsClient) BeginPostAsyncRelativeRetryInvalidHeader(ctx contex
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PostAsyncRelativeRetryInvalidHeaderHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PostAsyncRelativeRetryInvalidHeaderHandleResponse(resp)
@@ -1034,14 +1073,14 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidHeaderCreateRequest(ct
 
 // PostAsyncRelativeRetryInvalidHeaderHandleResponse handles the PostAsyncRelativeRetryInvalidHeader response.
 func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidHeaderHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PostAsyncRelativeRetryInvalidHeaderHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PostAsyncRelativeRetryInvalidHeaderHandleError handles the PostAsyncRelativeRetryInvalidHeader error response.
 func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidHeaderHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1058,6 +1097,9 @@ func (client *LrosaDsClient) BeginPostAsyncRelativeRetryInvalidJSONPolling(ctx c
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PostAsyncRelativeRetryInvalidJSONPollingHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PostAsyncRelativeRetryInvalidJSONPollingHandleResponse(resp)
@@ -1106,14 +1148,14 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidJSONPollingCreateReque
 
 // PostAsyncRelativeRetryInvalidJSONPollingHandleResponse handles the PostAsyncRelativeRetryInvalidJSONPolling response.
 func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidJSONPollingHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PostAsyncRelativeRetryInvalidJSONPollingHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PostAsyncRelativeRetryInvalidJSONPollingHandleError handles the PostAsyncRelativeRetryInvalidJSONPolling error response.
 func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidJSONPollingHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1130,6 +1172,9 @@ func (client *LrosaDsClient) BeginPostAsyncRelativeRetryNoPayload(ctx context.Co
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PostAsyncRelativeRetryNoPayloadHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PostAsyncRelativeRetryNoPayloadHandleResponse(resp)
@@ -1178,14 +1223,14 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryNoPayloadCreateRequest(ctx co
 
 // PostAsyncRelativeRetryNoPayloadHandleResponse handles the PostAsyncRelativeRetryNoPayload response.
 func (client *LrosaDsClient) PostAsyncRelativeRetryNoPayloadHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PostAsyncRelativeRetryNoPayloadHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PostAsyncRelativeRetryNoPayloadHandleError handles the PostAsyncRelativeRetryNoPayload error response.
 func (client *LrosaDsClient) PostAsyncRelativeRetryNoPayloadHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1202,6 +1247,9 @@ func (client *LrosaDsClient) BeginPostNonRetry400(ctx context.Context, lrosaDsPo
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PostNonRetry400HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PostNonRetry400HandleResponse(resp)
@@ -1250,14 +1298,14 @@ func (client *LrosaDsClient) PostNonRetry400CreateRequest(ctx context.Context, l
 
 // PostNonRetry400HandleResponse handles the PostNonRetry400 response.
 func (client *LrosaDsClient) PostNonRetry400HandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PostNonRetry400HandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PostNonRetry400HandleError handles the PostNonRetry400 error response.
 func (client *LrosaDsClient) PostNonRetry400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1274,6 +1322,9 @@ func (client *LrosaDsClient) BeginPut200InvalidJSON(ctx context.Context, lrosaDs
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Put200InvalidJSONHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Put200InvalidJSONHandleResponse(resp)
@@ -1322,14 +1373,14 @@ func (client *LrosaDsClient) Put200InvalidJSONCreateRequest(ctx context.Context,
 
 // Put200InvalidJSONHandleResponse handles the Put200InvalidJSON response.
 func (client *LrosaDsClient) Put200InvalidJSONHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.Put200InvalidJSONHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Put200InvalidJSONHandleError handles the Put200InvalidJSON error response.
 func (client *LrosaDsClient) Put200InvalidJSONHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1346,6 +1397,9 @@ func (client *LrosaDsClient) BeginPutAsyncRelativeRetry400(ctx context.Context, 
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutAsyncRelativeRetry400HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutAsyncRelativeRetry400HandleResponse(resp)
@@ -1394,14 +1448,14 @@ func (client *LrosaDsClient) PutAsyncRelativeRetry400CreateRequest(ctx context.C
 
 // PutAsyncRelativeRetry400HandleResponse handles the PutAsyncRelativeRetry400 response.
 func (client *LrosaDsClient) PutAsyncRelativeRetry400HandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.PutAsyncRelativeRetry400HandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutAsyncRelativeRetry400HandleError handles the PutAsyncRelativeRetry400 error response.
 func (client *LrosaDsClient) PutAsyncRelativeRetry400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1418,6 +1472,9 @@ func (client *LrosaDsClient) BeginPutAsyncRelativeRetryInvalidHeader(ctx context
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutAsyncRelativeRetryInvalidHeaderHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutAsyncRelativeRetryInvalidHeaderHandleResponse(resp)
@@ -1466,14 +1523,14 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidHeaderCreateRequest(ctx
 
 // PutAsyncRelativeRetryInvalidHeaderHandleResponse handles the PutAsyncRelativeRetryInvalidHeader response.
 func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidHeaderHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.PutAsyncRelativeRetryInvalidHeaderHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutAsyncRelativeRetryInvalidHeaderHandleError handles the PutAsyncRelativeRetryInvalidHeader error response.
 func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidHeaderHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1490,6 +1547,9 @@ func (client *LrosaDsClient) BeginPutAsyncRelativeRetryInvalidJSONPolling(ctx co
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutAsyncRelativeRetryInvalidJSONPollingHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutAsyncRelativeRetryInvalidJSONPollingHandleResponse(resp)
@@ -1538,14 +1598,14 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidJSONPollingCreateReques
 
 // PutAsyncRelativeRetryInvalidJSONPollingHandleResponse handles the PutAsyncRelativeRetryInvalidJSONPolling response.
 func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidJSONPollingHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.PutAsyncRelativeRetryInvalidJSONPollingHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutAsyncRelativeRetryInvalidJSONPollingHandleError handles the PutAsyncRelativeRetryInvalidJSONPolling error response.
 func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidJSONPollingHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1562,6 +1622,9 @@ func (client *LrosaDsClient) BeginPutAsyncRelativeRetryNoStatus(ctx context.Cont
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutAsyncRelativeRetryNoStatusHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutAsyncRelativeRetryNoStatusHandleResponse(resp)
@@ -1610,14 +1673,14 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusCreateRequest(ctx cont
 
 // PutAsyncRelativeRetryNoStatusHandleResponse handles the PutAsyncRelativeRetryNoStatus response.
 func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.PutAsyncRelativeRetryNoStatusHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutAsyncRelativeRetryNoStatusHandleError handles the PutAsyncRelativeRetryNoStatus error response.
 func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1634,6 +1697,9 @@ func (client *LrosaDsClient) BeginPutAsyncRelativeRetryNoStatusPayload(ctx conte
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutAsyncRelativeRetryNoStatusPayloadHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutAsyncRelativeRetryNoStatusPayloadHandleResponse(resp)
@@ -1682,14 +1748,14 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusPayloadCreateRequest(c
 
 // PutAsyncRelativeRetryNoStatusPayloadHandleResponse handles the PutAsyncRelativeRetryNoStatusPayload response.
 func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusPayloadHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.PutAsyncRelativeRetryNoStatusPayloadHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutAsyncRelativeRetryNoStatusPayloadHandleError handles the PutAsyncRelativeRetryNoStatusPayload error response.
 func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusPayloadHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1706,6 +1772,9 @@ func (client *LrosaDsClient) BeginPutError201NoProvisioningStatePayload(ctx cont
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutError201NoProvisioningStatePayloadHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutError201NoProvisioningStatePayloadHandleResponse(resp)
@@ -1754,14 +1823,14 @@ func (client *LrosaDsClient) PutError201NoProvisioningStatePayloadCreateRequest(
 
 // PutError201NoProvisioningStatePayloadHandleResponse handles the PutError201NoProvisioningStatePayload response.
 func (client *LrosaDsClient) PutError201NoProvisioningStatePayloadHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.PutError201NoProvisioningStatePayloadHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutError201NoProvisioningStatePayloadHandleError handles the PutError201NoProvisioningStatePayload error response.
 func (client *LrosaDsClient) PutError201NoProvisioningStatePayloadHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1778,6 +1847,9 @@ func (client *LrosaDsClient) BeginPutNonRetry201Creating400(ctx context.Context,
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutNonRetry201Creating400HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutNonRetry201Creating400HandleResponse(resp)
@@ -1826,14 +1898,14 @@ func (client *LrosaDsClient) PutNonRetry201Creating400CreateRequest(ctx context.
 
 // PutNonRetry201Creating400HandleResponse handles the PutNonRetry201Creating400 response.
 func (client *LrosaDsClient) PutNonRetry201Creating400HandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.PutNonRetry201Creating400HandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutNonRetry201Creating400HandleError handles the PutNonRetry201Creating400 error response.
 func (client *LrosaDsClient) PutNonRetry201Creating400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1850,6 +1922,9 @@ func (client *LrosaDsClient) BeginPutNonRetry201Creating400InvalidJSON(ctx conte
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutNonRetry201Creating400InvalidJSONHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutNonRetry201Creating400InvalidJSONHandleResponse(resp)
@@ -1898,14 +1973,14 @@ func (client *LrosaDsClient) PutNonRetry201Creating400InvalidJSONCreateRequest(c
 
 // PutNonRetry201Creating400InvalidJSONHandleResponse handles the PutNonRetry201Creating400InvalidJSON response.
 func (client *LrosaDsClient) PutNonRetry201Creating400InvalidJSONHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.PutNonRetry201Creating400InvalidJSONHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutNonRetry201Creating400InvalidJSONHandleError handles the PutNonRetry201Creating400InvalidJSON error response.
 func (client *LrosaDsClient) PutNonRetry201Creating400InvalidJSONHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1922,6 +1997,9 @@ func (client *LrosaDsClient) BeginPutNonRetry400(ctx context.Context, lrosaDsPut
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutNonRetry400HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutNonRetry400HandleResponse(resp)
@@ -1970,14 +2048,14 @@ func (client *LrosaDsClient) PutNonRetry400CreateRequest(ctx context.Context, lr
 
 // PutNonRetry400HandleResponse handles the PutNonRetry400 response.
 func (client *LrosaDsClient) PutNonRetry400HandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.PutNonRetry400HandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutNonRetry400HandleError handles the PutNonRetry400 error response.
 func (client *LrosaDsClient) PutNonRetry400HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/lrogroup/zz_generated_lrosads.go
+++ b/test/autorest/lrogroup/zz_generated_lrosads.go
@@ -148,8 +148,8 @@ func (client *LrosaDsClient) BeginDelete202NonRetry400(ctx context.Context) (*HT
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete202NonRetry400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.Delete202NonRetry400HandleError(resp)
 	}
 	result, err := client.Delete202NonRetry400HandleResponse(resp)
 	if err != nil {
@@ -199,9 +199,6 @@ func (client *LrosaDsClient) Delete202NonRetry400HandleResponse(resp *azcore.Res
 
 // Delete202NonRetry400HandleError handles the Delete202NonRetry400 error response.
 func (client *LrosaDsClient) Delete202NonRetry400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -220,8 +217,8 @@ func (client *LrosaDsClient) BeginDelete202RetryInvalidHeader(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete202RetryInvalidHeaderHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.Delete202RetryInvalidHeaderHandleError(resp)
 	}
 	result, err := client.Delete202RetryInvalidHeaderHandleResponse(resp)
 	if err != nil {
@@ -271,9 +268,6 @@ func (client *LrosaDsClient) Delete202RetryInvalidHeaderHandleResponse(resp *azc
 
 // Delete202RetryInvalidHeaderHandleError handles the Delete202RetryInvalidHeader error response.
 func (client *LrosaDsClient) Delete202RetryInvalidHeaderHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -292,8 +286,8 @@ func (client *LrosaDsClient) BeginDelete204Succeeded(ctx context.Context) (*HTTP
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Delete204SucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusNoContent) {
+		return nil, client.Delete204SucceededHandleError(resp)
 	}
 	result, err := client.Delete204SucceededHandleResponse(resp)
 	if err != nil {
@@ -343,9 +337,6 @@ func (client *LrosaDsClient) Delete204SucceededHandleResponse(resp *azcore.Respo
 
 // Delete204SucceededHandleError handles the Delete204Succeeded error response.
 func (client *LrosaDsClient) Delete204SucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -364,8 +355,8 @@ func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetry400(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteAsyncRelativeRetry400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.DeleteAsyncRelativeRetry400HandleError(resp)
 	}
 	result, err := client.DeleteAsyncRelativeRetry400HandleResponse(resp)
 	if err != nil {
@@ -415,9 +406,6 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetry400HandleResponse(resp *azc
 
 // DeleteAsyncRelativeRetry400HandleError handles the DeleteAsyncRelativeRetry400 error response.
 func (client *LrosaDsClient) DeleteAsyncRelativeRetry400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -436,8 +424,8 @@ func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteAsyncRelativeRetryInvalidHeaderHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.DeleteAsyncRelativeRetryInvalidHeaderHandleError(resp)
 	}
 	result, err := client.DeleteAsyncRelativeRetryInvalidHeaderHandleResponse(resp)
 	if err != nil {
@@ -487,9 +475,6 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidHeaderHandleResponse
 
 // DeleteAsyncRelativeRetryInvalidHeaderHandleError handles the DeleteAsyncRelativeRetryInvalidHeader error response.
 func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidHeaderHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -508,8 +493,8 @@ func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetryInvalidJSONPolling(ctx
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteAsyncRelativeRetryInvalidJSONPollingHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.DeleteAsyncRelativeRetryInvalidJSONPollingHandleError(resp)
 	}
 	result, err := client.DeleteAsyncRelativeRetryInvalidJSONPollingHandleResponse(resp)
 	if err != nil {
@@ -559,9 +544,6 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidJSONPollingHandleRes
 
 // DeleteAsyncRelativeRetryInvalidJSONPollingHandleError handles the DeleteAsyncRelativeRetryInvalidJSONPolling error response.
 func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidJSONPollingHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -580,8 +562,8 @@ func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetryNoStatus(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteAsyncRelativeRetryNoStatusHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.DeleteAsyncRelativeRetryNoStatusHandleError(resp)
 	}
 	result, err := client.DeleteAsyncRelativeRetryNoStatusHandleResponse(resp)
 	if err != nil {
@@ -631,9 +613,6 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryNoStatusHandleResponse(resp
 
 // DeleteAsyncRelativeRetryNoStatusHandleError handles the DeleteAsyncRelativeRetryNoStatus error response.
 func (client *LrosaDsClient) DeleteAsyncRelativeRetryNoStatusHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -652,8 +631,8 @@ func (client *LrosaDsClient) BeginDeleteNonRetry400(ctx context.Context) (*HTTPP
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteNonRetry400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.DeleteNonRetry400HandleError(resp)
 	}
 	result, err := client.DeleteNonRetry400HandleResponse(resp)
 	if err != nil {
@@ -703,9 +682,6 @@ func (client *LrosaDsClient) DeleteNonRetry400HandleResponse(resp *azcore.Respon
 
 // DeleteNonRetry400HandleError handles the DeleteNonRetry400 error response.
 func (client *LrosaDsClient) DeleteNonRetry400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -724,8 +700,8 @@ func (client *LrosaDsClient) BeginPost202NoLocation(ctx context.Context, lrosaDs
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post202NoLocationHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.Post202NoLocationHandleError(resp)
 	}
 	result, err := client.Post202NoLocationHandleResponse(resp)
 	if err != nil {
@@ -778,9 +754,6 @@ func (client *LrosaDsClient) Post202NoLocationHandleResponse(resp *azcore.Respon
 
 // Post202NoLocationHandleError handles the Post202NoLocation error response.
 func (client *LrosaDsClient) Post202NoLocationHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -799,8 +772,8 @@ func (client *LrosaDsClient) BeginPost202NonRetry400(ctx context.Context, lrosaD
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post202NonRetry400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.Post202NonRetry400HandleError(resp)
 	}
 	result, err := client.Post202NonRetry400HandleResponse(resp)
 	if err != nil {
@@ -853,9 +826,6 @@ func (client *LrosaDsClient) Post202NonRetry400HandleResponse(resp *azcore.Respo
 
 // Post202NonRetry400HandleError handles the Post202NonRetry400 error response.
 func (client *LrosaDsClient) Post202NonRetry400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -874,8 +844,8 @@ func (client *LrosaDsClient) BeginPost202RetryInvalidHeader(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post202RetryInvalidHeaderHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.Post202RetryInvalidHeaderHandleError(resp)
 	}
 	result, err := client.Post202RetryInvalidHeaderHandleResponse(resp)
 	if err != nil {
@@ -928,9 +898,6 @@ func (client *LrosaDsClient) Post202RetryInvalidHeaderHandleResponse(resp *azcor
 
 // Post202RetryInvalidHeaderHandleError handles the Post202RetryInvalidHeader error response.
 func (client *LrosaDsClient) Post202RetryInvalidHeaderHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -949,8 +916,8 @@ func (client *LrosaDsClient) BeginPostAsyncRelativeRetry400(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostAsyncRelativeRetry400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PostAsyncRelativeRetry400HandleError(resp)
 	}
 	result, err := client.PostAsyncRelativeRetry400HandleResponse(resp)
 	if err != nil {
@@ -1003,9 +970,6 @@ func (client *LrosaDsClient) PostAsyncRelativeRetry400HandleResponse(resp *azcor
 
 // PostAsyncRelativeRetry400HandleError handles the PostAsyncRelativeRetry400 error response.
 func (client *LrosaDsClient) PostAsyncRelativeRetry400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1024,8 +988,8 @@ func (client *LrosaDsClient) BeginPostAsyncRelativeRetryInvalidHeader(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostAsyncRelativeRetryInvalidHeaderHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PostAsyncRelativeRetryInvalidHeaderHandleError(resp)
 	}
 	result, err := client.PostAsyncRelativeRetryInvalidHeaderHandleResponse(resp)
 	if err != nil {
@@ -1078,9 +1042,6 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidHeaderHandleResponse(r
 
 // PostAsyncRelativeRetryInvalidHeaderHandleError handles the PostAsyncRelativeRetryInvalidHeader error response.
 func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidHeaderHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1099,8 +1060,8 @@ func (client *LrosaDsClient) BeginPostAsyncRelativeRetryInvalidJSONPolling(ctx c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostAsyncRelativeRetryInvalidJSONPollingHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PostAsyncRelativeRetryInvalidJSONPollingHandleError(resp)
 	}
 	result, err := client.PostAsyncRelativeRetryInvalidJSONPollingHandleResponse(resp)
 	if err != nil {
@@ -1153,9 +1114,6 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidJSONPollingHandleRespo
 
 // PostAsyncRelativeRetryInvalidJSONPollingHandleError handles the PostAsyncRelativeRetryInvalidJSONPolling error response.
 func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidJSONPollingHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1174,8 +1132,8 @@ func (client *LrosaDsClient) BeginPostAsyncRelativeRetryNoPayload(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostAsyncRelativeRetryNoPayloadHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PostAsyncRelativeRetryNoPayloadHandleError(resp)
 	}
 	result, err := client.PostAsyncRelativeRetryNoPayloadHandleResponse(resp)
 	if err != nil {
@@ -1228,9 +1186,6 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryNoPayloadHandleResponse(resp 
 
 // PostAsyncRelativeRetryNoPayloadHandleError handles the PostAsyncRelativeRetryNoPayload error response.
 func (client *LrosaDsClient) PostAsyncRelativeRetryNoPayloadHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1249,8 +1204,8 @@ func (client *LrosaDsClient) BeginPostNonRetry400(ctx context.Context, lrosaDsPo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostNonRetry400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PostNonRetry400HandleError(resp)
 	}
 	result, err := client.PostNonRetry400HandleResponse(resp)
 	if err != nil {
@@ -1303,9 +1258,6 @@ func (client *LrosaDsClient) PostNonRetry400HandleResponse(resp *azcore.Response
 
 // PostNonRetry400HandleError handles the PostNonRetry400 error response.
 func (client *LrosaDsClient) PostNonRetry400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1324,8 +1276,8 @@ func (client *LrosaDsClient) BeginPut200InvalidJSON(ctx context.Context, lrosaDs
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put200InvalidJSONHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil, client.Put200InvalidJSONHandleError(resp)
 	}
 	result, err := client.Put200InvalidJSONHandleResponse(resp)
 	if err != nil {
@@ -1378,9 +1330,6 @@ func (client *LrosaDsClient) Put200InvalidJSONHandleResponse(resp *azcore.Respon
 
 // Put200InvalidJSONHandleError handles the Put200InvalidJSON error response.
 func (client *LrosaDsClient) Put200InvalidJSONHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1399,8 +1348,8 @@ func (client *LrosaDsClient) BeginPutAsyncRelativeRetry400(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutAsyncRelativeRetry400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutAsyncRelativeRetry400HandleError(resp)
 	}
 	result, err := client.PutAsyncRelativeRetry400HandleResponse(resp)
 	if err != nil {
@@ -1453,9 +1402,6 @@ func (client *LrosaDsClient) PutAsyncRelativeRetry400HandleResponse(resp *azcore
 
 // PutAsyncRelativeRetry400HandleError handles the PutAsyncRelativeRetry400 error response.
 func (client *LrosaDsClient) PutAsyncRelativeRetry400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1474,8 +1420,8 @@ func (client *LrosaDsClient) BeginPutAsyncRelativeRetryInvalidHeader(ctx context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutAsyncRelativeRetryInvalidHeaderHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutAsyncRelativeRetryInvalidHeaderHandleError(resp)
 	}
 	result, err := client.PutAsyncRelativeRetryInvalidHeaderHandleResponse(resp)
 	if err != nil {
@@ -1528,9 +1474,6 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidHeaderHandleResponse(re
 
 // PutAsyncRelativeRetryInvalidHeaderHandleError handles the PutAsyncRelativeRetryInvalidHeader error response.
 func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidHeaderHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1549,8 +1492,8 @@ func (client *LrosaDsClient) BeginPutAsyncRelativeRetryInvalidJSONPolling(ctx co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutAsyncRelativeRetryInvalidJSONPollingHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutAsyncRelativeRetryInvalidJSONPollingHandleError(resp)
 	}
 	result, err := client.PutAsyncRelativeRetryInvalidJSONPollingHandleResponse(resp)
 	if err != nil {
@@ -1603,9 +1546,6 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidJSONPollingHandleRespon
 
 // PutAsyncRelativeRetryInvalidJSONPollingHandleError handles the PutAsyncRelativeRetryInvalidJSONPolling error response.
 func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidJSONPollingHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1624,8 +1564,8 @@ func (client *LrosaDsClient) BeginPutAsyncRelativeRetryNoStatus(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutAsyncRelativeRetryNoStatusHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutAsyncRelativeRetryNoStatusHandleError(resp)
 	}
 	result, err := client.PutAsyncRelativeRetryNoStatusHandleResponse(resp)
 	if err != nil {
@@ -1678,9 +1618,6 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusHandleResponse(resp *a
 
 // PutAsyncRelativeRetryNoStatusHandleError handles the PutAsyncRelativeRetryNoStatus error response.
 func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1699,8 +1636,8 @@ func (client *LrosaDsClient) BeginPutAsyncRelativeRetryNoStatusPayload(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutAsyncRelativeRetryNoStatusPayloadHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutAsyncRelativeRetryNoStatusPayloadHandleError(resp)
 	}
 	result, err := client.PutAsyncRelativeRetryNoStatusPayloadHandleResponse(resp)
 	if err != nil {
@@ -1753,9 +1690,6 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusPayloadHandleResponse(
 
 // PutAsyncRelativeRetryNoStatusPayloadHandleError handles the PutAsyncRelativeRetryNoStatusPayload error response.
 func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusPayloadHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1774,8 +1708,8 @@ func (client *LrosaDsClient) BeginPutError201NoProvisioningStatePayload(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutError201NoProvisioningStatePayloadHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.PutError201NoProvisioningStatePayloadHandleError(resp)
 	}
 	result, err := client.PutError201NoProvisioningStatePayloadHandleResponse(resp)
 	if err != nil {
@@ -1828,9 +1762,6 @@ func (client *LrosaDsClient) PutError201NoProvisioningStatePayloadHandleResponse
 
 // PutError201NoProvisioningStatePayloadHandleError handles the PutError201NoProvisioningStatePayload error response.
 func (client *LrosaDsClient) PutError201NoProvisioningStatePayloadHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1849,8 +1780,8 @@ func (client *LrosaDsClient) BeginPutNonRetry201Creating400(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutNonRetry201Creating400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.PutNonRetry201Creating400HandleError(resp)
 	}
 	result, err := client.PutNonRetry201Creating400HandleResponse(resp)
 	if err != nil {
@@ -1903,9 +1834,6 @@ func (client *LrosaDsClient) PutNonRetry201Creating400HandleResponse(resp *azcor
 
 // PutNonRetry201Creating400HandleError handles the PutNonRetry201Creating400 error response.
 func (client *LrosaDsClient) PutNonRetry201Creating400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1924,8 +1852,8 @@ func (client *LrosaDsClient) BeginPutNonRetry201Creating400InvalidJSON(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutNonRetry201Creating400InvalidJSONHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.PutNonRetry201Creating400InvalidJSONHandleError(resp)
 	}
 	result, err := client.PutNonRetry201Creating400InvalidJSONHandleResponse(resp)
 	if err != nil {
@@ -1978,9 +1906,6 @@ func (client *LrosaDsClient) PutNonRetry201Creating400InvalidJSONHandleResponse(
 
 // PutNonRetry201Creating400InvalidJSONHandleError handles the PutNonRetry201Creating400InvalidJSON error response.
 func (client *LrosaDsClient) PutNonRetry201Creating400InvalidJSONHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1999,8 +1924,8 @@ func (client *LrosaDsClient) BeginPutNonRetry400(ctx context.Context, lrosaDsPut
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutNonRetry400HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.PutNonRetry400HandleError(resp)
 	}
 	result, err := client.PutNonRetry400HandleResponse(resp)
 	if err != nil {
@@ -2053,9 +1978,6 @@ func (client *LrosaDsClient) PutNonRetry400HandleResponse(resp *azcore.Response)
 
 // PutNonRetry400HandleError handles the PutNonRetry400 error response.
 func (client *LrosaDsClient) PutNonRetry400HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/lrogroup/zz_generated_lroscustomheader.go
+++ b/test/autorest/lrogroup/zz_generated_lroscustomheader.go
@@ -60,6 +60,9 @@ func (client *LrOSCustomHeaderClient) BeginPost202Retry200(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
+	if err := client.Post202Retry200HandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.Post202Retry200HandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -106,14 +109,14 @@ func (client *LrOSCustomHeaderClient) Post202Retry200CreateRequest(ctx context.C
 
 // Post202Retry200HandleResponse handles the Post202Retry200 response.
 func (client *LrOSCustomHeaderClient) Post202Retry200HandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.Post202Retry200HandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Post202Retry200HandleError handles the Post202Retry200 error response.
 func (client *LrOSCustomHeaderClient) Post202Retry200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -130,6 +133,9 @@ func (client *LrOSCustomHeaderClient) BeginPostAsyncRetrySucceeded(ctx context.C
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PostAsyncRetrySucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PostAsyncRetrySucceededHandleResponse(resp)
@@ -178,14 +184,14 @@ func (client *LrOSCustomHeaderClient) PostAsyncRetrySucceededCreateRequest(ctx c
 
 // PostAsyncRetrySucceededHandleResponse handles the PostAsyncRetrySucceeded response.
 func (client *LrOSCustomHeaderClient) PostAsyncRetrySucceededHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PostAsyncRetrySucceededHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PostAsyncRetrySucceededHandleError handles the PostAsyncRetrySucceeded error response.
 func (client *LrOSCustomHeaderClient) PostAsyncRetrySucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -202,6 +208,9 @@ func (client *LrOSCustomHeaderClient) BeginPut201CreatingSucceeded200(ctx contex
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.Put201CreatingSucceeded200HandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.Put201CreatingSucceeded200HandleResponse(resp)
@@ -250,14 +259,14 @@ func (client *LrOSCustomHeaderClient) Put201CreatingSucceeded200CreateRequest(ct
 
 // Put201CreatingSucceeded200HandleResponse handles the Put201CreatingSucceeded200 response.
 func (client *LrOSCustomHeaderClient) Put201CreatingSucceeded200HandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.Put201CreatingSucceeded200HandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // Put201CreatingSucceeded200HandleError handles the Put201CreatingSucceeded200 error response.
 func (client *LrOSCustomHeaderClient) Put201CreatingSucceeded200HandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -274,6 +283,9 @@ func (client *LrOSCustomHeaderClient) BeginPutAsyncRetrySucceeded(ctx context.Co
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutAsyncRetrySucceededHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutAsyncRetrySucceededHandleResponse(resp)
@@ -322,14 +334,14 @@ func (client *LrOSCustomHeaderClient) PutAsyncRetrySucceededCreateRequest(ctx co
 
 // PutAsyncRetrySucceededHandleResponse handles the PutAsyncRetrySucceeded response.
 func (client *LrOSCustomHeaderClient) PutAsyncRetrySucceededHandleResponse(resp *azcore.Response) (*ProductPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.PutAsyncRetrySucceededHandleError(resp)
-	}
 	return &ProductPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PutAsyncRetrySucceededHandleError handles the PutAsyncRetrySucceeded error response.
 func (client *LrOSCustomHeaderClient) PutAsyncRetrySucceededHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/lrogroup/zz_generated_lroscustomheader.go
+++ b/test/autorest/lrogroup/zz_generated_lroscustomheader.go
@@ -60,8 +60,8 @@ func (client *LrOSCustomHeaderClient) BeginPost202Retry200(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Post202Retry200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.Post202Retry200HandleError(resp)
 	}
 	result, err := client.Post202Retry200HandleResponse(resp)
 	if err != nil {
@@ -114,9 +114,6 @@ func (client *LrOSCustomHeaderClient) Post202Retry200HandleResponse(resp *azcore
 
 // Post202Retry200HandleError handles the Post202Retry200 error response.
 func (client *LrOSCustomHeaderClient) Post202Retry200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -135,8 +132,8 @@ func (client *LrOSCustomHeaderClient) BeginPostAsyncRetrySucceeded(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostAsyncRetrySucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.PostAsyncRetrySucceededHandleError(resp)
 	}
 	result, err := client.PostAsyncRetrySucceededHandleResponse(resp)
 	if err != nil {
@@ -189,9 +186,6 @@ func (client *LrOSCustomHeaderClient) PostAsyncRetrySucceededHandleResponse(resp
 
 // PostAsyncRetrySucceededHandleError handles the PostAsyncRetrySucceeded error response.
 func (client *LrOSCustomHeaderClient) PostAsyncRetrySucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,8 +204,8 @@ func (client *LrOSCustomHeaderClient) BeginPut201CreatingSucceeded200(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Put201CreatingSucceeded200HandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.Put201CreatingSucceeded200HandleError(resp)
 	}
 	result, err := client.Put201CreatingSucceeded200HandleResponse(resp)
 	if err != nil {
@@ -264,9 +258,6 @@ func (client *LrOSCustomHeaderClient) Put201CreatingSucceeded200HandleResponse(r
 
 // Put201CreatingSucceeded200HandleError handles the Put201CreatingSucceeded200 error response.
 func (client *LrOSCustomHeaderClient) Put201CreatingSucceeded200HandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -285,8 +276,8 @@ func (client *LrOSCustomHeaderClient) BeginPutAsyncRetrySucceeded(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutAsyncRetrySucceededHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutAsyncRetrySucceededHandleError(resp)
 	}
 	result, err := client.PutAsyncRetrySucceededHandleResponse(resp)
 	if err != nil {
@@ -339,9 +330,6 @@ func (client *LrOSCustomHeaderClient) PutAsyncRetrySucceededHandleResponse(resp 
 
 // PutAsyncRetrySucceededHandleError handles the PutAsyncRetrySucceeded error response.
 func (client *LrOSCustomHeaderClient) PutAsyncRetrySucceededHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/mediatypesgroup/zz_generated_mediatypesclient.go
+++ b/test/autorest/mediatypesgroup/zz_generated_mediatypesclient.go
@@ -51,6 +51,9 @@ func (client *MediaTypesClient) AnalyzeBody(ctx context.Context, contentType Con
 	if err != nil {
 		return nil, err
 	}
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.AnalyzeBodyHandleError(resp)
+	}
 	result, err := client.AnalyzeBodyHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -72,9 +75,6 @@ func (client *MediaTypesClient) AnalyzeBodyCreateRequest(ctx context.Context, co
 
 // AnalyzeBodyHandleResponse handles the AnalyzeBody response.
 func (client *MediaTypesClient) AnalyzeBodyHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.AnalyzeBodyHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
@@ -101,6 +101,9 @@ func (client *MediaTypesClient) AnalyzeBodyWithSourcePath(ctx context.Context, m
 	if err != nil {
 		return nil, err
 	}
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.AnalyzeBodyWithSourcePathHandleError(resp)
+	}
 	result, err := client.AnalyzeBodyWithSourcePathHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -124,9 +127,6 @@ func (client *MediaTypesClient) AnalyzeBodyWithSourcePathCreateRequest(ctx conte
 
 // AnalyzeBodyWithSourcePathHandleResponse handles the AnalyzeBodyWithSourcePath response.
 func (client *MediaTypesClient) AnalyzeBodyWithSourcePathHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.AnalyzeBodyWithSourcePathHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
@@ -153,6 +153,9 @@ func (client *MediaTypesClient) ContentTypeWithEncoding(ctx context.Context, inp
 	if err != nil {
 		return nil, err
 	}
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ContentTypeWithEncodingHandleError(resp)
+	}
 	result, err := client.ContentTypeWithEncodingHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -174,9 +177,6 @@ func (client *MediaTypesClient) ContentTypeWithEncodingCreateRequest(ctx context
 
 // ContentTypeWithEncodingHandleResponse handles the ContentTypeWithEncoding response.
 func (client *MediaTypesClient) ContentTypeWithEncodingHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ContentTypeWithEncodingHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }

--- a/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient.go
+++ b/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient.go
@@ -64,8 +64,8 @@ func (client *MultipleInheritanceServiceClient) GetCat(ctx context.Context) (*Ca
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetCatHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetCatHandleError(resp)
 	}
 	result, err := client.GetCatHandleResponse(resp)
 	if err != nil {
@@ -93,9 +93,6 @@ func (client *MultipleInheritanceServiceClient) GetCatHandleResponse(resp *azcor
 
 // GetCatHandleError handles the GetCat error response.
 func (client *MultipleInheritanceServiceClient) GetCatHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -113,8 +110,8 @@ func (client *MultipleInheritanceServiceClient) GetFeline(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetFelineHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetFelineHandleError(resp)
 	}
 	result, err := client.GetFelineHandleResponse(resp)
 	if err != nil {
@@ -142,9 +139,6 @@ func (client *MultipleInheritanceServiceClient) GetFelineHandleResponse(resp *az
 
 // GetFelineHandleError handles the GetFeline error response.
 func (client *MultipleInheritanceServiceClient) GetFelineHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -162,8 +156,8 @@ func (client *MultipleInheritanceServiceClient) GetHorse(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHorseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHorseHandleError(resp)
 	}
 	result, err := client.GetHorseHandleResponse(resp)
 	if err != nil {
@@ -191,9 +185,6 @@ func (client *MultipleInheritanceServiceClient) GetHorseHandleResponse(resp *azc
 
 // GetHorseHandleError handles the GetHorse error response.
 func (client *MultipleInheritanceServiceClient) GetHorseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -211,8 +202,8 @@ func (client *MultipleInheritanceServiceClient) GetKitten(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetKittenHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetKittenHandleError(resp)
 	}
 	result, err := client.GetKittenHandleResponse(resp)
 	if err != nil {
@@ -240,9 +231,6 @@ func (client *MultipleInheritanceServiceClient) GetKittenHandleResponse(resp *az
 
 // GetKittenHandleError handles the GetKitten error response.
 func (client *MultipleInheritanceServiceClient) GetKittenHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -260,8 +248,8 @@ func (client *MultipleInheritanceServiceClient) GetPet(ctx context.Context) (*Pe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetPetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetPetHandleError(resp)
 	}
 	result, err := client.GetPetHandleResponse(resp)
 	if err != nil {
@@ -289,9 +277,6 @@ func (client *MultipleInheritanceServiceClient) GetPetHandleResponse(resp *azcor
 
 // GetPetHandleError handles the GetPet error response.
 func (client *MultipleInheritanceServiceClient) GetPetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -309,8 +294,8 @@ func (client *MultipleInheritanceServiceClient) PutCat(ctx context.Context, cat 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutCatHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutCatHandleError(resp)
 	}
 	result, err := client.PutCatHandleResponse(resp)
 	if err != nil {
@@ -338,9 +323,6 @@ func (client *MultipleInheritanceServiceClient) PutCatHandleResponse(resp *azcor
 
 // PutCatHandleError handles the PutCat error response.
 func (client *MultipleInheritanceServiceClient) PutCatHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -361,8 +343,8 @@ func (client *MultipleInheritanceServiceClient) PutFeline(ctx context.Context, f
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutFelineHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutFelineHandleError(resp)
 	}
 	result, err := client.PutFelineHandleResponse(resp)
 	if err != nil {
@@ -390,9 +372,6 @@ func (client *MultipleInheritanceServiceClient) PutFelineHandleResponse(resp *az
 
 // PutFelineHandleError handles the PutFeline error response.
 func (client *MultipleInheritanceServiceClient) PutFelineHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -413,8 +392,8 @@ func (client *MultipleInheritanceServiceClient) PutHorse(ctx context.Context, ho
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutHorseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutHorseHandleError(resp)
 	}
 	result, err := client.PutHorseHandleResponse(resp)
 	if err != nil {
@@ -442,9 +421,6 @@ func (client *MultipleInheritanceServiceClient) PutHorseHandleResponse(resp *azc
 
 // PutHorseHandleError handles the PutHorse error response.
 func (client *MultipleInheritanceServiceClient) PutHorseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -465,8 +441,8 @@ func (client *MultipleInheritanceServiceClient) PutKitten(ctx context.Context, k
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutKittenHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutKittenHandleError(resp)
 	}
 	result, err := client.PutKittenHandleResponse(resp)
 	if err != nil {
@@ -494,9 +470,6 @@ func (client *MultipleInheritanceServiceClient) PutKittenHandleResponse(resp *az
 
 // PutKittenHandleError handles the PutKitten error response.
 func (client *MultipleInheritanceServiceClient) PutKittenHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -517,8 +490,8 @@ func (client *MultipleInheritanceServiceClient) PutPet(ctx context.Context, pet 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutPetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutPetHandleError(resp)
 	}
 	result, err := client.PutPetHandleResponse(resp)
 	if err != nil {
@@ -546,9 +519,6 @@ func (client *MultipleInheritanceServiceClient) PutPetHandleResponse(resp *azcor
 
 // PutPetHandleError handles the PutPet error response.
 func (client *MultipleInheritanceServiceClient) PutPetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient.go
+++ b/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient.go
@@ -64,6 +64,9 @@ func (client *MultipleInheritanceServiceClient) GetCat(ctx context.Context) (*Ca
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetCatHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetCatHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -84,15 +87,15 @@ func (client *MultipleInheritanceServiceClient) GetCatCreateRequest(ctx context.
 
 // GetCatHandleResponse handles the GetCat response.
 func (client *MultipleInheritanceServiceClient) GetCatHandleResponse(resp *azcore.Response) (*CatResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetCatHandleError(resp)
-	}
 	result := CatResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Cat)
 }
 
 // GetCatHandleError handles the GetCat error response.
 func (client *MultipleInheritanceServiceClient) GetCatHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -108,6 +111,9 @@ func (client *MultipleInheritanceServiceClient) GetFeline(ctx context.Context) (
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetFelineHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetFelineHandleResponse(resp)
@@ -130,15 +136,15 @@ func (client *MultipleInheritanceServiceClient) GetFelineCreateRequest(ctx conte
 
 // GetFelineHandleResponse handles the GetFeline response.
 func (client *MultipleInheritanceServiceClient) GetFelineHandleResponse(resp *azcore.Response) (*FelineResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetFelineHandleError(resp)
-	}
 	result := FelineResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Feline)
 }
 
 // GetFelineHandleError handles the GetFeline error response.
 func (client *MultipleInheritanceServiceClient) GetFelineHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -154,6 +160,9 @@ func (client *MultipleInheritanceServiceClient) GetHorse(ctx context.Context) (*
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHorseHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHorseHandleResponse(resp)
@@ -176,15 +185,15 @@ func (client *MultipleInheritanceServiceClient) GetHorseCreateRequest(ctx contex
 
 // GetHorseHandleResponse handles the GetHorse response.
 func (client *MultipleInheritanceServiceClient) GetHorseHandleResponse(resp *azcore.Response) (*HorseResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHorseHandleError(resp)
-	}
 	result := HorseResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Horse)
 }
 
 // GetHorseHandleError handles the GetHorse error response.
 func (client *MultipleInheritanceServiceClient) GetHorseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -200,6 +209,9 @@ func (client *MultipleInheritanceServiceClient) GetKitten(ctx context.Context) (
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetKittenHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetKittenHandleResponse(resp)
@@ -222,15 +234,15 @@ func (client *MultipleInheritanceServiceClient) GetKittenCreateRequest(ctx conte
 
 // GetKittenHandleResponse handles the GetKitten response.
 func (client *MultipleInheritanceServiceClient) GetKittenHandleResponse(resp *azcore.Response) (*KittenResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetKittenHandleError(resp)
-	}
 	result := KittenResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Kitten)
 }
 
 // GetKittenHandleError handles the GetKitten error response.
 func (client *MultipleInheritanceServiceClient) GetKittenHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -246,6 +258,9 @@ func (client *MultipleInheritanceServiceClient) GetPet(ctx context.Context) (*Pe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetPetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetPetHandleResponse(resp)
@@ -268,15 +283,15 @@ func (client *MultipleInheritanceServiceClient) GetPetCreateRequest(ctx context.
 
 // GetPetHandleResponse handles the GetPet response.
 func (client *MultipleInheritanceServiceClient) GetPetHandleResponse(resp *azcore.Response) (*PetResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetPetHandleError(resp)
-	}
 	result := PetResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Pet)
 }
 
 // GetPetHandleError handles the GetPet error response.
 func (client *MultipleInheritanceServiceClient) GetPetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -292,6 +307,9 @@ func (client *MultipleInheritanceServiceClient) PutCat(ctx context.Context, cat 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutCatHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutCatHandleResponse(resp)
@@ -314,15 +332,15 @@ func (client *MultipleInheritanceServiceClient) PutCatCreateRequest(ctx context.
 
 // PutCatHandleResponse handles the PutCat response.
 func (client *MultipleInheritanceServiceClient) PutCatHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutCatHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // PutCatHandleError handles the PutCat error response.
 func (client *MultipleInheritanceServiceClient) PutCatHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -341,6 +359,9 @@ func (client *MultipleInheritanceServiceClient) PutFeline(ctx context.Context, f
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutFelineHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutFelineHandleResponse(resp)
@@ -363,15 +384,15 @@ func (client *MultipleInheritanceServiceClient) PutFelineCreateRequest(ctx conte
 
 // PutFelineHandleResponse handles the PutFeline response.
 func (client *MultipleInheritanceServiceClient) PutFelineHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutFelineHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // PutFelineHandleError handles the PutFeline error response.
 func (client *MultipleInheritanceServiceClient) PutFelineHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -390,6 +411,9 @@ func (client *MultipleInheritanceServiceClient) PutHorse(ctx context.Context, ho
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutHorseHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutHorseHandleResponse(resp)
@@ -412,15 +436,15 @@ func (client *MultipleInheritanceServiceClient) PutHorseCreateRequest(ctx contex
 
 // PutHorseHandleResponse handles the PutHorse response.
 func (client *MultipleInheritanceServiceClient) PutHorseHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutHorseHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // PutHorseHandleError handles the PutHorse error response.
 func (client *MultipleInheritanceServiceClient) PutHorseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -439,6 +463,9 @@ func (client *MultipleInheritanceServiceClient) PutKitten(ctx context.Context, k
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutKittenHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutKittenHandleResponse(resp)
@@ -461,15 +488,15 @@ func (client *MultipleInheritanceServiceClient) PutKittenCreateRequest(ctx conte
 
 // PutKittenHandleResponse handles the PutKitten response.
 func (client *MultipleInheritanceServiceClient) PutKittenHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutKittenHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // PutKittenHandleError handles the PutKitten error response.
 func (client *MultipleInheritanceServiceClient) PutKittenHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -488,6 +515,9 @@ func (client *MultipleInheritanceServiceClient) PutPet(ctx context.Context, pet 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutPetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutPetHandleResponse(resp)
@@ -510,15 +540,15 @@ func (client *MultipleInheritanceServiceClient) PutPetCreateRequest(ctx context.
 
 // PutPetHandleResponse handles the PutPet response.
 func (client *MultipleInheritanceServiceClient) PutPetHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutPetHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // PutPetHandleError handles the PutPet error response.
 func (client *MultipleInheritanceServiceClient) PutPetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/morecustombaseurigroup/zz_generated_paths.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_paths.go
@@ -46,8 +46,8 @@ func (client *PathsClient) GetEmpty(ctx context.Context, vault string, secret st
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -76,9 +76,6 @@ func (client *PathsClient) GetEmptyCreateRequest(ctx context.Context, vault stri
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *PathsClient) GetEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/morecustombaseurigroup/zz_generated_paths.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_paths.go
@@ -46,11 +46,10 @@ func (client *PathsClient) GetEmpty(ctx context.Context, vault string, secret st
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetEmptyHandleResponse(resp)
-	if err != nil {
+	if err := client.GetEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetEmptyCreateRequest creates the GetEmpty request.
@@ -75,16 +74,11 @@ func (client *PathsClient) GetEmptyCreateRequest(ctx context.Context, vault stri
 	return req, nil
 }
 
-// GetEmptyHandleResponse handles the GetEmpty response.
-func (client *PathsClient) GetEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *PathsClient) GetEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/nonstringenumgroup/zz_generated_float.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_float.go
@@ -48,8 +48,8 @@ func (client *FloatClient) Get(ctx context.Context) (*FloatEnumResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -77,9 +77,6 @@ func (client *FloatClient) GetHandleResponse(resp *azcore.Response) (*FloatEnumR
 
 // GetHandleError handles the Get error response.
 func (client *FloatClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -100,8 +97,8 @@ func (client *FloatClient) Put(ctx context.Context, floatPutOptions *FloatPutOpt
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutHandleError(resp)
 	}
 	result, err := client.PutHandleResponse(resp)
 	if err != nil {
@@ -132,9 +129,6 @@ func (client *FloatClient) PutHandleResponse(resp *azcore.Response) (*StringResp
 
 // PutHandleError handles the Put error response.
 func (client *FloatClient) PutHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/nonstringenumgroup/zz_generated_float.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_float.go
@@ -48,6 +48,9 @@ func (client *FloatClient) Get(ctx context.Context) (*FloatEnumResponse, error) 
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -68,15 +71,15 @@ func (client *FloatClient) GetCreateRequest(ctx context.Context) (*azcore.Reques
 
 // GetHandleResponse handles the Get response.
 func (client *FloatClient) GetHandleResponse(resp *azcore.Response) (*FloatEnumResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := FloatEnumResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetHandleError handles the Get error response.
 func (client *FloatClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -95,6 +98,9 @@ func (client *FloatClient) Put(ctx context.Context, floatPutOptions *FloatPutOpt
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutHandleResponse(resp)
@@ -120,15 +126,15 @@ func (client *FloatClient) PutCreateRequest(ctx context.Context, floatPutOptions
 
 // PutHandleResponse handles the Put response.
 func (client *FloatClient) PutHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // PutHandleError handles the Put error response.
 func (client *FloatClient) PutHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/nonstringenumgroup/zz_generated_int.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_int.go
@@ -48,8 +48,8 @@ func (client *IntClient) Get(ctx context.Context) (*IntEnumResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -77,9 +77,6 @@ func (client *IntClient) GetHandleResponse(resp *azcore.Response) (*IntEnumRespo
 
 // GetHandleError handles the Get error response.
 func (client *IntClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -100,8 +97,8 @@ func (client *IntClient) Put(ctx context.Context, intPutOptions *IntPutOptions) 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutHandleError(resp)
 	}
 	result, err := client.PutHandleResponse(resp)
 	if err != nil {
@@ -132,9 +129,6 @@ func (client *IntClient) PutHandleResponse(resp *azcore.Response) (*StringRespon
 
 // PutHandleError handles the Put error response.
 func (client *IntClient) PutHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/nonstringenumgroup/zz_generated_int.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_int.go
@@ -48,6 +48,9 @@ func (client *IntClient) Get(ctx context.Context) (*IntEnumResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -68,15 +71,15 @@ func (client *IntClient) GetCreateRequest(ctx context.Context) (*azcore.Request,
 
 // GetHandleResponse handles the Get response.
 func (client *IntClient) GetHandleResponse(resp *azcore.Response) (*IntEnumResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := IntEnumResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetHandleError handles the Get error response.
 func (client *IntClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -95,6 +98,9 @@ func (client *IntClient) Put(ctx context.Context, intPutOptions *IntPutOptions) 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PutHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PutHandleResponse(resp)
@@ -120,15 +126,15 @@ func (client *IntClient) PutCreateRequest(ctx context.Context, intPutOptions *In
 
 // PutHandleResponse handles the Put response.
 func (client *IntClient) PutHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // PutHandleError handles the Put error response.
 func (client *IntClient) PutHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/numbergroup/zz_generated_number.go
+++ b/test/autorest/numbergroup/zz_generated_number.go
@@ -89,8 +89,8 @@ func (client *NumberClient) GetBigDecimal(ctx context.Context) (*Float64Response
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBigDecimalHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBigDecimalHandleError(resp)
 	}
 	result, err := client.GetBigDecimalHandleResponse(resp)
 	if err != nil {
@@ -118,9 +118,6 @@ func (client *NumberClient) GetBigDecimalHandleResponse(resp *azcore.Response) (
 
 // GetBigDecimalHandleError handles the GetBigDecimal error response.
 func (client *NumberClient) GetBigDecimalHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *NumberClient) GetBigDecimalNegativeDecimal(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBigDecimalNegativeDecimalHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBigDecimalNegativeDecimalHandleError(resp)
 	}
 	result, err := client.GetBigDecimalNegativeDecimalHandleResponse(resp)
 	if err != nil {
@@ -167,9 +164,6 @@ func (client *NumberClient) GetBigDecimalNegativeDecimalHandleResponse(resp *azc
 
 // GetBigDecimalNegativeDecimalHandleError handles the GetBigDecimalNegativeDecimal error response.
 func (client *NumberClient) GetBigDecimalNegativeDecimalHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -187,8 +181,8 @@ func (client *NumberClient) GetBigDecimalPositiveDecimal(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBigDecimalPositiveDecimalHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBigDecimalPositiveDecimalHandleError(resp)
 	}
 	result, err := client.GetBigDecimalPositiveDecimalHandleResponse(resp)
 	if err != nil {
@@ -216,9 +210,6 @@ func (client *NumberClient) GetBigDecimalPositiveDecimalHandleResponse(resp *azc
 
 // GetBigDecimalPositiveDecimalHandleError handles the GetBigDecimalPositiveDecimal error response.
 func (client *NumberClient) GetBigDecimalPositiveDecimalHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -236,8 +227,8 @@ func (client *NumberClient) GetBigDouble(ctx context.Context) (*Float64Response,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBigDoubleHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBigDoubleHandleError(resp)
 	}
 	result, err := client.GetBigDoubleHandleResponse(resp)
 	if err != nil {
@@ -265,9 +256,6 @@ func (client *NumberClient) GetBigDoubleHandleResponse(resp *azcore.Response) (*
 
 // GetBigDoubleHandleError handles the GetBigDouble error response.
 func (client *NumberClient) GetBigDoubleHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -285,8 +273,8 @@ func (client *NumberClient) GetBigDoubleNegativeDecimal(ctx context.Context) (*F
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBigDoubleNegativeDecimalHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBigDoubleNegativeDecimalHandleError(resp)
 	}
 	result, err := client.GetBigDoubleNegativeDecimalHandleResponse(resp)
 	if err != nil {
@@ -314,9 +302,6 @@ func (client *NumberClient) GetBigDoubleNegativeDecimalHandleResponse(resp *azco
 
 // GetBigDoubleNegativeDecimalHandleError handles the GetBigDoubleNegativeDecimal error response.
 func (client *NumberClient) GetBigDoubleNegativeDecimalHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -334,8 +319,8 @@ func (client *NumberClient) GetBigDoublePositiveDecimal(ctx context.Context) (*F
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBigDoublePositiveDecimalHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBigDoublePositiveDecimalHandleError(resp)
 	}
 	result, err := client.GetBigDoublePositiveDecimalHandleResponse(resp)
 	if err != nil {
@@ -363,9 +348,6 @@ func (client *NumberClient) GetBigDoublePositiveDecimalHandleResponse(resp *azco
 
 // GetBigDoublePositiveDecimalHandleError handles the GetBigDoublePositiveDecimal error response.
 func (client *NumberClient) GetBigDoublePositiveDecimalHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -383,8 +365,8 @@ func (client *NumberClient) GetBigFloat(ctx context.Context) (*Float32Response, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBigFloatHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBigFloatHandleError(resp)
 	}
 	result, err := client.GetBigFloatHandleResponse(resp)
 	if err != nil {
@@ -412,9 +394,6 @@ func (client *NumberClient) GetBigFloatHandleResponse(resp *azcore.Response) (*F
 
 // GetBigFloatHandleError handles the GetBigFloat error response.
 func (client *NumberClient) GetBigFloatHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -432,8 +411,8 @@ func (client *NumberClient) GetInvalidDecimal(ctx context.Context) (*Float64Resp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetInvalidDecimalHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetInvalidDecimalHandleError(resp)
 	}
 	result, err := client.GetInvalidDecimalHandleResponse(resp)
 	if err != nil {
@@ -461,9 +440,6 @@ func (client *NumberClient) GetInvalidDecimalHandleResponse(resp *azcore.Respons
 
 // GetInvalidDecimalHandleError handles the GetInvalidDecimal error response.
 func (client *NumberClient) GetInvalidDecimalHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -481,8 +457,8 @@ func (client *NumberClient) GetInvalidDouble(ctx context.Context) (*Float64Respo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetInvalidDoubleHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetInvalidDoubleHandleError(resp)
 	}
 	result, err := client.GetInvalidDoubleHandleResponse(resp)
 	if err != nil {
@@ -510,9 +486,6 @@ func (client *NumberClient) GetInvalidDoubleHandleResponse(resp *azcore.Response
 
 // GetInvalidDoubleHandleError handles the GetInvalidDouble error response.
 func (client *NumberClient) GetInvalidDoubleHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -530,8 +503,8 @@ func (client *NumberClient) GetInvalidFloat(ctx context.Context) (*Float32Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetInvalidFloatHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetInvalidFloatHandleError(resp)
 	}
 	result, err := client.GetInvalidFloatHandleResponse(resp)
 	if err != nil {
@@ -559,9 +532,6 @@ func (client *NumberClient) GetInvalidFloatHandleResponse(resp *azcore.Response)
 
 // GetInvalidFloatHandleError handles the GetInvalidFloat error response.
 func (client *NumberClient) GetInvalidFloatHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -579,8 +549,8 @@ func (client *NumberClient) GetNull(ctx context.Context) (*Float32Response, erro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullHandleError(resp)
 	}
 	result, err := client.GetNullHandleResponse(resp)
 	if err != nil {
@@ -608,9 +578,6 @@ func (client *NumberClient) GetNullHandleResponse(resp *azcore.Response) (*Float
 
 // GetNullHandleError handles the GetNull error response.
 func (client *NumberClient) GetNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -628,8 +595,8 @@ func (client *NumberClient) GetSmallDecimal(ctx context.Context) (*Float64Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetSmallDecimalHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetSmallDecimalHandleError(resp)
 	}
 	result, err := client.GetSmallDecimalHandleResponse(resp)
 	if err != nil {
@@ -657,9 +624,6 @@ func (client *NumberClient) GetSmallDecimalHandleResponse(resp *azcore.Response)
 
 // GetSmallDecimalHandleError handles the GetSmallDecimal error response.
 func (client *NumberClient) GetSmallDecimalHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -677,8 +641,8 @@ func (client *NumberClient) GetSmallDouble(ctx context.Context) (*Float64Respons
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetSmallDoubleHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetSmallDoubleHandleError(resp)
 	}
 	result, err := client.GetSmallDoubleHandleResponse(resp)
 	if err != nil {
@@ -706,9 +670,6 @@ func (client *NumberClient) GetSmallDoubleHandleResponse(resp *azcore.Response) 
 
 // GetSmallDoubleHandleError handles the GetSmallDouble error response.
 func (client *NumberClient) GetSmallDoubleHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -726,8 +687,8 @@ func (client *NumberClient) GetSmallFloat(ctx context.Context) (*Float64Response
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetSmallFloatHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetSmallFloatHandleError(resp)
 	}
 	result, err := client.GetSmallFloatHandleResponse(resp)
 	if err != nil {
@@ -755,9 +716,6 @@ func (client *NumberClient) GetSmallFloatHandleResponse(resp *azcore.Response) (
 
 // GetSmallFloatHandleError handles the GetSmallFloat error response.
 func (client *NumberClient) GetSmallFloatHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -775,8 +733,8 @@ func (client *NumberClient) PutBigDecimal(ctx context.Context, numberBody float6
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutBigDecimalHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutBigDecimalHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -794,9 +752,6 @@ func (client *NumberClient) PutBigDecimalCreateRequest(ctx context.Context, numb
 
 // PutBigDecimalHandleError handles the PutBigDecimal error response.
 func (client *NumberClient) PutBigDecimalHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -814,8 +769,8 @@ func (client *NumberClient) PutBigDecimalNegativeDecimal(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutBigDecimalNegativeDecimalHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutBigDecimalNegativeDecimalHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -833,9 +788,6 @@ func (client *NumberClient) PutBigDecimalNegativeDecimalCreateRequest(ctx contex
 
 // PutBigDecimalNegativeDecimalHandleError handles the PutBigDecimalNegativeDecimal error response.
 func (client *NumberClient) PutBigDecimalNegativeDecimalHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -853,8 +805,8 @@ func (client *NumberClient) PutBigDecimalPositiveDecimal(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutBigDecimalPositiveDecimalHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutBigDecimalPositiveDecimalHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -872,9 +824,6 @@ func (client *NumberClient) PutBigDecimalPositiveDecimalCreateRequest(ctx contex
 
 // PutBigDecimalPositiveDecimalHandleError handles the PutBigDecimalPositiveDecimal error response.
 func (client *NumberClient) PutBigDecimalPositiveDecimalHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -892,8 +841,8 @@ func (client *NumberClient) PutBigDouble(ctx context.Context, numberBody float64
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutBigDoubleHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutBigDoubleHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -911,9 +860,6 @@ func (client *NumberClient) PutBigDoubleCreateRequest(ctx context.Context, numbe
 
 // PutBigDoubleHandleError handles the PutBigDouble error response.
 func (client *NumberClient) PutBigDoubleHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -931,8 +877,8 @@ func (client *NumberClient) PutBigDoubleNegativeDecimal(ctx context.Context) (*h
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutBigDoubleNegativeDecimalHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutBigDoubleNegativeDecimalHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -950,9 +896,6 @@ func (client *NumberClient) PutBigDoubleNegativeDecimalCreateRequest(ctx context
 
 // PutBigDoubleNegativeDecimalHandleError handles the PutBigDoubleNegativeDecimal error response.
 func (client *NumberClient) PutBigDoubleNegativeDecimalHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -970,8 +913,8 @@ func (client *NumberClient) PutBigDoublePositiveDecimal(ctx context.Context) (*h
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutBigDoublePositiveDecimalHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutBigDoublePositiveDecimalHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -989,9 +932,6 @@ func (client *NumberClient) PutBigDoublePositiveDecimalCreateRequest(ctx context
 
 // PutBigDoublePositiveDecimalHandleError handles the PutBigDoublePositiveDecimal error response.
 func (client *NumberClient) PutBigDoublePositiveDecimalHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1009,8 +949,8 @@ func (client *NumberClient) PutBigFloat(ctx context.Context, numberBody float32)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutBigFloatHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutBigFloatHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1028,9 +968,6 @@ func (client *NumberClient) PutBigFloatCreateRequest(ctx context.Context, number
 
 // PutBigFloatHandleError handles the PutBigFloat error response.
 func (client *NumberClient) PutBigFloatHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1048,8 +985,8 @@ func (client *NumberClient) PutSmallDecimal(ctx context.Context, numberBody floa
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutSmallDecimalHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutSmallDecimalHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1067,9 +1004,6 @@ func (client *NumberClient) PutSmallDecimalCreateRequest(ctx context.Context, nu
 
 // PutSmallDecimalHandleError handles the PutSmallDecimal error response.
 func (client *NumberClient) PutSmallDecimalHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1087,8 +1021,8 @@ func (client *NumberClient) PutSmallDouble(ctx context.Context, numberBody float
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutSmallDoubleHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutSmallDoubleHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1106,9 +1040,6 @@ func (client *NumberClient) PutSmallDoubleCreateRequest(ctx context.Context, num
 
 // PutSmallDoubleHandleError handles the PutSmallDouble error response.
 func (client *NumberClient) PutSmallDoubleHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1126,8 +1057,8 @@ func (client *NumberClient) PutSmallFloat(ctx context.Context, numberBody float3
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutSmallFloatHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutSmallFloatHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1145,9 +1076,6 @@ func (client *NumberClient) PutSmallFloatCreateRequest(ctx context.Context, numb
 
 // PutSmallFloatHandleError handles the PutSmallFloat error response.
 func (client *NumberClient) PutSmallFloatHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/numbergroup/zz_generated_number.go
+++ b/test/autorest/numbergroup/zz_generated_number.go
@@ -89,6 +89,9 @@ func (client *NumberClient) GetBigDecimal(ctx context.Context) (*Float64Response
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetBigDecimalHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetBigDecimalHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,15 +112,15 @@ func (client *NumberClient) GetBigDecimalCreateRequest(ctx context.Context) (*az
 
 // GetBigDecimalHandleResponse handles the GetBigDecimal response.
 func (client *NumberClient) GetBigDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBigDecimalHandleError(resp)
-	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBigDecimalHandleError handles the GetBigDecimal error response.
 func (client *NumberClient) GetBigDecimalHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *NumberClient) GetBigDecimalNegativeDecimal(ctx context.Context) (*
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBigDecimalNegativeDecimalHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBigDecimalNegativeDecimalHandleResponse(resp)
@@ -155,15 +161,15 @@ func (client *NumberClient) GetBigDecimalNegativeDecimalCreateRequest(ctx contex
 
 // GetBigDecimalNegativeDecimalHandleResponse handles the GetBigDecimalNegativeDecimal response.
 func (client *NumberClient) GetBigDecimalNegativeDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBigDecimalNegativeDecimalHandleError(resp)
-	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBigDecimalNegativeDecimalHandleError handles the GetBigDecimalNegativeDecimal error response.
 func (client *NumberClient) GetBigDecimalNegativeDecimalHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -179,6 +185,9 @@ func (client *NumberClient) GetBigDecimalPositiveDecimal(ctx context.Context) (*
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBigDecimalPositiveDecimalHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBigDecimalPositiveDecimalHandleResponse(resp)
@@ -201,15 +210,15 @@ func (client *NumberClient) GetBigDecimalPositiveDecimalCreateRequest(ctx contex
 
 // GetBigDecimalPositiveDecimalHandleResponse handles the GetBigDecimalPositiveDecimal response.
 func (client *NumberClient) GetBigDecimalPositiveDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBigDecimalPositiveDecimalHandleError(resp)
-	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBigDecimalPositiveDecimalHandleError handles the GetBigDecimalPositiveDecimal error response.
 func (client *NumberClient) GetBigDecimalPositiveDecimalHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -225,6 +234,9 @@ func (client *NumberClient) GetBigDouble(ctx context.Context) (*Float64Response,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBigDoubleHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBigDoubleHandleResponse(resp)
@@ -247,15 +259,15 @@ func (client *NumberClient) GetBigDoubleCreateRequest(ctx context.Context) (*azc
 
 // GetBigDoubleHandleResponse handles the GetBigDouble response.
 func (client *NumberClient) GetBigDoubleHandleResponse(resp *azcore.Response) (*Float64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBigDoubleHandleError(resp)
-	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBigDoubleHandleError handles the GetBigDouble error response.
 func (client *NumberClient) GetBigDoubleHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -271,6 +283,9 @@ func (client *NumberClient) GetBigDoubleNegativeDecimal(ctx context.Context) (*F
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBigDoubleNegativeDecimalHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBigDoubleNegativeDecimalHandleResponse(resp)
@@ -293,15 +308,15 @@ func (client *NumberClient) GetBigDoubleNegativeDecimalCreateRequest(ctx context
 
 // GetBigDoubleNegativeDecimalHandleResponse handles the GetBigDoubleNegativeDecimal response.
 func (client *NumberClient) GetBigDoubleNegativeDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBigDoubleNegativeDecimalHandleError(resp)
-	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBigDoubleNegativeDecimalHandleError handles the GetBigDoubleNegativeDecimal error response.
 func (client *NumberClient) GetBigDoubleNegativeDecimalHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -317,6 +332,9 @@ func (client *NumberClient) GetBigDoublePositiveDecimal(ctx context.Context) (*F
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBigDoublePositiveDecimalHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBigDoublePositiveDecimalHandleResponse(resp)
@@ -339,15 +357,15 @@ func (client *NumberClient) GetBigDoublePositiveDecimalCreateRequest(ctx context
 
 // GetBigDoublePositiveDecimalHandleResponse handles the GetBigDoublePositiveDecimal response.
 func (client *NumberClient) GetBigDoublePositiveDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBigDoublePositiveDecimalHandleError(resp)
-	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBigDoublePositiveDecimalHandleError handles the GetBigDoublePositiveDecimal error response.
 func (client *NumberClient) GetBigDoublePositiveDecimalHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -363,6 +381,9 @@ func (client *NumberClient) GetBigFloat(ctx context.Context) (*Float32Response, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBigFloatHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBigFloatHandleResponse(resp)
@@ -385,15 +406,15 @@ func (client *NumberClient) GetBigFloatCreateRequest(ctx context.Context) (*azco
 
 // GetBigFloatHandleResponse handles the GetBigFloat response.
 func (client *NumberClient) GetBigFloatHandleResponse(resp *azcore.Response) (*Float32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBigFloatHandleError(resp)
-	}
 	result := Float32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetBigFloatHandleError handles the GetBigFloat error response.
 func (client *NumberClient) GetBigFloatHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -409,6 +430,9 @@ func (client *NumberClient) GetInvalidDecimal(ctx context.Context) (*Float64Resp
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetInvalidDecimalHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetInvalidDecimalHandleResponse(resp)
@@ -431,15 +455,15 @@ func (client *NumberClient) GetInvalidDecimalCreateRequest(ctx context.Context) 
 
 // GetInvalidDecimalHandleResponse handles the GetInvalidDecimal response.
 func (client *NumberClient) GetInvalidDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetInvalidDecimalHandleError(resp)
-	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetInvalidDecimalHandleError handles the GetInvalidDecimal error response.
 func (client *NumberClient) GetInvalidDecimalHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -455,6 +479,9 @@ func (client *NumberClient) GetInvalidDouble(ctx context.Context) (*Float64Respo
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetInvalidDoubleHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetInvalidDoubleHandleResponse(resp)
@@ -477,15 +504,15 @@ func (client *NumberClient) GetInvalidDoubleCreateRequest(ctx context.Context) (
 
 // GetInvalidDoubleHandleResponse handles the GetInvalidDouble response.
 func (client *NumberClient) GetInvalidDoubleHandleResponse(resp *azcore.Response) (*Float64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetInvalidDoubleHandleError(resp)
-	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetInvalidDoubleHandleError handles the GetInvalidDouble error response.
 func (client *NumberClient) GetInvalidDoubleHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -501,6 +528,9 @@ func (client *NumberClient) GetInvalidFloat(ctx context.Context) (*Float32Respon
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetInvalidFloatHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetInvalidFloatHandleResponse(resp)
@@ -523,15 +553,15 @@ func (client *NumberClient) GetInvalidFloatCreateRequest(ctx context.Context) (*
 
 // GetInvalidFloatHandleResponse handles the GetInvalidFloat response.
 func (client *NumberClient) GetInvalidFloatHandleResponse(resp *azcore.Response) (*Float32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetInvalidFloatHandleError(resp)
-	}
 	result := Float32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetInvalidFloatHandleError handles the GetInvalidFloat error response.
 func (client *NumberClient) GetInvalidFloatHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -547,6 +577,9 @@ func (client *NumberClient) GetNull(ctx context.Context) (*Float32Response, erro
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullHandleResponse(resp)
@@ -569,15 +602,15 @@ func (client *NumberClient) GetNullCreateRequest(ctx context.Context) (*azcore.R
 
 // GetNullHandleResponse handles the GetNull response.
 func (client *NumberClient) GetNullHandleResponse(resp *azcore.Response) (*Float32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullHandleError(resp)
-	}
 	result := Float32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNullHandleError handles the GetNull error response.
 func (client *NumberClient) GetNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -593,6 +626,9 @@ func (client *NumberClient) GetSmallDecimal(ctx context.Context) (*Float64Respon
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetSmallDecimalHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetSmallDecimalHandleResponse(resp)
@@ -615,15 +651,15 @@ func (client *NumberClient) GetSmallDecimalCreateRequest(ctx context.Context) (*
 
 // GetSmallDecimalHandleResponse handles the GetSmallDecimal response.
 func (client *NumberClient) GetSmallDecimalHandleResponse(resp *azcore.Response) (*Float64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetSmallDecimalHandleError(resp)
-	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetSmallDecimalHandleError handles the GetSmallDecimal error response.
 func (client *NumberClient) GetSmallDecimalHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -639,6 +675,9 @@ func (client *NumberClient) GetSmallDouble(ctx context.Context) (*Float64Respons
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetSmallDoubleHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetSmallDoubleHandleResponse(resp)
@@ -661,15 +700,15 @@ func (client *NumberClient) GetSmallDoubleCreateRequest(ctx context.Context) (*a
 
 // GetSmallDoubleHandleResponse handles the GetSmallDouble response.
 func (client *NumberClient) GetSmallDoubleHandleResponse(resp *azcore.Response) (*Float64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetSmallDoubleHandleError(resp)
-	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetSmallDoubleHandleError handles the GetSmallDouble error response.
 func (client *NumberClient) GetSmallDoubleHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -685,6 +724,9 @@ func (client *NumberClient) GetSmallFloat(ctx context.Context) (*Float64Response
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetSmallFloatHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetSmallFloatHandleResponse(resp)
@@ -707,15 +749,15 @@ func (client *NumberClient) GetSmallFloatCreateRequest(ctx context.Context) (*az
 
 // GetSmallFloatHandleResponse handles the GetSmallFloat response.
 func (client *NumberClient) GetSmallFloatHandleResponse(resp *azcore.Response) (*Float64Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetSmallFloatHandleError(resp)
-	}
 	result := Float64Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetSmallFloatHandleError handles the GetSmallFloat error response.
 func (client *NumberClient) GetSmallFloatHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -733,11 +775,10 @@ func (client *NumberClient) PutBigDecimal(ctx context.Context, numberBody float6
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutBigDecimalHandleResponse(resp)
-	if err != nil {
+	if err := client.PutBigDecimalHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutBigDecimalCreateRequest creates the PutBigDecimal request.
@@ -751,16 +792,11 @@ func (client *NumberClient) PutBigDecimalCreateRequest(ctx context.Context, numb
 	return req, req.MarshalAsJSON(numberBody)
 }
 
-// PutBigDecimalHandleResponse handles the PutBigDecimal response.
-func (client *NumberClient) PutBigDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutBigDecimalHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutBigDecimalHandleError handles the PutBigDecimal error response.
 func (client *NumberClient) PutBigDecimalHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -778,11 +814,10 @@ func (client *NumberClient) PutBigDecimalNegativeDecimal(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutBigDecimalNegativeDecimalHandleResponse(resp)
-	if err != nil {
+	if err := client.PutBigDecimalNegativeDecimalHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutBigDecimalNegativeDecimalCreateRequest creates the PutBigDecimalNegativeDecimal request.
@@ -796,16 +831,11 @@ func (client *NumberClient) PutBigDecimalNegativeDecimalCreateRequest(ctx contex
 	return req, req.MarshalAsJSON(-99999999.99)
 }
 
-// PutBigDecimalNegativeDecimalHandleResponse handles the PutBigDecimalNegativeDecimal response.
-func (client *NumberClient) PutBigDecimalNegativeDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutBigDecimalNegativeDecimalHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutBigDecimalNegativeDecimalHandleError handles the PutBigDecimalNegativeDecimal error response.
 func (client *NumberClient) PutBigDecimalNegativeDecimalHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -823,11 +853,10 @@ func (client *NumberClient) PutBigDecimalPositiveDecimal(ctx context.Context) (*
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutBigDecimalPositiveDecimalHandleResponse(resp)
-	if err != nil {
+	if err := client.PutBigDecimalPositiveDecimalHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutBigDecimalPositiveDecimalCreateRequest creates the PutBigDecimalPositiveDecimal request.
@@ -841,16 +870,11 @@ func (client *NumberClient) PutBigDecimalPositiveDecimalCreateRequest(ctx contex
 	return req, req.MarshalAsJSON(99999999.99)
 }
 
-// PutBigDecimalPositiveDecimalHandleResponse handles the PutBigDecimalPositiveDecimal response.
-func (client *NumberClient) PutBigDecimalPositiveDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutBigDecimalPositiveDecimalHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutBigDecimalPositiveDecimalHandleError handles the PutBigDecimalPositiveDecimal error response.
 func (client *NumberClient) PutBigDecimalPositiveDecimalHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -868,11 +892,10 @@ func (client *NumberClient) PutBigDouble(ctx context.Context, numberBody float64
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutBigDoubleHandleResponse(resp)
-	if err != nil {
+	if err := client.PutBigDoubleHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutBigDoubleCreateRequest creates the PutBigDouble request.
@@ -886,16 +909,11 @@ func (client *NumberClient) PutBigDoubleCreateRequest(ctx context.Context, numbe
 	return req, req.MarshalAsJSON(numberBody)
 }
 
-// PutBigDoubleHandleResponse handles the PutBigDouble response.
-func (client *NumberClient) PutBigDoubleHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutBigDoubleHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutBigDoubleHandleError handles the PutBigDouble error response.
 func (client *NumberClient) PutBigDoubleHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -913,11 +931,10 @@ func (client *NumberClient) PutBigDoubleNegativeDecimal(ctx context.Context) (*h
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutBigDoubleNegativeDecimalHandleResponse(resp)
-	if err != nil {
+	if err := client.PutBigDoubleNegativeDecimalHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutBigDoubleNegativeDecimalCreateRequest creates the PutBigDoubleNegativeDecimal request.
@@ -931,16 +948,11 @@ func (client *NumberClient) PutBigDoubleNegativeDecimalCreateRequest(ctx context
 	return req, req.MarshalAsJSON(-99999999.99)
 }
 
-// PutBigDoubleNegativeDecimalHandleResponse handles the PutBigDoubleNegativeDecimal response.
-func (client *NumberClient) PutBigDoubleNegativeDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutBigDoubleNegativeDecimalHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutBigDoubleNegativeDecimalHandleError handles the PutBigDoubleNegativeDecimal error response.
 func (client *NumberClient) PutBigDoubleNegativeDecimalHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -958,11 +970,10 @@ func (client *NumberClient) PutBigDoublePositiveDecimal(ctx context.Context) (*h
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutBigDoublePositiveDecimalHandleResponse(resp)
-	if err != nil {
+	if err := client.PutBigDoublePositiveDecimalHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutBigDoublePositiveDecimalCreateRequest creates the PutBigDoublePositiveDecimal request.
@@ -976,16 +987,11 @@ func (client *NumberClient) PutBigDoublePositiveDecimalCreateRequest(ctx context
 	return req, req.MarshalAsJSON(99999999.99)
 }
 
-// PutBigDoublePositiveDecimalHandleResponse handles the PutBigDoublePositiveDecimal response.
-func (client *NumberClient) PutBigDoublePositiveDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutBigDoublePositiveDecimalHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutBigDoublePositiveDecimalHandleError handles the PutBigDoublePositiveDecimal error response.
 func (client *NumberClient) PutBigDoublePositiveDecimalHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1003,11 +1009,10 @@ func (client *NumberClient) PutBigFloat(ctx context.Context, numberBody float32)
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutBigFloatHandleResponse(resp)
-	if err != nil {
+	if err := client.PutBigFloatHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutBigFloatCreateRequest creates the PutBigFloat request.
@@ -1021,16 +1026,11 @@ func (client *NumberClient) PutBigFloatCreateRequest(ctx context.Context, number
 	return req, req.MarshalAsJSON(numberBody)
 }
 
-// PutBigFloatHandleResponse handles the PutBigFloat response.
-func (client *NumberClient) PutBigFloatHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutBigFloatHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutBigFloatHandleError handles the PutBigFloat error response.
 func (client *NumberClient) PutBigFloatHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1048,11 +1048,10 @@ func (client *NumberClient) PutSmallDecimal(ctx context.Context, numberBody floa
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutSmallDecimalHandleResponse(resp)
-	if err != nil {
+	if err := client.PutSmallDecimalHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutSmallDecimalCreateRequest creates the PutSmallDecimal request.
@@ -1066,16 +1065,11 @@ func (client *NumberClient) PutSmallDecimalCreateRequest(ctx context.Context, nu
 	return req, req.MarshalAsJSON(numberBody)
 }
 
-// PutSmallDecimalHandleResponse handles the PutSmallDecimal response.
-func (client *NumberClient) PutSmallDecimalHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutSmallDecimalHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutSmallDecimalHandleError handles the PutSmallDecimal error response.
 func (client *NumberClient) PutSmallDecimalHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1093,11 +1087,10 @@ func (client *NumberClient) PutSmallDouble(ctx context.Context, numberBody float
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutSmallDoubleHandleResponse(resp)
-	if err != nil {
+	if err := client.PutSmallDoubleHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutSmallDoubleCreateRequest creates the PutSmallDouble request.
@@ -1111,16 +1104,11 @@ func (client *NumberClient) PutSmallDoubleCreateRequest(ctx context.Context, num
 	return req, req.MarshalAsJSON(numberBody)
 }
 
-// PutSmallDoubleHandleResponse handles the PutSmallDouble response.
-func (client *NumberClient) PutSmallDoubleHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutSmallDoubleHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutSmallDoubleHandleError handles the PutSmallDouble error response.
 func (client *NumberClient) PutSmallDoubleHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1138,11 +1126,10 @@ func (client *NumberClient) PutSmallFloat(ctx context.Context, numberBody float3
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutSmallFloatHandleResponse(resp)
-	if err != nil {
+	if err := client.PutSmallFloatHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutSmallFloatCreateRequest creates the PutSmallFloat request.
@@ -1156,16 +1143,11 @@ func (client *NumberClient) PutSmallFloatCreateRequest(ctx context.Context, numb
 	return req, req.MarshalAsJSON(numberBody)
 }
 
-// PutSmallFloatHandleResponse handles the PutSmallFloat response.
-func (client *NumberClient) PutSmallFloatHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutSmallFloatHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutSmallFloatHandleError handles the PutSmallFloat error response.
 func (client *NumberClient) PutSmallFloatHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/optionalgroup/zz_generated_explicit.go
+++ b/test/autorest/optionalgroup/zz_generated_explicit.go
@@ -87,8 +87,8 @@ func (client *ExplicitClient) PostOptionalArrayHeader(ctx context.Context, expli
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostOptionalArrayHeaderHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostOptionalArrayHeaderHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -109,9 +109,6 @@ func (client *ExplicitClient) PostOptionalArrayHeaderCreateRequest(ctx context.C
 
 // PostOptionalArrayHeaderHandleError handles the PostOptionalArrayHeader error response.
 func (client *ExplicitClient) PostOptionalArrayHeaderHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -129,8 +126,8 @@ func (client *ExplicitClient) PostOptionalArrayParameter(ctx context.Context, ex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostOptionalArrayParameterHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostOptionalArrayParameterHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -151,9 +148,6 @@ func (client *ExplicitClient) PostOptionalArrayParameterCreateRequest(ctx contex
 
 // PostOptionalArrayParameterHandleError handles the PostOptionalArrayParameter error response.
 func (client *ExplicitClient) PostOptionalArrayParameterHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -171,8 +165,8 @@ func (client *ExplicitClient) PostOptionalArrayProperty(ctx context.Context, exp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostOptionalArrayPropertyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostOptionalArrayPropertyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -193,9 +187,6 @@ func (client *ExplicitClient) PostOptionalArrayPropertyCreateRequest(ctx context
 
 // PostOptionalArrayPropertyHandleError handles the PostOptionalArrayProperty error response.
 func (client *ExplicitClient) PostOptionalArrayPropertyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -213,8 +204,8 @@ func (client *ExplicitClient) PostOptionalClassParameter(ctx context.Context, ex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostOptionalClassParameterHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostOptionalClassParameterHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -235,9 +226,6 @@ func (client *ExplicitClient) PostOptionalClassParameterCreateRequest(ctx contex
 
 // PostOptionalClassParameterHandleError handles the PostOptionalClassParameter error response.
 func (client *ExplicitClient) PostOptionalClassParameterHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -255,8 +243,8 @@ func (client *ExplicitClient) PostOptionalClassProperty(ctx context.Context, exp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostOptionalClassPropertyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostOptionalClassPropertyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -277,9 +265,6 @@ func (client *ExplicitClient) PostOptionalClassPropertyCreateRequest(ctx context
 
 // PostOptionalClassPropertyHandleError handles the PostOptionalClassProperty error response.
 func (client *ExplicitClient) PostOptionalClassPropertyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -297,8 +282,8 @@ func (client *ExplicitClient) PostOptionalIntegerHeader(ctx context.Context, exp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostOptionalIntegerHeaderHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostOptionalIntegerHeaderHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -319,9 +304,6 @@ func (client *ExplicitClient) PostOptionalIntegerHeaderCreateRequest(ctx context
 
 // PostOptionalIntegerHeaderHandleError handles the PostOptionalIntegerHeader error response.
 func (client *ExplicitClient) PostOptionalIntegerHeaderHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -339,8 +321,8 @@ func (client *ExplicitClient) PostOptionalIntegerParameter(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostOptionalIntegerParameterHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostOptionalIntegerParameterHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -361,9 +343,6 @@ func (client *ExplicitClient) PostOptionalIntegerParameterCreateRequest(ctx cont
 
 // PostOptionalIntegerParameterHandleError handles the PostOptionalIntegerParameter error response.
 func (client *ExplicitClient) PostOptionalIntegerParameterHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -381,8 +360,8 @@ func (client *ExplicitClient) PostOptionalIntegerProperty(ctx context.Context, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostOptionalIntegerPropertyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostOptionalIntegerPropertyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -403,9 +382,6 @@ func (client *ExplicitClient) PostOptionalIntegerPropertyCreateRequest(ctx conte
 
 // PostOptionalIntegerPropertyHandleError handles the PostOptionalIntegerProperty error response.
 func (client *ExplicitClient) PostOptionalIntegerPropertyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -423,8 +399,8 @@ func (client *ExplicitClient) PostOptionalStringHeader(ctx context.Context, expl
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostOptionalStringHeaderHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostOptionalStringHeaderHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -445,9 +421,6 @@ func (client *ExplicitClient) PostOptionalStringHeaderCreateRequest(ctx context.
 
 // PostOptionalStringHeaderHandleError handles the PostOptionalStringHeader error response.
 func (client *ExplicitClient) PostOptionalStringHeaderHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -465,8 +438,8 @@ func (client *ExplicitClient) PostOptionalStringParameter(ctx context.Context, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostOptionalStringParameterHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostOptionalStringParameterHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -487,9 +460,6 @@ func (client *ExplicitClient) PostOptionalStringParameterCreateRequest(ctx conte
 
 // PostOptionalStringParameterHandleError handles the PostOptionalStringParameter error response.
 func (client *ExplicitClient) PostOptionalStringParameterHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -507,8 +477,8 @@ func (client *ExplicitClient) PostOptionalStringProperty(ctx context.Context, ex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostOptionalStringPropertyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostOptionalStringPropertyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -529,9 +499,6 @@ func (client *ExplicitClient) PostOptionalStringPropertyCreateRequest(ctx contex
 
 // PostOptionalStringPropertyHandleError handles the PostOptionalStringProperty error response.
 func (client *ExplicitClient) PostOptionalStringPropertyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -549,8 +516,8 @@ func (client *ExplicitClient) PostRequiredArrayHeader(ctx context.Context, heade
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostRequiredArrayHeaderHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostRequiredArrayHeaderHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -569,9 +536,6 @@ func (client *ExplicitClient) PostRequiredArrayHeaderCreateRequest(ctx context.C
 
 // PostRequiredArrayHeaderHandleError handles the PostRequiredArrayHeader error response.
 func (client *ExplicitClient) PostRequiredArrayHeaderHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -589,8 +553,8 @@ func (client *ExplicitClient) PostRequiredArrayParameter(ctx context.Context, bo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostRequiredArrayParameterHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostRequiredArrayParameterHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -608,9 +572,6 @@ func (client *ExplicitClient) PostRequiredArrayParameterCreateRequest(ctx contex
 
 // PostRequiredArrayParameterHandleError handles the PostRequiredArrayParameter error response.
 func (client *ExplicitClient) PostRequiredArrayParameterHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -628,8 +589,8 @@ func (client *ExplicitClient) PostRequiredArrayProperty(ctx context.Context, bod
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostRequiredArrayPropertyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostRequiredArrayPropertyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -647,9 +608,6 @@ func (client *ExplicitClient) PostRequiredArrayPropertyCreateRequest(ctx context
 
 // PostRequiredArrayPropertyHandleError handles the PostRequiredArrayProperty error response.
 func (client *ExplicitClient) PostRequiredArrayPropertyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -667,8 +625,8 @@ func (client *ExplicitClient) PostRequiredClassParameter(ctx context.Context, bo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostRequiredClassParameterHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostRequiredClassParameterHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -686,9 +644,6 @@ func (client *ExplicitClient) PostRequiredClassParameterCreateRequest(ctx contex
 
 // PostRequiredClassParameterHandleError handles the PostRequiredClassParameter error response.
 func (client *ExplicitClient) PostRequiredClassParameterHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -706,8 +661,8 @@ func (client *ExplicitClient) PostRequiredClassProperty(ctx context.Context, bod
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostRequiredClassPropertyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostRequiredClassPropertyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -725,9 +680,6 @@ func (client *ExplicitClient) PostRequiredClassPropertyCreateRequest(ctx context
 
 // PostRequiredClassPropertyHandleError handles the PostRequiredClassProperty error response.
 func (client *ExplicitClient) PostRequiredClassPropertyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -745,8 +697,8 @@ func (client *ExplicitClient) PostRequiredIntegerHeader(ctx context.Context, hea
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostRequiredIntegerHeaderHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostRequiredIntegerHeaderHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -765,9 +717,6 @@ func (client *ExplicitClient) PostRequiredIntegerHeaderCreateRequest(ctx context
 
 // PostRequiredIntegerHeaderHandleError handles the PostRequiredIntegerHeader error response.
 func (client *ExplicitClient) PostRequiredIntegerHeaderHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -785,8 +734,8 @@ func (client *ExplicitClient) PostRequiredIntegerParameter(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostRequiredIntegerParameterHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostRequiredIntegerParameterHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -804,9 +753,6 @@ func (client *ExplicitClient) PostRequiredIntegerParameterCreateRequest(ctx cont
 
 // PostRequiredIntegerParameterHandleError handles the PostRequiredIntegerParameter error response.
 func (client *ExplicitClient) PostRequiredIntegerParameterHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -824,8 +770,8 @@ func (client *ExplicitClient) PostRequiredIntegerProperty(ctx context.Context, b
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostRequiredIntegerPropertyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostRequiredIntegerPropertyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -843,9 +789,6 @@ func (client *ExplicitClient) PostRequiredIntegerPropertyCreateRequest(ctx conte
 
 // PostRequiredIntegerPropertyHandleError handles the PostRequiredIntegerProperty error response.
 func (client *ExplicitClient) PostRequiredIntegerPropertyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -863,8 +806,8 @@ func (client *ExplicitClient) PostRequiredStringHeader(ctx context.Context, head
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostRequiredStringHeaderHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostRequiredStringHeaderHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -883,9 +826,6 @@ func (client *ExplicitClient) PostRequiredStringHeaderCreateRequest(ctx context.
 
 // PostRequiredStringHeaderHandleError handles the PostRequiredStringHeader error response.
 func (client *ExplicitClient) PostRequiredStringHeaderHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -903,8 +843,8 @@ func (client *ExplicitClient) PostRequiredStringParameter(ctx context.Context, b
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostRequiredStringParameterHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostRequiredStringParameterHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -922,9 +862,6 @@ func (client *ExplicitClient) PostRequiredStringParameterCreateRequest(ctx conte
 
 // PostRequiredStringParameterHandleError handles the PostRequiredStringParameter error response.
 func (client *ExplicitClient) PostRequiredStringParameterHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -942,8 +879,8 @@ func (client *ExplicitClient) PostRequiredStringProperty(ctx context.Context, bo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostRequiredStringPropertyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostRequiredStringPropertyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -961,9 +898,6 @@ func (client *ExplicitClient) PostRequiredStringPropertyCreateRequest(ctx contex
 
 // PostRequiredStringPropertyHandleError handles the PostRequiredStringProperty error response.
 func (client *ExplicitClient) PostRequiredStringPropertyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/optionalgroup/zz_generated_explicit.go
+++ b/test/autorest/optionalgroup/zz_generated_explicit.go
@@ -87,11 +87,10 @@ func (client *ExplicitClient) PostOptionalArrayHeader(ctx context.Context, expli
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostOptionalArrayHeaderHandleResponse(resp)
-	if err != nil {
+	if err := client.PostOptionalArrayHeaderHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostOptionalArrayHeaderCreateRequest creates the PostOptionalArrayHeader request.
@@ -108,16 +107,11 @@ func (client *ExplicitClient) PostOptionalArrayHeaderCreateRequest(ctx context.C
 	return req, nil
 }
 
-// PostOptionalArrayHeaderHandleResponse handles the PostOptionalArrayHeader response.
-func (client *ExplicitClient) PostOptionalArrayHeaderHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostOptionalArrayHeaderHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostOptionalArrayHeaderHandleError handles the PostOptionalArrayHeader error response.
 func (client *ExplicitClient) PostOptionalArrayHeaderHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -135,11 +129,10 @@ func (client *ExplicitClient) PostOptionalArrayParameter(ctx context.Context, ex
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostOptionalArrayParameterHandleResponse(resp)
-	if err != nil {
+	if err := client.PostOptionalArrayParameterHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostOptionalArrayParameterCreateRequest creates the PostOptionalArrayParameter request.
@@ -156,16 +149,11 @@ func (client *ExplicitClient) PostOptionalArrayParameterCreateRequest(ctx contex
 	return req, nil
 }
 
-// PostOptionalArrayParameterHandleResponse handles the PostOptionalArrayParameter response.
-func (client *ExplicitClient) PostOptionalArrayParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostOptionalArrayParameterHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostOptionalArrayParameterHandleError handles the PostOptionalArrayParameter error response.
 func (client *ExplicitClient) PostOptionalArrayParameterHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -183,11 +171,10 @@ func (client *ExplicitClient) PostOptionalArrayProperty(ctx context.Context, exp
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostOptionalArrayPropertyHandleResponse(resp)
-	if err != nil {
+	if err := client.PostOptionalArrayPropertyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostOptionalArrayPropertyCreateRequest creates the PostOptionalArrayProperty request.
@@ -204,16 +191,11 @@ func (client *ExplicitClient) PostOptionalArrayPropertyCreateRequest(ctx context
 	return req, nil
 }
 
-// PostOptionalArrayPropertyHandleResponse handles the PostOptionalArrayProperty response.
-func (client *ExplicitClient) PostOptionalArrayPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostOptionalArrayPropertyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostOptionalArrayPropertyHandleError handles the PostOptionalArrayProperty error response.
 func (client *ExplicitClient) PostOptionalArrayPropertyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -231,11 +213,10 @@ func (client *ExplicitClient) PostOptionalClassParameter(ctx context.Context, ex
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostOptionalClassParameterHandleResponse(resp)
-	if err != nil {
+	if err := client.PostOptionalClassParameterHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostOptionalClassParameterCreateRequest creates the PostOptionalClassParameter request.
@@ -252,16 +233,11 @@ func (client *ExplicitClient) PostOptionalClassParameterCreateRequest(ctx contex
 	return req, nil
 }
 
-// PostOptionalClassParameterHandleResponse handles the PostOptionalClassParameter response.
-func (client *ExplicitClient) PostOptionalClassParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostOptionalClassParameterHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostOptionalClassParameterHandleError handles the PostOptionalClassParameter error response.
 func (client *ExplicitClient) PostOptionalClassParameterHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -279,11 +255,10 @@ func (client *ExplicitClient) PostOptionalClassProperty(ctx context.Context, exp
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostOptionalClassPropertyHandleResponse(resp)
-	if err != nil {
+	if err := client.PostOptionalClassPropertyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostOptionalClassPropertyCreateRequest creates the PostOptionalClassProperty request.
@@ -300,16 +275,11 @@ func (client *ExplicitClient) PostOptionalClassPropertyCreateRequest(ctx context
 	return req, nil
 }
 
-// PostOptionalClassPropertyHandleResponse handles the PostOptionalClassProperty response.
-func (client *ExplicitClient) PostOptionalClassPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostOptionalClassPropertyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostOptionalClassPropertyHandleError handles the PostOptionalClassProperty error response.
 func (client *ExplicitClient) PostOptionalClassPropertyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -327,11 +297,10 @@ func (client *ExplicitClient) PostOptionalIntegerHeader(ctx context.Context, exp
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostOptionalIntegerHeaderHandleResponse(resp)
-	if err != nil {
+	if err := client.PostOptionalIntegerHeaderHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostOptionalIntegerHeaderCreateRequest creates the PostOptionalIntegerHeader request.
@@ -348,16 +317,11 @@ func (client *ExplicitClient) PostOptionalIntegerHeaderCreateRequest(ctx context
 	return req, nil
 }
 
-// PostOptionalIntegerHeaderHandleResponse handles the PostOptionalIntegerHeader response.
-func (client *ExplicitClient) PostOptionalIntegerHeaderHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostOptionalIntegerHeaderHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostOptionalIntegerHeaderHandleError handles the PostOptionalIntegerHeader error response.
 func (client *ExplicitClient) PostOptionalIntegerHeaderHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -375,11 +339,10 @@ func (client *ExplicitClient) PostOptionalIntegerParameter(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostOptionalIntegerParameterHandleResponse(resp)
-	if err != nil {
+	if err := client.PostOptionalIntegerParameterHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostOptionalIntegerParameterCreateRequest creates the PostOptionalIntegerParameter request.
@@ -396,16 +359,11 @@ func (client *ExplicitClient) PostOptionalIntegerParameterCreateRequest(ctx cont
 	return req, nil
 }
 
-// PostOptionalIntegerParameterHandleResponse handles the PostOptionalIntegerParameter response.
-func (client *ExplicitClient) PostOptionalIntegerParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostOptionalIntegerParameterHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostOptionalIntegerParameterHandleError handles the PostOptionalIntegerParameter error response.
 func (client *ExplicitClient) PostOptionalIntegerParameterHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -423,11 +381,10 @@ func (client *ExplicitClient) PostOptionalIntegerProperty(ctx context.Context, e
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostOptionalIntegerPropertyHandleResponse(resp)
-	if err != nil {
+	if err := client.PostOptionalIntegerPropertyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostOptionalIntegerPropertyCreateRequest creates the PostOptionalIntegerProperty request.
@@ -444,16 +401,11 @@ func (client *ExplicitClient) PostOptionalIntegerPropertyCreateRequest(ctx conte
 	return req, nil
 }
 
-// PostOptionalIntegerPropertyHandleResponse handles the PostOptionalIntegerProperty response.
-func (client *ExplicitClient) PostOptionalIntegerPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostOptionalIntegerPropertyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostOptionalIntegerPropertyHandleError handles the PostOptionalIntegerProperty error response.
 func (client *ExplicitClient) PostOptionalIntegerPropertyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -471,11 +423,10 @@ func (client *ExplicitClient) PostOptionalStringHeader(ctx context.Context, expl
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostOptionalStringHeaderHandleResponse(resp)
-	if err != nil {
+	if err := client.PostOptionalStringHeaderHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostOptionalStringHeaderCreateRequest creates the PostOptionalStringHeader request.
@@ -492,16 +443,11 @@ func (client *ExplicitClient) PostOptionalStringHeaderCreateRequest(ctx context.
 	return req, nil
 }
 
-// PostOptionalStringHeaderHandleResponse handles the PostOptionalStringHeader response.
-func (client *ExplicitClient) PostOptionalStringHeaderHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostOptionalStringHeaderHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostOptionalStringHeaderHandleError handles the PostOptionalStringHeader error response.
 func (client *ExplicitClient) PostOptionalStringHeaderHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -519,11 +465,10 @@ func (client *ExplicitClient) PostOptionalStringParameter(ctx context.Context, e
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostOptionalStringParameterHandleResponse(resp)
-	if err != nil {
+	if err := client.PostOptionalStringParameterHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostOptionalStringParameterCreateRequest creates the PostOptionalStringParameter request.
@@ -540,16 +485,11 @@ func (client *ExplicitClient) PostOptionalStringParameterCreateRequest(ctx conte
 	return req, nil
 }
 
-// PostOptionalStringParameterHandleResponse handles the PostOptionalStringParameter response.
-func (client *ExplicitClient) PostOptionalStringParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostOptionalStringParameterHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostOptionalStringParameterHandleError handles the PostOptionalStringParameter error response.
 func (client *ExplicitClient) PostOptionalStringParameterHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -567,11 +507,10 @@ func (client *ExplicitClient) PostOptionalStringProperty(ctx context.Context, ex
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostOptionalStringPropertyHandleResponse(resp)
-	if err != nil {
+	if err := client.PostOptionalStringPropertyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostOptionalStringPropertyCreateRequest creates the PostOptionalStringProperty request.
@@ -588,16 +527,11 @@ func (client *ExplicitClient) PostOptionalStringPropertyCreateRequest(ctx contex
 	return req, nil
 }
 
-// PostOptionalStringPropertyHandleResponse handles the PostOptionalStringProperty response.
-func (client *ExplicitClient) PostOptionalStringPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostOptionalStringPropertyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostOptionalStringPropertyHandleError handles the PostOptionalStringProperty error response.
 func (client *ExplicitClient) PostOptionalStringPropertyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -615,11 +549,10 @@ func (client *ExplicitClient) PostRequiredArrayHeader(ctx context.Context, heade
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostRequiredArrayHeaderHandleResponse(resp)
-	if err != nil {
+	if err := client.PostRequiredArrayHeaderHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostRequiredArrayHeaderCreateRequest creates the PostRequiredArrayHeader request.
@@ -634,16 +567,11 @@ func (client *ExplicitClient) PostRequiredArrayHeaderCreateRequest(ctx context.C
 	return req, nil
 }
 
-// PostRequiredArrayHeaderHandleResponse handles the PostRequiredArrayHeader response.
-func (client *ExplicitClient) PostRequiredArrayHeaderHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostRequiredArrayHeaderHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostRequiredArrayHeaderHandleError handles the PostRequiredArrayHeader error response.
 func (client *ExplicitClient) PostRequiredArrayHeaderHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -661,11 +589,10 @@ func (client *ExplicitClient) PostRequiredArrayParameter(ctx context.Context, bo
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostRequiredArrayParameterHandleResponse(resp)
-	if err != nil {
+	if err := client.PostRequiredArrayParameterHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostRequiredArrayParameterCreateRequest creates the PostRequiredArrayParameter request.
@@ -679,16 +606,11 @@ func (client *ExplicitClient) PostRequiredArrayParameterCreateRequest(ctx contex
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
-// PostRequiredArrayParameterHandleResponse handles the PostRequiredArrayParameter response.
-func (client *ExplicitClient) PostRequiredArrayParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostRequiredArrayParameterHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostRequiredArrayParameterHandleError handles the PostRequiredArrayParameter error response.
 func (client *ExplicitClient) PostRequiredArrayParameterHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -706,11 +628,10 @@ func (client *ExplicitClient) PostRequiredArrayProperty(ctx context.Context, bod
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostRequiredArrayPropertyHandleResponse(resp)
-	if err != nil {
+	if err := client.PostRequiredArrayPropertyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostRequiredArrayPropertyCreateRequest creates the PostRequiredArrayProperty request.
@@ -724,16 +645,11 @@ func (client *ExplicitClient) PostRequiredArrayPropertyCreateRequest(ctx context
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
-// PostRequiredArrayPropertyHandleResponse handles the PostRequiredArrayProperty response.
-func (client *ExplicitClient) PostRequiredArrayPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostRequiredArrayPropertyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostRequiredArrayPropertyHandleError handles the PostRequiredArrayProperty error response.
 func (client *ExplicitClient) PostRequiredArrayPropertyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -751,11 +667,10 @@ func (client *ExplicitClient) PostRequiredClassParameter(ctx context.Context, bo
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostRequiredClassParameterHandleResponse(resp)
-	if err != nil {
+	if err := client.PostRequiredClassParameterHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostRequiredClassParameterCreateRequest creates the PostRequiredClassParameter request.
@@ -769,16 +684,11 @@ func (client *ExplicitClient) PostRequiredClassParameterCreateRequest(ctx contex
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
-// PostRequiredClassParameterHandleResponse handles the PostRequiredClassParameter response.
-func (client *ExplicitClient) PostRequiredClassParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostRequiredClassParameterHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostRequiredClassParameterHandleError handles the PostRequiredClassParameter error response.
 func (client *ExplicitClient) PostRequiredClassParameterHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -796,11 +706,10 @@ func (client *ExplicitClient) PostRequiredClassProperty(ctx context.Context, bod
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostRequiredClassPropertyHandleResponse(resp)
-	if err != nil {
+	if err := client.PostRequiredClassPropertyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostRequiredClassPropertyCreateRequest creates the PostRequiredClassProperty request.
@@ -814,16 +723,11 @@ func (client *ExplicitClient) PostRequiredClassPropertyCreateRequest(ctx context
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
-// PostRequiredClassPropertyHandleResponse handles the PostRequiredClassProperty response.
-func (client *ExplicitClient) PostRequiredClassPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostRequiredClassPropertyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostRequiredClassPropertyHandleError handles the PostRequiredClassProperty error response.
 func (client *ExplicitClient) PostRequiredClassPropertyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -841,11 +745,10 @@ func (client *ExplicitClient) PostRequiredIntegerHeader(ctx context.Context, hea
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostRequiredIntegerHeaderHandleResponse(resp)
-	if err != nil {
+	if err := client.PostRequiredIntegerHeaderHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostRequiredIntegerHeaderCreateRequest creates the PostRequiredIntegerHeader request.
@@ -860,16 +763,11 @@ func (client *ExplicitClient) PostRequiredIntegerHeaderCreateRequest(ctx context
 	return req, nil
 }
 
-// PostRequiredIntegerHeaderHandleResponse handles the PostRequiredIntegerHeader response.
-func (client *ExplicitClient) PostRequiredIntegerHeaderHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostRequiredIntegerHeaderHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostRequiredIntegerHeaderHandleError handles the PostRequiredIntegerHeader error response.
 func (client *ExplicitClient) PostRequiredIntegerHeaderHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -887,11 +785,10 @@ func (client *ExplicitClient) PostRequiredIntegerParameter(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostRequiredIntegerParameterHandleResponse(resp)
-	if err != nil {
+	if err := client.PostRequiredIntegerParameterHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostRequiredIntegerParameterCreateRequest creates the PostRequiredIntegerParameter request.
@@ -905,16 +802,11 @@ func (client *ExplicitClient) PostRequiredIntegerParameterCreateRequest(ctx cont
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
-// PostRequiredIntegerParameterHandleResponse handles the PostRequiredIntegerParameter response.
-func (client *ExplicitClient) PostRequiredIntegerParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostRequiredIntegerParameterHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostRequiredIntegerParameterHandleError handles the PostRequiredIntegerParameter error response.
 func (client *ExplicitClient) PostRequiredIntegerParameterHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -932,11 +824,10 @@ func (client *ExplicitClient) PostRequiredIntegerProperty(ctx context.Context, b
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostRequiredIntegerPropertyHandleResponse(resp)
-	if err != nil {
+	if err := client.PostRequiredIntegerPropertyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostRequiredIntegerPropertyCreateRequest creates the PostRequiredIntegerProperty request.
@@ -950,16 +841,11 @@ func (client *ExplicitClient) PostRequiredIntegerPropertyCreateRequest(ctx conte
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
-// PostRequiredIntegerPropertyHandleResponse handles the PostRequiredIntegerProperty response.
-func (client *ExplicitClient) PostRequiredIntegerPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostRequiredIntegerPropertyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostRequiredIntegerPropertyHandleError handles the PostRequiredIntegerProperty error response.
 func (client *ExplicitClient) PostRequiredIntegerPropertyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -977,11 +863,10 @@ func (client *ExplicitClient) PostRequiredStringHeader(ctx context.Context, head
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostRequiredStringHeaderHandleResponse(resp)
-	if err != nil {
+	if err := client.PostRequiredStringHeaderHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostRequiredStringHeaderCreateRequest creates the PostRequiredStringHeader request.
@@ -996,16 +881,11 @@ func (client *ExplicitClient) PostRequiredStringHeaderCreateRequest(ctx context.
 	return req, nil
 }
 
-// PostRequiredStringHeaderHandleResponse handles the PostRequiredStringHeader response.
-func (client *ExplicitClient) PostRequiredStringHeaderHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostRequiredStringHeaderHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostRequiredStringHeaderHandleError handles the PostRequiredStringHeader error response.
 func (client *ExplicitClient) PostRequiredStringHeaderHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1023,11 +903,10 @@ func (client *ExplicitClient) PostRequiredStringParameter(ctx context.Context, b
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostRequiredStringParameterHandleResponse(resp)
-	if err != nil {
+	if err := client.PostRequiredStringParameterHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostRequiredStringParameterCreateRequest creates the PostRequiredStringParameter request.
@@ -1041,16 +920,11 @@ func (client *ExplicitClient) PostRequiredStringParameterCreateRequest(ctx conte
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
-// PostRequiredStringParameterHandleResponse handles the PostRequiredStringParameter response.
-func (client *ExplicitClient) PostRequiredStringParameterHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostRequiredStringParameterHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostRequiredStringParameterHandleError handles the PostRequiredStringParameter error response.
 func (client *ExplicitClient) PostRequiredStringParameterHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1068,11 +942,10 @@ func (client *ExplicitClient) PostRequiredStringProperty(ctx context.Context, bo
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostRequiredStringPropertyHandleResponse(resp)
-	if err != nil {
+	if err := client.PostRequiredStringPropertyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostRequiredStringPropertyCreateRequest creates the PostRequiredStringProperty request.
@@ -1086,16 +959,11 @@ func (client *ExplicitClient) PostRequiredStringPropertyCreateRequest(ctx contex
 	return req, req.MarshalAsJSON(bodyParameter)
 }
 
-// PostRequiredStringPropertyHandleResponse handles the PostRequiredStringProperty response.
-func (client *ExplicitClient) PostRequiredStringPropertyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostRequiredStringPropertyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostRequiredStringPropertyHandleError handles the PostRequiredStringProperty error response.
 func (client *ExplicitClient) PostRequiredStringPropertyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/optionalgroup/zz_generated_implicit.go
+++ b/test/autorest/optionalgroup/zz_generated_implicit.go
@@ -61,8 +61,8 @@ func (client *ImplicitClient) GetOptionalGlobalQuery(ctx context.Context) (*http
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetOptionalGlobalQueryHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetOptionalGlobalQueryHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -85,9 +85,6 @@ func (client *ImplicitClient) GetOptionalGlobalQueryCreateRequest(ctx context.Co
 
 // GetOptionalGlobalQueryHandleError handles the GetOptionalGlobalQuery error response.
 func (client *ImplicitClient) GetOptionalGlobalQueryHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -105,8 +102,8 @@ func (client *ImplicitClient) GetRequiredGlobalPath(ctx context.Context) (*http.
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetRequiredGlobalPathHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetRequiredGlobalPathHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -125,9 +122,6 @@ func (client *ImplicitClient) GetRequiredGlobalPathCreateRequest(ctx context.Con
 
 // GetRequiredGlobalPathHandleError handles the GetRequiredGlobalPath error response.
 func (client *ImplicitClient) GetRequiredGlobalPathHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -145,8 +139,8 @@ func (client *ImplicitClient) GetRequiredGlobalQuery(ctx context.Context) (*http
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetRequiredGlobalQueryHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetRequiredGlobalQueryHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -167,9 +161,6 @@ func (client *ImplicitClient) GetRequiredGlobalQueryCreateRequest(ctx context.Co
 
 // GetRequiredGlobalQueryHandleError handles the GetRequiredGlobalQuery error response.
 func (client *ImplicitClient) GetRequiredGlobalQueryHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -187,8 +178,8 @@ func (client *ImplicitClient) GetRequiredPath(ctx context.Context, pathParameter
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetRequiredPathHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetRequiredPathHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -207,9 +198,6 @@ func (client *ImplicitClient) GetRequiredPathCreateRequest(ctx context.Context, 
 
 // GetRequiredPathHandleError handles the GetRequiredPath error response.
 func (client *ImplicitClient) GetRequiredPathHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -227,8 +215,8 @@ func (client *ImplicitClient) PutOptionalBody(ctx context.Context, implicitPutOp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutOptionalBodyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutOptionalBodyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -249,9 +237,6 @@ func (client *ImplicitClient) PutOptionalBodyCreateRequest(ctx context.Context, 
 
 // PutOptionalBodyHandleError handles the PutOptionalBody error response.
 func (client *ImplicitClient) PutOptionalBodyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -269,8 +254,8 @@ func (client *ImplicitClient) PutOptionalHeader(ctx context.Context, implicitPut
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutOptionalHeaderHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutOptionalHeaderHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -291,9 +276,6 @@ func (client *ImplicitClient) PutOptionalHeaderCreateRequest(ctx context.Context
 
 // PutOptionalHeaderHandleError handles the PutOptionalHeader error response.
 func (client *ImplicitClient) PutOptionalHeaderHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -311,8 +293,8 @@ func (client *ImplicitClient) PutOptionalQuery(ctx context.Context, implicitPutO
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutOptionalQueryHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutOptionalQueryHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -335,9 +317,6 @@ func (client *ImplicitClient) PutOptionalQueryCreateRequest(ctx context.Context,
 
 // PutOptionalQueryHandleError handles the PutOptionalQuery error response.
 func (client *ImplicitClient) PutOptionalQueryHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/optionalgroup/zz_generated_implicit.go
+++ b/test/autorest/optionalgroup/zz_generated_implicit.go
@@ -61,11 +61,10 @@ func (client *ImplicitClient) GetOptionalGlobalQuery(ctx context.Context) (*http
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetOptionalGlobalQueryHandleResponse(resp)
-	if err != nil {
+	if err := client.GetOptionalGlobalQueryHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetOptionalGlobalQueryCreateRequest creates the GetOptionalGlobalQuery request.
@@ -84,16 +83,11 @@ func (client *ImplicitClient) GetOptionalGlobalQueryCreateRequest(ctx context.Co
 	return req, nil
 }
 
-// GetOptionalGlobalQueryHandleResponse handles the GetOptionalGlobalQuery response.
-func (client *ImplicitClient) GetOptionalGlobalQueryHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetOptionalGlobalQueryHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetOptionalGlobalQueryHandleError handles the GetOptionalGlobalQuery error response.
 func (client *ImplicitClient) GetOptionalGlobalQueryHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -111,11 +105,10 @@ func (client *ImplicitClient) GetRequiredGlobalPath(ctx context.Context) (*http.
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetRequiredGlobalPathHandleResponse(resp)
-	if err != nil {
+	if err := client.GetRequiredGlobalPathHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetRequiredGlobalPathCreateRequest creates the GetRequiredGlobalPath request.
@@ -130,16 +123,11 @@ func (client *ImplicitClient) GetRequiredGlobalPathCreateRequest(ctx context.Con
 	return req, nil
 }
 
-// GetRequiredGlobalPathHandleResponse handles the GetRequiredGlobalPath response.
-func (client *ImplicitClient) GetRequiredGlobalPathHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetRequiredGlobalPathHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetRequiredGlobalPathHandleError handles the GetRequiredGlobalPath error response.
 func (client *ImplicitClient) GetRequiredGlobalPathHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -157,11 +145,10 @@ func (client *ImplicitClient) GetRequiredGlobalQuery(ctx context.Context) (*http
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetRequiredGlobalQueryHandleResponse(resp)
-	if err != nil {
+	if err := client.GetRequiredGlobalQueryHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetRequiredGlobalQueryCreateRequest creates the GetRequiredGlobalQuery request.
@@ -178,16 +165,11 @@ func (client *ImplicitClient) GetRequiredGlobalQueryCreateRequest(ctx context.Co
 	return req, nil
 }
 
-// GetRequiredGlobalQueryHandleResponse handles the GetRequiredGlobalQuery response.
-func (client *ImplicitClient) GetRequiredGlobalQueryHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetRequiredGlobalQueryHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetRequiredGlobalQueryHandleError handles the GetRequiredGlobalQuery error response.
 func (client *ImplicitClient) GetRequiredGlobalQueryHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -205,11 +187,10 @@ func (client *ImplicitClient) GetRequiredPath(ctx context.Context, pathParameter
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetRequiredPathHandleResponse(resp)
-	if err != nil {
+	if err := client.GetRequiredPathHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetRequiredPathCreateRequest creates the GetRequiredPath request.
@@ -224,16 +205,11 @@ func (client *ImplicitClient) GetRequiredPathCreateRequest(ctx context.Context, 
 	return req, nil
 }
 
-// GetRequiredPathHandleResponse handles the GetRequiredPath response.
-func (client *ImplicitClient) GetRequiredPathHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetRequiredPathHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetRequiredPathHandleError handles the GetRequiredPath error response.
 func (client *ImplicitClient) GetRequiredPathHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -251,11 +227,10 @@ func (client *ImplicitClient) PutOptionalBody(ctx context.Context, implicitPutOp
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutOptionalBodyHandleResponse(resp)
-	if err != nil {
+	if err := client.PutOptionalBodyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutOptionalBodyCreateRequest creates the PutOptionalBody request.
@@ -272,16 +247,11 @@ func (client *ImplicitClient) PutOptionalBodyCreateRequest(ctx context.Context, 
 	return req, nil
 }
 
-// PutOptionalBodyHandleResponse handles the PutOptionalBody response.
-func (client *ImplicitClient) PutOptionalBodyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutOptionalBodyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutOptionalBodyHandleError handles the PutOptionalBody error response.
 func (client *ImplicitClient) PutOptionalBodyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -299,11 +269,10 @@ func (client *ImplicitClient) PutOptionalHeader(ctx context.Context, implicitPut
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutOptionalHeaderHandleResponse(resp)
-	if err != nil {
+	if err := client.PutOptionalHeaderHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutOptionalHeaderCreateRequest creates the PutOptionalHeader request.
@@ -320,16 +289,11 @@ func (client *ImplicitClient) PutOptionalHeaderCreateRequest(ctx context.Context
 	return req, nil
 }
 
-// PutOptionalHeaderHandleResponse handles the PutOptionalHeader response.
-func (client *ImplicitClient) PutOptionalHeaderHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutOptionalHeaderHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutOptionalHeaderHandleError handles the PutOptionalHeader error response.
 func (client *ImplicitClient) PutOptionalHeaderHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -347,11 +311,10 @@ func (client *ImplicitClient) PutOptionalQuery(ctx context.Context, implicitPutO
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutOptionalQueryHandleResponse(resp)
-	if err != nil {
+	if err := client.PutOptionalQueryHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutOptionalQueryCreateRequest creates the PutOptionalQuery request.
@@ -370,16 +333,11 @@ func (client *ImplicitClient) PutOptionalQueryCreateRequest(ctx context.Context,
 	return req, nil
 }
 
-// PutOptionalQueryHandleResponse handles the PutOptionalQuery response.
-func (client *ImplicitClient) PutOptionalQueryHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutOptionalQueryHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutOptionalQueryHandleError handles the PutOptionalQuery error response.
 func (client *ImplicitClient) PutOptionalQueryHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/paginggroup/zz_generated_pagers.go
+++ b/test/autorest/paginggroup/zz_generated_pagers.go
@@ -25,6 +25,8 @@ type OdataProductResultPager interface {
 
 type odataProductResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type odataProductResultHandleError func(*azcore.Response) error
+
 type odataProductResultHandleResponse func(*azcore.Response) (*OdataProductResultResponse, error)
 
 type odataProductResultAdvancePage func(context.Context, *OdataProductResultResponse) (*azcore.Request, error)
@@ -34,6 +36,8 @@ type odataProductResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester odataProductResultCreateRequest
+	// callback for handling response errors
+	errorer odataProductResultHandleError
 	// callback for handling the HTTP response
 	responder odataProductResultHandleResponse
 	// callback for advancing to the next page
@@ -64,6 +68,13 @@ func (p *odataProductResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -92,6 +103,8 @@ type ProductResultPager interface {
 
 type productResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type productResultHandleError func(*azcore.Response) error
+
 type productResultHandleResponse func(*azcore.Response) (*ProductResultResponse, error)
 
 type productResultAdvancePage func(context.Context, *ProductResultResponse) (*azcore.Request, error)
@@ -101,6 +114,8 @@ type productResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester productResultCreateRequest
+	// callback for handling response errors
+	errorer productResultHandleError
 	// callback for handling the HTTP response
 	responder productResultHandleResponse
 	// callback for advancing to the next page
@@ -138,6 +153,13 @@ func (p *productResultPager) NextPage(ctx context.Context) bool {
 	} else {
 		p.resp = nil
 	}
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -166,6 +188,8 @@ type ProductResultValuePager interface {
 
 type productResultValueCreateRequest func(context.Context) (*azcore.Request, error)
 
+type productResultValueHandleError func(*azcore.Response) error
+
 type productResultValueHandleResponse func(*azcore.Response) (*ProductResultValueResponse, error)
 
 type productResultValueAdvancePage func(context.Context, *ProductResultValueResponse) (*azcore.Request, error)
@@ -175,6 +199,8 @@ type productResultValuePager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester productResultValueCreateRequest
+	// callback for handling response errors
+	errorer productResultValueHandleError
 	// callback for handling the HTTP response
 	responder productResultValueHandleResponse
 	// callback for advancing to the next page
@@ -205,6 +231,13 @@ func (p *productResultValuePager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -233,6 +266,8 @@ type ProductResultValueWithXmsClientNamePager interface {
 
 type productResultValueWithXmsClientNameCreateRequest func(context.Context) (*azcore.Request, error)
 
+type productResultValueWithXmsClientNameHandleError func(*azcore.Response) error
+
 type productResultValueWithXmsClientNameHandleResponse func(*azcore.Response) (*ProductResultValueWithXmsClientNameResponse, error)
 
 type productResultValueWithXmsClientNameAdvancePage func(context.Context, *ProductResultValueWithXmsClientNameResponse) (*azcore.Request, error)
@@ -242,6 +277,8 @@ type productResultValueWithXmsClientNamePager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester productResultValueWithXmsClientNameCreateRequest
+	// callback for handling response errors
+	errorer productResultValueWithXmsClientNameHandleError
 	// callback for handling the HTTP response
 	responder productResultValueWithXmsClientNameHandleResponse
 	// callback for advancing to the next page
@@ -272,6 +309,13 @@ func (p *productResultValueWithXmsClientNamePager) NextPage(ctx context.Context)
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err

--- a/test/autorest/paginggroup/zz_generated_pagers.go
+++ b/test/autorest/paginggroup/zz_generated_pagers.go
@@ -8,6 +8,7 @@ package paginggroup
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"net/http"
 )
 
 // OdataProductResultPager provides iteration over OdataProductResult pages.
@@ -72,7 +73,8 @@ func (p *odataProductResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -157,7 +159,8 @@ func (p *productResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -235,7 +238,8 @@ func (p *productResultValuePager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -313,7 +317,8 @@ func (p *productResultValueWithXmsClientNamePager) NextPage(ctx context.Context)
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)

--- a/test/autorest/paginggroup/zz_generated_paging.go
+++ b/test/autorest/paginggroup/zz_generated_paging.go
@@ -116,9 +116,6 @@ func (client *PagingClient) GetMultiplePagesHandleResponse(resp *azcore.Response
 
 // GetMultiplePagesHandleError handles the GetMultiplePages error response.
 func (client *PagingClient) GetMultiplePagesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -163,9 +160,6 @@ func (client *PagingClient) GetMultiplePagesFailureHandleResponse(resp *azcore.R
 
 // GetMultiplePagesFailureHandleError handles the GetMultiplePagesFailure error response.
 func (client *PagingClient) GetMultiplePagesFailureHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -210,9 +204,6 @@ func (client *PagingClient) GetMultiplePagesFailureURIHandleResponse(resp *azcor
 
 // GetMultiplePagesFailureURIHandleError handles the GetMultiplePagesFailureURI error response.
 func (client *PagingClient) GetMultiplePagesFailureURIHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -261,9 +252,6 @@ func (client *PagingClient) GetMultiplePagesFragmentNextLinkHandleResponse(resp 
 
 // GetMultiplePagesFragmentNextLinkHandleError handles the GetMultiplePagesFragmentNextLink error response.
 func (client *PagingClient) GetMultiplePagesFragmentNextLinkHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -312,9 +300,6 @@ func (client *PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkHandleRe
 
 // GetMultiplePagesFragmentWithGroupingNextLinkHandleError handles the GetMultiplePagesFragmentWithGroupingNextLink error response.
 func (client *PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -336,8 +321,8 @@ func (client *PagingClient) BeginGetMultiplePagesLro(ctx context.Context, paging
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetMultiplePagesLroHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.GetMultiplePagesLroHandleError(resp)
 	}
 	result, err := client.GetMultiplePagesLroHandleResponse(resp)
 	if err != nil {
@@ -406,9 +391,6 @@ func (client *PagingClient) GetMultiplePagesLroHandleResponse(resp *azcore.Respo
 
 // GetMultiplePagesLroHandleError handles the GetMultiplePagesLro error response.
 func (client *PagingClient) GetMultiplePagesLroHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -453,9 +435,6 @@ func (client *PagingClient) GetMultiplePagesRetryFirstHandleResponse(resp *azcor
 
 // GetMultiplePagesRetryFirstHandleError handles the GetMultiplePagesRetryFirst error response.
 func (client *PagingClient) GetMultiplePagesRetryFirstHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -500,9 +479,6 @@ func (client *PagingClient) GetMultiplePagesRetrySecondHandleResponse(resp *azco
 
 // GetMultiplePagesRetrySecondHandleError handles the GetMultiplePagesRetrySecond error response.
 func (client *PagingClient) GetMultiplePagesRetrySecondHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -557,9 +533,6 @@ func (client *PagingClient) GetMultiplePagesWithOffsetHandleResponse(resp *azcor
 
 // GetMultiplePagesWithOffsetHandleError handles the GetMultiplePagesWithOffset error response.
 func (client *PagingClient) GetMultiplePagesWithOffsetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -604,9 +577,6 @@ func (client *PagingClient) GetNoItemNamePagesHandleResponse(resp *azcore.Respon
 
 // GetNoItemNamePagesHandleError handles the GetNoItemNamePages error response.
 func (client *PagingClient) GetNoItemNamePagesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -627,8 +597,8 @@ func (client *PagingClient) GetNullNextLinkNamePages(ctx context.Context) (*Prod
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullNextLinkNamePagesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullNextLinkNamePagesHandleError(resp)
 	}
 	result, err := client.GetNullNextLinkNamePagesHandleResponse(resp)
 	if err != nil {
@@ -656,9 +626,6 @@ func (client *PagingClient) GetNullNextLinkNamePagesHandleResponse(resp *azcore.
 
 // GetNullNextLinkNamePagesHandleError handles the GetNullNextLinkNamePages error response.
 func (client *PagingClient) GetNullNextLinkNamePagesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -712,9 +679,6 @@ func (client *PagingClient) GetOdataMultiplePagesHandleResponse(resp *azcore.Res
 
 // GetOdataMultiplePagesHandleError handles the GetOdataMultiplePages error response.
 func (client *PagingClient) GetOdataMultiplePagesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -759,9 +723,6 @@ func (client *PagingClient) GetPagingModelWithItemNameWithXmsClientNameHandleRes
 
 // GetPagingModelWithItemNameWithXmsClientNameHandleError handles the GetPagingModelWithItemNameWithXmsClientName error response.
 func (client *PagingClient) GetPagingModelWithItemNameWithXmsClientNameHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -806,9 +767,6 @@ func (client *PagingClient) GetSinglePagesHandleResponse(resp *azcore.Response) 
 
 // GetSinglePagesHandleError handles the GetSinglePages error response.
 func (client *PagingClient) GetSinglePagesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -853,9 +811,6 @@ func (client *PagingClient) GetSinglePagesFailureHandleResponse(resp *azcore.Res
 
 // GetSinglePagesFailureHandleError handles the GetSinglePagesFailure error response.
 func (client *PagingClient) GetSinglePagesFailureHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -904,9 +859,6 @@ func (client *PagingClient) GetWithQueryParamsHandleResponse(resp *azcore.Respon
 
 // GetWithQueryParamsHandleError handles the GetWithQueryParams error response.
 func (client *PagingClient) GetWithQueryParamsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -941,9 +893,6 @@ func (client *PagingClient) NextFragmentHandleResponse(resp *azcore.Response) (*
 
 // NextFragmentHandleError handles the NextFragment error response.
 func (client *PagingClient) NextFragmentHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -978,9 +927,6 @@ func (client *PagingClient) NextFragmentWithGroupingHandleResponse(resp *azcore.
 
 // NextFragmentWithGroupingHandleError handles the NextFragmentWithGrouping error response.
 func (client *PagingClient) NextFragmentWithGroupingHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1013,9 +959,6 @@ func (client *PagingClient) NextOperationWithQueryParamsHandleResponse(resp *azc
 
 // NextOperationWithQueryParamsHandleError handles the NextOperationWithQueryParams error response.
 func (client *PagingClient) NextOperationWithQueryParamsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/paginggroup/zz_generated_paging.go
+++ b/test/autorest/paginggroup/zz_generated_paging.go
@@ -81,6 +81,7 @@ func (client *PagingClient) GetMultiplePages(pagingGetMultiplePagesOptions *Pagi
 			return client.GetMultiplePagesCreateRequest(ctx, pagingGetMultiplePagesOptions)
 		},
 		responder: client.GetMultiplePagesHandleResponse,
+		errorer:   client.GetMultiplePagesHandleError,
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
@@ -109,15 +110,15 @@ func (client *PagingClient) GetMultiplePagesCreateRequest(ctx context.Context, p
 
 // GetMultiplePagesHandleResponse handles the GetMultiplePages response.
 func (client *PagingClient) GetMultiplePagesHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMultiplePagesHandleError(resp)
-	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
 }
 
 // GetMultiplePagesHandleError handles the GetMultiplePages error response.
 func (client *PagingClient) GetMultiplePagesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -136,6 +137,7 @@ func (client *PagingClient) GetMultiplePagesFailure() ProductResultPager {
 			return client.GetMultiplePagesFailureCreateRequest(ctx)
 		},
 		responder: client.GetMultiplePagesFailureHandleResponse,
+		errorer:   client.GetMultiplePagesFailureHandleError,
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
@@ -155,15 +157,15 @@ func (client *PagingClient) GetMultiplePagesFailureCreateRequest(ctx context.Con
 
 // GetMultiplePagesFailureHandleResponse handles the GetMultiplePagesFailure response.
 func (client *PagingClient) GetMultiplePagesFailureHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMultiplePagesFailureHandleError(resp)
-	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
 }
 
 // GetMultiplePagesFailureHandleError handles the GetMultiplePagesFailure error response.
 func (client *PagingClient) GetMultiplePagesFailureHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -182,6 +184,7 @@ func (client *PagingClient) GetMultiplePagesFailureURI() ProductResultPager {
 			return client.GetMultiplePagesFailureURICreateRequest(ctx)
 		},
 		responder: client.GetMultiplePagesFailureURIHandleResponse,
+		errorer:   client.GetMultiplePagesFailureURIHandleError,
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
@@ -201,15 +204,15 @@ func (client *PagingClient) GetMultiplePagesFailureURICreateRequest(ctx context.
 
 // GetMultiplePagesFailureURIHandleResponse handles the GetMultiplePagesFailureURI response.
 func (client *PagingClient) GetMultiplePagesFailureURIHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMultiplePagesFailureURIHandleError(resp)
-	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
 }
 
 // GetMultiplePagesFailureURIHandleError handles the GetMultiplePagesFailureURI error response.
 func (client *PagingClient) GetMultiplePagesFailureURIHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -228,6 +231,7 @@ func (client *PagingClient) GetMultiplePagesFragmentNextLink(apiVersion string, 
 			return client.GetMultiplePagesFragmentNextLinkCreateRequest(ctx, apiVersion, tenant)
 		},
 		responder: client.GetMultiplePagesFragmentNextLinkHandleResponse,
+		errorer:   client.GetMultiplePagesFragmentNextLinkHandleError,
 		advancer: func(ctx context.Context, resp *OdataProductResultResponse) (*azcore.Request, error) {
 			return client.NextFragmentCreateRequest(ctx, apiVersion, tenant, *resp.OdataProductResult.OdataNextLink)
 		},
@@ -251,15 +255,15 @@ func (client *PagingClient) GetMultiplePagesFragmentNextLinkCreateRequest(ctx co
 
 // GetMultiplePagesFragmentNextLinkHandleResponse handles the GetMultiplePagesFragmentNextLink response.
 func (client *PagingClient) GetMultiplePagesFragmentNextLinkHandleResponse(resp *azcore.Response) (*OdataProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMultiplePagesFragmentNextLinkHandleError(resp)
-	}
 	result := OdataProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.OdataProductResult)
 }
 
 // GetMultiplePagesFragmentNextLinkHandleError handles the GetMultiplePagesFragmentNextLink error response.
 func (client *PagingClient) GetMultiplePagesFragmentNextLinkHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -278,6 +282,7 @@ func (client *PagingClient) GetMultiplePagesFragmentWithGroupingNextLink(customP
 			return client.GetMultiplePagesFragmentWithGroupingNextLinkCreateRequest(ctx, customParameterGroup)
 		},
 		responder: client.GetMultiplePagesFragmentWithGroupingNextLinkHandleResponse,
+		errorer:   client.GetMultiplePagesFragmentWithGroupingNextLinkHandleError,
 		advancer: func(ctx context.Context, resp *OdataProductResultResponse) (*azcore.Request, error) {
 			return client.NextFragmentWithGroupingCreateRequest(ctx, *resp.OdataProductResult.OdataNextLink, customParameterGroup)
 		},
@@ -301,15 +306,15 @@ func (client *PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkCreateRe
 
 // GetMultiplePagesFragmentWithGroupingNextLinkHandleResponse handles the GetMultiplePagesFragmentWithGroupingNextLink response.
 func (client *PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkHandleResponse(resp *azcore.Response) (*OdataProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMultiplePagesFragmentWithGroupingNextLinkHandleError(resp)
-	}
 	result := OdataProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.OdataProductResult)
 }
 
 // GetMultiplePagesFragmentWithGroupingNextLinkHandleError handles the GetMultiplePagesFragmentWithGroupingNextLink error response.
 func (client *PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -331,6 +336,9 @@ func (client *PagingClient) BeginGetMultiplePagesLro(ctx context.Context, paging
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetMultiplePagesLroHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetMultiplePagesLroHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -340,9 +348,18 @@ func (client *PagingClient) BeginGetMultiplePagesLro(ctx context.Context, paging
 		return nil, err
 	}
 	poller := &productResultPagerPoller{
-		pt:          pt,
-		respHandler: client.productResultPagerHandleResponse,
-		pipeline:    client.p,
+		pt: pt,
+		errHandler: func(resp *azcore.Response) error {
+			if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+				return nil
+			}
+			return client.GetMultiplePagesLroHandleError(resp)
+		},
+		respHandler: func(resp *azcore.Response) (*ProductResultResponse, error) {
+			result := ProductResultResponse{RawResponse: resp.Response}
+			return &result, resp.UnmarshalAsJSON(&result.ProductResult)
+		},
+		pipeline: client.p,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResultPager, error) {
@@ -384,23 +401,14 @@ func (client *PagingClient) GetMultiplePagesLroCreateRequest(ctx context.Context
 
 // GetMultiplePagesLroHandleResponse handles the GetMultiplePagesLro response.
 func (client *PagingClient) GetMultiplePagesLroHandleResponse(resp *azcore.Response) (*ProductResultPagerPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetMultiplePagesLroHandleError(resp)
-	}
 	return &ProductResultPagerPollerResponse{RawResponse: resp.Response}, nil
-}
-
-// GetMultiplePagesLroHandleResponse handles the GetMultiplePagesLro response.
-func (client *PagingClient) productResultPagerHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusOK) {
-		return nil, client.GetMultiplePagesLroHandleError(resp)
-	}
-	result := ProductResultResponse{RawResponse: resp.Response}
-	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
 }
 
 // GetMultiplePagesLroHandleError handles the GetMultiplePagesLro error response.
 func (client *PagingClient) GetMultiplePagesLroHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -419,6 +427,7 @@ func (client *PagingClient) GetMultiplePagesRetryFirst() ProductResultPager {
 			return client.GetMultiplePagesRetryFirstCreateRequest(ctx)
 		},
 		responder: client.GetMultiplePagesRetryFirstHandleResponse,
+		errorer:   client.GetMultiplePagesRetryFirstHandleError,
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
@@ -438,15 +447,15 @@ func (client *PagingClient) GetMultiplePagesRetryFirstCreateRequest(ctx context.
 
 // GetMultiplePagesRetryFirstHandleResponse handles the GetMultiplePagesRetryFirst response.
 func (client *PagingClient) GetMultiplePagesRetryFirstHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMultiplePagesRetryFirstHandleError(resp)
-	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
 }
 
 // GetMultiplePagesRetryFirstHandleError handles the GetMultiplePagesRetryFirst error response.
 func (client *PagingClient) GetMultiplePagesRetryFirstHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -465,6 +474,7 @@ func (client *PagingClient) GetMultiplePagesRetrySecond() ProductResultPager {
 			return client.GetMultiplePagesRetrySecondCreateRequest(ctx)
 		},
 		responder: client.GetMultiplePagesRetrySecondHandleResponse,
+		errorer:   client.GetMultiplePagesRetrySecondHandleError,
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
@@ -484,15 +494,15 @@ func (client *PagingClient) GetMultiplePagesRetrySecondCreateRequest(ctx context
 
 // GetMultiplePagesRetrySecondHandleResponse handles the GetMultiplePagesRetrySecond response.
 func (client *PagingClient) GetMultiplePagesRetrySecondHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMultiplePagesRetrySecondHandleError(resp)
-	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
 }
 
 // GetMultiplePagesRetrySecondHandleError handles the GetMultiplePagesRetrySecond error response.
 func (client *PagingClient) GetMultiplePagesRetrySecondHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -511,6 +521,7 @@ func (client *PagingClient) GetMultiplePagesWithOffset(pagingGetMultiplePagesWit
 			return client.GetMultiplePagesWithOffsetCreateRequest(ctx, pagingGetMultiplePagesWithOffsetOptions)
 		},
 		responder: client.GetMultiplePagesWithOffsetHandleResponse,
+		errorer:   client.GetMultiplePagesWithOffsetHandleError,
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
@@ -540,15 +551,15 @@ func (client *PagingClient) GetMultiplePagesWithOffsetCreateRequest(ctx context.
 
 // GetMultiplePagesWithOffsetHandleResponse handles the GetMultiplePagesWithOffset response.
 func (client *PagingClient) GetMultiplePagesWithOffsetHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMultiplePagesWithOffsetHandleError(resp)
-	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
 }
 
 // GetMultiplePagesWithOffsetHandleError handles the GetMultiplePagesWithOffset error response.
 func (client *PagingClient) GetMultiplePagesWithOffsetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -567,6 +578,7 @@ func (client *PagingClient) GetNoItemNamePages() ProductResultValuePager {
 			return client.GetNoItemNamePagesCreateRequest(ctx)
 		},
 		responder: client.GetNoItemNamePagesHandleResponse,
+		errorer:   client.GetNoItemNamePagesHandleError,
 		advancer: func(ctx context.Context, resp *ProductResultValueResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResultValue.NextLink)
 		},
@@ -586,15 +598,15 @@ func (client *PagingClient) GetNoItemNamePagesCreateRequest(ctx context.Context)
 
 // GetNoItemNamePagesHandleResponse handles the GetNoItemNamePages response.
 func (client *PagingClient) GetNoItemNamePagesHandleResponse(resp *azcore.Response) (*ProductResultValueResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNoItemNamePagesHandleError(resp)
-	}
 	result := ProductResultValueResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResultValue)
 }
 
 // GetNoItemNamePagesHandleError handles the GetNoItemNamePages error response.
 func (client *PagingClient) GetNoItemNamePagesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -613,6 +625,9 @@ func (client *PagingClient) GetNullNextLinkNamePages(ctx context.Context) (*Prod
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullNextLinkNamePagesHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullNextLinkNamePagesHandleResponse(resp)
@@ -635,15 +650,15 @@ func (client *PagingClient) GetNullNextLinkNamePagesCreateRequest(ctx context.Co
 
 // GetNullNextLinkNamePagesHandleResponse handles the GetNullNextLinkNamePages response.
 func (client *PagingClient) GetNullNextLinkNamePagesHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullNextLinkNamePagesHandleError(resp)
-	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
 }
 
 // GetNullNextLinkNamePagesHandleError handles the GetNullNextLinkNamePages error response.
 func (client *PagingClient) GetNullNextLinkNamePagesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -662,6 +677,7 @@ func (client *PagingClient) GetOdataMultiplePages(pagingGetOdataMultiplePagesOpt
 			return client.GetOdataMultiplePagesCreateRequest(ctx, pagingGetOdataMultiplePagesOptions)
 		},
 		responder: client.GetOdataMultiplePagesHandleResponse,
+		errorer:   client.GetOdataMultiplePagesHandleError,
 		advancer: func(ctx context.Context, resp *OdataProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.OdataProductResult.OdataNextLink)
 		},
@@ -690,15 +706,15 @@ func (client *PagingClient) GetOdataMultiplePagesCreateRequest(ctx context.Conte
 
 // GetOdataMultiplePagesHandleResponse handles the GetOdataMultiplePages response.
 func (client *PagingClient) GetOdataMultiplePagesHandleResponse(resp *azcore.Response) (*OdataProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetOdataMultiplePagesHandleError(resp)
-	}
 	result := OdataProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.OdataProductResult)
 }
 
 // GetOdataMultiplePagesHandleError handles the GetOdataMultiplePages error response.
 func (client *PagingClient) GetOdataMultiplePagesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -717,6 +733,7 @@ func (client *PagingClient) GetPagingModelWithItemNameWithXmsClientName() Produc
 			return client.GetPagingModelWithItemNameWithXmsClientNameCreateRequest(ctx)
 		},
 		responder: client.GetPagingModelWithItemNameWithXmsClientNameHandleResponse,
+		errorer:   client.GetPagingModelWithItemNameWithXmsClientNameHandleError,
 		advancer: func(ctx context.Context, resp *ProductResultValueWithXmsClientNameResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResultValueWithXmsClientName.NextLink)
 		},
@@ -736,15 +753,15 @@ func (client *PagingClient) GetPagingModelWithItemNameWithXmsClientNameCreateReq
 
 // GetPagingModelWithItemNameWithXmsClientNameHandleResponse handles the GetPagingModelWithItemNameWithXmsClientName response.
 func (client *PagingClient) GetPagingModelWithItemNameWithXmsClientNameHandleResponse(resp *azcore.Response) (*ProductResultValueWithXmsClientNameResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetPagingModelWithItemNameWithXmsClientNameHandleError(resp)
-	}
 	result := ProductResultValueWithXmsClientNameResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResultValueWithXmsClientName)
 }
 
 // GetPagingModelWithItemNameWithXmsClientNameHandleError handles the GetPagingModelWithItemNameWithXmsClientName error response.
 func (client *PagingClient) GetPagingModelWithItemNameWithXmsClientNameHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -763,6 +780,7 @@ func (client *PagingClient) GetSinglePages() ProductResultPager {
 			return client.GetSinglePagesCreateRequest(ctx)
 		},
 		responder: client.GetSinglePagesHandleResponse,
+		errorer:   client.GetSinglePagesHandleError,
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
@@ -782,15 +800,15 @@ func (client *PagingClient) GetSinglePagesCreateRequest(ctx context.Context) (*a
 
 // GetSinglePagesHandleResponse handles the GetSinglePages response.
 func (client *PagingClient) GetSinglePagesHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetSinglePagesHandleError(resp)
-	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
 }
 
 // GetSinglePagesHandleError handles the GetSinglePages error response.
 func (client *PagingClient) GetSinglePagesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -809,6 +827,7 @@ func (client *PagingClient) GetSinglePagesFailure() ProductResultPager {
 			return client.GetSinglePagesFailureCreateRequest(ctx)
 		},
 		responder: client.GetSinglePagesFailureHandleResponse,
+		errorer:   client.GetSinglePagesFailureHandleError,
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
@@ -828,15 +847,15 @@ func (client *PagingClient) GetSinglePagesFailureCreateRequest(ctx context.Conte
 
 // GetSinglePagesFailureHandleResponse handles the GetSinglePagesFailure response.
 func (client *PagingClient) GetSinglePagesFailureHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetSinglePagesFailureHandleError(resp)
-	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
 }
 
 // GetSinglePagesFailureHandleError handles the GetSinglePagesFailure error response.
 func (client *PagingClient) GetSinglePagesFailureHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -855,6 +874,7 @@ func (client *PagingClient) GetWithQueryParams(requiredQueryParameter int32) Pro
 			return client.GetWithQueryParamsCreateRequest(ctx, requiredQueryParameter)
 		},
 		responder: client.GetWithQueryParamsHandleResponse,
+		errorer:   client.GetWithQueryParamsHandleError,
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return client.NextOperationWithQueryParamsCreateRequest(ctx)
 		},
@@ -878,15 +898,15 @@ func (client *PagingClient) GetWithQueryParamsCreateRequest(ctx context.Context,
 
 // GetWithQueryParamsHandleResponse handles the GetWithQueryParams response.
 func (client *PagingClient) GetWithQueryParamsHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetWithQueryParamsHandleError(resp)
-	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
 }
 
 // GetWithQueryParamsHandleError handles the GetWithQueryParams error response.
 func (client *PagingClient) GetWithQueryParamsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -915,15 +935,15 @@ func (client *PagingClient) NextFragmentCreateRequest(ctx context.Context, apiVe
 
 // NextFragmentHandleResponse handles the NextFragment response.
 func (client *PagingClient) NextFragmentHandleResponse(resp *azcore.Response) (*OdataProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.NextFragmentHandleError(resp)
-	}
 	result := OdataProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.OdataProductResult)
 }
 
 // NextFragmentHandleError handles the NextFragment error response.
 func (client *PagingClient) NextFragmentHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -952,15 +972,15 @@ func (client *PagingClient) NextFragmentWithGroupingCreateRequest(ctx context.Co
 
 // NextFragmentWithGroupingHandleResponse handles the NextFragmentWithGrouping response.
 func (client *PagingClient) NextFragmentWithGroupingHandleResponse(resp *azcore.Response) (*OdataProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.NextFragmentWithGroupingHandleError(resp)
-	}
 	result := OdataProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.OdataProductResult)
 }
 
 // NextFragmentWithGroupingHandleError handles the NextFragmentWithGrouping error response.
 func (client *PagingClient) NextFragmentWithGroupingHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -987,15 +1007,15 @@ func (client *PagingClient) NextOperationWithQueryParamsCreateRequest(ctx contex
 
 // NextOperationWithQueryParamsHandleResponse handles the NextOperationWithQueryParams response.
 func (client *PagingClient) NextOperationWithQueryParamsHandleResponse(resp *azcore.Response) (*ProductResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.NextOperationWithQueryParamsHandleError(resp)
-	}
 	result := ProductResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ProductResult)
 }
 
 // NextOperationWithQueryParamsHandleError handles the NextOperationWithQueryParams error response.
 func (client *PagingClient) NextOperationWithQueryParamsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)

--- a/test/autorest/paginggroup/zz_generated_pollers.go
+++ b/test/autorest/paginggroup/zz_generated_pollers.go
@@ -45,7 +45,7 @@ func (p *productResultPagerPoller) FinalResponse(ctx context.Context) (ProductRe
 	if err != nil {
 		return nil, err
 	}
-	return p.handleResponse(&azcore.Response{resp})
+	return p.handleResponse(&azcore.Response{Response: resp})
 }
 
 // ResumeToken generates the string token that can be used with the ResumeProductResultPagerPoller method
@@ -60,7 +60,7 @@ func (p *productResultPagerPoller) pollUntilDone(ctx context.Context, frequency 
 	if err != nil {
 		return nil, err
 	}
-	return p.handleResponse(&azcore.Response{resp})
+	return p.handleResponse(&azcore.Response{Response: resp})
 }
 
 func (p *productResultPagerPoller) handleResponse(resp *azcore.Response) (ProductResultPager, error) {

--- a/test/autorest/paginggroup/zz_generated_pollers.go
+++ b/test/autorest/paginggroup/zz_generated_pollers.go
@@ -24,6 +24,7 @@ type ProductResultPagerPoller interface {
 type productResultPagerPoller struct {
 	// the client for making the request
 	pipeline    azcore.Pipeline
+	errHandler  productResultHandleError
 	respHandler productResultHandleResponse
 	pt          armcore.Poller
 }
@@ -66,6 +67,7 @@ func (p *productResultPagerPoller) handleResponse(resp *azcore.Response) (Produc
 	return &productResultPager{
 		pipeline:  p.pipeline,
 		resp:      resp,
+		errorer:   p.errHandler,
 		responder: p.respHandler,
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)

--- a/test/autorest/paramgroupinggroup/zz_generated_parametergrouping.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_parametergrouping.go
@@ -52,8 +52,8 @@ func (client *ParameterGroupingClient) PostMultiParamGroups(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostMultiParamGroupsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostMultiParamGroupsHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -85,9 +85,6 @@ func (client *ParameterGroupingClient) PostMultiParamGroupsCreateRequest(ctx con
 
 // PostMultiParamGroupsHandleError handles the PostMultiParamGroups error response.
 func (client *ParameterGroupingClient) PostMultiParamGroupsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -105,8 +102,8 @@ func (client *ParameterGroupingClient) PostOptional(ctx context.Context, paramet
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostOptionalHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostOptionalHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -132,9 +129,6 @@ func (client *ParameterGroupingClient) PostOptionalCreateRequest(ctx context.Con
 
 // PostOptionalHandleError handles the PostOptional error response.
 func (client *ParameterGroupingClient) PostOptionalHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -152,8 +146,8 @@ func (client *ParameterGroupingClient) PostRequired(ctx context.Context, paramet
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostRequiredHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostRequiredHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -180,9 +174,6 @@ func (client *ParameterGroupingClient) PostRequiredCreateRequest(ctx context.Con
 
 // PostRequiredHandleError handles the PostRequired error response.
 func (client *ParameterGroupingClient) PostRequiredHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -200,8 +191,8 @@ func (client *ParameterGroupingClient) PostSharedParameterGroupObject(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostSharedParameterGroupObjectHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostSharedParameterGroupObjectHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -227,9 +218,6 @@ func (client *ParameterGroupingClient) PostSharedParameterGroupObjectCreateReque
 
 // PostSharedParameterGroupObjectHandleError handles the PostSharedParameterGroupObject error response.
 func (client *ParameterGroupingClient) PostSharedParameterGroupObjectHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/paramgroupinggroup/zz_generated_parametergrouping.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_parametergrouping.go
@@ -52,11 +52,10 @@ func (client *ParameterGroupingClient) PostMultiParamGroups(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostMultiParamGroupsHandleResponse(resp)
-	if err != nil {
+	if err := client.PostMultiParamGroupsHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostMultiParamGroupsCreateRequest creates the PostMultiParamGroups request.
@@ -84,16 +83,11 @@ func (client *ParameterGroupingClient) PostMultiParamGroupsCreateRequest(ctx con
 	return req, nil
 }
 
-// PostMultiParamGroupsHandleResponse handles the PostMultiParamGroups response.
-func (client *ParameterGroupingClient) PostMultiParamGroupsHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostMultiParamGroupsHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostMultiParamGroupsHandleError handles the PostMultiParamGroups error response.
 func (client *ParameterGroupingClient) PostMultiParamGroupsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -111,11 +105,10 @@ func (client *ParameterGroupingClient) PostOptional(ctx context.Context, paramet
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostOptionalHandleResponse(resp)
-	if err != nil {
+	if err := client.PostOptionalHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostOptionalCreateRequest creates the PostOptional request.
@@ -137,16 +130,11 @@ func (client *ParameterGroupingClient) PostOptionalCreateRequest(ctx context.Con
 	return req, nil
 }
 
-// PostOptionalHandleResponse handles the PostOptional response.
-func (client *ParameterGroupingClient) PostOptionalHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostOptionalHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostOptionalHandleError handles the PostOptional error response.
 func (client *ParameterGroupingClient) PostOptionalHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -164,11 +152,10 @@ func (client *ParameterGroupingClient) PostRequired(ctx context.Context, paramet
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostRequiredHandleResponse(resp)
-	if err != nil {
+	if err := client.PostRequiredHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostRequiredCreateRequest creates the PostRequired request.
@@ -191,16 +178,11 @@ func (client *ParameterGroupingClient) PostRequiredCreateRequest(ctx context.Con
 	return req, req.MarshalAsJSON(parameterGroupingPostRequiredParameters.Body)
 }
 
-// PostRequiredHandleResponse handles the PostRequired response.
-func (client *ParameterGroupingClient) PostRequiredHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostRequiredHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostRequiredHandleError handles the PostRequired error response.
 func (client *ParameterGroupingClient) PostRequiredHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,11 +200,10 @@ func (client *ParameterGroupingClient) PostSharedParameterGroupObject(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PostSharedParameterGroupObjectHandleResponse(resp)
-	if err != nil {
+	if err := client.PostSharedParameterGroupObjectHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PostSharedParameterGroupObjectCreateRequest creates the PostSharedParameterGroupObject request.
@@ -244,16 +225,11 @@ func (client *ParameterGroupingClient) PostSharedParameterGroupObjectCreateReque
 	return req, nil
 }
 
-// PostSharedParameterGroupObjectHandleResponse handles the PostSharedParameterGroupObject response.
-func (client *ParameterGroupingClient) PostSharedParameterGroupObjectHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostSharedParameterGroupObjectHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PostSharedParameterGroupObjectHandleError handles the PostSharedParameterGroupObject error response.
 func (client *ParameterGroupingClient) PostSharedParameterGroupObjectHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/reportgroup/zz_generated_autorestreportservice.go
+++ b/test/autorest/reportgroup/zz_generated_autorestreportservice.go
@@ -45,6 +45,9 @@ func (client *AutoRestReportServiceClient) GetOptionalReport(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetOptionalReportHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetOptionalReportHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -70,15 +73,15 @@ func (client *AutoRestReportServiceClient) GetOptionalReportCreateRequest(ctx co
 
 // GetOptionalReportHandleResponse handles the GetOptionalReport response.
 func (client *AutoRestReportServiceClient) GetOptionalReportHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetOptionalReportHandleError(resp)
-	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetOptionalReportHandleError handles the GetOptionalReport error response.
 func (client *AutoRestReportServiceClient) GetOptionalReportHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -94,6 +97,9 @@ func (client *AutoRestReportServiceClient) GetReport(ctx context.Context, autoRe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetReportHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetReportHandleResponse(resp)
@@ -121,15 +127,15 @@ func (client *AutoRestReportServiceClient) GetReportCreateRequest(ctx context.Co
 
 // GetReportHandleResponse handles the GetReport response.
 func (client *AutoRestReportServiceClient) GetReportHandleResponse(resp *azcore.Response) (*MapOfInt32Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetReportHandleError(resp)
-	}
 	result := MapOfInt32Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetReportHandleError handles the GetReport error response.
 func (client *AutoRestReportServiceClient) GetReportHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/reportgroup/zz_generated_autorestreportservice.go
+++ b/test/autorest/reportgroup/zz_generated_autorestreportservice.go
@@ -45,8 +45,8 @@ func (client *AutoRestReportServiceClient) GetOptionalReport(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetOptionalReportHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetOptionalReportHandleError(resp)
 	}
 	result, err := client.GetOptionalReportHandleResponse(resp)
 	if err != nil {
@@ -79,9 +79,6 @@ func (client *AutoRestReportServiceClient) GetOptionalReportHandleResponse(resp 
 
 // GetOptionalReportHandleError handles the GetOptionalReport error response.
 func (client *AutoRestReportServiceClient) GetOptionalReportHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -99,8 +96,8 @@ func (client *AutoRestReportServiceClient) GetReport(ctx context.Context, autoRe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetReportHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetReportHandleError(resp)
 	}
 	result, err := client.GetReportHandleResponse(resp)
 	if err != nil {
@@ -133,9 +130,6 @@ func (client *AutoRestReportServiceClient) GetReportHandleResponse(resp *azcore.
 
 // GetReportHandleError handles the GetReport error response.
 func (client *AutoRestReportServiceClient) GetReportHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/stringgroup/zz_generated_enum.go
+++ b/test/autorest/stringgroup/zz_generated_enum.go
@@ -53,8 +53,8 @@ func (client *EnumClient) GetNotExpandable(ctx context.Context) (*ColorsResponse
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNotExpandableHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNotExpandableHandleError(resp)
 	}
 	result, err := client.GetNotExpandableHandleResponse(resp)
 	if err != nil {
@@ -82,9 +82,6 @@ func (client *EnumClient) GetNotExpandableHandleResponse(resp *azcore.Response) 
 
 // GetNotExpandableHandleError handles the GetNotExpandable error response.
 func (client *EnumClient) GetNotExpandableHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -102,8 +99,8 @@ func (client *EnumClient) GetReferenced(ctx context.Context) (*ColorsResponse, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetReferencedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetReferencedHandleError(resp)
 	}
 	result, err := client.GetReferencedHandleResponse(resp)
 	if err != nil {
@@ -131,9 +128,6 @@ func (client *EnumClient) GetReferencedHandleResponse(resp *azcore.Response) (*C
 
 // GetReferencedHandleError handles the GetReferenced error response.
 func (client *EnumClient) GetReferencedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -151,8 +145,8 @@ func (client *EnumClient) GetReferencedConstant(ctx context.Context) (*RefColorC
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetReferencedConstantHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetReferencedConstantHandleError(resp)
 	}
 	result, err := client.GetReferencedConstantHandleResponse(resp)
 	if err != nil {
@@ -180,9 +174,6 @@ func (client *EnumClient) GetReferencedConstantHandleResponse(resp *azcore.Respo
 
 // GetReferencedConstantHandleError handles the GetReferencedConstant error response.
 func (client *EnumClient) GetReferencedConstantHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -200,8 +191,8 @@ func (client *EnumClient) PutNotExpandable(ctx context.Context, stringBody Color
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutNotExpandableHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutNotExpandableHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -219,9 +210,6 @@ func (client *EnumClient) PutNotExpandableCreateRequest(ctx context.Context, str
 
 // PutNotExpandableHandleError handles the PutNotExpandable error response.
 func (client *EnumClient) PutNotExpandableHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -239,8 +227,8 @@ func (client *EnumClient) PutReferenced(ctx context.Context, enumStringBody Colo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutReferencedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutReferencedHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -258,9 +246,6 @@ func (client *EnumClient) PutReferencedCreateRequest(ctx context.Context, enumSt
 
 // PutReferencedHandleError handles the PutReferenced error response.
 func (client *EnumClient) PutReferencedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -278,8 +263,8 @@ func (client *EnumClient) PutReferencedConstant(ctx context.Context, enumStringB
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutReferencedConstantHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutReferencedConstantHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -297,9 +282,6 @@ func (client *EnumClient) PutReferencedConstantCreateRequest(ctx context.Context
 
 // PutReferencedConstantHandleError handles the PutReferencedConstant error response.
 func (client *EnumClient) PutReferencedConstantHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/stringgroup/zz_generated_enum.go
+++ b/test/autorest/stringgroup/zz_generated_enum.go
@@ -53,6 +53,9 @@ func (client *EnumClient) GetNotExpandable(ctx context.Context) (*ColorsResponse
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetNotExpandableHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetNotExpandableHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -73,15 +76,15 @@ func (client *EnumClient) GetNotExpandableCreateRequest(ctx context.Context) (*a
 
 // GetNotExpandableHandleResponse handles the GetNotExpandable response.
 func (client *EnumClient) GetNotExpandableHandleResponse(resp *azcore.Response) (*ColorsResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNotExpandableHandleError(resp)
-	}
 	result := ColorsResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNotExpandableHandleError handles the GetNotExpandable error response.
 func (client *EnumClient) GetNotExpandableHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -97,6 +100,9 @@ func (client *EnumClient) GetReferenced(ctx context.Context) (*ColorsResponse, e
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetReferencedHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetReferencedHandleResponse(resp)
@@ -119,15 +125,15 @@ func (client *EnumClient) GetReferencedCreateRequest(ctx context.Context) (*azco
 
 // GetReferencedHandleResponse handles the GetReferenced response.
 func (client *EnumClient) GetReferencedHandleResponse(resp *azcore.Response) (*ColorsResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetReferencedHandleError(resp)
-	}
 	result := ColorsResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetReferencedHandleError handles the GetReferenced error response.
 func (client *EnumClient) GetReferencedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -143,6 +149,9 @@ func (client *EnumClient) GetReferencedConstant(ctx context.Context) (*RefColorC
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetReferencedConstantHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetReferencedConstantHandleResponse(resp)
@@ -165,15 +174,15 @@ func (client *EnumClient) GetReferencedConstantCreateRequest(ctx context.Context
 
 // GetReferencedConstantHandleResponse handles the GetReferencedConstant response.
 func (client *EnumClient) GetReferencedConstantHandleResponse(resp *azcore.Response) (*RefColorConstantResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetReferencedConstantHandleError(resp)
-	}
 	result := RefColorConstantResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.RefColorConstant)
 }
 
 // GetReferencedConstantHandleError handles the GetReferencedConstant error response.
 func (client *EnumClient) GetReferencedConstantHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -191,11 +200,10 @@ func (client *EnumClient) PutNotExpandable(ctx context.Context, stringBody Color
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutNotExpandableHandleResponse(resp)
-	if err != nil {
+	if err := client.PutNotExpandableHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutNotExpandableCreateRequest creates the PutNotExpandable request.
@@ -209,16 +217,11 @@ func (client *EnumClient) PutNotExpandableCreateRequest(ctx context.Context, str
 	return req, req.MarshalAsJSON(stringBody)
 }
 
-// PutNotExpandableHandleResponse handles the PutNotExpandable response.
-func (client *EnumClient) PutNotExpandableHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutNotExpandableHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutNotExpandableHandleError handles the PutNotExpandable error response.
 func (client *EnumClient) PutNotExpandableHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -236,11 +239,10 @@ func (client *EnumClient) PutReferenced(ctx context.Context, enumStringBody Colo
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutReferencedHandleResponse(resp)
-	if err != nil {
+	if err := client.PutReferencedHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutReferencedCreateRequest creates the PutReferenced request.
@@ -254,16 +256,11 @@ func (client *EnumClient) PutReferencedCreateRequest(ctx context.Context, enumSt
 	return req, req.MarshalAsJSON(enumStringBody)
 }
 
-// PutReferencedHandleResponse handles the PutReferenced response.
-func (client *EnumClient) PutReferencedHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutReferencedHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutReferencedHandleError handles the PutReferenced error response.
 func (client *EnumClient) PutReferencedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -281,11 +278,10 @@ func (client *EnumClient) PutReferencedConstant(ctx context.Context, enumStringB
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutReferencedConstantHandleResponse(resp)
-	if err != nil {
+	if err := client.PutReferencedConstantHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutReferencedConstantCreateRequest creates the PutReferencedConstant request.
@@ -299,16 +295,11 @@ func (client *EnumClient) PutReferencedConstantCreateRequest(ctx context.Context
 	return req, req.MarshalAsJSON(enumStringBody)
 }
 
-// PutReferencedConstantHandleResponse handles the PutReferencedConstant response.
-func (client *EnumClient) PutReferencedConstantHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutReferencedConstantHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutReferencedConstantHandleError handles the PutReferencedConstant error response.
 func (client *EnumClient) PutReferencedConstantHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/stringgroup/zz_generated_string.go
+++ b/test/autorest/stringgroup/zz_generated_string.go
@@ -67,8 +67,8 @@ func (client *StringClient) GetBase64Encoded(ctx context.Context) (*ByteArrayRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBase64EncodedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBase64EncodedHandleError(resp)
 	}
 	result, err := client.GetBase64EncodedHandleResponse(resp)
 	if err != nil {
@@ -96,9 +96,6 @@ func (client *StringClient) GetBase64EncodedHandleResponse(resp *azcore.Response
 
 // GetBase64EncodedHandleError handles the GetBase64Encoded error response.
 func (client *StringClient) GetBase64EncodedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -116,8 +113,8 @@ func (client *StringClient) GetBase64URLEncoded(ctx context.Context) (*ByteArray
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBase64URLEncodedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBase64URLEncodedHandleError(resp)
 	}
 	result, err := client.GetBase64URLEncodedHandleResponse(resp)
 	if err != nil {
@@ -145,9 +142,6 @@ func (client *StringClient) GetBase64URLEncodedHandleResponse(resp *azcore.Respo
 
 // GetBase64URLEncodedHandleError handles the GetBase64URLEncoded error response.
 func (client *StringClient) GetBase64URLEncodedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -165,8 +159,8 @@ func (client *StringClient) GetEmpty(ctx context.Context) (*StringResponse, erro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyHandleError(resp)
 	}
 	result, err := client.GetEmptyHandleResponse(resp)
 	if err != nil {
@@ -194,9 +188,6 @@ func (client *StringClient) GetEmptyHandleResponse(resp *azcore.Response) (*Stri
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *StringClient) GetEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -214,8 +205,8 @@ func (client *StringClient) GetMBCS(ctx context.Context) (*StringResponse, error
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetMBCSHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetMBCSHandleError(resp)
 	}
 	result, err := client.GetMBCSHandleResponse(resp)
 	if err != nil {
@@ -243,9 +234,6 @@ func (client *StringClient) GetMBCSHandleResponse(resp *azcore.Response) (*Strin
 
 // GetMBCSHandleError handles the GetMBCS error response.
 func (client *StringClient) GetMBCSHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -263,8 +251,8 @@ func (client *StringClient) GetNotProvided(ctx context.Context) (*StringResponse
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNotProvidedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNotProvidedHandleError(resp)
 	}
 	result, err := client.GetNotProvidedHandleResponse(resp)
 	if err != nil {
@@ -292,9 +280,6 @@ func (client *StringClient) GetNotProvidedHandleResponse(resp *azcore.Response) 
 
 // GetNotProvidedHandleError handles the GetNotProvided error response.
 func (client *StringClient) GetNotProvidedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -312,8 +297,8 @@ func (client *StringClient) GetNull(ctx context.Context) (*StringResponse, error
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullHandleError(resp)
 	}
 	result, err := client.GetNullHandleResponse(resp)
 	if err != nil {
@@ -341,9 +326,6 @@ func (client *StringClient) GetNullHandleResponse(resp *azcore.Response) (*Strin
 
 // GetNullHandleError handles the GetNull error response.
 func (client *StringClient) GetNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -361,8 +343,8 @@ func (client *StringClient) GetNullBase64URLEncoded(ctx context.Context) (*ByteA
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNullBase64URLEncodedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNullBase64URLEncodedHandleError(resp)
 	}
 	result, err := client.GetNullBase64URLEncodedHandleResponse(resp)
 	if err != nil {
@@ -390,9 +372,6 @@ func (client *StringClient) GetNullBase64URLEncodedHandleResponse(resp *azcore.R
 
 // GetNullBase64URLEncodedHandleError handles the GetNullBase64URLEncoded error response.
 func (client *StringClient) GetNullBase64URLEncodedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -410,8 +389,8 @@ func (client *StringClient) GetWhitespace(ctx context.Context) (*StringResponse,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetWhitespaceHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetWhitespaceHandleError(resp)
 	}
 	result, err := client.GetWhitespaceHandleResponse(resp)
 	if err != nil {
@@ -439,9 +418,6 @@ func (client *StringClient) GetWhitespaceHandleResponse(resp *azcore.Response) (
 
 // GetWhitespaceHandleError handles the GetWhitespace error response.
 func (client *StringClient) GetWhitespaceHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -459,8 +435,8 @@ func (client *StringClient) PutBase64URLEncoded(ctx context.Context, stringBody 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutBase64URLEncodedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutBase64URLEncodedHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -478,9 +454,6 @@ func (client *StringClient) PutBase64URLEncodedCreateRequest(ctx context.Context
 
 // PutBase64URLEncodedHandleError handles the PutBase64URLEncoded error response.
 func (client *StringClient) PutBase64URLEncodedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -498,8 +471,8 @@ func (client *StringClient) PutEmpty(ctx context.Context) (*http.Response, error
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutEmptyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -517,9 +490,6 @@ func (client *StringClient) PutEmptyCreateRequest(ctx context.Context) (*azcore.
 
 // PutEmptyHandleError handles the PutEmpty error response.
 func (client *StringClient) PutEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -537,8 +507,8 @@ func (client *StringClient) PutMBCS(ctx context.Context) (*http.Response, error)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutMBCSHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutMBCSHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -556,9 +526,6 @@ func (client *StringClient) PutMBCSCreateRequest(ctx context.Context) (*azcore.R
 
 // PutMBCSHandleError handles the PutMBCS error response.
 func (client *StringClient) PutMBCSHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -576,8 +543,8 @@ func (client *StringClient) PutNull(ctx context.Context, stringPutNullOptions *S
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -598,9 +565,6 @@ func (client *StringClient) PutNullCreateRequest(ctx context.Context, stringPutN
 
 // PutNullHandleError handles the PutNull error response.
 func (client *StringClient) PutNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -618,8 +582,8 @@ func (client *StringClient) PutWhitespace(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutWhitespaceHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PutWhitespaceHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -637,9 +601,6 @@ func (client *StringClient) PutWhitespaceCreateRequest(ctx context.Context) (*az
 
 // PutWhitespaceHandleError handles the PutWhitespace error response.
 func (client *StringClient) PutWhitespaceHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/stringgroup/zz_generated_string.go
+++ b/test/autorest/stringgroup/zz_generated_string.go
@@ -67,6 +67,9 @@ func (client *StringClient) GetBase64Encoded(ctx context.Context) (*ByteArrayRes
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetBase64EncodedHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetBase64EncodedHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -87,15 +90,15 @@ func (client *StringClient) GetBase64EncodedCreateRequest(ctx context.Context) (
 
 // GetBase64EncodedHandleResponse handles the GetBase64Encoded response.
 func (client *StringClient) GetBase64EncodedHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBase64EncodedHandleError(resp)
-	}
 	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsByteArray(&result.Value, azcore.Base64StdFormat)
 }
 
 // GetBase64EncodedHandleError handles the GetBase64Encoded error response.
 func (client *StringClient) GetBase64EncodedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -111,6 +114,9 @@ func (client *StringClient) GetBase64URLEncoded(ctx context.Context) (*ByteArray
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBase64URLEncodedHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBase64URLEncodedHandleResponse(resp)
@@ -133,15 +139,15 @@ func (client *StringClient) GetBase64URLEncodedCreateRequest(ctx context.Context
 
 // GetBase64URLEncodedHandleResponse handles the GetBase64URLEncoded response.
 func (client *StringClient) GetBase64URLEncodedHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBase64URLEncodedHandleError(resp)
-	}
 	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsByteArray(&result.Value, azcore.Base64URLFormat)
 }
 
 // GetBase64URLEncodedHandleError handles the GetBase64URLEncoded error response.
 func (client *StringClient) GetBase64URLEncodedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -157,6 +163,9 @@ func (client *StringClient) GetEmpty(ctx context.Context) (*StringResponse, erro
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetEmptyHandleResponse(resp)
@@ -179,15 +188,15 @@ func (client *StringClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.
 
 // GetEmptyHandleResponse handles the GetEmpty response.
 func (client *StringClient) GetEmptyHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetEmptyHandleError handles the GetEmpty error response.
 func (client *StringClient) GetEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -203,6 +212,9 @@ func (client *StringClient) GetMBCS(ctx context.Context) (*StringResponse, error
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetMBCSHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetMBCSHandleResponse(resp)
@@ -225,15 +237,15 @@ func (client *StringClient) GetMBCSCreateRequest(ctx context.Context) (*azcore.R
 
 // GetMBCSHandleResponse handles the GetMBCS response.
 func (client *StringClient) GetMBCSHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetMBCSHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetMBCSHandleError handles the GetMBCS error response.
 func (client *StringClient) GetMBCSHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -249,6 +261,9 @@ func (client *StringClient) GetNotProvided(ctx context.Context) (*StringResponse
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNotProvidedHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNotProvidedHandleResponse(resp)
@@ -271,15 +286,15 @@ func (client *StringClient) GetNotProvidedCreateRequest(ctx context.Context) (*a
 
 // GetNotProvidedHandleResponse handles the GetNotProvided response.
 func (client *StringClient) GetNotProvidedHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNotProvidedHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNotProvidedHandleError handles the GetNotProvided error response.
 func (client *StringClient) GetNotProvidedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -295,6 +310,9 @@ func (client *StringClient) GetNull(ctx context.Context) (*StringResponse, error
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullHandleResponse(resp)
@@ -317,15 +335,15 @@ func (client *StringClient) GetNullCreateRequest(ctx context.Context) (*azcore.R
 
 // GetNullHandleResponse handles the GetNull response.
 func (client *StringClient) GetNullHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetNullHandleError handles the GetNull error response.
 func (client *StringClient) GetNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -341,6 +359,9 @@ func (client *StringClient) GetNullBase64URLEncoded(ctx context.Context) (*ByteA
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNullBase64URLEncodedHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNullBase64URLEncodedHandleResponse(resp)
@@ -363,15 +384,15 @@ func (client *StringClient) GetNullBase64URLEncodedCreateRequest(ctx context.Con
 
 // GetNullBase64URLEncodedHandleResponse handles the GetNullBase64URLEncoded response.
 func (client *StringClient) GetNullBase64URLEncodedHandleResponse(resp *azcore.Response) (*ByteArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNullBase64URLEncodedHandleError(resp)
-	}
 	result := ByteArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsByteArray(&result.Value, azcore.Base64URLFormat)
 }
 
 // GetNullBase64URLEncodedHandleError handles the GetNullBase64URLEncoded error response.
 func (client *StringClient) GetNullBase64URLEncodedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -387,6 +408,9 @@ func (client *StringClient) GetWhitespace(ctx context.Context) (*StringResponse,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetWhitespaceHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetWhitespaceHandleResponse(resp)
@@ -409,15 +433,15 @@ func (client *StringClient) GetWhitespaceCreateRequest(ctx context.Context) (*az
 
 // GetWhitespaceHandleResponse handles the GetWhitespace response.
 func (client *StringClient) GetWhitespaceHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetWhitespaceHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // GetWhitespaceHandleError handles the GetWhitespace error response.
 func (client *StringClient) GetWhitespaceHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -435,11 +459,10 @@ func (client *StringClient) PutBase64URLEncoded(ctx context.Context, stringBody 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutBase64URLEncodedHandleResponse(resp)
-	if err != nil {
+	if err := client.PutBase64URLEncodedHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutBase64URLEncodedCreateRequest creates the PutBase64URLEncoded request.
@@ -453,16 +476,11 @@ func (client *StringClient) PutBase64URLEncodedCreateRequest(ctx context.Context
 	return req, req.MarshalAsByteArray(stringBody, azcore.Base64URLFormat)
 }
 
-// PutBase64URLEncodedHandleResponse handles the PutBase64URLEncoded response.
-func (client *StringClient) PutBase64URLEncodedHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutBase64URLEncodedHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutBase64URLEncodedHandleError handles the PutBase64URLEncoded error response.
 func (client *StringClient) PutBase64URLEncodedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -480,11 +498,10 @@ func (client *StringClient) PutEmpty(ctx context.Context) (*http.Response, error
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutEmptyHandleResponse(resp)
-	if err != nil {
+	if err := client.PutEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutEmptyCreateRequest creates the PutEmpty request.
@@ -498,16 +515,11 @@ func (client *StringClient) PutEmptyCreateRequest(ctx context.Context) (*azcore.
 	return req, req.MarshalAsJSON("")
 }
 
-// PutEmptyHandleResponse handles the PutEmpty response.
-func (client *StringClient) PutEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutEmptyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutEmptyHandleError handles the PutEmpty error response.
 func (client *StringClient) PutEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -525,11 +537,10 @@ func (client *StringClient) PutMBCS(ctx context.Context) (*http.Response, error)
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutMBCSHandleResponse(resp)
-	if err != nil {
+	if err := client.PutMBCSHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutMBCSCreateRequest creates the PutMBCS request.
@@ -543,16 +554,11 @@ func (client *StringClient) PutMBCSCreateRequest(ctx context.Context) (*azcore.R
 	return req, req.MarshalAsJSON("啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€")
 }
 
-// PutMBCSHandleResponse handles the PutMBCS response.
-func (client *StringClient) PutMBCSHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutMBCSHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutMBCSHandleError handles the PutMBCS error response.
 func (client *StringClient) PutMBCSHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -570,11 +576,10 @@ func (client *StringClient) PutNull(ctx context.Context, stringPutNullOptions *S
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutNullHandleResponse(resp)
-	if err != nil {
+	if err := client.PutNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutNullCreateRequest creates the PutNull request.
@@ -591,16 +596,11 @@ func (client *StringClient) PutNullCreateRequest(ctx context.Context, stringPutN
 	return req, nil
 }
 
-// PutNullHandleResponse handles the PutNull response.
-func (client *StringClient) PutNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutNullHandleError handles the PutNull error response.
 func (client *StringClient) PutNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -618,11 +618,10 @@ func (client *StringClient) PutWhitespace(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutWhitespaceHandleResponse(resp)
-	if err != nil {
+	if err := client.PutWhitespaceHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutWhitespaceCreateRequest creates the PutWhitespace request.
@@ -636,16 +635,11 @@ func (client *StringClient) PutWhitespaceCreateRequest(ctx context.Context) (*az
 	return req, req.MarshalAsJSON("    Now is the time for all good men to come to the aid of their country    ")
 }
 
-// PutWhitespaceHandleResponse handles the PutWhitespace response.
-func (client *StringClient) PutWhitespaceHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PutWhitespaceHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutWhitespaceHandleError handles the PutWhitespace error response.
 func (client *StringClient) PutWhitespaceHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/urlgroup/zz_generated_pathitems.go
+++ b/test/autorest/urlgroup/zz_generated_pathitems.go
@@ -53,11 +53,10 @@ func (client *PathItemsClient) GetAllWithValues(ctx context.Context, pathItemStr
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetAllWithValuesHandleResponse(resp)
-	if err != nil {
+	if err := client.GetAllWithValuesHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetAllWithValuesCreateRequest creates the GetAllWithValues request.
@@ -85,16 +84,11 @@ func (client *PathItemsClient) GetAllWithValuesCreateRequest(ctx context.Context
 	return req, nil
 }
 
-// GetAllWithValuesHandleResponse handles the GetAllWithValues response.
-func (client *PathItemsClient) GetAllWithValuesHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetAllWithValuesHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetAllWithValuesHandleError handles the GetAllWithValues error response.
 func (client *PathItemsClient) GetAllWithValuesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -112,11 +106,10 @@ func (client *PathItemsClient) GetGlobalAndLocalQueryNull(ctx context.Context, p
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetGlobalAndLocalQueryNullHandleResponse(resp)
-	if err != nil {
+	if err := client.GetGlobalAndLocalQueryNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetGlobalAndLocalQueryNullCreateRequest creates the GetGlobalAndLocalQueryNull request.
@@ -144,16 +137,11 @@ func (client *PathItemsClient) GetGlobalAndLocalQueryNullCreateRequest(ctx conte
 	return req, nil
 }
 
-// GetGlobalAndLocalQueryNullHandleResponse handles the GetGlobalAndLocalQueryNull response.
-func (client *PathItemsClient) GetGlobalAndLocalQueryNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetGlobalAndLocalQueryNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetGlobalAndLocalQueryNullHandleError handles the GetGlobalAndLocalQueryNull error response.
 func (client *PathItemsClient) GetGlobalAndLocalQueryNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -171,11 +159,10 @@ func (client *PathItemsClient) GetGlobalQueryNull(ctx context.Context, pathItemS
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetGlobalQueryNullHandleResponse(resp)
-	if err != nil {
+	if err := client.GetGlobalQueryNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetGlobalQueryNullCreateRequest creates the GetGlobalQueryNull request.
@@ -203,16 +190,11 @@ func (client *PathItemsClient) GetGlobalQueryNullCreateRequest(ctx context.Conte
 	return req, nil
 }
 
-// GetGlobalQueryNullHandleResponse handles the GetGlobalQueryNull response.
-func (client *PathItemsClient) GetGlobalQueryNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetGlobalQueryNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetGlobalQueryNullHandleError handles the GetGlobalQueryNull error response.
 func (client *PathItemsClient) GetGlobalQueryNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -230,11 +212,10 @@ func (client *PathItemsClient) GetLocalPathItemQueryNull(ctx context.Context, pa
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetLocalPathItemQueryNullHandleResponse(resp)
-	if err != nil {
+	if err := client.GetLocalPathItemQueryNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetLocalPathItemQueryNullCreateRequest creates the GetLocalPathItemQueryNull request.
@@ -262,16 +243,11 @@ func (client *PathItemsClient) GetLocalPathItemQueryNullCreateRequest(ctx contex
 	return req, nil
 }
 
-// GetLocalPathItemQueryNullHandleResponse handles the GetLocalPathItemQueryNull response.
-func (client *PathItemsClient) GetLocalPathItemQueryNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLocalPathItemQueryNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetLocalPathItemQueryNullHandleError handles the GetLocalPathItemQueryNull error response.
 func (client *PathItemsClient) GetLocalPathItemQueryNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/urlgroup/zz_generated_pathitems.go
+++ b/test/autorest/urlgroup/zz_generated_pathitems.go
@@ -53,8 +53,8 @@ func (client *PathItemsClient) GetAllWithValues(ctx context.Context, pathItemStr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetAllWithValuesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetAllWithValuesHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -86,9 +86,6 @@ func (client *PathItemsClient) GetAllWithValuesCreateRequest(ctx context.Context
 
 // GetAllWithValuesHandleError handles the GetAllWithValues error response.
 func (client *PathItemsClient) GetAllWithValuesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -106,8 +103,8 @@ func (client *PathItemsClient) GetGlobalAndLocalQueryNull(ctx context.Context, p
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetGlobalAndLocalQueryNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetGlobalAndLocalQueryNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -139,9 +136,6 @@ func (client *PathItemsClient) GetGlobalAndLocalQueryNullCreateRequest(ctx conte
 
 // GetGlobalAndLocalQueryNullHandleError handles the GetGlobalAndLocalQueryNull error response.
 func (client *PathItemsClient) GetGlobalAndLocalQueryNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -159,8 +153,8 @@ func (client *PathItemsClient) GetGlobalQueryNull(ctx context.Context, pathItemS
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetGlobalQueryNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetGlobalQueryNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -192,9 +186,6 @@ func (client *PathItemsClient) GetGlobalQueryNullCreateRequest(ctx context.Conte
 
 // GetGlobalQueryNullHandleError handles the GetGlobalQueryNull error response.
 func (client *PathItemsClient) GetGlobalQueryNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -212,8 +203,8 @@ func (client *PathItemsClient) GetLocalPathItemQueryNull(ctx context.Context, pa
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLocalPathItemQueryNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLocalPathItemQueryNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -245,9 +236,6 @@ func (client *PathItemsClient) GetLocalPathItemQueryNullCreateRequest(ctx contex
 
 // GetLocalPathItemQueryNullHandleError handles the GetLocalPathItemQueryNull error response.
 func (client *PathItemsClient) GetLocalPathItemQueryNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/urlgroup/zz_generated_paths.go
+++ b/test/autorest/urlgroup/zz_generated_paths.go
@@ -99,8 +99,8 @@ func (client *PathsClient) ArrayCSVInPath(ctx context.Context, arrayPath []strin
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ArrayCSVInPathHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ArrayCSVInPathHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -119,9 +119,6 @@ func (client *PathsClient) ArrayCSVInPathCreateRequest(ctx context.Context, arra
 
 // ArrayCSVInPathHandleError handles the ArrayCSVInPath error response.
 func (client *PathsClient) ArrayCSVInPathHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -139,8 +136,8 @@ func (client *PathsClient) Base64URL(ctx context.Context, base64UrlPath []byte) 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Base64URLHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.Base64URLHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -159,9 +156,6 @@ func (client *PathsClient) Base64URLCreateRequest(ctx context.Context, base64Url
 
 // Base64URLHandleError handles the Base64URL error response.
 func (client *PathsClient) Base64URLHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -179,8 +173,8 @@ func (client *PathsClient) ByteEmpty(ctx context.Context) (*http.Response, error
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ByteEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ByteEmptyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -199,9 +193,6 @@ func (client *PathsClient) ByteEmptyCreateRequest(ctx context.Context) (*azcore.
 
 // ByteEmptyHandleError handles the ByteEmpty error response.
 func (client *PathsClient) ByteEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -219,8 +210,8 @@ func (client *PathsClient) ByteMultiByte(ctx context.Context, bytePath []byte) (
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ByteMultiByteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ByteMultiByteHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -239,9 +230,6 @@ func (client *PathsClient) ByteMultiByteCreateRequest(ctx context.Context, byteP
 
 // ByteMultiByteHandleError handles the ByteMultiByte error response.
 func (client *PathsClient) ByteMultiByteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -259,8 +247,8 @@ func (client *PathsClient) ByteNull(ctx context.Context, bytePath []byte) (*http
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ByteNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusBadRequest) {
+		return nil, client.ByteNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -279,9 +267,6 @@ func (client *PathsClient) ByteNullCreateRequest(ctx context.Context, bytePath [
 
 // ByteNullHandleError handles the ByteNull error response.
 func (client *PathsClient) ByteNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusBadRequest) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -299,8 +284,8 @@ func (client *PathsClient) DateNull(ctx context.Context, datePath time.Time) (*h
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DateNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusBadRequest) {
+		return nil, client.DateNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -319,9 +304,6 @@ func (client *PathsClient) DateNullCreateRequest(ctx context.Context, datePath t
 
 // DateNullHandleError handles the DateNull error response.
 func (client *PathsClient) DateNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusBadRequest) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -339,8 +321,8 @@ func (client *PathsClient) DateTimeNull(ctx context.Context, dateTimePath time.T
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DateTimeNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusBadRequest) {
+		return nil, client.DateTimeNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -359,9 +341,6 @@ func (client *PathsClient) DateTimeNullCreateRequest(ctx context.Context, dateTi
 
 // DateTimeNullHandleError handles the DateTimeNull error response.
 func (client *PathsClient) DateTimeNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusBadRequest) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -379,8 +358,8 @@ func (client *PathsClient) DateTimeValid(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DateTimeValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.DateTimeValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -399,9 +378,6 @@ func (client *PathsClient) DateTimeValidCreateRequest(ctx context.Context) (*azc
 
 // DateTimeValidHandleError handles the DateTimeValid error response.
 func (client *PathsClient) DateTimeValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -419,8 +395,8 @@ func (client *PathsClient) DateValid(ctx context.Context) (*http.Response, error
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DateValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.DateValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -439,9 +415,6 @@ func (client *PathsClient) DateValidCreateRequest(ctx context.Context) (*azcore.
 
 // DateValidHandleError handles the DateValid error response.
 func (client *PathsClient) DateValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -459,8 +432,8 @@ func (client *PathsClient) DoubleDecimalNegative(ctx context.Context) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DoubleDecimalNegativeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.DoubleDecimalNegativeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -479,9 +452,6 @@ func (client *PathsClient) DoubleDecimalNegativeCreateRequest(ctx context.Contex
 
 // DoubleDecimalNegativeHandleError handles the DoubleDecimalNegative error response.
 func (client *PathsClient) DoubleDecimalNegativeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -499,8 +469,8 @@ func (client *PathsClient) DoubleDecimalPositive(ctx context.Context) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DoubleDecimalPositiveHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.DoubleDecimalPositiveHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -519,9 +489,6 @@ func (client *PathsClient) DoubleDecimalPositiveCreateRequest(ctx context.Contex
 
 // DoubleDecimalPositiveHandleError handles the DoubleDecimalPositive error response.
 func (client *PathsClient) DoubleDecimalPositiveHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -539,8 +506,8 @@ func (client *PathsClient) EnumNull(ctx context.Context, enumPath URIColor) (*ht
 	if err != nil {
 		return nil, err
 	}
-	if err := client.EnumNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusBadRequest) {
+		return nil, client.EnumNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -559,9 +526,6 @@ func (client *PathsClient) EnumNullCreateRequest(ctx context.Context, enumPath U
 
 // EnumNullHandleError handles the EnumNull error response.
 func (client *PathsClient) EnumNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusBadRequest) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -579,8 +543,8 @@ func (client *PathsClient) EnumValid(ctx context.Context, enumPath URIColor) (*h
 	if err != nil {
 		return nil, err
 	}
-	if err := client.EnumValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.EnumValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -599,9 +563,6 @@ func (client *PathsClient) EnumValidCreateRequest(ctx context.Context, enumPath 
 
 // EnumValidHandleError handles the EnumValid error response.
 func (client *PathsClient) EnumValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -619,8 +580,8 @@ func (client *PathsClient) FloatScientificNegative(ctx context.Context) (*http.R
 	if err != nil {
 		return nil, err
 	}
-	if err := client.FloatScientificNegativeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.FloatScientificNegativeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -639,9 +600,6 @@ func (client *PathsClient) FloatScientificNegativeCreateRequest(ctx context.Cont
 
 // FloatScientificNegativeHandleError handles the FloatScientificNegative error response.
 func (client *PathsClient) FloatScientificNegativeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -659,8 +617,8 @@ func (client *PathsClient) FloatScientificPositive(ctx context.Context) (*http.R
 	if err != nil {
 		return nil, err
 	}
-	if err := client.FloatScientificPositiveHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.FloatScientificPositiveHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -679,9 +637,6 @@ func (client *PathsClient) FloatScientificPositiveCreateRequest(ctx context.Cont
 
 // FloatScientificPositiveHandleError handles the FloatScientificPositive error response.
 func (client *PathsClient) FloatScientificPositiveHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -699,8 +654,8 @@ func (client *PathsClient) GetBooleanFalse(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBooleanFalseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBooleanFalseHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -719,9 +674,6 @@ func (client *PathsClient) GetBooleanFalseCreateRequest(ctx context.Context) (*a
 
 // GetBooleanFalseHandleError handles the GetBooleanFalse error response.
 func (client *PathsClient) GetBooleanFalseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -739,8 +691,8 @@ func (client *PathsClient) GetBooleanTrue(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBooleanTrueHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBooleanTrueHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -759,9 +711,6 @@ func (client *PathsClient) GetBooleanTrueCreateRequest(ctx context.Context) (*az
 
 // GetBooleanTrueHandleError handles the GetBooleanTrue error response.
 func (client *PathsClient) GetBooleanTrueHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -779,8 +728,8 @@ func (client *PathsClient) GetIntNegativeOneMillion(ctx context.Context) (*http.
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetIntNegativeOneMillionHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetIntNegativeOneMillionHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -799,9 +748,6 @@ func (client *PathsClient) GetIntNegativeOneMillionCreateRequest(ctx context.Con
 
 // GetIntNegativeOneMillionHandleError handles the GetIntNegativeOneMillion error response.
 func (client *PathsClient) GetIntNegativeOneMillionHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -819,8 +765,8 @@ func (client *PathsClient) GetIntOneMillion(ctx context.Context) (*http.Response
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetIntOneMillionHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetIntOneMillionHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -839,9 +785,6 @@ func (client *PathsClient) GetIntOneMillionCreateRequest(ctx context.Context) (*
 
 // GetIntOneMillionHandleError handles the GetIntOneMillion error response.
 func (client *PathsClient) GetIntOneMillionHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -859,8 +802,8 @@ func (client *PathsClient) GetNegativeTenBillion(ctx context.Context) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNegativeTenBillionHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNegativeTenBillionHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -879,9 +822,6 @@ func (client *PathsClient) GetNegativeTenBillionCreateRequest(ctx context.Contex
 
 // GetNegativeTenBillionHandleError handles the GetNegativeTenBillion error response.
 func (client *PathsClient) GetNegativeTenBillionHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -899,8 +839,8 @@ func (client *PathsClient) GetTenBillion(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetTenBillionHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetTenBillionHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -919,9 +859,6 @@ func (client *PathsClient) GetTenBillionCreateRequest(ctx context.Context) (*azc
 
 // GetTenBillionHandleError handles the GetTenBillion error response.
 func (client *PathsClient) GetTenBillionHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -939,8 +876,8 @@ func (client *PathsClient) StringEmpty(ctx context.Context) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StringEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.StringEmptyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -959,9 +896,6 @@ func (client *PathsClient) StringEmptyCreateRequest(ctx context.Context) (*azcor
 
 // StringEmptyHandleError handles the StringEmpty error response.
 func (client *PathsClient) StringEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -979,8 +913,8 @@ func (client *PathsClient) StringNull(ctx context.Context, stringPath string) (*
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StringNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusBadRequest) {
+		return nil, client.StringNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -999,9 +933,6 @@ func (client *PathsClient) StringNullCreateRequest(ctx context.Context, stringPa
 
 // StringNullHandleError handles the StringNull error response.
 func (client *PathsClient) StringNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusBadRequest) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1019,8 +950,8 @@ func (client *PathsClient) StringURLEncoded(ctx context.Context) (*http.Response
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StringURLEncodedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.StringURLEncodedHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1039,9 +970,6 @@ func (client *PathsClient) StringURLEncodedCreateRequest(ctx context.Context) (*
 
 // StringURLEncodedHandleError handles the StringURLEncoded error response.
 func (client *PathsClient) StringURLEncodedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1059,8 +987,8 @@ func (client *PathsClient) StringURLNonEncoded(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StringURLNonEncodedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.StringURLNonEncodedHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1079,9 +1007,6 @@ func (client *PathsClient) StringURLNonEncodedCreateRequest(ctx context.Context)
 
 // StringURLNonEncodedHandleError handles the StringURLNonEncoded error response.
 func (client *PathsClient) StringURLNonEncodedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1099,8 +1024,8 @@ func (client *PathsClient) StringUnicode(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StringUnicodeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.StringUnicodeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1119,9 +1044,6 @@ func (client *PathsClient) StringUnicodeCreateRequest(ctx context.Context) (*azc
 
 // StringUnicodeHandleError handles the StringUnicode error response.
 func (client *PathsClient) StringUnicodeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1139,8 +1061,8 @@ func (client *PathsClient) UnixTimeURL(ctx context.Context, unixTimeUrlPath time
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UnixTimeURLHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UnixTimeURLHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1159,9 +1081,6 @@ func (client *PathsClient) UnixTimeURLCreateRequest(ctx context.Context, unixTim
 
 // UnixTimeURLHandleError handles the UnixTimeURL error response.
 func (client *PathsClient) UnixTimeURLHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/urlgroup/zz_generated_paths.go
+++ b/test/autorest/urlgroup/zz_generated_paths.go
@@ -99,11 +99,10 @@ func (client *PathsClient) ArrayCSVInPath(ctx context.Context, arrayPath []strin
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ArrayCSVInPathHandleResponse(resp)
-	if err != nil {
+	if err := client.ArrayCSVInPathHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ArrayCSVInPathCreateRequest creates the ArrayCSVInPath request.
@@ -118,16 +117,11 @@ func (client *PathsClient) ArrayCSVInPathCreateRequest(ctx context.Context, arra
 	return req, nil
 }
 
-// ArrayCSVInPathHandleResponse handles the ArrayCSVInPath response.
-func (client *PathsClient) ArrayCSVInPathHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ArrayCSVInPathHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ArrayCSVInPathHandleError handles the ArrayCSVInPath error response.
 func (client *PathsClient) ArrayCSVInPathHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -145,11 +139,10 @@ func (client *PathsClient) Base64URL(ctx context.Context, base64UrlPath []byte) 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.Base64URLHandleResponse(resp)
-	if err != nil {
+	if err := client.Base64URLHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // Base64URLCreateRequest creates the Base64URL request.
@@ -164,16 +157,11 @@ func (client *PathsClient) Base64URLCreateRequest(ctx context.Context, base64Url
 	return req, nil
 }
 
-// Base64URLHandleResponse handles the Base64URL response.
-func (client *PathsClient) Base64URLHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.Base64URLHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // Base64URLHandleError handles the Base64URL error response.
 func (client *PathsClient) Base64URLHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -191,11 +179,10 @@ func (client *PathsClient) ByteEmpty(ctx context.Context) (*http.Response, error
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ByteEmptyHandleResponse(resp)
-	if err != nil {
+	if err := client.ByteEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ByteEmptyCreateRequest creates the ByteEmpty request.
@@ -210,16 +197,11 @@ func (client *PathsClient) ByteEmptyCreateRequest(ctx context.Context) (*azcore.
 	return req, nil
 }
 
-// ByteEmptyHandleResponse handles the ByteEmpty response.
-func (client *PathsClient) ByteEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ByteEmptyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ByteEmptyHandleError handles the ByteEmpty error response.
 func (client *PathsClient) ByteEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -237,11 +219,10 @@ func (client *PathsClient) ByteMultiByte(ctx context.Context, bytePath []byte) (
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ByteMultiByteHandleResponse(resp)
-	if err != nil {
+	if err := client.ByteMultiByteHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ByteMultiByteCreateRequest creates the ByteMultiByte request.
@@ -256,16 +237,11 @@ func (client *PathsClient) ByteMultiByteCreateRequest(ctx context.Context, byteP
 	return req, nil
 }
 
-// ByteMultiByteHandleResponse handles the ByteMultiByte response.
-func (client *PathsClient) ByteMultiByteHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ByteMultiByteHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ByteMultiByteHandleError handles the ByteMultiByte error response.
 func (client *PathsClient) ByteMultiByteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -283,11 +259,10 @@ func (client *PathsClient) ByteNull(ctx context.Context, bytePath []byte) (*http
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ByteNullHandleResponse(resp)
-	if err != nil {
+	if err := client.ByteNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ByteNullCreateRequest creates the ByteNull request.
@@ -302,16 +277,11 @@ func (client *PathsClient) ByteNullCreateRequest(ctx context.Context, bytePath [
 	return req, nil
 }
 
-// ByteNullHandleResponse handles the ByteNull response.
-func (client *PathsClient) ByteNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusBadRequest) {
-		return nil, client.ByteNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ByteNullHandleError handles the ByteNull error response.
 func (client *PathsClient) ByteNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusBadRequest) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -329,11 +299,10 @@ func (client *PathsClient) DateNull(ctx context.Context, datePath time.Time) (*h
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.DateNullHandleResponse(resp)
-	if err != nil {
+	if err := client.DateNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // DateNullCreateRequest creates the DateNull request.
@@ -348,16 +317,11 @@ func (client *PathsClient) DateNullCreateRequest(ctx context.Context, datePath t
 	return req, nil
 }
 
-// DateNullHandleResponse handles the DateNull response.
-func (client *PathsClient) DateNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusBadRequest) {
-		return nil, client.DateNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // DateNullHandleError handles the DateNull error response.
 func (client *PathsClient) DateNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusBadRequest) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -375,11 +339,10 @@ func (client *PathsClient) DateTimeNull(ctx context.Context, dateTimePath time.T
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.DateTimeNullHandleResponse(resp)
-	if err != nil {
+	if err := client.DateTimeNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // DateTimeNullCreateRequest creates the DateTimeNull request.
@@ -394,16 +357,11 @@ func (client *PathsClient) DateTimeNullCreateRequest(ctx context.Context, dateTi
 	return req, nil
 }
 
-// DateTimeNullHandleResponse handles the DateTimeNull response.
-func (client *PathsClient) DateTimeNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusBadRequest) {
-		return nil, client.DateTimeNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // DateTimeNullHandleError handles the DateTimeNull error response.
 func (client *PathsClient) DateTimeNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusBadRequest) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -421,11 +379,10 @@ func (client *PathsClient) DateTimeValid(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.DateTimeValidHandleResponse(resp)
-	if err != nil {
+	if err := client.DateTimeValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // DateTimeValidCreateRequest creates the DateTimeValid request.
@@ -440,16 +397,11 @@ func (client *PathsClient) DateTimeValidCreateRequest(ctx context.Context) (*azc
 	return req, nil
 }
 
-// DateTimeValidHandleResponse handles the DateTimeValid response.
-func (client *PathsClient) DateTimeValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.DateTimeValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // DateTimeValidHandleError handles the DateTimeValid error response.
 func (client *PathsClient) DateTimeValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -467,11 +419,10 @@ func (client *PathsClient) DateValid(ctx context.Context) (*http.Response, error
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.DateValidHandleResponse(resp)
-	if err != nil {
+	if err := client.DateValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // DateValidCreateRequest creates the DateValid request.
@@ -486,16 +437,11 @@ func (client *PathsClient) DateValidCreateRequest(ctx context.Context) (*azcore.
 	return req, nil
 }
 
-// DateValidHandleResponse handles the DateValid response.
-func (client *PathsClient) DateValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.DateValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // DateValidHandleError handles the DateValid error response.
 func (client *PathsClient) DateValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -513,11 +459,10 @@ func (client *PathsClient) DoubleDecimalNegative(ctx context.Context) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.DoubleDecimalNegativeHandleResponse(resp)
-	if err != nil {
+	if err := client.DoubleDecimalNegativeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // DoubleDecimalNegativeCreateRequest creates the DoubleDecimalNegative request.
@@ -532,16 +477,11 @@ func (client *PathsClient) DoubleDecimalNegativeCreateRequest(ctx context.Contex
 	return req, nil
 }
 
-// DoubleDecimalNegativeHandleResponse handles the DoubleDecimalNegative response.
-func (client *PathsClient) DoubleDecimalNegativeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.DoubleDecimalNegativeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // DoubleDecimalNegativeHandleError handles the DoubleDecimalNegative error response.
 func (client *PathsClient) DoubleDecimalNegativeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -559,11 +499,10 @@ func (client *PathsClient) DoubleDecimalPositive(ctx context.Context) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.DoubleDecimalPositiveHandleResponse(resp)
-	if err != nil {
+	if err := client.DoubleDecimalPositiveHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // DoubleDecimalPositiveCreateRequest creates the DoubleDecimalPositive request.
@@ -578,16 +517,11 @@ func (client *PathsClient) DoubleDecimalPositiveCreateRequest(ctx context.Contex
 	return req, nil
 }
 
-// DoubleDecimalPositiveHandleResponse handles the DoubleDecimalPositive response.
-func (client *PathsClient) DoubleDecimalPositiveHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.DoubleDecimalPositiveHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // DoubleDecimalPositiveHandleError handles the DoubleDecimalPositive error response.
 func (client *PathsClient) DoubleDecimalPositiveHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -605,11 +539,10 @@ func (client *PathsClient) EnumNull(ctx context.Context, enumPath URIColor) (*ht
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.EnumNullHandleResponse(resp)
-	if err != nil {
+	if err := client.EnumNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // EnumNullCreateRequest creates the EnumNull request.
@@ -624,16 +557,11 @@ func (client *PathsClient) EnumNullCreateRequest(ctx context.Context, enumPath U
 	return req, nil
 }
 
-// EnumNullHandleResponse handles the EnumNull response.
-func (client *PathsClient) EnumNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusBadRequest) {
-		return nil, client.EnumNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // EnumNullHandleError handles the EnumNull error response.
 func (client *PathsClient) EnumNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusBadRequest) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -651,11 +579,10 @@ func (client *PathsClient) EnumValid(ctx context.Context, enumPath URIColor) (*h
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.EnumValidHandleResponse(resp)
-	if err != nil {
+	if err := client.EnumValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // EnumValidCreateRequest creates the EnumValid request.
@@ -670,16 +597,11 @@ func (client *PathsClient) EnumValidCreateRequest(ctx context.Context, enumPath 
 	return req, nil
 }
 
-// EnumValidHandleResponse handles the EnumValid response.
-func (client *PathsClient) EnumValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.EnumValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // EnumValidHandleError handles the EnumValid error response.
 func (client *PathsClient) EnumValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -697,11 +619,10 @@ func (client *PathsClient) FloatScientificNegative(ctx context.Context) (*http.R
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.FloatScientificNegativeHandleResponse(resp)
-	if err != nil {
+	if err := client.FloatScientificNegativeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // FloatScientificNegativeCreateRequest creates the FloatScientificNegative request.
@@ -716,16 +637,11 @@ func (client *PathsClient) FloatScientificNegativeCreateRequest(ctx context.Cont
 	return req, nil
 }
 
-// FloatScientificNegativeHandleResponse handles the FloatScientificNegative response.
-func (client *PathsClient) FloatScientificNegativeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.FloatScientificNegativeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // FloatScientificNegativeHandleError handles the FloatScientificNegative error response.
 func (client *PathsClient) FloatScientificNegativeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -743,11 +659,10 @@ func (client *PathsClient) FloatScientificPositive(ctx context.Context) (*http.R
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.FloatScientificPositiveHandleResponse(resp)
-	if err != nil {
+	if err := client.FloatScientificPositiveHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // FloatScientificPositiveCreateRequest creates the FloatScientificPositive request.
@@ -762,16 +677,11 @@ func (client *PathsClient) FloatScientificPositiveCreateRequest(ctx context.Cont
 	return req, nil
 }
 
-// FloatScientificPositiveHandleResponse handles the FloatScientificPositive response.
-func (client *PathsClient) FloatScientificPositiveHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.FloatScientificPositiveHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // FloatScientificPositiveHandleError handles the FloatScientificPositive error response.
 func (client *PathsClient) FloatScientificPositiveHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -789,11 +699,10 @@ func (client *PathsClient) GetBooleanFalse(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetBooleanFalseHandleResponse(resp)
-	if err != nil {
+	if err := client.GetBooleanFalseHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetBooleanFalseCreateRequest creates the GetBooleanFalse request.
@@ -808,16 +717,11 @@ func (client *PathsClient) GetBooleanFalseCreateRequest(ctx context.Context) (*a
 	return req, nil
 }
 
-// GetBooleanFalseHandleResponse handles the GetBooleanFalse response.
-func (client *PathsClient) GetBooleanFalseHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBooleanFalseHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetBooleanFalseHandleError handles the GetBooleanFalse error response.
 func (client *PathsClient) GetBooleanFalseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -835,11 +739,10 @@ func (client *PathsClient) GetBooleanTrue(ctx context.Context) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetBooleanTrueHandleResponse(resp)
-	if err != nil {
+	if err := client.GetBooleanTrueHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetBooleanTrueCreateRequest creates the GetBooleanTrue request.
@@ -854,16 +757,11 @@ func (client *PathsClient) GetBooleanTrueCreateRequest(ctx context.Context) (*az
 	return req, nil
 }
 
-// GetBooleanTrueHandleResponse handles the GetBooleanTrue response.
-func (client *PathsClient) GetBooleanTrueHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBooleanTrueHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetBooleanTrueHandleError handles the GetBooleanTrue error response.
 func (client *PathsClient) GetBooleanTrueHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -881,11 +779,10 @@ func (client *PathsClient) GetIntNegativeOneMillion(ctx context.Context) (*http.
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetIntNegativeOneMillionHandleResponse(resp)
-	if err != nil {
+	if err := client.GetIntNegativeOneMillionHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetIntNegativeOneMillionCreateRequest creates the GetIntNegativeOneMillion request.
@@ -900,16 +797,11 @@ func (client *PathsClient) GetIntNegativeOneMillionCreateRequest(ctx context.Con
 	return req, nil
 }
 
-// GetIntNegativeOneMillionHandleResponse handles the GetIntNegativeOneMillion response.
-func (client *PathsClient) GetIntNegativeOneMillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetIntNegativeOneMillionHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetIntNegativeOneMillionHandleError handles the GetIntNegativeOneMillion error response.
 func (client *PathsClient) GetIntNegativeOneMillionHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -927,11 +819,10 @@ func (client *PathsClient) GetIntOneMillion(ctx context.Context) (*http.Response
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetIntOneMillionHandleResponse(resp)
-	if err != nil {
+	if err := client.GetIntOneMillionHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetIntOneMillionCreateRequest creates the GetIntOneMillion request.
@@ -946,16 +837,11 @@ func (client *PathsClient) GetIntOneMillionCreateRequest(ctx context.Context) (*
 	return req, nil
 }
 
-// GetIntOneMillionHandleResponse handles the GetIntOneMillion response.
-func (client *PathsClient) GetIntOneMillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetIntOneMillionHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetIntOneMillionHandleError handles the GetIntOneMillion error response.
 func (client *PathsClient) GetIntOneMillionHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -973,11 +859,10 @@ func (client *PathsClient) GetNegativeTenBillion(ctx context.Context) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetNegativeTenBillionHandleResponse(resp)
-	if err != nil {
+	if err := client.GetNegativeTenBillionHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetNegativeTenBillionCreateRequest creates the GetNegativeTenBillion request.
@@ -992,16 +877,11 @@ func (client *PathsClient) GetNegativeTenBillionCreateRequest(ctx context.Contex
 	return req, nil
 }
 
-// GetNegativeTenBillionHandleResponse handles the GetNegativeTenBillion response.
-func (client *PathsClient) GetNegativeTenBillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNegativeTenBillionHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetNegativeTenBillionHandleError handles the GetNegativeTenBillion error response.
 func (client *PathsClient) GetNegativeTenBillionHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1019,11 +899,10 @@ func (client *PathsClient) GetTenBillion(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetTenBillionHandleResponse(resp)
-	if err != nil {
+	if err := client.GetTenBillionHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetTenBillionCreateRequest creates the GetTenBillion request.
@@ -1038,16 +917,11 @@ func (client *PathsClient) GetTenBillionCreateRequest(ctx context.Context) (*azc
 	return req, nil
 }
 
-// GetTenBillionHandleResponse handles the GetTenBillion response.
-func (client *PathsClient) GetTenBillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetTenBillionHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetTenBillionHandleError handles the GetTenBillion error response.
 func (client *PathsClient) GetTenBillionHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1065,11 +939,10 @@ func (client *PathsClient) StringEmpty(ctx context.Context) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.StringEmptyHandleResponse(resp)
-	if err != nil {
+	if err := client.StringEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // StringEmptyCreateRequest creates the StringEmpty request.
@@ -1084,16 +957,11 @@ func (client *PathsClient) StringEmptyCreateRequest(ctx context.Context) (*azcor
 	return req, nil
 }
 
-// StringEmptyHandleResponse handles the StringEmpty response.
-func (client *PathsClient) StringEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.StringEmptyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // StringEmptyHandleError handles the StringEmpty error response.
 func (client *PathsClient) StringEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1111,11 +979,10 @@ func (client *PathsClient) StringNull(ctx context.Context, stringPath string) (*
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.StringNullHandleResponse(resp)
-	if err != nil {
+	if err := client.StringNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // StringNullCreateRequest creates the StringNull request.
@@ -1130,16 +997,11 @@ func (client *PathsClient) StringNullCreateRequest(ctx context.Context, stringPa
 	return req, nil
 }
 
-// StringNullHandleResponse handles the StringNull response.
-func (client *PathsClient) StringNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusBadRequest) {
-		return nil, client.StringNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // StringNullHandleError handles the StringNull error response.
 func (client *PathsClient) StringNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusBadRequest) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1157,11 +1019,10 @@ func (client *PathsClient) StringURLEncoded(ctx context.Context) (*http.Response
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.StringURLEncodedHandleResponse(resp)
-	if err != nil {
+	if err := client.StringURLEncodedHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // StringURLEncodedCreateRequest creates the StringURLEncoded request.
@@ -1176,16 +1037,11 @@ func (client *PathsClient) StringURLEncodedCreateRequest(ctx context.Context) (*
 	return req, nil
 }
 
-// StringURLEncodedHandleResponse handles the StringURLEncoded response.
-func (client *PathsClient) StringURLEncodedHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.StringURLEncodedHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // StringURLEncodedHandleError handles the StringURLEncoded error response.
 func (client *PathsClient) StringURLEncodedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1203,11 +1059,10 @@ func (client *PathsClient) StringURLNonEncoded(ctx context.Context) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.StringURLNonEncodedHandleResponse(resp)
-	if err != nil {
+	if err := client.StringURLNonEncodedHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // StringURLNonEncodedCreateRequest creates the StringURLNonEncoded request.
@@ -1222,16 +1077,11 @@ func (client *PathsClient) StringURLNonEncodedCreateRequest(ctx context.Context)
 	return req, nil
 }
 
-// StringURLNonEncodedHandleResponse handles the StringURLNonEncoded response.
-func (client *PathsClient) StringURLNonEncodedHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.StringURLNonEncodedHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // StringURLNonEncodedHandleError handles the StringURLNonEncoded error response.
 func (client *PathsClient) StringURLNonEncodedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1249,11 +1099,10 @@ func (client *PathsClient) StringUnicode(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.StringUnicodeHandleResponse(resp)
-	if err != nil {
+	if err := client.StringUnicodeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // StringUnicodeCreateRequest creates the StringUnicode request.
@@ -1268,16 +1117,11 @@ func (client *PathsClient) StringUnicodeCreateRequest(ctx context.Context) (*azc
 	return req, nil
 }
 
-// StringUnicodeHandleResponse handles the StringUnicode response.
-func (client *PathsClient) StringUnicodeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.StringUnicodeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // StringUnicodeHandleError handles the StringUnicode error response.
 func (client *PathsClient) StringUnicodeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1295,11 +1139,10 @@ func (client *PathsClient) UnixTimeURL(ctx context.Context, unixTimeUrlPath time
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.UnixTimeURLHandleResponse(resp)
-	if err != nil {
+	if err := client.UnixTimeURLHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // UnixTimeURLCreateRequest creates the UnixTimeURL request.
@@ -1314,16 +1157,11 @@ func (client *PathsClient) UnixTimeURLCreateRequest(ctx context.Context, unixTim
 	return req, nil
 }
 
-// UnixTimeURLHandleResponse handles the UnixTimeURL response.
-func (client *PathsClient) UnixTimeURLHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UnixTimeURLHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // UnixTimeURLHandleError handles the UnixTimeURL error response.
 func (client *PathsClient) UnixTimeURLHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/urlgroup/zz_generated_queries.go
+++ b/test/autorest/urlgroup/zz_generated_queries.go
@@ -115,8 +115,8 @@ func (client *QueriesClient) ArrayStringCSVEmpty(ctx context.Context, queriesArr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ArrayStringCSVEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ArrayStringCSVEmptyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -139,9 +139,6 @@ func (client *QueriesClient) ArrayStringCSVEmptyCreateRequest(ctx context.Contex
 
 // ArrayStringCSVEmptyHandleError handles the ArrayStringCSVEmpty error response.
 func (client *QueriesClient) ArrayStringCSVEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -159,8 +156,8 @@ func (client *QueriesClient) ArrayStringCSVNull(ctx context.Context, queriesArra
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ArrayStringCSVNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ArrayStringCSVNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -183,9 +180,6 @@ func (client *QueriesClient) ArrayStringCSVNullCreateRequest(ctx context.Context
 
 // ArrayStringCSVNullHandleError handles the ArrayStringCSVNull error response.
 func (client *QueriesClient) ArrayStringCSVNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -203,8 +197,8 @@ func (client *QueriesClient) ArrayStringCSVValid(ctx context.Context, queriesArr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ArrayStringCSVValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ArrayStringCSVValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -227,9 +221,6 @@ func (client *QueriesClient) ArrayStringCSVValidCreateRequest(ctx context.Contex
 
 // ArrayStringCSVValidHandleError handles the ArrayStringCSVValid error response.
 func (client *QueriesClient) ArrayStringCSVValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -247,8 +238,8 @@ func (client *QueriesClient) ArrayStringNoCollectionFormatEmpty(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ArrayStringNoCollectionFormatEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ArrayStringNoCollectionFormatEmptyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -271,9 +262,6 @@ func (client *QueriesClient) ArrayStringNoCollectionFormatEmptyCreateRequest(ctx
 
 // ArrayStringNoCollectionFormatEmptyHandleError handles the ArrayStringNoCollectionFormatEmpty error response.
 func (client *QueriesClient) ArrayStringNoCollectionFormatEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -291,8 +279,8 @@ func (client *QueriesClient) ArrayStringPipesValid(ctx context.Context, queriesA
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ArrayStringPipesValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ArrayStringPipesValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -315,9 +303,6 @@ func (client *QueriesClient) ArrayStringPipesValidCreateRequest(ctx context.Cont
 
 // ArrayStringPipesValidHandleError handles the ArrayStringPipesValid error response.
 func (client *QueriesClient) ArrayStringPipesValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -335,8 +320,8 @@ func (client *QueriesClient) ArrayStringSsvValid(ctx context.Context, queriesArr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ArrayStringSsvValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ArrayStringSsvValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -359,9 +344,6 @@ func (client *QueriesClient) ArrayStringSsvValidCreateRequest(ctx context.Contex
 
 // ArrayStringSsvValidHandleError handles the ArrayStringSsvValid error response.
 func (client *QueriesClient) ArrayStringSsvValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -379,8 +361,8 @@ func (client *QueriesClient) ArrayStringTsvValid(ctx context.Context, queriesArr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ArrayStringTsvValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ArrayStringTsvValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -403,9 +385,6 @@ func (client *QueriesClient) ArrayStringTsvValidCreateRequest(ctx context.Contex
 
 // ArrayStringTsvValidHandleError handles the ArrayStringTsvValid error response.
 func (client *QueriesClient) ArrayStringTsvValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -423,8 +402,8 @@ func (client *QueriesClient) ByteEmpty(ctx context.Context) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ByteEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ByteEmptyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -445,9 +424,6 @@ func (client *QueriesClient) ByteEmptyCreateRequest(ctx context.Context) (*azcor
 
 // ByteEmptyHandleError handles the ByteEmpty error response.
 func (client *QueriesClient) ByteEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -465,8 +441,8 @@ func (client *QueriesClient) ByteMultiByte(ctx context.Context, queriesByteMulti
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ByteMultiByteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ByteMultiByteHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -489,9 +465,6 @@ func (client *QueriesClient) ByteMultiByteCreateRequest(ctx context.Context, que
 
 // ByteMultiByteHandleError handles the ByteMultiByte error response.
 func (client *QueriesClient) ByteMultiByteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -509,8 +482,8 @@ func (client *QueriesClient) ByteNull(ctx context.Context, queriesByteNullOption
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ByteNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ByteNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -533,9 +506,6 @@ func (client *QueriesClient) ByteNullCreateRequest(ctx context.Context, queriesB
 
 // ByteNullHandleError handles the ByteNull error response.
 func (client *QueriesClient) ByteNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -553,8 +523,8 @@ func (client *QueriesClient) DateNull(ctx context.Context, queriesDateNullOption
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DateNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.DateNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -577,9 +547,6 @@ func (client *QueriesClient) DateNullCreateRequest(ctx context.Context, queriesD
 
 // DateNullHandleError handles the DateNull error response.
 func (client *QueriesClient) DateNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -597,8 +564,8 @@ func (client *QueriesClient) DateTimeNull(ctx context.Context, queriesDateTimeNu
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DateTimeNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.DateTimeNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -621,9 +588,6 @@ func (client *QueriesClient) DateTimeNullCreateRequest(ctx context.Context, quer
 
 // DateTimeNullHandleError handles the DateTimeNull error response.
 func (client *QueriesClient) DateTimeNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -641,8 +605,8 @@ func (client *QueriesClient) DateTimeValid(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DateTimeValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.DateTimeValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -663,9 +627,6 @@ func (client *QueriesClient) DateTimeValidCreateRequest(ctx context.Context) (*a
 
 // DateTimeValidHandleError handles the DateTimeValid error response.
 func (client *QueriesClient) DateTimeValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -683,8 +644,8 @@ func (client *QueriesClient) DateValid(ctx context.Context) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DateValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.DateValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -705,9 +666,6 @@ func (client *QueriesClient) DateValidCreateRequest(ctx context.Context) (*azcor
 
 // DateValidHandleError handles the DateValid error response.
 func (client *QueriesClient) DateValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -725,8 +683,8 @@ func (client *QueriesClient) DoubleDecimalNegative(ctx context.Context) (*http.R
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DoubleDecimalNegativeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.DoubleDecimalNegativeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -747,9 +705,6 @@ func (client *QueriesClient) DoubleDecimalNegativeCreateRequest(ctx context.Cont
 
 // DoubleDecimalNegativeHandleError handles the DoubleDecimalNegative error response.
 func (client *QueriesClient) DoubleDecimalNegativeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -767,8 +722,8 @@ func (client *QueriesClient) DoubleDecimalPositive(ctx context.Context) (*http.R
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DoubleDecimalPositiveHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.DoubleDecimalPositiveHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -789,9 +744,6 @@ func (client *QueriesClient) DoubleDecimalPositiveCreateRequest(ctx context.Cont
 
 // DoubleDecimalPositiveHandleError handles the DoubleDecimalPositive error response.
 func (client *QueriesClient) DoubleDecimalPositiveHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -809,8 +761,8 @@ func (client *QueriesClient) DoubleNull(ctx context.Context, queriesDoubleNullOp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DoubleNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.DoubleNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -833,9 +785,6 @@ func (client *QueriesClient) DoubleNullCreateRequest(ctx context.Context, querie
 
 // DoubleNullHandleError handles the DoubleNull error response.
 func (client *QueriesClient) DoubleNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -853,8 +802,8 @@ func (client *QueriesClient) EnumNull(ctx context.Context, queriesEnumNullOption
 	if err != nil {
 		return nil, err
 	}
-	if err := client.EnumNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.EnumNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -877,9 +826,6 @@ func (client *QueriesClient) EnumNullCreateRequest(ctx context.Context, queriesE
 
 // EnumNullHandleError handles the EnumNull error response.
 func (client *QueriesClient) EnumNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -897,8 +843,8 @@ func (client *QueriesClient) EnumValid(ctx context.Context, queriesEnumValidOpti
 	if err != nil {
 		return nil, err
 	}
-	if err := client.EnumValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.EnumValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -921,9 +867,6 @@ func (client *QueriesClient) EnumValidCreateRequest(ctx context.Context, queries
 
 // EnumValidHandleError handles the EnumValid error response.
 func (client *QueriesClient) EnumValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -941,8 +884,8 @@ func (client *QueriesClient) FloatNull(ctx context.Context, queriesFloatNullOpti
 	if err != nil {
 		return nil, err
 	}
-	if err := client.FloatNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.FloatNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -965,9 +908,6 @@ func (client *QueriesClient) FloatNullCreateRequest(ctx context.Context, queries
 
 // FloatNullHandleError handles the FloatNull error response.
 func (client *QueriesClient) FloatNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -985,8 +925,8 @@ func (client *QueriesClient) FloatScientificNegative(ctx context.Context) (*http
 	if err != nil {
 		return nil, err
 	}
-	if err := client.FloatScientificNegativeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.FloatScientificNegativeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1007,9 +947,6 @@ func (client *QueriesClient) FloatScientificNegativeCreateRequest(ctx context.Co
 
 // FloatScientificNegativeHandleError handles the FloatScientificNegative error response.
 func (client *QueriesClient) FloatScientificNegativeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1027,8 +964,8 @@ func (client *QueriesClient) FloatScientificPositive(ctx context.Context) (*http
 	if err != nil {
 		return nil, err
 	}
-	if err := client.FloatScientificPositiveHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.FloatScientificPositiveHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1049,9 +986,6 @@ func (client *QueriesClient) FloatScientificPositiveCreateRequest(ctx context.Co
 
 // FloatScientificPositiveHandleError handles the FloatScientificPositive error response.
 func (client *QueriesClient) FloatScientificPositiveHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1069,8 +1003,8 @@ func (client *QueriesClient) GetBooleanFalse(ctx context.Context) (*http.Respons
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBooleanFalseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBooleanFalseHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1091,9 +1025,6 @@ func (client *QueriesClient) GetBooleanFalseCreateRequest(ctx context.Context) (
 
 // GetBooleanFalseHandleError handles the GetBooleanFalse error response.
 func (client *QueriesClient) GetBooleanFalseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1111,8 +1042,8 @@ func (client *QueriesClient) GetBooleanNull(ctx context.Context, queriesGetBoole
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBooleanNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBooleanNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1135,9 +1066,6 @@ func (client *QueriesClient) GetBooleanNullCreateRequest(ctx context.Context, qu
 
 // GetBooleanNullHandleError handles the GetBooleanNull error response.
 func (client *QueriesClient) GetBooleanNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1155,8 +1083,8 @@ func (client *QueriesClient) GetBooleanTrue(ctx context.Context) (*http.Response
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBooleanTrueHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBooleanTrueHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1177,9 +1105,6 @@ func (client *QueriesClient) GetBooleanTrueCreateRequest(ctx context.Context) (*
 
 // GetBooleanTrueHandleError handles the GetBooleanTrue error response.
 func (client *QueriesClient) GetBooleanTrueHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1197,8 +1122,8 @@ func (client *QueriesClient) GetIntNegativeOneMillion(ctx context.Context) (*htt
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetIntNegativeOneMillionHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetIntNegativeOneMillionHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1219,9 +1144,6 @@ func (client *QueriesClient) GetIntNegativeOneMillionCreateRequest(ctx context.C
 
 // GetIntNegativeOneMillionHandleError handles the GetIntNegativeOneMillion error response.
 func (client *QueriesClient) GetIntNegativeOneMillionHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1239,8 +1161,8 @@ func (client *QueriesClient) GetIntNull(ctx context.Context, queriesGetIntNullOp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetIntNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetIntNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1263,9 +1185,6 @@ func (client *QueriesClient) GetIntNullCreateRequest(ctx context.Context, querie
 
 // GetIntNullHandleError handles the GetIntNull error response.
 func (client *QueriesClient) GetIntNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1283,8 +1202,8 @@ func (client *QueriesClient) GetIntOneMillion(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetIntOneMillionHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetIntOneMillionHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1305,9 +1224,6 @@ func (client *QueriesClient) GetIntOneMillionCreateRequest(ctx context.Context) 
 
 // GetIntOneMillionHandleError handles the GetIntOneMillion error response.
 func (client *QueriesClient) GetIntOneMillionHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1325,8 +1241,8 @@ func (client *QueriesClient) GetLongNull(ctx context.Context, queriesGetLongNull
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLongNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetLongNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1349,9 +1265,6 @@ func (client *QueriesClient) GetLongNullCreateRequest(ctx context.Context, queri
 
 // GetLongNullHandleError handles the GetLongNull error response.
 func (client *QueriesClient) GetLongNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1369,8 +1282,8 @@ func (client *QueriesClient) GetNegativeTenBillion(ctx context.Context) (*http.R
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNegativeTenBillionHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetNegativeTenBillionHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1391,9 +1304,6 @@ func (client *QueriesClient) GetNegativeTenBillionCreateRequest(ctx context.Cont
 
 // GetNegativeTenBillionHandleError handles the GetNegativeTenBillion error response.
 func (client *QueriesClient) GetNegativeTenBillionHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1411,8 +1321,8 @@ func (client *QueriesClient) GetTenBillion(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetTenBillionHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetTenBillionHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1433,9 +1343,6 @@ func (client *QueriesClient) GetTenBillionCreateRequest(ctx context.Context) (*a
 
 // GetTenBillionHandleError handles the GetTenBillion error response.
 func (client *QueriesClient) GetTenBillionHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1453,8 +1360,8 @@ func (client *QueriesClient) StringEmpty(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StringEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.StringEmptyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1475,9 +1382,6 @@ func (client *QueriesClient) StringEmptyCreateRequest(ctx context.Context) (*azc
 
 // StringEmptyHandleError handles the StringEmpty error response.
 func (client *QueriesClient) StringEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1495,8 +1399,8 @@ func (client *QueriesClient) StringNull(ctx context.Context, queriesStringNullOp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StringNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.StringNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1519,9 +1423,6 @@ func (client *QueriesClient) StringNullCreateRequest(ctx context.Context, querie
 
 // StringNullHandleError handles the StringNull error response.
 func (client *QueriesClient) StringNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1539,8 +1440,8 @@ func (client *QueriesClient) StringURLEncoded(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StringURLEncodedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.StringURLEncodedHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1561,9 +1462,6 @@ func (client *QueriesClient) StringURLEncodedCreateRequest(ctx context.Context) 
 
 // StringURLEncodedHandleError handles the StringURLEncoded error response.
 func (client *QueriesClient) StringURLEncodedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1581,8 +1479,8 @@ func (client *QueriesClient) StringUnicode(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StringUnicodeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.StringUnicodeHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1603,9 +1501,6 @@ func (client *QueriesClient) StringUnicodeCreateRequest(ctx context.Context) (*a
 
 // StringUnicodeHandleError handles the StringUnicode error response.
 func (client *QueriesClient) StringUnicodeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/urlgroup/zz_generated_queries.go
+++ b/test/autorest/urlgroup/zz_generated_queries.go
@@ -115,11 +115,10 @@ func (client *QueriesClient) ArrayStringCSVEmpty(ctx context.Context, queriesArr
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ArrayStringCSVEmptyHandleResponse(resp)
-	if err != nil {
+	if err := client.ArrayStringCSVEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ArrayStringCSVEmptyCreateRequest creates the ArrayStringCSVEmpty request.
@@ -138,16 +137,11 @@ func (client *QueriesClient) ArrayStringCSVEmptyCreateRequest(ctx context.Contex
 	return req, nil
 }
 
-// ArrayStringCSVEmptyHandleResponse handles the ArrayStringCSVEmpty response.
-func (client *QueriesClient) ArrayStringCSVEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ArrayStringCSVEmptyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ArrayStringCSVEmptyHandleError handles the ArrayStringCSVEmpty error response.
 func (client *QueriesClient) ArrayStringCSVEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -165,11 +159,10 @@ func (client *QueriesClient) ArrayStringCSVNull(ctx context.Context, queriesArra
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ArrayStringCSVNullHandleResponse(resp)
-	if err != nil {
+	if err := client.ArrayStringCSVNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ArrayStringCSVNullCreateRequest creates the ArrayStringCSVNull request.
@@ -188,16 +181,11 @@ func (client *QueriesClient) ArrayStringCSVNullCreateRequest(ctx context.Context
 	return req, nil
 }
 
-// ArrayStringCSVNullHandleResponse handles the ArrayStringCSVNull response.
-func (client *QueriesClient) ArrayStringCSVNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ArrayStringCSVNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ArrayStringCSVNullHandleError handles the ArrayStringCSVNull error response.
 func (client *QueriesClient) ArrayStringCSVNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -215,11 +203,10 @@ func (client *QueriesClient) ArrayStringCSVValid(ctx context.Context, queriesArr
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ArrayStringCSVValidHandleResponse(resp)
-	if err != nil {
+	if err := client.ArrayStringCSVValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ArrayStringCSVValidCreateRequest creates the ArrayStringCSVValid request.
@@ -238,16 +225,11 @@ func (client *QueriesClient) ArrayStringCSVValidCreateRequest(ctx context.Contex
 	return req, nil
 }
 
-// ArrayStringCSVValidHandleResponse handles the ArrayStringCSVValid response.
-func (client *QueriesClient) ArrayStringCSVValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ArrayStringCSVValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ArrayStringCSVValidHandleError handles the ArrayStringCSVValid error response.
 func (client *QueriesClient) ArrayStringCSVValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -265,11 +247,10 @@ func (client *QueriesClient) ArrayStringNoCollectionFormatEmpty(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ArrayStringNoCollectionFormatEmptyHandleResponse(resp)
-	if err != nil {
+	if err := client.ArrayStringNoCollectionFormatEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ArrayStringNoCollectionFormatEmptyCreateRequest creates the ArrayStringNoCollectionFormatEmpty request.
@@ -288,16 +269,11 @@ func (client *QueriesClient) ArrayStringNoCollectionFormatEmptyCreateRequest(ctx
 	return req, nil
 }
 
-// ArrayStringNoCollectionFormatEmptyHandleResponse handles the ArrayStringNoCollectionFormatEmpty response.
-func (client *QueriesClient) ArrayStringNoCollectionFormatEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ArrayStringNoCollectionFormatEmptyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ArrayStringNoCollectionFormatEmptyHandleError handles the ArrayStringNoCollectionFormatEmpty error response.
 func (client *QueriesClient) ArrayStringNoCollectionFormatEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -315,11 +291,10 @@ func (client *QueriesClient) ArrayStringPipesValid(ctx context.Context, queriesA
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ArrayStringPipesValidHandleResponse(resp)
-	if err != nil {
+	if err := client.ArrayStringPipesValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ArrayStringPipesValidCreateRequest creates the ArrayStringPipesValid request.
@@ -338,16 +313,11 @@ func (client *QueriesClient) ArrayStringPipesValidCreateRequest(ctx context.Cont
 	return req, nil
 }
 
-// ArrayStringPipesValidHandleResponse handles the ArrayStringPipesValid response.
-func (client *QueriesClient) ArrayStringPipesValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ArrayStringPipesValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ArrayStringPipesValidHandleError handles the ArrayStringPipesValid error response.
 func (client *QueriesClient) ArrayStringPipesValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -365,11 +335,10 @@ func (client *QueriesClient) ArrayStringSsvValid(ctx context.Context, queriesArr
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ArrayStringSsvValidHandleResponse(resp)
-	if err != nil {
+	if err := client.ArrayStringSsvValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ArrayStringSsvValidCreateRequest creates the ArrayStringSsvValid request.
@@ -388,16 +357,11 @@ func (client *QueriesClient) ArrayStringSsvValidCreateRequest(ctx context.Contex
 	return req, nil
 }
 
-// ArrayStringSsvValidHandleResponse handles the ArrayStringSsvValid response.
-func (client *QueriesClient) ArrayStringSsvValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ArrayStringSsvValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ArrayStringSsvValidHandleError handles the ArrayStringSsvValid error response.
 func (client *QueriesClient) ArrayStringSsvValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -415,11 +379,10 @@ func (client *QueriesClient) ArrayStringTsvValid(ctx context.Context, queriesArr
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ArrayStringTsvValidHandleResponse(resp)
-	if err != nil {
+	if err := client.ArrayStringTsvValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ArrayStringTsvValidCreateRequest creates the ArrayStringTsvValid request.
@@ -438,16 +401,11 @@ func (client *QueriesClient) ArrayStringTsvValidCreateRequest(ctx context.Contex
 	return req, nil
 }
 
-// ArrayStringTsvValidHandleResponse handles the ArrayStringTsvValid response.
-func (client *QueriesClient) ArrayStringTsvValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ArrayStringTsvValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ArrayStringTsvValidHandleError handles the ArrayStringTsvValid error response.
 func (client *QueriesClient) ArrayStringTsvValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -465,11 +423,10 @@ func (client *QueriesClient) ByteEmpty(ctx context.Context) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ByteEmptyHandleResponse(resp)
-	if err != nil {
+	if err := client.ByteEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ByteEmptyCreateRequest creates the ByteEmpty request.
@@ -486,16 +443,11 @@ func (client *QueriesClient) ByteEmptyCreateRequest(ctx context.Context) (*azcor
 	return req, nil
 }
 
-// ByteEmptyHandleResponse handles the ByteEmpty response.
-func (client *QueriesClient) ByteEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ByteEmptyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ByteEmptyHandleError handles the ByteEmpty error response.
 func (client *QueriesClient) ByteEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -513,11 +465,10 @@ func (client *QueriesClient) ByteMultiByte(ctx context.Context, queriesByteMulti
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ByteMultiByteHandleResponse(resp)
-	if err != nil {
+	if err := client.ByteMultiByteHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ByteMultiByteCreateRequest creates the ByteMultiByte request.
@@ -536,16 +487,11 @@ func (client *QueriesClient) ByteMultiByteCreateRequest(ctx context.Context, que
 	return req, nil
 }
 
-// ByteMultiByteHandleResponse handles the ByteMultiByte response.
-func (client *QueriesClient) ByteMultiByteHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ByteMultiByteHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ByteMultiByteHandleError handles the ByteMultiByte error response.
 func (client *QueriesClient) ByteMultiByteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -563,11 +509,10 @@ func (client *QueriesClient) ByteNull(ctx context.Context, queriesByteNullOption
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ByteNullHandleResponse(resp)
-	if err != nil {
+	if err := client.ByteNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ByteNullCreateRequest creates the ByteNull request.
@@ -586,16 +531,11 @@ func (client *QueriesClient) ByteNullCreateRequest(ctx context.Context, queriesB
 	return req, nil
 }
 
-// ByteNullHandleResponse handles the ByteNull response.
-func (client *QueriesClient) ByteNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ByteNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ByteNullHandleError handles the ByteNull error response.
 func (client *QueriesClient) ByteNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -613,11 +553,10 @@ func (client *QueriesClient) DateNull(ctx context.Context, queriesDateNullOption
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.DateNullHandleResponse(resp)
-	if err != nil {
+	if err := client.DateNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // DateNullCreateRequest creates the DateNull request.
@@ -636,16 +575,11 @@ func (client *QueriesClient) DateNullCreateRequest(ctx context.Context, queriesD
 	return req, nil
 }
 
-// DateNullHandleResponse handles the DateNull response.
-func (client *QueriesClient) DateNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.DateNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // DateNullHandleError handles the DateNull error response.
 func (client *QueriesClient) DateNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -663,11 +597,10 @@ func (client *QueriesClient) DateTimeNull(ctx context.Context, queriesDateTimeNu
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.DateTimeNullHandleResponse(resp)
-	if err != nil {
+	if err := client.DateTimeNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // DateTimeNullCreateRequest creates the DateTimeNull request.
@@ -686,16 +619,11 @@ func (client *QueriesClient) DateTimeNullCreateRequest(ctx context.Context, quer
 	return req, nil
 }
 
-// DateTimeNullHandleResponse handles the DateTimeNull response.
-func (client *QueriesClient) DateTimeNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.DateTimeNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // DateTimeNullHandleError handles the DateTimeNull error response.
 func (client *QueriesClient) DateTimeNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -713,11 +641,10 @@ func (client *QueriesClient) DateTimeValid(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.DateTimeValidHandleResponse(resp)
-	if err != nil {
+	if err := client.DateTimeValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // DateTimeValidCreateRequest creates the DateTimeValid request.
@@ -734,16 +661,11 @@ func (client *QueriesClient) DateTimeValidCreateRequest(ctx context.Context) (*a
 	return req, nil
 }
 
-// DateTimeValidHandleResponse handles the DateTimeValid response.
-func (client *QueriesClient) DateTimeValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.DateTimeValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // DateTimeValidHandleError handles the DateTimeValid error response.
 func (client *QueriesClient) DateTimeValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -761,11 +683,10 @@ func (client *QueriesClient) DateValid(ctx context.Context) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.DateValidHandleResponse(resp)
-	if err != nil {
+	if err := client.DateValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // DateValidCreateRequest creates the DateValid request.
@@ -782,16 +703,11 @@ func (client *QueriesClient) DateValidCreateRequest(ctx context.Context) (*azcor
 	return req, nil
 }
 
-// DateValidHandleResponse handles the DateValid response.
-func (client *QueriesClient) DateValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.DateValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // DateValidHandleError handles the DateValid error response.
 func (client *QueriesClient) DateValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -809,11 +725,10 @@ func (client *QueriesClient) DoubleDecimalNegative(ctx context.Context) (*http.R
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.DoubleDecimalNegativeHandleResponse(resp)
-	if err != nil {
+	if err := client.DoubleDecimalNegativeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // DoubleDecimalNegativeCreateRequest creates the DoubleDecimalNegative request.
@@ -830,16 +745,11 @@ func (client *QueriesClient) DoubleDecimalNegativeCreateRequest(ctx context.Cont
 	return req, nil
 }
 
-// DoubleDecimalNegativeHandleResponse handles the DoubleDecimalNegative response.
-func (client *QueriesClient) DoubleDecimalNegativeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.DoubleDecimalNegativeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // DoubleDecimalNegativeHandleError handles the DoubleDecimalNegative error response.
 func (client *QueriesClient) DoubleDecimalNegativeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -857,11 +767,10 @@ func (client *QueriesClient) DoubleDecimalPositive(ctx context.Context) (*http.R
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.DoubleDecimalPositiveHandleResponse(resp)
-	if err != nil {
+	if err := client.DoubleDecimalPositiveHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // DoubleDecimalPositiveCreateRequest creates the DoubleDecimalPositive request.
@@ -878,16 +787,11 @@ func (client *QueriesClient) DoubleDecimalPositiveCreateRequest(ctx context.Cont
 	return req, nil
 }
 
-// DoubleDecimalPositiveHandleResponse handles the DoubleDecimalPositive response.
-func (client *QueriesClient) DoubleDecimalPositiveHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.DoubleDecimalPositiveHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // DoubleDecimalPositiveHandleError handles the DoubleDecimalPositive error response.
 func (client *QueriesClient) DoubleDecimalPositiveHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -905,11 +809,10 @@ func (client *QueriesClient) DoubleNull(ctx context.Context, queriesDoubleNullOp
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.DoubleNullHandleResponse(resp)
-	if err != nil {
+	if err := client.DoubleNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // DoubleNullCreateRequest creates the DoubleNull request.
@@ -928,16 +831,11 @@ func (client *QueriesClient) DoubleNullCreateRequest(ctx context.Context, querie
 	return req, nil
 }
 
-// DoubleNullHandleResponse handles the DoubleNull response.
-func (client *QueriesClient) DoubleNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.DoubleNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // DoubleNullHandleError handles the DoubleNull error response.
 func (client *QueriesClient) DoubleNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -955,11 +853,10 @@ func (client *QueriesClient) EnumNull(ctx context.Context, queriesEnumNullOption
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.EnumNullHandleResponse(resp)
-	if err != nil {
+	if err := client.EnumNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // EnumNullCreateRequest creates the EnumNull request.
@@ -978,16 +875,11 @@ func (client *QueriesClient) EnumNullCreateRequest(ctx context.Context, queriesE
 	return req, nil
 }
 
-// EnumNullHandleResponse handles the EnumNull response.
-func (client *QueriesClient) EnumNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.EnumNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // EnumNullHandleError handles the EnumNull error response.
 func (client *QueriesClient) EnumNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1005,11 +897,10 @@ func (client *QueriesClient) EnumValid(ctx context.Context, queriesEnumValidOpti
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.EnumValidHandleResponse(resp)
-	if err != nil {
+	if err := client.EnumValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // EnumValidCreateRequest creates the EnumValid request.
@@ -1028,16 +919,11 @@ func (client *QueriesClient) EnumValidCreateRequest(ctx context.Context, queries
 	return req, nil
 }
 
-// EnumValidHandleResponse handles the EnumValid response.
-func (client *QueriesClient) EnumValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.EnumValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // EnumValidHandleError handles the EnumValid error response.
 func (client *QueriesClient) EnumValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1055,11 +941,10 @@ func (client *QueriesClient) FloatNull(ctx context.Context, queriesFloatNullOpti
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.FloatNullHandleResponse(resp)
-	if err != nil {
+	if err := client.FloatNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // FloatNullCreateRequest creates the FloatNull request.
@@ -1078,16 +963,11 @@ func (client *QueriesClient) FloatNullCreateRequest(ctx context.Context, queries
 	return req, nil
 }
 
-// FloatNullHandleResponse handles the FloatNull response.
-func (client *QueriesClient) FloatNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.FloatNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // FloatNullHandleError handles the FloatNull error response.
 func (client *QueriesClient) FloatNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1105,11 +985,10 @@ func (client *QueriesClient) FloatScientificNegative(ctx context.Context) (*http
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.FloatScientificNegativeHandleResponse(resp)
-	if err != nil {
+	if err := client.FloatScientificNegativeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // FloatScientificNegativeCreateRequest creates the FloatScientificNegative request.
@@ -1126,16 +1005,11 @@ func (client *QueriesClient) FloatScientificNegativeCreateRequest(ctx context.Co
 	return req, nil
 }
 
-// FloatScientificNegativeHandleResponse handles the FloatScientificNegative response.
-func (client *QueriesClient) FloatScientificNegativeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.FloatScientificNegativeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // FloatScientificNegativeHandleError handles the FloatScientificNegative error response.
 func (client *QueriesClient) FloatScientificNegativeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1153,11 +1027,10 @@ func (client *QueriesClient) FloatScientificPositive(ctx context.Context) (*http
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.FloatScientificPositiveHandleResponse(resp)
-	if err != nil {
+	if err := client.FloatScientificPositiveHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // FloatScientificPositiveCreateRequest creates the FloatScientificPositive request.
@@ -1174,16 +1047,11 @@ func (client *QueriesClient) FloatScientificPositiveCreateRequest(ctx context.Co
 	return req, nil
 }
 
-// FloatScientificPositiveHandleResponse handles the FloatScientificPositive response.
-func (client *QueriesClient) FloatScientificPositiveHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.FloatScientificPositiveHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // FloatScientificPositiveHandleError handles the FloatScientificPositive error response.
 func (client *QueriesClient) FloatScientificPositiveHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1201,11 +1069,10 @@ func (client *QueriesClient) GetBooleanFalse(ctx context.Context) (*http.Respons
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetBooleanFalseHandleResponse(resp)
-	if err != nil {
+	if err := client.GetBooleanFalseHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetBooleanFalseCreateRequest creates the GetBooleanFalse request.
@@ -1222,16 +1089,11 @@ func (client *QueriesClient) GetBooleanFalseCreateRequest(ctx context.Context) (
 	return req, nil
 }
 
-// GetBooleanFalseHandleResponse handles the GetBooleanFalse response.
-func (client *QueriesClient) GetBooleanFalseHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBooleanFalseHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetBooleanFalseHandleError handles the GetBooleanFalse error response.
 func (client *QueriesClient) GetBooleanFalseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1249,11 +1111,10 @@ func (client *QueriesClient) GetBooleanNull(ctx context.Context, queriesGetBoole
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetBooleanNullHandleResponse(resp)
-	if err != nil {
+	if err := client.GetBooleanNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetBooleanNullCreateRequest creates the GetBooleanNull request.
@@ -1272,16 +1133,11 @@ func (client *QueriesClient) GetBooleanNullCreateRequest(ctx context.Context, qu
 	return req, nil
 }
 
-// GetBooleanNullHandleResponse handles the GetBooleanNull response.
-func (client *QueriesClient) GetBooleanNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBooleanNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetBooleanNullHandleError handles the GetBooleanNull error response.
 func (client *QueriesClient) GetBooleanNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1299,11 +1155,10 @@ func (client *QueriesClient) GetBooleanTrue(ctx context.Context) (*http.Response
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetBooleanTrueHandleResponse(resp)
-	if err != nil {
+	if err := client.GetBooleanTrueHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetBooleanTrueCreateRequest creates the GetBooleanTrue request.
@@ -1320,16 +1175,11 @@ func (client *QueriesClient) GetBooleanTrueCreateRequest(ctx context.Context) (*
 	return req, nil
 }
 
-// GetBooleanTrueHandleResponse handles the GetBooleanTrue response.
-func (client *QueriesClient) GetBooleanTrueHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBooleanTrueHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetBooleanTrueHandleError handles the GetBooleanTrue error response.
 func (client *QueriesClient) GetBooleanTrueHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1347,11 +1197,10 @@ func (client *QueriesClient) GetIntNegativeOneMillion(ctx context.Context) (*htt
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetIntNegativeOneMillionHandleResponse(resp)
-	if err != nil {
+	if err := client.GetIntNegativeOneMillionHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetIntNegativeOneMillionCreateRequest creates the GetIntNegativeOneMillion request.
@@ -1368,16 +1217,11 @@ func (client *QueriesClient) GetIntNegativeOneMillionCreateRequest(ctx context.C
 	return req, nil
 }
 
-// GetIntNegativeOneMillionHandleResponse handles the GetIntNegativeOneMillion response.
-func (client *QueriesClient) GetIntNegativeOneMillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetIntNegativeOneMillionHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetIntNegativeOneMillionHandleError handles the GetIntNegativeOneMillion error response.
 func (client *QueriesClient) GetIntNegativeOneMillionHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1395,11 +1239,10 @@ func (client *QueriesClient) GetIntNull(ctx context.Context, queriesGetIntNullOp
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetIntNullHandleResponse(resp)
-	if err != nil {
+	if err := client.GetIntNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetIntNullCreateRequest creates the GetIntNull request.
@@ -1418,16 +1261,11 @@ func (client *QueriesClient) GetIntNullCreateRequest(ctx context.Context, querie
 	return req, nil
 }
 
-// GetIntNullHandleResponse handles the GetIntNull response.
-func (client *QueriesClient) GetIntNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetIntNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetIntNullHandleError handles the GetIntNull error response.
 func (client *QueriesClient) GetIntNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1445,11 +1283,10 @@ func (client *QueriesClient) GetIntOneMillion(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetIntOneMillionHandleResponse(resp)
-	if err != nil {
+	if err := client.GetIntOneMillionHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetIntOneMillionCreateRequest creates the GetIntOneMillion request.
@@ -1466,16 +1303,11 @@ func (client *QueriesClient) GetIntOneMillionCreateRequest(ctx context.Context) 
 	return req, nil
 }
 
-// GetIntOneMillionHandleResponse handles the GetIntOneMillion response.
-func (client *QueriesClient) GetIntOneMillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetIntOneMillionHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetIntOneMillionHandleError handles the GetIntOneMillion error response.
 func (client *QueriesClient) GetIntOneMillionHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1493,11 +1325,10 @@ func (client *QueriesClient) GetLongNull(ctx context.Context, queriesGetLongNull
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetLongNullHandleResponse(resp)
-	if err != nil {
+	if err := client.GetLongNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetLongNullCreateRequest creates the GetLongNull request.
@@ -1516,16 +1347,11 @@ func (client *QueriesClient) GetLongNullCreateRequest(ctx context.Context, queri
 	return req, nil
 }
 
-// GetLongNullHandleResponse handles the GetLongNull response.
-func (client *QueriesClient) GetLongNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetLongNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetLongNullHandleError handles the GetLongNull error response.
 func (client *QueriesClient) GetLongNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1543,11 +1369,10 @@ func (client *QueriesClient) GetNegativeTenBillion(ctx context.Context) (*http.R
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetNegativeTenBillionHandleResponse(resp)
-	if err != nil {
+	if err := client.GetNegativeTenBillionHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetNegativeTenBillionCreateRequest creates the GetNegativeTenBillion request.
@@ -1564,16 +1389,11 @@ func (client *QueriesClient) GetNegativeTenBillionCreateRequest(ctx context.Cont
 	return req, nil
 }
 
-// GetNegativeTenBillionHandleResponse handles the GetNegativeTenBillion response.
-func (client *QueriesClient) GetNegativeTenBillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetNegativeTenBillionHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetNegativeTenBillionHandleError handles the GetNegativeTenBillion error response.
 func (client *QueriesClient) GetNegativeTenBillionHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1591,11 +1411,10 @@ func (client *QueriesClient) GetTenBillion(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetTenBillionHandleResponse(resp)
-	if err != nil {
+	if err := client.GetTenBillionHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetTenBillionCreateRequest creates the GetTenBillion request.
@@ -1612,16 +1431,11 @@ func (client *QueriesClient) GetTenBillionCreateRequest(ctx context.Context) (*a
 	return req, nil
 }
 
-// GetTenBillionHandleResponse handles the GetTenBillion response.
-func (client *QueriesClient) GetTenBillionHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetTenBillionHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetTenBillionHandleError handles the GetTenBillion error response.
 func (client *QueriesClient) GetTenBillionHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1639,11 +1453,10 @@ func (client *QueriesClient) StringEmpty(ctx context.Context) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.StringEmptyHandleResponse(resp)
-	if err != nil {
+	if err := client.StringEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // StringEmptyCreateRequest creates the StringEmpty request.
@@ -1660,16 +1473,11 @@ func (client *QueriesClient) StringEmptyCreateRequest(ctx context.Context) (*azc
 	return req, nil
 }
 
-// StringEmptyHandleResponse handles the StringEmpty response.
-func (client *QueriesClient) StringEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.StringEmptyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // StringEmptyHandleError handles the StringEmpty error response.
 func (client *QueriesClient) StringEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1687,11 +1495,10 @@ func (client *QueriesClient) StringNull(ctx context.Context, queriesStringNullOp
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.StringNullHandleResponse(resp)
-	if err != nil {
+	if err := client.StringNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // StringNullCreateRequest creates the StringNull request.
@@ -1710,16 +1517,11 @@ func (client *QueriesClient) StringNullCreateRequest(ctx context.Context, querie
 	return req, nil
 }
 
-// StringNullHandleResponse handles the StringNull response.
-func (client *QueriesClient) StringNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.StringNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // StringNullHandleError handles the StringNull error response.
 func (client *QueriesClient) StringNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1737,11 +1539,10 @@ func (client *QueriesClient) StringURLEncoded(ctx context.Context) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.StringURLEncodedHandleResponse(resp)
-	if err != nil {
+	if err := client.StringURLEncodedHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // StringURLEncodedCreateRequest creates the StringURLEncoded request.
@@ -1758,16 +1559,11 @@ func (client *QueriesClient) StringURLEncodedCreateRequest(ctx context.Context) 
 	return req, nil
 }
 
-// StringURLEncodedHandleResponse handles the StringURLEncoded response.
-func (client *QueriesClient) StringURLEncodedHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.StringURLEncodedHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // StringURLEncodedHandleError handles the StringURLEncoded error response.
 func (client *QueriesClient) StringURLEncodedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1785,11 +1581,10 @@ func (client *QueriesClient) StringUnicode(ctx context.Context) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.StringUnicodeHandleResponse(resp)
-	if err != nil {
+	if err := client.StringUnicodeHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // StringUnicodeCreateRequest creates the StringUnicode request.
@@ -1806,16 +1601,11 @@ func (client *QueriesClient) StringUnicodeCreateRequest(ctx context.Context) (*a
 	return req, nil
 }
 
-// StringUnicodeHandleResponse handles the StringUnicode response.
-func (client *QueriesClient) StringUnicodeHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.StringUnicodeHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // StringUnicodeHandleError handles the StringUnicode error response.
 func (client *QueriesClient) StringUnicodeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/urlmultigroup/zz_generated_queries.go
+++ b/test/autorest/urlmultigroup/zz_generated_queries.go
@@ -47,11 +47,10 @@ func (client *QueriesClient) ArrayStringMultiEmpty(ctx context.Context, queriesA
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ArrayStringMultiEmptyHandleResponse(resp)
-	if err != nil {
+	if err := client.ArrayStringMultiEmptyHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ArrayStringMultiEmptyCreateRequest creates the ArrayStringMultiEmpty request.
@@ -72,16 +71,11 @@ func (client *QueriesClient) ArrayStringMultiEmptyCreateRequest(ctx context.Cont
 	return req, nil
 }
 
-// ArrayStringMultiEmptyHandleResponse handles the ArrayStringMultiEmpty response.
-func (client *QueriesClient) ArrayStringMultiEmptyHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ArrayStringMultiEmptyHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ArrayStringMultiEmptyHandleError handles the ArrayStringMultiEmpty error response.
 func (client *QueriesClient) ArrayStringMultiEmptyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -99,11 +93,10 @@ func (client *QueriesClient) ArrayStringMultiNull(ctx context.Context, queriesAr
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ArrayStringMultiNullHandleResponse(resp)
-	if err != nil {
+	if err := client.ArrayStringMultiNullHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ArrayStringMultiNullCreateRequest creates the ArrayStringMultiNull request.
@@ -124,16 +117,11 @@ func (client *QueriesClient) ArrayStringMultiNullCreateRequest(ctx context.Conte
 	return req, nil
 }
 
-// ArrayStringMultiNullHandleResponse handles the ArrayStringMultiNull response.
-func (client *QueriesClient) ArrayStringMultiNullHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ArrayStringMultiNullHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ArrayStringMultiNullHandleError handles the ArrayStringMultiNull error response.
 func (client *QueriesClient) ArrayStringMultiNullHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -151,11 +139,10 @@ func (client *QueriesClient) ArrayStringMultiValid(ctx context.Context, queriesA
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.ArrayStringMultiValidHandleResponse(resp)
-	if err != nil {
+	if err := client.ArrayStringMultiValidHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // ArrayStringMultiValidCreateRequest creates the ArrayStringMultiValid request.
@@ -176,16 +163,11 @@ func (client *QueriesClient) ArrayStringMultiValidCreateRequest(ctx context.Cont
 	return req, nil
 }
 
-// ArrayStringMultiValidHandleResponse handles the ArrayStringMultiValid response.
-func (client *QueriesClient) ArrayStringMultiValidHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ArrayStringMultiValidHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // ArrayStringMultiValidHandleError handles the ArrayStringMultiValid error response.
 func (client *QueriesClient) ArrayStringMultiValidHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/urlmultigroup/zz_generated_queries.go
+++ b/test/autorest/urlmultigroup/zz_generated_queries.go
@@ -47,8 +47,8 @@ func (client *QueriesClient) ArrayStringMultiEmpty(ctx context.Context, queriesA
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ArrayStringMultiEmptyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ArrayStringMultiEmptyHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -73,9 +73,6 @@ func (client *QueriesClient) ArrayStringMultiEmptyCreateRequest(ctx context.Cont
 
 // ArrayStringMultiEmptyHandleError handles the ArrayStringMultiEmpty error response.
 func (client *QueriesClient) ArrayStringMultiEmptyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -93,8 +90,8 @@ func (client *QueriesClient) ArrayStringMultiNull(ctx context.Context, queriesAr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ArrayStringMultiNullHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ArrayStringMultiNullHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -119,9 +116,6 @@ func (client *QueriesClient) ArrayStringMultiNullCreateRequest(ctx context.Conte
 
 // ArrayStringMultiNullHandleError handles the ArrayStringMultiNull error response.
 func (client *QueriesClient) ArrayStringMultiNullHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -139,8 +133,8 @@ func (client *QueriesClient) ArrayStringMultiValid(ctx context.Context, queriesA
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ArrayStringMultiValidHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ArrayStringMultiValidHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -165,9 +159,6 @@ func (client *QueriesClient) ArrayStringMultiValidCreateRequest(ctx context.Cont
 
 // ArrayStringMultiValidHandleError handles the ArrayStringMultiValid error response.
 func (client *QueriesClient) ArrayStringMultiValidHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/validationgroup/zz_generated_autorestvalidationtest.go
+++ b/test/autorest/validationgroup/zz_generated_autorestvalidationtest.go
@@ -53,8 +53,8 @@ func (client *AutoRestValidationTestClient) GetWithConstantInPath(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetWithConstantInPathHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetWithConstantInPathHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -72,9 +72,6 @@ func (client *AutoRestValidationTestClient) GetWithConstantInPathCreateRequest(c
 
 // GetWithConstantInPathHandleError handles the GetWithConstantInPath error response.
 func (client *AutoRestValidationTestClient) GetWithConstantInPathHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -94,8 +91,8 @@ func (client *AutoRestValidationTestClient) PostWithConstantInBody(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PostWithConstantInBodyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.PostWithConstantInBodyHandleError(resp)
 	}
 	result, err := client.PostWithConstantInBodyHandleResponse(resp)
 	if err != nil {
@@ -127,9 +124,6 @@ func (client *AutoRestValidationTestClient) PostWithConstantInBodyHandleResponse
 
 // PostWithConstantInBodyHandleError handles the PostWithConstantInBody error response.
 func (client *AutoRestValidationTestClient) PostWithConstantInBodyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -150,8 +144,8 @@ func (client *AutoRestValidationTestClient) ValidationOfBody(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ValidationOfBodyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ValidationOfBodyHandleError(resp)
 	}
 	result, err := client.ValidationOfBodyHandleResponse(resp)
 	if err != nil {
@@ -188,9 +182,6 @@ func (client *AutoRestValidationTestClient) ValidationOfBodyHandleResponse(resp 
 
 // ValidationOfBodyHandleError handles the ValidationOfBody error response.
 func (client *AutoRestValidationTestClient) ValidationOfBodyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,8 +199,8 @@ func (client *AutoRestValidationTestClient) ValidationOfMethodParameters(ctx con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ValidationOfMethodParametersHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ValidationOfMethodParametersHandleError(resp)
 	}
 	result, err := client.ValidationOfMethodParametersHandleResponse(resp)
 	if err != nil {
@@ -243,9 +234,6 @@ func (client *AutoRestValidationTestClient) ValidationOfMethodParametersHandleRe
 
 // ValidationOfMethodParametersHandleError handles the ValidationOfMethodParameters error response.
 func (client *AutoRestValidationTestClient) ValidationOfMethodParametersHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/validationgroup/zz_generated_autorestvalidationtest.go
+++ b/test/autorest/validationgroup/zz_generated_autorestvalidationtest.go
@@ -53,11 +53,10 @@ func (client *AutoRestValidationTestClient) GetWithConstantInPath(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.GetWithConstantInPathHandleResponse(resp)
-	if err != nil {
+	if err := client.GetWithConstantInPathHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // GetWithConstantInPathCreateRequest creates the GetWithConstantInPath request.
@@ -71,16 +70,11 @@ func (client *AutoRestValidationTestClient) GetWithConstantInPathCreateRequest(c
 	return req, nil
 }
 
-// GetWithConstantInPathHandleResponse handles the GetWithConstantInPath response.
-func (client *AutoRestValidationTestClient) GetWithConstantInPathHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetWithConstantInPathHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // GetWithConstantInPathHandleError handles the GetWithConstantInPath error response.
 func (client *AutoRestValidationTestClient) GetWithConstantInPathHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -98,6 +92,9 @@ func (client *AutoRestValidationTestClient) PostWithConstantInBody(ctx context.C
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PostWithConstantInBodyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PostWithConstantInBodyHandleResponse(resp)
@@ -124,15 +121,15 @@ func (client *AutoRestValidationTestClient) PostWithConstantInBodyCreateRequest(
 
 // PostWithConstantInBodyHandleResponse handles the PostWithConstantInBody response.
 func (client *AutoRestValidationTestClient) PostWithConstantInBodyHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.PostWithConstantInBodyHandleError(resp)
-	}
 	result := ProductResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
 // PostWithConstantInBodyHandleError handles the PostWithConstantInBody error response.
 func (client *AutoRestValidationTestClient) PostWithConstantInBodyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -151,6 +148,9 @@ func (client *AutoRestValidationTestClient) ValidationOfBody(ctx context.Context
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ValidationOfBodyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ValidationOfBodyHandleResponse(resp)
@@ -182,15 +182,15 @@ func (client *AutoRestValidationTestClient) ValidationOfBodyCreateRequest(ctx co
 
 // ValidationOfBodyHandleResponse handles the ValidationOfBody response.
 func (client *AutoRestValidationTestClient) ValidationOfBodyHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ValidationOfBodyHandleError(resp)
-	}
 	result := ProductResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
 // ValidationOfBodyHandleError handles the ValidationOfBody error response.
 func (client *AutoRestValidationTestClient) ValidationOfBodyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -206,6 +206,9 @@ func (client *AutoRestValidationTestClient) ValidationOfMethodParameters(ctx con
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ValidationOfMethodParametersHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ValidationOfMethodParametersHandleResponse(resp)
@@ -234,15 +237,15 @@ func (client *AutoRestValidationTestClient) ValidationOfMethodParametersCreateRe
 
 // ValidationOfMethodParametersHandleResponse handles the ValidationOfMethodParameters response.
 func (client *AutoRestValidationTestClient) ValidationOfMethodParametersHandleResponse(resp *azcore.Response) (*ProductResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ValidationOfMethodParametersHandleError(resp)
-	}
 	result := ProductResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Product)
 }
 
 // ValidationOfMethodParametersHandleError handles the ValidationOfMethodParameters error response.
 func (client *AutoRestValidationTestClient) ValidationOfMethodParametersHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/autorest/xmlgroup/zz_generated_xml.go
+++ b/test/autorest/xmlgroup/zz_generated_xml.go
@@ -105,6 +105,9 @@ func (client *XMLClient) GetACLs(ctx context.Context) (*SignedIDentifierArrayRes
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetACLsHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetACLsHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -129,15 +132,15 @@ func (client *XMLClient) GetACLsCreateRequest(ctx context.Context) (*azcore.Requ
 
 // GetACLsHandleResponse handles the GetACLs response.
 func (client *XMLClient) GetACLsHandleResponse(resp *azcore.Response) (*SignedIDentifierArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetACLsHandleError(resp)
-	}
 	result := SignedIDentifierArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result)
 }
 
 // GetACLsHandleError handles the GetACLs error response.
 func (client *XMLClient) GetACLsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -156,6 +159,9 @@ func (client *XMLClient) GetComplexTypeRefNoMeta(ctx context.Context) (*RootWith
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetComplexTypeRefNoMetaHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetComplexTypeRefNoMetaHandleResponse(resp)
@@ -178,15 +184,15 @@ func (client *XMLClient) GetComplexTypeRefNoMetaCreateRequest(ctx context.Contex
 
 // GetComplexTypeRefNoMetaHandleResponse handles the GetComplexTypeRefNoMeta response.
 func (client *XMLClient) GetComplexTypeRefNoMetaHandleResponse(resp *azcore.Response) (*RootWithRefAndNoMetaResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetComplexTypeRefNoMetaHandleError(resp)
-	}
 	result := RootWithRefAndNoMetaResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.RootWithRefAndNoMeta)
 }
 
 // GetComplexTypeRefNoMetaHandleError handles the GetComplexTypeRefNoMeta error response.
 func (client *XMLClient) GetComplexTypeRefNoMetaHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -205,6 +211,9 @@ func (client *XMLClient) GetComplexTypeRefWithMeta(ctx context.Context) (*RootWi
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetComplexTypeRefWithMetaHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetComplexTypeRefWithMetaHandleResponse(resp)
@@ -227,15 +236,15 @@ func (client *XMLClient) GetComplexTypeRefWithMetaCreateRequest(ctx context.Cont
 
 // GetComplexTypeRefWithMetaHandleResponse handles the GetComplexTypeRefWithMeta response.
 func (client *XMLClient) GetComplexTypeRefWithMetaHandleResponse(resp *azcore.Response) (*RootWithRefAndMetaResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetComplexTypeRefWithMetaHandleError(resp)
-	}
 	result := RootWithRefAndMetaResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.RootWithRefAndMeta)
 }
 
 // GetComplexTypeRefWithMetaHandleError handles the GetComplexTypeRefWithMeta error response.
 func (client *XMLClient) GetComplexTypeRefWithMetaHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -254,6 +263,9 @@ func (client *XMLClient) GetEmptyChildElement(ctx context.Context) (*BananaRespo
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetEmptyChildElementHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetEmptyChildElementHandleResponse(resp)
@@ -276,15 +288,15 @@ func (client *XMLClient) GetEmptyChildElementCreateRequest(ctx context.Context) 
 
 // GetEmptyChildElementHandleResponse handles the GetEmptyChildElement response.
 func (client *XMLClient) GetEmptyChildElementHandleResponse(resp *azcore.Response) (*BananaResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyChildElementHandleError(resp)
-	}
 	result := BananaResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.Banana)
 }
 
 // GetEmptyChildElementHandleError handles the GetEmptyChildElement error response.
 func (client *XMLClient) GetEmptyChildElementHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -303,6 +315,9 @@ func (client *XMLClient) GetEmptyList(ctx context.Context) (*SlideshowResponse, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetEmptyListHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetEmptyListHandleResponse(resp)
@@ -325,15 +340,15 @@ func (client *XMLClient) GetEmptyListCreateRequest(ctx context.Context) (*azcore
 
 // GetEmptyListHandleResponse handles the GetEmptyList response.
 func (client *XMLClient) GetEmptyListHandleResponse(resp *azcore.Response) (*SlideshowResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyListHandleError(resp)
-	}
 	result := SlideshowResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.Slideshow)
 }
 
 // GetEmptyListHandleError handles the GetEmptyList error response.
 func (client *XMLClient) GetEmptyListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -352,6 +367,9 @@ func (client *XMLClient) GetEmptyRootList(ctx context.Context) (*BananaArrayResp
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetEmptyRootListHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetEmptyRootListHandleResponse(resp)
@@ -374,15 +392,15 @@ func (client *XMLClient) GetEmptyRootListCreateRequest(ctx context.Context) (*az
 
 // GetEmptyRootListHandleResponse handles the GetEmptyRootList response.
 func (client *XMLClient) GetEmptyRootListHandleResponse(resp *azcore.Response) (*BananaArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyRootListHandleError(resp)
-	}
 	result := BananaArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result)
 }
 
 // GetEmptyRootListHandleError handles the GetEmptyRootList error response.
 func (client *XMLClient) GetEmptyRootListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -401,6 +419,9 @@ func (client *XMLClient) GetEmptyWrappedLists(ctx context.Context) (*AppleBarrel
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetEmptyWrappedListsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetEmptyWrappedListsHandleResponse(resp)
@@ -423,15 +444,15 @@ func (client *XMLClient) GetEmptyWrappedListsCreateRequest(ctx context.Context) 
 
 // GetEmptyWrappedListsHandleResponse handles the GetEmptyWrappedLists response.
 func (client *XMLClient) GetEmptyWrappedListsHandleResponse(resp *azcore.Response) (*AppleBarrelResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetEmptyWrappedListsHandleError(resp)
-	}
 	result := AppleBarrelResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.AppleBarrel)
 }
 
 // GetEmptyWrappedListsHandleError handles the GetEmptyWrappedLists error response.
 func (client *XMLClient) GetEmptyWrappedListsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -450,6 +471,9 @@ func (client *XMLClient) GetHeaders(ctx context.Context) (*XMLGetHeadersResponse
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHeadersHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHeadersHandleResponse(resp)
@@ -471,9 +495,6 @@ func (client *XMLClient) GetHeadersCreateRequest(ctx context.Context) (*azcore.R
 
 // GetHeadersHandleResponse handles the GetHeaders response.
 func (client *XMLClient) GetHeadersHandleResponse(resp *azcore.Response) (*XMLGetHeadersResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHeadersHandleError(resp)
-	}
 	result := XMLGetHeadersResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Custom-Header"); val != "" {
 		result.CustomHeader = &val
@@ -483,6 +504,9 @@ func (client *XMLClient) GetHeadersHandleResponse(resp *azcore.Response) (*XMLGe
 
 // GetHeadersHandleError handles the GetHeaders error response.
 func (client *XMLClient) GetHeadersHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -501,6 +525,9 @@ func (client *XMLClient) GetRootList(ctx context.Context) (*BananaArrayResponse,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetRootListHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetRootListHandleResponse(resp)
@@ -523,15 +550,15 @@ func (client *XMLClient) GetRootListCreateRequest(ctx context.Context) (*azcore.
 
 // GetRootListHandleResponse handles the GetRootList response.
 func (client *XMLClient) GetRootListHandleResponse(resp *azcore.Response) (*BananaArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetRootListHandleError(resp)
-	}
 	result := BananaArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result)
 }
 
 // GetRootListHandleError handles the GetRootList error response.
 func (client *XMLClient) GetRootListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -550,6 +577,9 @@ func (client *XMLClient) GetRootListSingleItem(ctx context.Context) (*BananaArra
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetRootListSingleItemHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetRootListSingleItemHandleResponse(resp)
@@ -572,15 +602,15 @@ func (client *XMLClient) GetRootListSingleItemCreateRequest(ctx context.Context)
 
 // GetRootListSingleItemHandleResponse handles the GetRootListSingleItem response.
 func (client *XMLClient) GetRootListSingleItemHandleResponse(resp *azcore.Response) (*BananaArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetRootListSingleItemHandleError(resp)
-	}
 	result := BananaArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result)
 }
 
 // GetRootListSingleItemHandleError handles the GetRootListSingleItem error response.
 func (client *XMLClient) GetRootListSingleItemHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -599,6 +629,9 @@ func (client *XMLClient) GetServiceProperties(ctx context.Context) (*StorageServ
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetServicePropertiesHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetServicePropertiesHandleResponse(resp)
@@ -625,15 +658,15 @@ func (client *XMLClient) GetServicePropertiesCreateRequest(ctx context.Context) 
 
 // GetServicePropertiesHandleResponse handles the GetServiceProperties response.
 func (client *XMLClient) GetServicePropertiesHandleResponse(resp *azcore.Response) (*StorageServicePropertiesResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetServicePropertiesHandleError(resp)
-	}
 	result := StorageServicePropertiesResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.StorageServiceProperties)
 }
 
 // GetServicePropertiesHandleError handles the GetServiceProperties error response.
 func (client *XMLClient) GetServicePropertiesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -652,6 +685,9 @@ func (client *XMLClient) GetSimple(ctx context.Context) (*SlideshowResponse, err
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetSimpleHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetSimpleHandleResponse(resp)
@@ -674,15 +710,15 @@ func (client *XMLClient) GetSimpleCreateRequest(ctx context.Context) (*azcore.Re
 
 // GetSimpleHandleResponse handles the GetSimple response.
 func (client *XMLClient) GetSimpleHandleResponse(resp *azcore.Response) (*SlideshowResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetSimpleHandleError(resp)
-	}
 	result := SlideshowResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.Slideshow)
 }
 
 // GetSimpleHandleError handles the GetSimple error response.
 func (client *XMLClient) GetSimpleHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -698,6 +734,9 @@ func (client *XMLClient) GetWrappedLists(ctx context.Context) (*AppleBarrelRespo
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetWrappedListsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetWrappedListsHandleResponse(resp)
@@ -720,15 +759,15 @@ func (client *XMLClient) GetWrappedListsCreateRequest(ctx context.Context) (*azc
 
 // GetWrappedListsHandleResponse handles the GetWrappedLists response.
 func (client *XMLClient) GetWrappedListsHandleResponse(resp *azcore.Response) (*AppleBarrelResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetWrappedListsHandleError(resp)
-	}
 	result := AppleBarrelResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.AppleBarrel)
 }
 
 // GetWrappedListsHandleError handles the GetWrappedLists error response.
 func (client *XMLClient) GetWrappedListsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -747,6 +786,9 @@ func (client *XMLClient) GetXMSText(ctx context.Context) (*ObjectWithXMSTextProp
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetXMSTextHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetXMSTextHandleResponse(resp)
@@ -769,15 +811,15 @@ func (client *XMLClient) GetXMSTextCreateRequest(ctx context.Context) (*azcore.R
 
 // GetXMSTextHandleResponse handles the GetXMSText response.
 func (client *XMLClient) GetXMSTextHandleResponse(resp *azcore.Response) (*ObjectWithXMSTextPropertyResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetXMSTextHandleError(resp)
-	}
 	result := ObjectWithXMSTextPropertyResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.Data)
 }
 
 // GetXMSTextHandleError handles the GetXMSText error response.
 func (client *XMLClient) GetXMSTextHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -798,11 +840,10 @@ func (client *XMLClient) JSONInput(ctx context.Context, properties JSONInput) (*
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.JSONInputHandleResponse(resp)
-	if err != nil {
+	if err := client.JSONInputHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // JSONInputCreateRequest creates the JSONInput request.
@@ -815,16 +856,11 @@ func (client *XMLClient) JSONInputCreateRequest(ctx context.Context, properties 
 	return req, req.MarshalAsJSON(properties)
 }
 
-// JSONInputHandleResponse handles the JSONInput response.
-func (client *XMLClient) JSONInputHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.JSONInputHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // JSONInputHandleError handles the JSONInput error response.
 func (client *XMLClient) JSONInputHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -843,6 +879,9 @@ func (client *XMLClient) JSONOutput(ctx context.Context) (*JSONOutputResponse, e
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.JSONOutputHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.JSONOutputHandleResponse(resp)
@@ -865,15 +904,15 @@ func (client *XMLClient) JSONOutputCreateRequest(ctx context.Context) (*azcore.R
 
 // JSONOutputHandleResponse handles the JSONOutput response.
 func (client *XMLClient) JSONOutputHandleResponse(resp *azcore.Response) (*JSONOutputResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.JSONOutputHandleError(resp)
-	}
 	result := JSONOutputResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.JSONOutput)
 }
 
 // JSONOutputHandleError handles the JSONOutput error response.
 func (client *XMLClient) JSONOutputHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -892,6 +931,9 @@ func (client *XMLClient) ListBlobs(ctx context.Context) (*ListBlobsResponseRespo
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListBlobsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListBlobsHandleResponse(resp)
@@ -918,15 +960,15 @@ func (client *XMLClient) ListBlobsCreateRequest(ctx context.Context) (*azcore.Re
 
 // ListBlobsHandleResponse handles the ListBlobs response.
 func (client *XMLClient) ListBlobsHandleResponse(resp *azcore.Response) (*ListBlobsResponseResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListBlobsHandleError(resp)
-	}
 	result := ListBlobsResponseResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.EnumerationResults)
 }
 
 // ListBlobsHandleError handles the ListBlobs error response.
 func (client *XMLClient) ListBlobsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -945,6 +987,9 @@ func (client *XMLClient) ListContainers(ctx context.Context) (*ListContainersRes
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListContainersHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListContainersHandleResponse(resp)
@@ -970,15 +1015,15 @@ func (client *XMLClient) ListContainersCreateRequest(ctx context.Context) (*azco
 
 // ListContainersHandleResponse handles the ListContainers response.
 func (client *XMLClient) ListContainersHandleResponse(resp *azcore.Response) (*ListContainersResponseResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListContainersHandleError(resp)
-	}
 	result := ListContainersResponseResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsXML(&result.EnumerationResults)
 }
 
 // ListContainersHandleError handles the ListContainers error response.
 func (client *XMLClient) ListContainersHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -999,11 +1044,10 @@ func (client *XMLClient) PutACLs(ctx context.Context, properties []SignedIDentif
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutACLsHandleResponse(resp)
-	if err != nil {
+	if err := client.PutACLsHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutACLsCreateRequest creates the PutACLs request.
@@ -1024,16 +1068,11 @@ func (client *XMLClient) PutACLsCreateRequest(ctx context.Context, properties []
 	return req, req.MarshalAsXML(wrapper{Properties: &properties})
 }
 
-// PutACLsHandleResponse handles the PutACLs response.
-func (client *XMLClient) PutACLsHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.PutACLsHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutACLsHandleError handles the PutACLs error response.
 func (client *XMLClient) PutACLsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1054,11 +1093,10 @@ func (client *XMLClient) PutComplexTypeRefNoMeta(ctx context.Context, model Root
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutComplexTypeRefNoMetaHandleResponse(resp)
-	if err != nil {
+	if err := client.PutComplexTypeRefNoMetaHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutComplexTypeRefNoMetaCreateRequest creates the PutComplexTypeRefNoMeta request.
@@ -1071,16 +1109,11 @@ func (client *XMLClient) PutComplexTypeRefNoMetaCreateRequest(ctx context.Contex
 	return req, req.MarshalAsXML(model)
 }
 
-// PutComplexTypeRefNoMetaHandleResponse handles the PutComplexTypeRefNoMeta response.
-func (client *XMLClient) PutComplexTypeRefNoMetaHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.PutComplexTypeRefNoMetaHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutComplexTypeRefNoMetaHandleError handles the PutComplexTypeRefNoMeta error response.
 func (client *XMLClient) PutComplexTypeRefNoMetaHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1101,11 +1134,10 @@ func (client *XMLClient) PutComplexTypeRefWithMeta(ctx context.Context, model Ro
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutComplexTypeRefWithMetaHandleResponse(resp)
-	if err != nil {
+	if err := client.PutComplexTypeRefWithMetaHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutComplexTypeRefWithMetaCreateRequest creates the PutComplexTypeRefWithMeta request.
@@ -1118,16 +1150,11 @@ func (client *XMLClient) PutComplexTypeRefWithMetaCreateRequest(ctx context.Cont
 	return req, req.MarshalAsXML(model)
 }
 
-// PutComplexTypeRefWithMetaHandleResponse handles the PutComplexTypeRefWithMeta response.
-func (client *XMLClient) PutComplexTypeRefWithMetaHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.PutComplexTypeRefWithMetaHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutComplexTypeRefWithMetaHandleError handles the PutComplexTypeRefWithMeta error response.
 func (client *XMLClient) PutComplexTypeRefWithMetaHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1148,11 +1175,10 @@ func (client *XMLClient) PutEmptyChildElement(ctx context.Context, banana Banana
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutEmptyChildElementHandleResponse(resp)
-	if err != nil {
+	if err := client.PutEmptyChildElementHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutEmptyChildElementCreateRequest creates the PutEmptyChildElement request.
@@ -1165,16 +1191,11 @@ func (client *XMLClient) PutEmptyChildElementCreateRequest(ctx context.Context, 
 	return req, req.MarshalAsXML(banana)
 }
 
-// PutEmptyChildElementHandleResponse handles the PutEmptyChildElement response.
-func (client *XMLClient) PutEmptyChildElementHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.PutEmptyChildElementHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutEmptyChildElementHandleError handles the PutEmptyChildElement error response.
 func (client *XMLClient) PutEmptyChildElementHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1195,11 +1216,10 @@ func (client *XMLClient) PutEmptyList(ctx context.Context, slideshow Slideshow) 
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutEmptyListHandleResponse(resp)
-	if err != nil {
+	if err := client.PutEmptyListHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutEmptyListCreateRequest creates the PutEmptyList request.
@@ -1212,16 +1232,11 @@ func (client *XMLClient) PutEmptyListCreateRequest(ctx context.Context, slidesho
 	return req, req.MarshalAsXML(slideshow)
 }
 
-// PutEmptyListHandleResponse handles the PutEmptyList response.
-func (client *XMLClient) PutEmptyListHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.PutEmptyListHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutEmptyListHandleError handles the PutEmptyList error response.
 func (client *XMLClient) PutEmptyListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1242,11 +1257,10 @@ func (client *XMLClient) PutEmptyRootList(ctx context.Context, bananas []Banana)
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutEmptyRootListHandleResponse(resp)
-	if err != nil {
+	if err := client.PutEmptyRootListHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutEmptyRootListCreateRequest creates the PutEmptyRootList request.
@@ -1263,16 +1277,11 @@ func (client *XMLClient) PutEmptyRootListCreateRequest(ctx context.Context, bana
 	return req, req.MarshalAsXML(wrapper{Bananas: &bananas})
 }
 
-// PutEmptyRootListHandleResponse handles the PutEmptyRootList response.
-func (client *XMLClient) PutEmptyRootListHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.PutEmptyRootListHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutEmptyRootListHandleError handles the PutEmptyRootList error response.
 func (client *XMLClient) PutEmptyRootListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1293,11 +1302,10 @@ func (client *XMLClient) PutEmptyWrappedLists(ctx context.Context, appleBarrel A
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutEmptyWrappedListsHandleResponse(resp)
-	if err != nil {
+	if err := client.PutEmptyWrappedListsHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutEmptyWrappedListsCreateRequest creates the PutEmptyWrappedLists request.
@@ -1310,16 +1318,11 @@ func (client *XMLClient) PutEmptyWrappedListsCreateRequest(ctx context.Context, 
 	return req, req.MarshalAsXML(appleBarrel)
 }
 
-// PutEmptyWrappedListsHandleResponse handles the PutEmptyWrappedLists response.
-func (client *XMLClient) PutEmptyWrappedListsHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.PutEmptyWrappedListsHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutEmptyWrappedListsHandleError handles the PutEmptyWrappedLists error response.
 func (client *XMLClient) PutEmptyWrappedListsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1340,11 +1343,10 @@ func (client *XMLClient) PutRootList(ctx context.Context, bananas []Banana) (*ht
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutRootListHandleResponse(resp)
-	if err != nil {
+	if err := client.PutRootListHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutRootListCreateRequest creates the PutRootList request.
@@ -1361,16 +1363,11 @@ func (client *XMLClient) PutRootListCreateRequest(ctx context.Context, bananas [
 	return req, req.MarshalAsXML(wrapper{Bananas: &bananas})
 }
 
-// PutRootListHandleResponse handles the PutRootList response.
-func (client *XMLClient) PutRootListHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.PutRootListHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutRootListHandleError handles the PutRootList error response.
 func (client *XMLClient) PutRootListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1391,11 +1388,10 @@ func (client *XMLClient) PutRootListSingleItem(ctx context.Context, bananas []Ba
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutRootListSingleItemHandleResponse(resp)
-	if err != nil {
+	if err := client.PutRootListSingleItemHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutRootListSingleItemCreateRequest creates the PutRootListSingleItem request.
@@ -1412,16 +1408,11 @@ func (client *XMLClient) PutRootListSingleItemCreateRequest(ctx context.Context,
 	return req, req.MarshalAsXML(wrapper{Bananas: &bananas})
 }
 
-// PutRootListSingleItemHandleResponse handles the PutRootListSingleItem response.
-func (client *XMLClient) PutRootListSingleItemHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.PutRootListSingleItemHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutRootListSingleItemHandleError handles the PutRootListSingleItem error response.
 func (client *XMLClient) PutRootListSingleItemHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1442,11 +1433,10 @@ func (client *XMLClient) PutServiceProperties(ctx context.Context, properties St
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutServicePropertiesHandleResponse(resp)
-	if err != nil {
+	if err := client.PutServicePropertiesHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutServicePropertiesCreateRequest creates the PutServiceProperties request.
@@ -1463,16 +1453,11 @@ func (client *XMLClient) PutServicePropertiesCreateRequest(ctx context.Context, 
 	return req, req.MarshalAsXML(properties)
 }
 
-// PutServicePropertiesHandleResponse handles the PutServiceProperties response.
-func (client *XMLClient) PutServicePropertiesHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.PutServicePropertiesHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutServicePropertiesHandleError handles the PutServiceProperties error response.
 func (client *XMLClient) PutServicePropertiesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1493,11 +1478,10 @@ func (client *XMLClient) PutSimple(ctx context.Context, slideshow Slideshow) (*h
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutSimpleHandleResponse(resp)
-	if err != nil {
+	if err := client.PutSimpleHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutSimpleCreateRequest creates the PutSimple request.
@@ -1511,16 +1495,11 @@ func (client *XMLClient) PutSimpleCreateRequest(ctx context.Context, slideshow S
 	return req, req.MarshalAsXML(slideshow)
 }
 
-// PutSimpleHandleResponse handles the PutSimple response.
-func (client *XMLClient) PutSimpleHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.PutSimpleHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutSimpleHandleError handles the PutSimple error response.
 func (client *XMLClient) PutSimpleHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1538,11 +1517,10 @@ func (client *XMLClient) PutWrappedLists(ctx context.Context, wrappedLists Apple
 	if err != nil {
 		return nil, err
 	}
-	result, err := client.PutWrappedListsHandleResponse(resp)
-	if err != nil {
+	if err := client.PutWrappedListsHandleError(resp); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return resp.Response, nil
 }
 
 // PutWrappedListsCreateRequest creates the PutWrappedLists request.
@@ -1556,16 +1534,11 @@ func (client *XMLClient) PutWrappedListsCreateRequest(ctx context.Context, wrapp
 	return req, req.MarshalAsXML(wrappedLists)
 }
 
-// PutWrappedListsHandleResponse handles the PutWrappedLists response.
-func (client *XMLClient) PutWrappedListsHandleResponse(resp *azcore.Response) (*http.Response, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.PutWrappedListsHandleError(resp)
-	}
-	return resp.Response, nil
-}
-
 // PutWrappedListsHandleError handles the PutWrappedLists error response.
 func (client *XMLClient) PutWrappedListsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err

--- a/test/autorest/xmlgroup/zz_generated_xml.go
+++ b/test/autorest/xmlgroup/zz_generated_xml.go
@@ -105,8 +105,8 @@ func (client *XMLClient) GetACLs(ctx context.Context) (*SignedIDentifierArrayRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetACLsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetACLsHandleError(resp)
 	}
 	result, err := client.GetACLsHandleResponse(resp)
 	if err != nil {
@@ -138,9 +138,6 @@ func (client *XMLClient) GetACLsHandleResponse(resp *azcore.Response) (*SignedID
 
 // GetACLsHandleError handles the GetACLs error response.
 func (client *XMLClient) GetACLsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -161,8 +158,8 @@ func (client *XMLClient) GetComplexTypeRefNoMeta(ctx context.Context) (*RootWith
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetComplexTypeRefNoMetaHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetComplexTypeRefNoMetaHandleError(resp)
 	}
 	result, err := client.GetComplexTypeRefNoMetaHandleResponse(resp)
 	if err != nil {
@@ -190,9 +187,6 @@ func (client *XMLClient) GetComplexTypeRefNoMetaHandleResponse(resp *azcore.Resp
 
 // GetComplexTypeRefNoMetaHandleError handles the GetComplexTypeRefNoMeta error response.
 func (client *XMLClient) GetComplexTypeRefNoMetaHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -213,8 +207,8 @@ func (client *XMLClient) GetComplexTypeRefWithMeta(ctx context.Context) (*RootWi
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetComplexTypeRefWithMetaHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetComplexTypeRefWithMetaHandleError(resp)
 	}
 	result, err := client.GetComplexTypeRefWithMetaHandleResponse(resp)
 	if err != nil {
@@ -242,9 +236,6 @@ func (client *XMLClient) GetComplexTypeRefWithMetaHandleResponse(resp *azcore.Re
 
 // GetComplexTypeRefWithMetaHandleError handles the GetComplexTypeRefWithMeta error response.
 func (client *XMLClient) GetComplexTypeRefWithMetaHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -265,8 +256,8 @@ func (client *XMLClient) GetEmptyChildElement(ctx context.Context) (*BananaRespo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyChildElementHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyChildElementHandleError(resp)
 	}
 	result, err := client.GetEmptyChildElementHandleResponse(resp)
 	if err != nil {
@@ -294,9 +285,6 @@ func (client *XMLClient) GetEmptyChildElementHandleResponse(resp *azcore.Respons
 
 // GetEmptyChildElementHandleError handles the GetEmptyChildElement error response.
 func (client *XMLClient) GetEmptyChildElementHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -317,8 +305,8 @@ func (client *XMLClient) GetEmptyList(ctx context.Context) (*SlideshowResponse, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyListHandleError(resp)
 	}
 	result, err := client.GetEmptyListHandleResponse(resp)
 	if err != nil {
@@ -346,9 +334,6 @@ func (client *XMLClient) GetEmptyListHandleResponse(resp *azcore.Response) (*Sli
 
 // GetEmptyListHandleError handles the GetEmptyList error response.
 func (client *XMLClient) GetEmptyListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -369,8 +354,8 @@ func (client *XMLClient) GetEmptyRootList(ctx context.Context) (*BananaArrayResp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyRootListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyRootListHandleError(resp)
 	}
 	result, err := client.GetEmptyRootListHandleResponse(resp)
 	if err != nil {
@@ -398,9 +383,6 @@ func (client *XMLClient) GetEmptyRootListHandleResponse(resp *azcore.Response) (
 
 // GetEmptyRootListHandleError handles the GetEmptyRootList error response.
 func (client *XMLClient) GetEmptyRootListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -421,8 +403,8 @@ func (client *XMLClient) GetEmptyWrappedLists(ctx context.Context) (*AppleBarrel
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEmptyWrappedListsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetEmptyWrappedListsHandleError(resp)
 	}
 	result, err := client.GetEmptyWrappedListsHandleResponse(resp)
 	if err != nil {
@@ -450,9 +432,6 @@ func (client *XMLClient) GetEmptyWrappedListsHandleResponse(resp *azcore.Respons
 
 // GetEmptyWrappedListsHandleError handles the GetEmptyWrappedLists error response.
 func (client *XMLClient) GetEmptyWrappedListsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -473,8 +452,8 @@ func (client *XMLClient) GetHeaders(ctx context.Context) (*XMLGetHeadersResponse
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHeadersHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHeadersHandleError(resp)
 	}
 	result, err := client.GetHeadersHandleResponse(resp)
 	if err != nil {
@@ -504,9 +483,6 @@ func (client *XMLClient) GetHeadersHandleResponse(resp *azcore.Response) (*XMLGe
 
 // GetHeadersHandleError handles the GetHeaders error response.
 func (client *XMLClient) GetHeadersHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -527,8 +503,8 @@ func (client *XMLClient) GetRootList(ctx context.Context) (*BananaArrayResponse,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetRootListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetRootListHandleError(resp)
 	}
 	result, err := client.GetRootListHandleResponse(resp)
 	if err != nil {
@@ -556,9 +532,6 @@ func (client *XMLClient) GetRootListHandleResponse(resp *azcore.Response) (*Bana
 
 // GetRootListHandleError handles the GetRootList error response.
 func (client *XMLClient) GetRootListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -579,8 +552,8 @@ func (client *XMLClient) GetRootListSingleItem(ctx context.Context) (*BananaArra
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetRootListSingleItemHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetRootListSingleItemHandleError(resp)
 	}
 	result, err := client.GetRootListSingleItemHandleResponse(resp)
 	if err != nil {
@@ -608,9 +581,6 @@ func (client *XMLClient) GetRootListSingleItemHandleResponse(resp *azcore.Respon
 
 // GetRootListSingleItemHandleError handles the GetRootListSingleItem error response.
 func (client *XMLClient) GetRootListSingleItemHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -631,8 +601,8 @@ func (client *XMLClient) GetServiceProperties(ctx context.Context) (*StorageServ
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetServicePropertiesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetServicePropertiesHandleError(resp)
 	}
 	result, err := client.GetServicePropertiesHandleResponse(resp)
 	if err != nil {
@@ -664,9 +634,6 @@ func (client *XMLClient) GetServicePropertiesHandleResponse(resp *azcore.Respons
 
 // GetServicePropertiesHandleError handles the GetServiceProperties error response.
 func (client *XMLClient) GetServicePropertiesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -687,8 +654,8 @@ func (client *XMLClient) GetSimple(ctx context.Context) (*SlideshowResponse, err
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetSimpleHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetSimpleHandleError(resp)
 	}
 	result, err := client.GetSimpleHandleResponse(resp)
 	if err != nil {
@@ -716,9 +683,6 @@ func (client *XMLClient) GetSimpleHandleResponse(resp *azcore.Response) (*Slides
 
 // GetSimpleHandleError handles the GetSimple error response.
 func (client *XMLClient) GetSimpleHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -736,8 +700,8 @@ func (client *XMLClient) GetWrappedLists(ctx context.Context) (*AppleBarrelRespo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetWrappedListsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetWrappedListsHandleError(resp)
 	}
 	result, err := client.GetWrappedListsHandleResponse(resp)
 	if err != nil {
@@ -765,9 +729,6 @@ func (client *XMLClient) GetWrappedListsHandleResponse(resp *azcore.Response) (*
 
 // GetWrappedListsHandleError handles the GetWrappedLists error response.
 func (client *XMLClient) GetWrappedListsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -788,8 +749,8 @@ func (client *XMLClient) GetXMSText(ctx context.Context) (*ObjectWithXMSTextProp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetXMSTextHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetXMSTextHandleError(resp)
 	}
 	result, err := client.GetXMSTextHandleResponse(resp)
 	if err != nil {
@@ -817,9 +778,6 @@ func (client *XMLClient) GetXMSTextHandleResponse(resp *azcore.Response) (*Objec
 
 // GetXMSTextHandleError handles the GetXMSText error response.
 func (client *XMLClient) GetXMSTextHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -840,8 +798,8 @@ func (client *XMLClient) JSONInput(ctx context.Context, properties JSONInput) (*
 	if err != nil {
 		return nil, err
 	}
-	if err := client.JSONInputHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.JSONInputHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -858,9 +816,6 @@ func (client *XMLClient) JSONInputCreateRequest(ctx context.Context, properties 
 
 // JSONInputHandleError handles the JSONInput error response.
 func (client *XMLClient) JSONInputHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -881,8 +836,8 @@ func (client *XMLClient) JSONOutput(ctx context.Context) (*JSONOutputResponse, e
 	if err != nil {
 		return nil, err
 	}
-	if err := client.JSONOutputHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.JSONOutputHandleError(resp)
 	}
 	result, err := client.JSONOutputHandleResponse(resp)
 	if err != nil {
@@ -910,9 +865,6 @@ func (client *XMLClient) JSONOutputHandleResponse(resp *azcore.Response) (*JSONO
 
 // JSONOutputHandleError handles the JSONOutput error response.
 func (client *XMLClient) JSONOutputHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -933,8 +885,8 @@ func (client *XMLClient) ListBlobs(ctx context.Context) (*ListBlobsResponseRespo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListBlobsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListBlobsHandleError(resp)
 	}
 	result, err := client.ListBlobsHandleResponse(resp)
 	if err != nil {
@@ -966,9 +918,6 @@ func (client *XMLClient) ListBlobsHandleResponse(resp *azcore.Response) (*ListBl
 
 // ListBlobsHandleError handles the ListBlobs error response.
 func (client *XMLClient) ListBlobsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -989,8 +938,8 @@ func (client *XMLClient) ListContainers(ctx context.Context) (*ListContainersRes
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListContainersHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListContainersHandleError(resp)
 	}
 	result, err := client.ListContainersHandleResponse(resp)
 	if err != nil {
@@ -1021,9 +970,6 @@ func (client *XMLClient) ListContainersHandleResponse(resp *azcore.Response) (*L
 
 // ListContainersHandleError handles the ListContainers error response.
 func (client *XMLClient) ListContainersHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1044,8 +990,8 @@ func (client *XMLClient) PutACLs(ctx context.Context, properties []SignedIDentif
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutACLsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.PutACLsHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1070,9 +1016,6 @@ func (client *XMLClient) PutACLsCreateRequest(ctx context.Context, properties []
 
 // PutACLsHandleError handles the PutACLs error response.
 func (client *XMLClient) PutACLsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1093,8 +1036,8 @@ func (client *XMLClient) PutComplexTypeRefNoMeta(ctx context.Context, model Root
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutComplexTypeRefNoMetaHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.PutComplexTypeRefNoMetaHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1111,9 +1054,6 @@ func (client *XMLClient) PutComplexTypeRefNoMetaCreateRequest(ctx context.Contex
 
 // PutComplexTypeRefNoMetaHandleError handles the PutComplexTypeRefNoMeta error response.
 func (client *XMLClient) PutComplexTypeRefNoMetaHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1134,8 +1074,8 @@ func (client *XMLClient) PutComplexTypeRefWithMeta(ctx context.Context, model Ro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutComplexTypeRefWithMetaHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.PutComplexTypeRefWithMetaHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1152,9 +1092,6 @@ func (client *XMLClient) PutComplexTypeRefWithMetaCreateRequest(ctx context.Cont
 
 // PutComplexTypeRefWithMetaHandleError handles the PutComplexTypeRefWithMeta error response.
 func (client *XMLClient) PutComplexTypeRefWithMetaHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1175,8 +1112,8 @@ func (client *XMLClient) PutEmptyChildElement(ctx context.Context, banana Banana
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutEmptyChildElementHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.PutEmptyChildElementHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1193,9 +1130,6 @@ func (client *XMLClient) PutEmptyChildElementCreateRequest(ctx context.Context, 
 
 // PutEmptyChildElementHandleError handles the PutEmptyChildElement error response.
 func (client *XMLClient) PutEmptyChildElementHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1216,8 +1150,8 @@ func (client *XMLClient) PutEmptyList(ctx context.Context, slideshow Slideshow) 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutEmptyListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.PutEmptyListHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1234,9 +1168,6 @@ func (client *XMLClient) PutEmptyListCreateRequest(ctx context.Context, slidesho
 
 // PutEmptyListHandleError handles the PutEmptyList error response.
 func (client *XMLClient) PutEmptyListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1257,8 +1188,8 @@ func (client *XMLClient) PutEmptyRootList(ctx context.Context, bananas []Banana)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutEmptyRootListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.PutEmptyRootListHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1279,9 +1210,6 @@ func (client *XMLClient) PutEmptyRootListCreateRequest(ctx context.Context, bana
 
 // PutEmptyRootListHandleError handles the PutEmptyRootList error response.
 func (client *XMLClient) PutEmptyRootListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1302,8 +1230,8 @@ func (client *XMLClient) PutEmptyWrappedLists(ctx context.Context, appleBarrel A
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutEmptyWrappedListsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.PutEmptyWrappedListsHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1320,9 +1248,6 @@ func (client *XMLClient) PutEmptyWrappedListsCreateRequest(ctx context.Context, 
 
 // PutEmptyWrappedListsHandleError handles the PutEmptyWrappedLists error response.
 func (client *XMLClient) PutEmptyWrappedListsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1343,8 +1268,8 @@ func (client *XMLClient) PutRootList(ctx context.Context, bananas []Banana) (*ht
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutRootListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.PutRootListHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1365,9 +1290,6 @@ func (client *XMLClient) PutRootListCreateRequest(ctx context.Context, bananas [
 
 // PutRootListHandleError handles the PutRootList error response.
 func (client *XMLClient) PutRootListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1388,8 +1310,8 @@ func (client *XMLClient) PutRootListSingleItem(ctx context.Context, bananas []Ba
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutRootListSingleItemHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.PutRootListSingleItemHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1410,9 +1332,6 @@ func (client *XMLClient) PutRootListSingleItemCreateRequest(ctx context.Context,
 
 // PutRootListSingleItemHandleError handles the PutRootListSingleItem error response.
 func (client *XMLClient) PutRootListSingleItemHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1433,8 +1352,8 @@ func (client *XMLClient) PutServiceProperties(ctx context.Context, properties St
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutServicePropertiesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.PutServicePropertiesHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1455,9 +1374,6 @@ func (client *XMLClient) PutServicePropertiesCreateRequest(ctx context.Context, 
 
 // PutServicePropertiesHandleError handles the PutServiceProperties error response.
 func (client *XMLClient) PutServicePropertiesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
@@ -1478,8 +1394,8 @@ func (client *XMLClient) PutSimple(ctx context.Context, slideshow Slideshow) (*h
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutSimpleHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.PutSimpleHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1497,9 +1413,6 @@ func (client *XMLClient) PutSimpleCreateRequest(ctx context.Context, slideshow S
 
 // PutSimpleHandleError handles the PutSimple error response.
 func (client *XMLClient) PutSimpleHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1517,8 +1430,8 @@ func (client *XMLClient) PutWrappedLists(ctx context.Context, wrappedLists Apple
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutWrappedListsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.PutWrappedListsHandleError(resp)
 	}
 	return resp.Response, nil
 }
@@ -1536,9 +1449,6 @@ func (client *XMLClient) PutWrappedListsCreateRequest(ctx context.Context, wrapp
 
 // PutWrappedListsHandleError handles the PutWrappedLists error response.
 func (client *XMLClient) PutWrappedListsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
@@ -93,6 +93,9 @@ func (client *ApplicationGatewaysClient) BeginBackendHealth(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	if err := client.BackendHealthHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.BackendHealthHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -145,14 +148,14 @@ func (client *ApplicationGatewaysClient) BackendHealthCreateRequest(ctx context.
 
 // BackendHealthHandleResponse handles the BackendHealth response.
 func (client *ApplicationGatewaysClient) BackendHealthHandleResponse(resp *azcore.Response) (*ApplicationGatewayBackendHealthPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.BackendHealthHandleError(resp)
-	}
 	return &ApplicationGatewayBackendHealthPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // BackendHealthHandleError handles the BackendHealth error response.
 func (client *ApplicationGatewaysClient) BackendHealthHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -169,6 +172,9 @@ func (client *ApplicationGatewaysClient) BeginBackendHealthOnDemand(ctx context.
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.BackendHealthOnDemandHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.BackendHealthOnDemandHandleResponse(resp)
@@ -223,14 +229,14 @@ func (client *ApplicationGatewaysClient) BackendHealthOnDemandCreateRequest(ctx 
 
 // BackendHealthOnDemandHandleResponse handles the BackendHealthOnDemand response.
 func (client *ApplicationGatewaysClient) BackendHealthOnDemandHandleResponse(resp *azcore.Response) (*ApplicationGatewayBackendHealthOnDemandPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.BackendHealthOnDemandHandleError(resp)
-	}
 	return &ApplicationGatewayBackendHealthOnDemandPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // BackendHealthOnDemandHandleError handles the BackendHealthOnDemand error response.
 func (client *ApplicationGatewaysClient) BackendHealthOnDemandHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -247,6 +253,9 @@ func (client *ApplicationGatewaysClient) BeginCreateOrUpdate(ctx context.Context
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
@@ -298,14 +307,14 @@ func (client *ApplicationGatewaysClient) CreateOrUpdateCreateRequest(ctx context
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ApplicationGatewaysClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*ApplicationGatewayPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &ApplicationGatewayPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ApplicationGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -322,6 +331,9 @@ func (client *ApplicationGatewaysClient) BeginDelete(ctx context.Context, resour
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -373,14 +385,14 @@ func (client *ApplicationGatewaysClient) DeleteCreateRequest(ctx context.Context
 
 // DeleteHandleResponse handles the Delete response.
 func (client *ApplicationGatewaysClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *ApplicationGatewaysClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -396,6 +408,9 @@ func (client *ApplicationGatewaysClient) Get(ctx context.Context, resourceGroupN
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -424,15 +439,15 @@ func (client *ApplicationGatewaysClient) GetCreateRequest(ctx context.Context, r
 
 // GetHandleResponse handles the Get response.
 func (client *ApplicationGatewaysClient) GetHandleResponse(resp *azcore.Response) (*ApplicationGatewayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ApplicationGatewayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ApplicationGateway)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ApplicationGatewaysClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -448,6 +463,9 @@ func (client *ApplicationGatewaysClient) GetSslPredefinedPolicy(ctx context.Cont
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetSslPredefinedPolicyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetSslPredefinedPolicyHandleResponse(resp)
@@ -475,15 +493,15 @@ func (client *ApplicationGatewaysClient) GetSslPredefinedPolicyCreateRequest(ctx
 
 // GetSslPredefinedPolicyHandleResponse handles the GetSslPredefinedPolicy response.
 func (client *ApplicationGatewaysClient) GetSslPredefinedPolicyHandleResponse(resp *azcore.Response) (*ApplicationGatewaySslPredefinedPolicyResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetSslPredefinedPolicyHandleError(resp)
-	}
 	result := ApplicationGatewaySslPredefinedPolicyResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ApplicationGatewaySslPredefinedPolicy)
 }
 
 // GetSslPredefinedPolicyHandleError handles the GetSslPredefinedPolicy error response.
 func (client *ApplicationGatewaysClient) GetSslPredefinedPolicyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -499,6 +517,7 @@ func (client *ApplicationGatewaysClient) List(resourceGroupName string) Applicat
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ApplicationGatewayListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ApplicationGatewayListResult.NextLink)
 		},
@@ -523,15 +542,15 @@ func (client *ApplicationGatewaysClient) ListCreateRequest(ctx context.Context, 
 
 // ListHandleResponse handles the List response.
 func (client *ApplicationGatewaysClient) ListHandleResponse(resp *azcore.Response) (*ApplicationGatewayListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ApplicationGatewayListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ApplicationGatewayListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ApplicationGatewaysClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -547,6 +566,7 @@ func (client *ApplicationGatewaysClient) ListAll() ApplicationGatewayListResultP
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *ApplicationGatewayListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ApplicationGatewayListResult.NextLink)
 		},
@@ -570,15 +590,15 @@ func (client *ApplicationGatewaysClient) ListAllCreateRequest(ctx context.Contex
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *ApplicationGatewaysClient) ListAllHandleResponse(resp *azcore.Response) (*ApplicationGatewayListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := ApplicationGatewayListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ApplicationGatewayListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *ApplicationGatewaysClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -594,6 +614,9 @@ func (client *ApplicationGatewaysClient) ListAvailableRequestHeaders(ctx context
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListAvailableRequestHeadersHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListAvailableRequestHeadersHandleResponse(resp)
@@ -620,15 +643,15 @@ func (client *ApplicationGatewaysClient) ListAvailableRequestHeadersCreateReques
 
 // ListAvailableRequestHeadersHandleResponse handles the ListAvailableRequestHeaders response.
 func (client *ApplicationGatewaysClient) ListAvailableRequestHeadersHandleResponse(resp *azcore.Response) (*StringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAvailableRequestHeadersHandleError(resp)
-	}
 	result := StringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArray)
 }
 
 // ListAvailableRequestHeadersHandleError handles the ListAvailableRequestHeaders error response.
 func (client *ApplicationGatewaysClient) ListAvailableRequestHeadersHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -644,6 +667,9 @@ func (client *ApplicationGatewaysClient) ListAvailableResponseHeaders(ctx contex
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListAvailableResponseHeadersHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListAvailableResponseHeadersHandleResponse(resp)
@@ -670,15 +696,15 @@ func (client *ApplicationGatewaysClient) ListAvailableResponseHeadersCreateReque
 
 // ListAvailableResponseHeadersHandleResponse handles the ListAvailableResponseHeaders response.
 func (client *ApplicationGatewaysClient) ListAvailableResponseHeadersHandleResponse(resp *azcore.Response) (*StringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAvailableResponseHeadersHandleError(resp)
-	}
 	result := StringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArray)
 }
 
 // ListAvailableResponseHeadersHandleError handles the ListAvailableResponseHeaders error response.
 func (client *ApplicationGatewaysClient) ListAvailableResponseHeadersHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -694,6 +720,9 @@ func (client *ApplicationGatewaysClient) ListAvailableServerVariables(ctx contex
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListAvailableServerVariablesHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListAvailableServerVariablesHandleResponse(resp)
@@ -720,15 +749,15 @@ func (client *ApplicationGatewaysClient) ListAvailableServerVariablesCreateReque
 
 // ListAvailableServerVariablesHandleResponse handles the ListAvailableServerVariables response.
 func (client *ApplicationGatewaysClient) ListAvailableServerVariablesHandleResponse(resp *azcore.Response) (*StringArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAvailableServerVariablesHandleError(resp)
-	}
 	result := StringArrayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.StringArray)
 }
 
 // ListAvailableServerVariablesHandleError handles the ListAvailableServerVariables error response.
 func (client *ApplicationGatewaysClient) ListAvailableServerVariablesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -744,6 +773,9 @@ func (client *ApplicationGatewaysClient) ListAvailableSslOptions(ctx context.Con
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListAvailableSslOptionsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListAvailableSslOptionsHandleResponse(resp)
@@ -770,15 +802,15 @@ func (client *ApplicationGatewaysClient) ListAvailableSslOptionsCreateRequest(ct
 
 // ListAvailableSslOptionsHandleResponse handles the ListAvailableSslOptions response.
 func (client *ApplicationGatewaysClient) ListAvailableSslOptionsHandleResponse(resp *azcore.Response) (*ApplicationGatewayAvailableSslOptionsResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAvailableSslOptionsHandleError(resp)
-	}
 	result := ApplicationGatewayAvailableSslOptionsResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ApplicationGatewayAvailableSslOptions)
 }
 
 // ListAvailableSslOptionsHandleError handles the ListAvailableSslOptions error response.
 func (client *ApplicationGatewaysClient) ListAvailableSslOptionsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -794,6 +826,7 @@ func (client *ApplicationGatewaysClient) ListAvailableSslPredefinedPolicies() Ap
 			return client.ListAvailableSslPredefinedPoliciesCreateRequest(ctx)
 		},
 		responder: client.ListAvailableSslPredefinedPoliciesHandleResponse,
+		errorer:   client.ListAvailableSslPredefinedPoliciesHandleError,
 		advancer: func(ctx context.Context, resp *ApplicationGatewayAvailableSslPredefinedPoliciesResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ApplicationGatewayAvailableSslPredefinedPolicies.NextLink)
 		},
@@ -817,15 +850,15 @@ func (client *ApplicationGatewaysClient) ListAvailableSslPredefinedPoliciesCreat
 
 // ListAvailableSslPredefinedPoliciesHandleResponse handles the ListAvailableSslPredefinedPolicies response.
 func (client *ApplicationGatewaysClient) ListAvailableSslPredefinedPoliciesHandleResponse(resp *azcore.Response) (*ApplicationGatewayAvailableSslPredefinedPoliciesResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAvailableSslPredefinedPoliciesHandleError(resp)
-	}
 	result := ApplicationGatewayAvailableSslPredefinedPoliciesResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ApplicationGatewayAvailableSslPredefinedPolicies)
 }
 
 // ListAvailableSslPredefinedPoliciesHandleError handles the ListAvailableSslPredefinedPolicies error response.
 func (client *ApplicationGatewaysClient) ListAvailableSslPredefinedPoliciesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -841,6 +874,9 @@ func (client *ApplicationGatewaysClient) ListAvailableWafRuleSets(ctx context.Co
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListAvailableWafRuleSetsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListAvailableWafRuleSetsHandleResponse(resp)
@@ -867,15 +903,15 @@ func (client *ApplicationGatewaysClient) ListAvailableWafRuleSetsCreateRequest(c
 
 // ListAvailableWafRuleSetsHandleResponse handles the ListAvailableWafRuleSets response.
 func (client *ApplicationGatewaysClient) ListAvailableWafRuleSetsHandleResponse(resp *azcore.Response) (*ApplicationGatewayAvailableWafRuleSetsResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAvailableWafRuleSetsHandleError(resp)
-	}
 	result := ApplicationGatewayAvailableWafRuleSetsResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ApplicationGatewayAvailableWafRuleSetsResult)
 }
 
 // ListAvailableWafRuleSetsHandleError handles the ListAvailableWafRuleSets error response.
 func (client *ApplicationGatewaysClient) ListAvailableWafRuleSetsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -892,6 +928,9 @@ func (client *ApplicationGatewaysClient) BeginStart(ctx context.Context, resourc
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.StartHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.StartHandleResponse(resp)
@@ -943,14 +982,14 @@ func (client *ApplicationGatewaysClient) StartCreateRequest(ctx context.Context,
 
 // StartHandleResponse handles the Start response.
 func (client *ApplicationGatewaysClient) StartHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.StartHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // StartHandleError handles the Start error response.
 func (client *ApplicationGatewaysClient) StartHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -967,6 +1006,9 @@ func (client *ApplicationGatewaysClient) BeginStop(ctx context.Context, resource
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.StopHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.StopHandleResponse(resp)
@@ -1018,14 +1060,14 @@ func (client *ApplicationGatewaysClient) StopCreateRequest(ctx context.Context, 
 
 // StopHandleResponse handles the Stop response.
 func (client *ApplicationGatewaysClient) StopHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.StopHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // StopHandleError handles the Stop error response.
 func (client *ApplicationGatewaysClient) StopHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1041,6 +1083,9 @@ func (client *ApplicationGatewaysClient) UpdateTags(ctx context.Context, resourc
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -1069,15 +1114,15 @@ func (client *ApplicationGatewaysClient) UpdateTagsCreateRequest(ctx context.Con
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *ApplicationGatewaysClient) UpdateTagsHandleResponse(resp *azcore.Response) (*ApplicationGatewayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := ApplicationGatewayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ApplicationGateway)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *ApplicationGatewaysClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
@@ -93,8 +93,8 @@ func (client *ApplicationGatewaysClient) BeginBackendHealth(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.BackendHealthHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.BackendHealthHandleError(resp)
 	}
 	result, err := client.BackendHealthHandleResponse(resp)
 	if err != nil {
@@ -153,9 +153,6 @@ func (client *ApplicationGatewaysClient) BackendHealthHandleResponse(resp *azcor
 
 // BackendHealthHandleError handles the BackendHealth error response.
 func (client *ApplicationGatewaysClient) BackendHealthHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -174,8 +171,8 @@ func (client *ApplicationGatewaysClient) BeginBackendHealthOnDemand(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	if err := client.BackendHealthOnDemandHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.BackendHealthOnDemandHandleError(resp)
 	}
 	result, err := client.BackendHealthOnDemandHandleResponse(resp)
 	if err != nil {
@@ -234,9 +231,6 @@ func (client *ApplicationGatewaysClient) BackendHealthOnDemandHandleResponse(res
 
 // BackendHealthOnDemandHandleError handles the BackendHealthOnDemand error response.
 func (client *ApplicationGatewaysClient) BackendHealthOnDemandHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -255,8 +249,8 @@ func (client *ApplicationGatewaysClient) BeginCreateOrUpdate(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -312,9 +306,6 @@ func (client *ApplicationGatewaysClient) CreateOrUpdateHandleResponse(resp *azco
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ApplicationGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -333,8 +324,8 @@ func (client *ApplicationGatewaysClient) BeginDelete(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -390,9 +381,6 @@ func (client *ApplicationGatewaysClient) DeleteHandleResponse(resp *azcore.Respo
 
 // DeleteHandleError handles the Delete error response.
 func (client *ApplicationGatewaysClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -410,8 +398,8 @@ func (client *ApplicationGatewaysClient) Get(ctx context.Context, resourceGroupN
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -445,9 +433,6 @@ func (client *ApplicationGatewaysClient) GetHandleResponse(resp *azcore.Response
 
 // GetHandleError handles the Get error response.
 func (client *ApplicationGatewaysClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -465,8 +450,8 @@ func (client *ApplicationGatewaysClient) GetSslPredefinedPolicy(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetSslPredefinedPolicyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetSslPredefinedPolicyHandleError(resp)
 	}
 	result, err := client.GetSslPredefinedPolicyHandleResponse(resp)
 	if err != nil {
@@ -499,9 +484,6 @@ func (client *ApplicationGatewaysClient) GetSslPredefinedPolicyHandleResponse(re
 
 // GetSslPredefinedPolicyHandleError handles the GetSslPredefinedPolicy error response.
 func (client *ApplicationGatewaysClient) GetSslPredefinedPolicyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -548,9 +530,6 @@ func (client *ApplicationGatewaysClient) ListHandleResponse(resp *azcore.Respons
 
 // ListHandleError handles the List error response.
 func (client *ApplicationGatewaysClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -596,9 +575,6 @@ func (client *ApplicationGatewaysClient) ListAllHandleResponse(resp *azcore.Resp
 
 // ListAllHandleError handles the ListAll error response.
 func (client *ApplicationGatewaysClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -616,8 +592,8 @@ func (client *ApplicationGatewaysClient) ListAvailableRequestHeaders(ctx context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListAvailableRequestHeadersHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListAvailableRequestHeadersHandleError(resp)
 	}
 	result, err := client.ListAvailableRequestHeadersHandleResponse(resp)
 	if err != nil {
@@ -649,9 +625,6 @@ func (client *ApplicationGatewaysClient) ListAvailableRequestHeadersHandleRespon
 
 // ListAvailableRequestHeadersHandleError handles the ListAvailableRequestHeaders error response.
 func (client *ApplicationGatewaysClient) ListAvailableRequestHeadersHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -669,8 +642,8 @@ func (client *ApplicationGatewaysClient) ListAvailableResponseHeaders(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListAvailableResponseHeadersHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListAvailableResponseHeadersHandleError(resp)
 	}
 	result, err := client.ListAvailableResponseHeadersHandleResponse(resp)
 	if err != nil {
@@ -702,9 +675,6 @@ func (client *ApplicationGatewaysClient) ListAvailableResponseHeadersHandleRespo
 
 // ListAvailableResponseHeadersHandleError handles the ListAvailableResponseHeaders error response.
 func (client *ApplicationGatewaysClient) ListAvailableResponseHeadersHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -722,8 +692,8 @@ func (client *ApplicationGatewaysClient) ListAvailableServerVariables(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListAvailableServerVariablesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListAvailableServerVariablesHandleError(resp)
 	}
 	result, err := client.ListAvailableServerVariablesHandleResponse(resp)
 	if err != nil {
@@ -755,9 +725,6 @@ func (client *ApplicationGatewaysClient) ListAvailableServerVariablesHandleRespo
 
 // ListAvailableServerVariablesHandleError handles the ListAvailableServerVariables error response.
 func (client *ApplicationGatewaysClient) ListAvailableServerVariablesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -775,8 +742,8 @@ func (client *ApplicationGatewaysClient) ListAvailableSslOptions(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListAvailableSslOptionsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListAvailableSslOptionsHandleError(resp)
 	}
 	result, err := client.ListAvailableSslOptionsHandleResponse(resp)
 	if err != nil {
@@ -808,9 +775,6 @@ func (client *ApplicationGatewaysClient) ListAvailableSslOptionsHandleResponse(r
 
 // ListAvailableSslOptionsHandleError handles the ListAvailableSslOptions error response.
 func (client *ApplicationGatewaysClient) ListAvailableSslOptionsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -856,9 +820,6 @@ func (client *ApplicationGatewaysClient) ListAvailableSslPredefinedPoliciesHandl
 
 // ListAvailableSslPredefinedPoliciesHandleError handles the ListAvailableSslPredefinedPolicies error response.
 func (client *ApplicationGatewaysClient) ListAvailableSslPredefinedPoliciesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -876,8 +837,8 @@ func (client *ApplicationGatewaysClient) ListAvailableWafRuleSets(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListAvailableWafRuleSetsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListAvailableWafRuleSetsHandleError(resp)
 	}
 	result, err := client.ListAvailableWafRuleSetsHandleResponse(resp)
 	if err != nil {
@@ -909,9 +870,6 @@ func (client *ApplicationGatewaysClient) ListAvailableWafRuleSetsHandleResponse(
 
 // ListAvailableWafRuleSetsHandleError handles the ListAvailableWafRuleSets error response.
 func (client *ApplicationGatewaysClient) ListAvailableWafRuleSetsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -930,8 +888,8 @@ func (client *ApplicationGatewaysClient) BeginStart(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StartHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.StartHandleError(resp)
 	}
 	result, err := client.StartHandleResponse(resp)
 	if err != nil {
@@ -987,9 +945,6 @@ func (client *ApplicationGatewaysClient) StartHandleResponse(resp *azcore.Respon
 
 // StartHandleError handles the Start error response.
 func (client *ApplicationGatewaysClient) StartHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1008,8 +963,8 @@ func (client *ApplicationGatewaysClient) BeginStop(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StopHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.StopHandleError(resp)
 	}
 	result, err := client.StopHandleResponse(resp)
 	if err != nil {
@@ -1065,9 +1020,6 @@ func (client *ApplicationGatewaysClient) StopHandleResponse(resp *azcore.Respons
 
 // StopHandleError handles the Stop error response.
 func (client *ApplicationGatewaysClient) StopHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1085,8 +1037,8 @@ func (client *ApplicationGatewaysClient) UpdateTags(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -1120,9 +1072,6 @@ func (client *ApplicationGatewaysClient) UpdateTagsHandleResponse(resp *azcore.R
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *ApplicationGatewaysClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups.go
@@ -63,6 +63,9 @@ func (client *ApplicationSecurityGroupsClient) BeginCreateOrUpdate(ctx context.C
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *ApplicationSecurityGroupsClient) CreateOrUpdateCreateRequest(ctx c
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ApplicationSecurityGroupsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*ApplicationSecurityGroupPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &ApplicationSecurityGroupPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ApplicationSecurityGroupsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *ApplicationSecurityGroupsClient) BeginDelete(ctx context.Context, 
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *ApplicationSecurityGroupsClient) DeleteCreateRequest(ctx context.C
 
 // DeleteHandleResponse handles the Delete response.
 func (client *ApplicationSecurityGroupsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *ApplicationSecurityGroupsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *ApplicationSecurityGroupsClient) Get(ctx context.Context, resource
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -238,15 +247,15 @@ func (client *ApplicationSecurityGroupsClient) GetCreateRequest(ctx context.Cont
 
 // GetHandleResponse handles the Get response.
 func (client *ApplicationSecurityGroupsClient) GetHandleResponse(resp *azcore.Response) (*ApplicationSecurityGroupResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ApplicationSecurityGroupResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ApplicationSecurityGroup)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ApplicationSecurityGroupsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -262,6 +271,7 @@ func (client *ApplicationSecurityGroupsClient) List(resourceGroupName string) Ap
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ApplicationSecurityGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ApplicationSecurityGroupListResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *ApplicationSecurityGroupsClient) ListCreateRequest(ctx context.Con
 
 // ListHandleResponse handles the List response.
 func (client *ApplicationSecurityGroupsClient) ListHandleResponse(resp *azcore.Response) (*ApplicationSecurityGroupListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ApplicationSecurityGroupListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ApplicationSecurityGroupListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ApplicationSecurityGroupsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -310,6 +320,7 @@ func (client *ApplicationSecurityGroupsClient) ListAll() ApplicationSecurityGrou
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *ApplicationSecurityGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ApplicationSecurityGroupListResult.NextLink)
 		},
@@ -333,15 +344,15 @@ func (client *ApplicationSecurityGroupsClient) ListAllCreateRequest(ctx context.
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *ApplicationSecurityGroupsClient) ListAllHandleResponse(resp *azcore.Response) (*ApplicationSecurityGroupListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := ApplicationSecurityGroupListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ApplicationSecurityGroupListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *ApplicationSecurityGroupsClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -357,6 +368,9 @@ func (client *ApplicationSecurityGroupsClient) UpdateTags(ctx context.Context, r
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -385,15 +399,15 @@ func (client *ApplicationSecurityGroupsClient) UpdateTagsCreateRequest(ctx conte
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *ApplicationSecurityGroupsClient) UpdateTagsHandleResponse(resp *azcore.Response) (*ApplicationSecurityGroupResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := ApplicationSecurityGroupResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ApplicationSecurityGroup)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *ApplicationSecurityGroupsClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups.go
@@ -63,8 +63,8 @@ func (client *ApplicationSecurityGroupsClient) BeginCreateOrUpdate(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *ApplicationSecurityGroupsClient) CreateOrUpdateHandleResponse(resp
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ApplicationSecurityGroupsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *ApplicationSecurityGroupsClient) BeginDelete(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *ApplicationSecurityGroupsClient) DeleteHandleResponse(resp *azcore
 
 // DeleteHandleError handles the Delete error response.
 func (client *ApplicationSecurityGroupsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *ApplicationSecurityGroupsClient) Get(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -253,9 +247,6 @@ func (client *ApplicationSecurityGroupsClient) GetHandleResponse(resp *azcore.Re
 
 // GetHandleError handles the Get error response.
 func (client *ApplicationSecurityGroupsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *ApplicationSecurityGroupsClient) ListHandleResponse(resp *azcore.R
 
 // ListHandleError handles the List error response.
 func (client *ApplicationSecurityGroupsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -350,9 +338,6 @@ func (client *ApplicationSecurityGroupsClient) ListAllHandleResponse(resp *azcor
 
 // ListAllHandleError handles the ListAll error response.
 func (client *ApplicationSecurityGroupsClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -370,8 +355,8 @@ func (client *ApplicationSecurityGroupsClient) UpdateTags(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -405,9 +390,6 @@ func (client *ApplicationSecurityGroupsClient) UpdateTagsHandleResponse(resp *az
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *ApplicationSecurityGroupsClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations.go
@@ -75,9 +75,6 @@ func (client *AvailableDelegationsClient) ListHandleResponse(resp *azcore.Respon
 
 // ListHandleError handles the List error response.
 func (client *AvailableDelegationsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations.go
@@ -44,6 +44,7 @@ func (client *AvailableDelegationsClient) List(location string) AvailableDelegat
 			return client.ListCreateRequest(ctx, location)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *AvailableDelegationsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AvailableDelegationsResult.NextLink)
 		},
@@ -68,15 +69,15 @@ func (client *AvailableDelegationsClient) ListCreateRequest(ctx context.Context,
 
 // ListHandleResponse handles the List response.
 func (client *AvailableDelegationsClient) ListHandleResponse(resp *azcore.Response) (*AvailableDelegationsResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := AvailableDelegationsResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.AvailableDelegationsResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *AvailableDelegationsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices.go
@@ -44,6 +44,7 @@ func (client *AvailableEndpointServicesClient) List(location string) EndpointSer
 			return client.ListCreateRequest(ctx, location)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *EndpointServicesListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.EndpointServicesListResult.NextLink)
 		},
@@ -68,15 +69,15 @@ func (client *AvailableEndpointServicesClient) ListCreateRequest(ctx context.Con
 
 // ListHandleResponse handles the List response.
 func (client *AvailableEndpointServicesClient) ListHandleResponse(resp *azcore.Response) (*EndpointServicesListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := EndpointServicesListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.EndpointServicesListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *AvailableEndpointServicesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices.go
@@ -75,9 +75,6 @@ func (client *AvailableEndpointServicesClient) ListHandleResponse(resp *azcore.R
 
 // ListHandleError handles the List error response.
 func (client *AvailableEndpointServicesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes.go
@@ -77,9 +77,6 @@ func (client *AvailablePrivateEndpointTypesClient) ListHandleResponse(resp *azco
 
 // ListHandleError handles the List error response.
 func (client *AvailablePrivateEndpointTypesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -127,9 +124,6 @@ func (client *AvailablePrivateEndpointTypesClient) ListByResourceGroupHandleResp
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *AvailablePrivateEndpointTypesClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes.go
@@ -46,6 +46,7 @@ func (client *AvailablePrivateEndpointTypesClient) List(location string) Availab
 			return client.ListCreateRequest(ctx, location)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *AvailablePrivateEndpointTypesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AvailablePrivateEndpointTypesResult.NextLink)
 		},
@@ -70,15 +71,15 @@ func (client *AvailablePrivateEndpointTypesClient) ListCreateRequest(ctx context
 
 // ListHandleResponse handles the List response.
 func (client *AvailablePrivateEndpointTypesClient) ListHandleResponse(resp *azcore.Response) (*AvailablePrivateEndpointTypesResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := AvailablePrivateEndpointTypesResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.AvailablePrivateEndpointTypesResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *AvailablePrivateEndpointTypesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -94,6 +95,7 @@ func (client *AvailablePrivateEndpointTypesClient) ListByResourceGroup(location 
 			return client.ListByResourceGroupCreateRequest(ctx, location, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *AvailablePrivateEndpointTypesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AvailablePrivateEndpointTypesResult.NextLink)
 		},
@@ -119,15 +121,15 @@ func (client *AvailablePrivateEndpointTypesClient) ListByResourceGroupCreateRequ
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *AvailablePrivateEndpointTypesClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*AvailablePrivateEndpointTypesResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := AvailablePrivateEndpointTypesResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.AvailablePrivateEndpointTypesResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *AvailablePrivateEndpointTypesClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations.go
@@ -44,6 +44,7 @@ func (client *AvailableResourceGroupDelegationsClient) List(location string, res
 			return client.ListCreateRequest(ctx, location, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *AvailableDelegationsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AvailableDelegationsResult.NextLink)
 		},
@@ -69,15 +70,15 @@ func (client *AvailableResourceGroupDelegationsClient) ListCreateRequest(ctx con
 
 // ListHandleResponse handles the List response.
 func (client *AvailableResourceGroupDelegationsClient) ListHandleResponse(resp *azcore.Response) (*AvailableDelegationsResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := AvailableDelegationsResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.AvailableDelegationsResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *AvailableResourceGroupDelegationsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations.go
@@ -76,9 +76,6 @@ func (client *AvailableResourceGroupDelegationsClient) ListHandleResponse(resp *
 
 // ListHandleError handles the List error response.
 func (client *AvailableResourceGroupDelegationsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases.go
@@ -77,9 +77,6 @@ func (client *AvailableServiceAliasesClient) ListHandleResponse(resp *azcore.Res
 
 // ListHandleError handles the List error response.
 func (client *AvailableServiceAliasesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -127,9 +124,6 @@ func (client *AvailableServiceAliasesClient) ListByResourceGroupHandleResponse(r
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *AvailableServiceAliasesClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases.go
@@ -46,6 +46,7 @@ func (client *AvailableServiceAliasesClient) List(location string) AvailableServ
 			return client.ListCreateRequest(ctx, location)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *AvailableServiceAliasesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AvailableServiceAliasesResult.NextLink)
 		},
@@ -70,15 +71,15 @@ func (client *AvailableServiceAliasesClient) ListCreateRequest(ctx context.Conte
 
 // ListHandleResponse handles the List response.
 func (client *AvailableServiceAliasesClient) ListHandleResponse(resp *azcore.Response) (*AvailableServiceAliasesResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := AvailableServiceAliasesResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.AvailableServiceAliasesResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *AvailableServiceAliasesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -94,6 +95,7 @@ func (client *AvailableServiceAliasesClient) ListByResourceGroup(resourceGroupNa
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, location)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *AvailableServiceAliasesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AvailableServiceAliasesResult.NextLink)
 		},
@@ -119,15 +121,15 @@ func (client *AvailableServiceAliasesClient) ListByResourceGroupCreateRequest(ct
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *AvailableServiceAliasesClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*AvailableServiceAliasesResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := AvailableServiceAliasesResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.AvailableServiceAliasesResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *AvailableServiceAliasesClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags.go
@@ -74,9 +74,6 @@ func (client *AzureFirewallFqdnTagsClient) ListAllHandleResponse(resp *azcore.Re
 
 // ListAllHandleError handles the ListAll error response.
 func (client *AzureFirewallFqdnTagsClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags.go
@@ -44,6 +44,7 @@ func (client *AzureFirewallFqdnTagsClient) ListAll() AzureFirewallFqdnTagListRes
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *AzureFirewallFqdnTagListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AzureFirewallFqdnTagListResult.NextLink)
 		},
@@ -67,15 +68,15 @@ func (client *AzureFirewallFqdnTagsClient) ListAllCreateRequest(ctx context.Cont
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *AzureFirewallFqdnTagsClient) ListAllHandleResponse(resp *azcore.Response) (*AzureFirewallFqdnTagListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := AzureFirewallFqdnTagListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.AzureFirewallFqdnTagListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *AzureFirewallFqdnTagsClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls.go
@@ -65,6 +65,9 @@ func (client *AzureFirewallsClient) BeginCreateOrUpdate(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -114,14 +117,14 @@ func (client *AzureFirewallsClient) CreateOrUpdateCreateRequest(ctx context.Cont
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *AzureFirewallsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*AzureFirewallPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &AzureFirewallPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *AzureFirewallsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,6 +141,9 @@ func (client *AzureFirewallsClient) BeginDelete(ctx context.Context, resourceGro
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -189,14 +195,14 @@ func (client *AzureFirewallsClient) DeleteCreateRequest(ctx context.Context, res
 
 // DeleteHandleResponse handles the Delete response.
 func (client *AzureFirewallsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *AzureFirewallsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -212,6 +218,9 @@ func (client *AzureFirewallsClient) Get(ctx context.Context, resourceGroupName s
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -240,15 +249,15 @@ func (client *AzureFirewallsClient) GetCreateRequest(ctx context.Context, resour
 
 // GetHandleResponse handles the Get response.
 func (client *AzureFirewallsClient) GetHandleResponse(resp *azcore.Response) (*AzureFirewallResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := AzureFirewallResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.AzureFirewall)
 }
 
 // GetHandleError handles the Get error response.
 func (client *AzureFirewallsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -264,6 +273,7 @@ func (client *AzureFirewallsClient) List(resourceGroupName string) AzureFirewall
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *AzureFirewallListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AzureFirewallListResult.NextLink)
 		},
@@ -288,15 +298,15 @@ func (client *AzureFirewallsClient) ListCreateRequest(ctx context.Context, resou
 
 // ListHandleResponse handles the List response.
 func (client *AzureFirewallsClient) ListHandleResponse(resp *azcore.Response) (*AzureFirewallListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := AzureFirewallListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.AzureFirewallListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *AzureFirewallsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -312,6 +322,7 @@ func (client *AzureFirewallsClient) ListAll() AzureFirewallListResultPager {
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *AzureFirewallListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AzureFirewallListResult.NextLink)
 		},
@@ -335,15 +346,15 @@ func (client *AzureFirewallsClient) ListAllCreateRequest(ctx context.Context) (*
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *AzureFirewallsClient) ListAllHandleResponse(resp *azcore.Response) (*AzureFirewallListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := AzureFirewallListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.AzureFirewallListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *AzureFirewallsClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -360,6 +371,9 @@ func (client *AzureFirewallsClient) BeginUpdateTags(ctx context.Context, resourc
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -411,14 +425,14 @@ func (client *AzureFirewallsClient) UpdateTagsCreateRequest(ctx context.Context,
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *AzureFirewallsClient) UpdateTagsHandleResponse(resp *azcore.Response) (*AzureFirewallPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	return &AzureFirewallPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *AzureFirewallsClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls.go
@@ -65,8 +65,8 @@ func (client *AzureFirewallsClient) BeginCreateOrUpdate(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -122,9 +122,6 @@ func (client *AzureFirewallsClient) CreateOrUpdateHandleResponse(resp *azcore.Re
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *AzureFirewallsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -143,8 +140,8 @@ func (client *AzureFirewallsClient) BeginDelete(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -200,9 +197,6 @@ func (client *AzureFirewallsClient) DeleteHandleResponse(resp *azcore.Response) 
 
 // DeleteHandleError handles the Delete error response.
 func (client *AzureFirewallsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -220,8 +214,8 @@ func (client *AzureFirewallsClient) Get(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -255,9 +249,6 @@ func (client *AzureFirewallsClient) GetHandleResponse(resp *azcore.Response) (*A
 
 // GetHandleError handles the Get error response.
 func (client *AzureFirewallsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -304,9 +295,6 @@ func (client *AzureFirewallsClient) ListHandleResponse(resp *azcore.Response) (*
 
 // ListHandleError handles the List error response.
 func (client *AzureFirewallsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -352,9 +340,6 @@ func (client *AzureFirewallsClient) ListAllHandleResponse(resp *azcore.Response)
 
 // ListAllHandleError handles the ListAll error response.
 func (client *AzureFirewallsClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -373,8 +358,8 @@ func (client *AzureFirewallsClient) BeginUpdateTags(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -430,9 +415,6 @@ func (client *AzureFirewallsClient) UpdateTagsHandleResponse(resp *azcore.Respon
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *AzureFirewallsClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts.go
@@ -61,6 +61,9 @@ func (client *BastionHostsClient) BeginCreateOrUpdate(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -110,14 +113,14 @@ func (client *BastionHostsClient) CreateOrUpdateCreateRequest(ctx context.Contex
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *BastionHostsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*BastionHostPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &BastionHostPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *BastionHostsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,6 +137,9 @@ func (client *BastionHostsClient) BeginDelete(ctx context.Context, resourceGroup
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *BastionHostsClient) DeleteCreateRequest(ctx context.Context, resou
 
 // DeleteHandleResponse handles the Delete response.
 func (client *BastionHostsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *BastionHostsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *BastionHostsClient) Get(ctx context.Context, resourceGroupName str
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -236,15 +245,15 @@ func (client *BastionHostsClient) GetCreateRequest(ctx context.Context, resource
 
 // GetHandleResponse handles the Get response.
 func (client *BastionHostsClient) GetHandleResponse(resp *azcore.Response) (*BastionHostResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := BastionHostResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.BastionHost)
 }
 
 // GetHandleError handles the Get error response.
 func (client *BastionHostsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -260,6 +269,7 @@ func (client *BastionHostsClient) List() BastionHostListResultPager {
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *BastionHostListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.BastionHostListResult.NextLink)
 		},
@@ -283,15 +293,15 @@ func (client *BastionHostsClient) ListCreateRequest(ctx context.Context) (*azcor
 
 // ListHandleResponse handles the List response.
 func (client *BastionHostsClient) ListHandleResponse(resp *azcore.Response) (*BastionHostListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := BastionHostListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.BastionHostListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *BastionHostsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -307,6 +317,7 @@ func (client *BastionHostsClient) ListByResourceGroup(resourceGroupName string) 
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *BastionHostListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.BastionHostListResult.NextLink)
 		},
@@ -331,15 +342,15 @@ func (client *BastionHostsClient) ListByResourceGroupCreateRequest(ctx context.C
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *BastionHostsClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*BastionHostListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := BastionHostListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.BastionHostListResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *BastionHostsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts.go
@@ -61,8 +61,8 @@ func (client *BastionHostsClient) BeginCreateOrUpdate(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -118,9 +118,6 @@ func (client *BastionHostsClient) CreateOrUpdateHandleResponse(resp *azcore.Resp
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *BastionHostsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -139,8 +136,8 @@ func (client *BastionHostsClient) BeginDelete(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *BastionHostsClient) DeleteHandleResponse(resp *azcore.Response) (*
 
 // DeleteHandleError handles the Delete error response.
 func (client *BastionHostsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *BastionHostsClient) Get(ctx context.Context, resourceGroupName str
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -251,9 +245,6 @@ func (client *BastionHostsClient) GetHandleResponse(resp *azcore.Response) (*Bas
 
 // GetHandleError handles the Get error response.
 func (client *BastionHostsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -299,9 +290,6 @@ func (client *BastionHostsClient) ListHandleResponse(resp *azcore.Response) (*Ba
 
 // ListHandleError handles the List error response.
 func (client *BastionHostsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -348,9 +336,6 @@ func (client *BastionHostsClient) ListByResourceGroupHandleResponse(resp *azcore
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *BastionHostsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities.go
@@ -44,6 +44,7 @@ func (client *BgpServiceCommunitiesClient) List() BgpServiceCommunityListResultP
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *BgpServiceCommunityListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.BgpServiceCommunityListResult.NextLink)
 		},
@@ -67,15 +68,15 @@ func (client *BgpServiceCommunitiesClient) ListCreateRequest(ctx context.Context
 
 // ListHandleResponse handles the List response.
 func (client *BgpServiceCommunitiesClient) ListHandleResponse(resp *azcore.Response) (*BgpServiceCommunityListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := BgpServiceCommunityListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.BgpServiceCommunityListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *BgpServiceCommunitiesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities.go
@@ -74,9 +74,6 @@ func (client *BgpServiceCommunitiesClient) ListHandleResponse(resp *azcore.Respo
 
 // ListHandleError handles the List error response.
 func (client *BgpServiceCommunitiesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors.go
@@ -73,8 +73,8 @@ func (client *ConnectionMonitorsClient) BeginCreateOrUpdate(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -131,9 +131,6 @@ func (client *ConnectionMonitorsClient) CreateOrUpdateHandleResponse(resp *azcor
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ConnectionMonitorsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -152,8 +149,8 @@ func (client *ConnectionMonitorsClient) BeginDelete(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -210,9 +207,6 @@ func (client *ConnectionMonitorsClient) DeleteHandleResponse(resp *azcore.Respon
 
 // DeleteHandleError handles the Delete error response.
 func (client *ConnectionMonitorsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -230,8 +224,8 @@ func (client *ConnectionMonitorsClient) Get(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -266,9 +260,6 @@ func (client *ConnectionMonitorsClient) GetHandleResponse(resp *azcore.Response)
 
 // GetHandleError handles the Get error response.
 func (client *ConnectionMonitorsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -286,8 +277,8 @@ func (client *ConnectionMonitorsClient) List(ctx context.Context, resourceGroupN
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListHandleError(resp)
 	}
 	result, err := client.ListHandleResponse(resp)
 	if err != nil {
@@ -321,9 +312,6 @@ func (client *ConnectionMonitorsClient) ListHandleResponse(resp *azcore.Response
 
 // ListHandleError handles the List error response.
 func (client *ConnectionMonitorsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -342,8 +330,8 @@ func (client *ConnectionMonitorsClient) BeginQuery(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	if err := client.QueryHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.QueryHandleError(resp)
 	}
 	result, err := client.QueryHandleResponse(resp)
 	if err != nil {
@@ -400,9 +388,6 @@ func (client *ConnectionMonitorsClient) QueryHandleResponse(resp *azcore.Respons
 
 // QueryHandleError handles the Query error response.
 func (client *ConnectionMonitorsClient) QueryHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -421,8 +406,8 @@ func (client *ConnectionMonitorsClient) BeginStart(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StartHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.StartHandleError(resp)
 	}
 	result, err := client.StartHandleResponse(resp)
 	if err != nil {
@@ -479,9 +464,6 @@ func (client *ConnectionMonitorsClient) StartHandleResponse(resp *azcore.Respons
 
 // StartHandleError handles the Start error response.
 func (client *ConnectionMonitorsClient) StartHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -500,8 +482,8 @@ func (client *ConnectionMonitorsClient) BeginStop(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StopHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.StopHandleError(resp)
 	}
 	result, err := client.StopHandleResponse(resp)
 	if err != nil {
@@ -558,9 +540,6 @@ func (client *ConnectionMonitorsClient) StopHandleResponse(resp *azcore.Response
 
 // StopHandleError handles the Stop error response.
 func (client *ConnectionMonitorsClient) StopHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -578,8 +557,8 @@ func (client *ConnectionMonitorsClient) UpdateTags(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -614,9 +593,6 @@ func (client *ConnectionMonitorsClient) UpdateTagsHandleResponse(resp *azcore.Re
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *ConnectionMonitorsClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors.go
@@ -73,6 +73,9 @@ func (client *ConnectionMonitorsClient) BeginCreateOrUpdate(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -123,14 +126,14 @@ func (client *ConnectionMonitorsClient) CreateOrUpdateCreateRequest(ctx context.
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ConnectionMonitorsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*ConnectionMonitorResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &ConnectionMonitorResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ConnectionMonitorsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -147,6 +150,9 @@ func (client *ConnectionMonitorsClient) BeginDelete(ctx context.Context, resourc
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -199,14 +205,14 @@ func (client *ConnectionMonitorsClient) DeleteCreateRequest(ctx context.Context,
 
 // DeleteHandleResponse handles the Delete response.
 func (client *ConnectionMonitorsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *ConnectionMonitorsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -222,6 +228,9 @@ func (client *ConnectionMonitorsClient) Get(ctx context.Context, resourceGroupNa
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -251,15 +260,15 @@ func (client *ConnectionMonitorsClient) GetCreateRequest(ctx context.Context, re
 
 // GetHandleResponse handles the Get response.
 func (client *ConnectionMonitorsClient) GetHandleResponse(resp *azcore.Response) (*ConnectionMonitorResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ConnectionMonitorResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ConnectionMonitorResult)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ConnectionMonitorsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -275,6 +284,9 @@ func (client *ConnectionMonitorsClient) List(ctx context.Context, resourceGroupN
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListHandleResponse(resp)
@@ -303,15 +315,15 @@ func (client *ConnectionMonitorsClient) ListCreateRequest(ctx context.Context, r
 
 // ListHandleResponse handles the List response.
 func (client *ConnectionMonitorsClient) ListHandleResponse(resp *azcore.Response) (*ConnectionMonitorListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ConnectionMonitorListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ConnectionMonitorListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ConnectionMonitorsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -328,6 +340,9 @@ func (client *ConnectionMonitorsClient) BeginQuery(ctx context.Context, resource
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.QueryHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.QueryHandleResponse(resp)
@@ -380,14 +395,14 @@ func (client *ConnectionMonitorsClient) QueryCreateRequest(ctx context.Context, 
 
 // QueryHandleResponse handles the Query response.
 func (client *ConnectionMonitorsClient) QueryHandleResponse(resp *azcore.Response) (*ConnectionMonitorQueryResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.QueryHandleError(resp)
-	}
 	return &ConnectionMonitorQueryResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // QueryHandleError handles the Query error response.
 func (client *ConnectionMonitorsClient) QueryHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -404,6 +419,9 @@ func (client *ConnectionMonitorsClient) BeginStart(ctx context.Context, resource
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.StartHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.StartHandleResponse(resp)
@@ -456,14 +474,14 @@ func (client *ConnectionMonitorsClient) StartCreateRequest(ctx context.Context, 
 
 // StartHandleResponse handles the Start response.
 func (client *ConnectionMonitorsClient) StartHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.StartHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // StartHandleError handles the Start error response.
 func (client *ConnectionMonitorsClient) StartHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -480,6 +498,9 @@ func (client *ConnectionMonitorsClient) BeginStop(ctx context.Context, resourceG
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.StopHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.StopHandleResponse(resp)
@@ -532,14 +553,14 @@ func (client *ConnectionMonitorsClient) StopCreateRequest(ctx context.Context, r
 
 // StopHandleResponse handles the Stop response.
 func (client *ConnectionMonitorsClient) StopHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.StopHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // StopHandleError handles the Stop error response.
 func (client *ConnectionMonitorsClient) StopHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -555,6 +576,9 @@ func (client *ConnectionMonitorsClient) UpdateTags(ctx context.Context, resource
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -584,15 +608,15 @@ func (client *ConnectionMonitorsClient) UpdateTagsCreateRequest(ctx context.Cont
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *ConnectionMonitorsClient) UpdateTagsHandleResponse(resp *azcore.Response) (*ConnectionMonitorResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := ConnectionMonitorResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ConnectionMonitorResult)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *ConnectionMonitorsClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies.go
@@ -59,6 +59,9 @@ func (client *DdosCustomPoliciesClient) BeginCreateOrUpdate(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -108,14 +111,14 @@ func (client *DdosCustomPoliciesClient) CreateOrUpdateCreateRequest(ctx context.
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *DdosCustomPoliciesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*DdosCustomPolicyPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &DdosCustomPolicyPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *DdosCustomPoliciesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -132,6 +135,9 @@ func (client *DdosCustomPoliciesClient) BeginDelete(ctx context.Context, resourc
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -183,14 +189,14 @@ func (client *DdosCustomPoliciesClient) DeleteCreateRequest(ctx context.Context,
 
 // DeleteHandleResponse handles the Delete response.
 func (client *DdosCustomPoliciesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *DdosCustomPoliciesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -206,6 +212,9 @@ func (client *DdosCustomPoliciesClient) Get(ctx context.Context, resourceGroupNa
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -234,15 +243,15 @@ func (client *DdosCustomPoliciesClient) GetCreateRequest(ctx context.Context, re
 
 // GetHandleResponse handles the Get response.
 func (client *DdosCustomPoliciesClient) GetHandleResponse(resp *azcore.Response) (*DdosCustomPolicyResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := DdosCustomPolicyResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DdosCustomPolicy)
 }
 
 // GetHandleError handles the Get error response.
 func (client *DdosCustomPoliciesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -258,6 +267,9 @@ func (client *DdosCustomPoliciesClient) UpdateTags(ctx context.Context, resource
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -286,15 +298,15 @@ func (client *DdosCustomPoliciesClient) UpdateTagsCreateRequest(ctx context.Cont
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *DdosCustomPoliciesClient) UpdateTagsHandleResponse(resp *azcore.Response) (*DdosCustomPolicyResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := DdosCustomPolicyResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DdosCustomPolicy)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *DdosCustomPoliciesClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies.go
@@ -59,8 +59,8 @@ func (client *DdosCustomPoliciesClient) BeginCreateOrUpdate(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -116,9 +116,6 @@ func (client *DdosCustomPoliciesClient) CreateOrUpdateHandleResponse(resp *azcor
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *DdosCustomPoliciesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -137,8 +134,8 @@ func (client *DdosCustomPoliciesClient) BeginDelete(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -194,9 +191,6 @@ func (client *DdosCustomPoliciesClient) DeleteHandleResponse(resp *azcore.Respon
 
 // DeleteHandleError handles the Delete error response.
 func (client *DdosCustomPoliciesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -214,8 +208,8 @@ func (client *DdosCustomPoliciesClient) Get(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -249,9 +243,6 @@ func (client *DdosCustomPoliciesClient) GetHandleResponse(resp *azcore.Response)
 
 // GetHandleError handles the Get error response.
 func (client *DdosCustomPoliciesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -269,8 +260,8 @@ func (client *DdosCustomPoliciesClient) UpdateTags(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -304,9 +295,6 @@ func (client *DdosCustomPoliciesClient) UpdateTagsHandleResponse(resp *azcore.Re
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *DdosCustomPoliciesClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans.go
@@ -63,8 +63,8 @@ func (client *DdosProtectionPlansClient) BeginCreateOrUpdate(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *DdosProtectionPlansClient) CreateOrUpdateHandleResponse(resp *azco
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *DdosProtectionPlansClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *DdosProtectionPlansClient) BeginDelete(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *DdosProtectionPlansClient) DeleteHandleResponse(resp *azcore.Respo
 
 // DeleteHandleError handles the Delete error response.
 func (client *DdosProtectionPlansClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *DdosProtectionPlansClient) Get(ctx context.Context, resourceGroupN
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -253,9 +247,6 @@ func (client *DdosProtectionPlansClient) GetHandleResponse(resp *azcore.Response
 
 // GetHandleError handles the Get error response.
 func (client *DdosProtectionPlansClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -301,9 +292,6 @@ func (client *DdosProtectionPlansClient) ListHandleResponse(resp *azcore.Respons
 
 // ListHandleError handles the List error response.
 func (client *DdosProtectionPlansClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -350,9 +338,6 @@ func (client *DdosProtectionPlansClient) ListByResourceGroupHandleResponse(resp 
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *DdosProtectionPlansClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -370,8 +355,8 @@ func (client *DdosProtectionPlansClient) UpdateTags(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -405,9 +390,6 @@ func (client *DdosProtectionPlansClient) UpdateTagsHandleResponse(resp *azcore.R
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *DdosProtectionPlansClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans.go
@@ -63,6 +63,9 @@ func (client *DdosProtectionPlansClient) BeginCreateOrUpdate(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *DdosProtectionPlansClient) CreateOrUpdateCreateRequest(ctx context
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *DdosProtectionPlansClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*DdosProtectionPlanPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &DdosProtectionPlanPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *DdosProtectionPlansClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *DdosProtectionPlansClient) BeginDelete(ctx context.Context, resour
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *DdosProtectionPlansClient) DeleteCreateRequest(ctx context.Context
 
 // DeleteHandleResponse handles the Delete response.
 func (client *DdosProtectionPlansClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *DdosProtectionPlansClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *DdosProtectionPlansClient) Get(ctx context.Context, resourceGroupN
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -238,15 +247,15 @@ func (client *DdosProtectionPlansClient) GetCreateRequest(ctx context.Context, r
 
 // GetHandleResponse handles the Get response.
 func (client *DdosProtectionPlansClient) GetHandleResponse(resp *azcore.Response) (*DdosProtectionPlanResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := DdosProtectionPlanResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DdosProtectionPlan)
 }
 
 // GetHandleError handles the Get error response.
 func (client *DdosProtectionPlansClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -262,6 +271,7 @@ func (client *DdosProtectionPlansClient) List() DdosProtectionPlanListResultPage
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *DdosProtectionPlanListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.DdosProtectionPlanListResult.NextLink)
 		},
@@ -285,15 +295,15 @@ func (client *DdosProtectionPlansClient) ListCreateRequest(ctx context.Context) 
 
 // ListHandleResponse handles the List response.
 func (client *DdosProtectionPlansClient) ListHandleResponse(resp *azcore.Response) (*DdosProtectionPlanListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := DdosProtectionPlanListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DdosProtectionPlanListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *DdosProtectionPlansClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -309,6 +319,7 @@ func (client *DdosProtectionPlansClient) ListByResourceGroup(resourceGroupName s
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *DdosProtectionPlanListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.DdosProtectionPlanListResult.NextLink)
 		},
@@ -333,15 +344,15 @@ func (client *DdosProtectionPlansClient) ListByResourceGroupCreateRequest(ctx co
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *DdosProtectionPlansClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*DdosProtectionPlanListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := DdosProtectionPlanListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DdosProtectionPlanListResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *DdosProtectionPlansClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -357,6 +368,9 @@ func (client *DdosProtectionPlansClient) UpdateTags(ctx context.Context, resourc
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -385,15 +399,15 @@ func (client *DdosProtectionPlansClient) UpdateTagsCreateRequest(ctx context.Con
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *DdosProtectionPlansClient) UpdateTagsHandleResponse(resp *azcore.Response) (*DdosProtectionPlanResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := DdosProtectionPlanResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DdosProtectionPlan)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *DdosProtectionPlansClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules.go
@@ -48,8 +48,8 @@ func (client *DefaultSecurityRulesClient) Get(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -84,9 +84,6 @@ func (client *DefaultSecurityRulesClient) GetHandleResponse(resp *azcore.Respons
 
 // GetHandleError handles the Get error response.
 func (client *DefaultSecurityRulesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,9 +131,6 @@ func (client *DefaultSecurityRulesClient) ListHandleResponse(resp *azcore.Respon
 
 // ListHandleError handles the List error response.
 func (client *DefaultSecurityRulesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules.go
@@ -48,6 +48,9 @@ func (client *DefaultSecurityRulesClient) Get(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -75,15 +78,15 @@ func (client *DefaultSecurityRulesClient) GetCreateRequest(ctx context.Context, 
 
 // GetHandleResponse handles the Get response.
 func (client *DefaultSecurityRulesClient) GetHandleResponse(resp *azcore.Response) (*SecurityRuleResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := SecurityRuleResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.SecurityRule)
 }
 
 // GetHandleError handles the Get error response.
 func (client *DefaultSecurityRulesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -99,6 +102,7 @@ func (client *DefaultSecurityRulesClient) List(resourceGroupName string, network
 			return client.ListCreateRequest(ctx, resourceGroupName, networkSecurityGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *SecurityRuleListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SecurityRuleListResult.NextLink)
 		},
@@ -124,15 +128,15 @@ func (client *DefaultSecurityRulesClient) ListCreateRequest(ctx context.Context,
 
 // ListHandleResponse handles the List response.
 func (client *DefaultSecurityRulesClient) ListHandleResponse(resp *azcore.Response) (*SecurityRuleListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := SecurityRuleListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.SecurityRuleListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *DefaultSecurityRulesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations.go
@@ -59,8 +59,8 @@ func (client *ExpressRouteCircuitAuthorizationsClient) BeginCreateOrUpdate(ctx c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *ExpressRouteCircuitAuthorizationsClient) CreateOrUpdateHandleRespo
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCircuitAuthorizationsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *ExpressRouteCircuitAuthorizationsClient) BeginDelete(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *ExpressRouteCircuitAuthorizationsClient) DeleteHandleResponse(resp
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRouteCircuitAuthorizationsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *ExpressRouteCircuitAuthorizationsClient) Get(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *ExpressRouteCircuitAuthorizationsClient) GetHandleResponse(resp *a
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteCircuitAuthorizationsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *ExpressRouteCircuitAuthorizationsClient) ListHandleResponse(resp *
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteCircuitAuthorizationsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations.go
@@ -59,6 +59,9 @@ func (client *ExpressRouteCircuitAuthorizationsClient) BeginCreateOrUpdate(ctx c
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *ExpressRouteCircuitAuthorizationsClient) CreateOrUpdateCreateReque
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ExpressRouteCircuitAuthorizationsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitAuthorizationPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &ExpressRouteCircuitAuthorizationPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCircuitAuthorizationsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *ExpressRouteCircuitAuthorizationsClient) BeginDelete(ctx context.C
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *ExpressRouteCircuitAuthorizationsClient) DeleteCreateRequest(ctx c
 
 // DeleteHandleResponse handles the Delete response.
 func (client *ExpressRouteCircuitAuthorizationsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRouteCircuitAuthorizationsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *ExpressRouteCircuitAuthorizationsClient) Get(ctx context.Context, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *ExpressRouteCircuitAuthorizationsClient) GetCreateRequest(ctx cont
 
 // GetHandleResponse handles the Get response.
 func (client *ExpressRouteCircuitAuthorizationsClient) GetHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitAuthorizationResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ExpressRouteCircuitAuthorizationResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCircuitAuthorization)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteCircuitAuthorizationsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) List(resourceGroupName st
 			return client.ListCreateRequest(ctx, resourceGroupName, circuitName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *AuthorizationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AuthorizationListResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *ExpressRouteCircuitAuthorizationsClient) ListCreateRequest(ctx con
 
 // ListHandleResponse handles the List response.
 func (client *ExpressRouteCircuitAuthorizationsClient) ListHandleResponse(resp *azcore.Response) (*AuthorizationListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := AuthorizationListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.AuthorizationListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteCircuitAuthorizationsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections.go
@@ -59,6 +59,9 @@ func (client *ExpressRouteCircuitConnectionsClient) BeginCreateOrUpdate(ctx cont
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -110,14 +113,14 @@ func (client *ExpressRouteCircuitConnectionsClient) CreateOrUpdateCreateRequest(
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ExpressRouteCircuitConnectionsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitConnectionPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &ExpressRouteCircuitConnectionPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCircuitConnectionsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,6 +137,9 @@ func (client *ExpressRouteCircuitConnectionsClient) BeginDelete(ctx context.Cont
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *ExpressRouteCircuitConnectionsClient) DeleteCreateRequest(ctx cont
 
 // DeleteHandleResponse handles the Delete response.
 func (client *ExpressRouteCircuitConnectionsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRouteCircuitConnectionsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *ExpressRouteCircuitConnectionsClient) Get(ctx context.Context, res
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -240,15 +249,15 @@ func (client *ExpressRouteCircuitConnectionsClient) GetCreateRequest(ctx context
 
 // GetHandleResponse handles the Get response.
 func (client *ExpressRouteCircuitConnectionsClient) GetHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitConnectionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ExpressRouteCircuitConnectionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCircuitConnection)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteCircuitConnectionsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -264,6 +273,7 @@ func (client *ExpressRouteCircuitConnectionsClient) List(resourceGroupName strin
 			return client.ListCreateRequest(ctx, resourceGroupName, circuitName, peeringName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ExpressRouteCircuitConnectionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteCircuitConnectionListResult.NextLink)
 		},
@@ -290,15 +300,15 @@ func (client *ExpressRouteCircuitConnectionsClient) ListCreateRequest(ctx contex
 
 // ListHandleResponse handles the List response.
 func (client *ExpressRouteCircuitConnectionsClient) ListHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitConnectionListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ExpressRouteCircuitConnectionListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCircuitConnectionListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteCircuitConnectionsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections.go
@@ -59,8 +59,8 @@ func (client *ExpressRouteCircuitConnectionsClient) BeginCreateOrUpdate(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -118,9 +118,6 @@ func (client *ExpressRouteCircuitConnectionsClient) CreateOrUpdateHandleResponse
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCircuitConnectionsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -139,8 +136,8 @@ func (client *ExpressRouteCircuitConnectionsClient) BeginDelete(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *ExpressRouteCircuitConnectionsClient) DeleteHandleResponse(resp *a
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRouteCircuitConnectionsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *ExpressRouteCircuitConnectionsClient) Get(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -255,9 +249,6 @@ func (client *ExpressRouteCircuitConnectionsClient) GetHandleResponse(resp *azco
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteCircuitConnectionsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -306,9 +297,6 @@ func (client *ExpressRouteCircuitConnectionsClient) ListHandleResponse(resp *azc
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteCircuitConnectionsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings.go
@@ -59,6 +59,9 @@ func (client *ExpressRouteCircuitPeeringsClient) BeginCreateOrUpdate(ctx context
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *ExpressRouteCircuitPeeringsClient) CreateOrUpdateCreateRequest(ctx
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ExpressRouteCircuitPeeringsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitPeeringPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &ExpressRouteCircuitPeeringPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCircuitPeeringsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *ExpressRouteCircuitPeeringsClient) BeginDelete(ctx context.Context
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *ExpressRouteCircuitPeeringsClient) DeleteCreateRequest(ctx context
 
 // DeleteHandleResponse handles the Delete response.
 func (client *ExpressRouteCircuitPeeringsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRouteCircuitPeeringsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *ExpressRouteCircuitPeeringsClient) Get(ctx context.Context, resour
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *ExpressRouteCircuitPeeringsClient) GetCreateRequest(ctx context.Co
 
 // GetHandleResponse handles the Get response.
 func (client *ExpressRouteCircuitPeeringsClient) GetHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitPeeringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ExpressRouteCircuitPeeringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCircuitPeering)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteCircuitPeeringsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,7 @@ func (client *ExpressRouteCircuitPeeringsClient) List(resourceGroupName string, 
 			return client.ListCreateRequest(ctx, resourceGroupName, circuitName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ExpressRouteCircuitPeeringListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteCircuitPeeringListResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *ExpressRouteCircuitPeeringsClient) ListCreateRequest(ctx context.C
 
 // ListHandleResponse handles the List response.
 func (client *ExpressRouteCircuitPeeringsClient) ListHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitPeeringListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ExpressRouteCircuitPeeringListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCircuitPeeringListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteCircuitPeeringsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings.go
@@ -59,8 +59,8 @@ func (client *ExpressRouteCircuitPeeringsClient) BeginCreateOrUpdate(ctx context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *ExpressRouteCircuitPeeringsClient) CreateOrUpdateHandleResponse(re
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCircuitPeeringsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *ExpressRouteCircuitPeeringsClient) BeginDelete(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *ExpressRouteCircuitPeeringsClient) DeleteHandleResponse(resp *azco
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRouteCircuitPeeringsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *ExpressRouteCircuitPeeringsClient) Get(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *ExpressRouteCircuitPeeringsClient) GetHandleResponse(resp *azcore.
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteCircuitPeeringsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *ExpressRouteCircuitPeeringsClient) ListHandleResponse(resp *azcore
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteCircuitPeeringsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits.go
@@ -79,8 +79,8 @@ func (client *ExpressRouteCircuitsClient) BeginCreateOrUpdate(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -136,9 +136,6 @@ func (client *ExpressRouteCircuitsClient) CreateOrUpdateHandleResponse(resp *azc
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCircuitsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -157,8 +154,8 @@ func (client *ExpressRouteCircuitsClient) BeginDelete(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -214,9 +211,6 @@ func (client *ExpressRouteCircuitsClient) DeleteHandleResponse(resp *azcore.Resp
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRouteCircuitsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -234,8 +228,8 @@ func (client *ExpressRouteCircuitsClient) Get(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -269,9 +263,6 @@ func (client *ExpressRouteCircuitsClient) GetHandleResponse(resp *azcore.Respons
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteCircuitsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -289,8 +280,8 @@ func (client *ExpressRouteCircuitsClient) GetPeeringStats(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetPeeringStatsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetPeeringStatsHandleError(resp)
 	}
 	result, err := client.GetPeeringStatsHandleResponse(resp)
 	if err != nil {
@@ -325,9 +316,6 @@ func (client *ExpressRouteCircuitsClient) GetPeeringStatsHandleResponse(resp *az
 
 // GetPeeringStatsHandleError handles the GetPeeringStats error response.
 func (client *ExpressRouteCircuitsClient) GetPeeringStatsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -345,8 +333,8 @@ func (client *ExpressRouteCircuitsClient) GetStats(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetStatsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetStatsHandleError(resp)
 	}
 	result, err := client.GetStatsHandleResponse(resp)
 	if err != nil {
@@ -380,9 +368,6 @@ func (client *ExpressRouteCircuitsClient) GetStatsHandleResponse(resp *azcore.Re
 
 // GetStatsHandleError handles the GetStats error response.
 func (client *ExpressRouteCircuitsClient) GetStatsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -429,9 +414,6 @@ func (client *ExpressRouteCircuitsClient) ListHandleResponse(resp *azcore.Respon
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteCircuitsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -477,9 +459,6 @@ func (client *ExpressRouteCircuitsClient) ListAllHandleResponse(resp *azcore.Res
 
 // ListAllHandleError handles the ListAll error response.
 func (client *ExpressRouteCircuitsClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -498,8 +477,8 @@ func (client *ExpressRouteCircuitsClient) BeginListArpTable(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListArpTableHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.ListArpTableHandleError(resp)
 	}
 	result, err := client.ListArpTableHandleResponse(resp)
 	if err != nil {
@@ -557,9 +536,6 @@ func (client *ExpressRouteCircuitsClient) ListArpTableHandleResponse(resp *azcor
 
 // ListArpTableHandleError handles the ListArpTable error response.
 func (client *ExpressRouteCircuitsClient) ListArpTableHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -578,8 +554,8 @@ func (client *ExpressRouteCircuitsClient) BeginListRoutesTable(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListRoutesTableHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.ListRoutesTableHandleError(resp)
 	}
 	result, err := client.ListRoutesTableHandleResponse(resp)
 	if err != nil {
@@ -637,9 +613,6 @@ func (client *ExpressRouteCircuitsClient) ListRoutesTableHandleResponse(resp *az
 
 // ListRoutesTableHandleError handles the ListRoutesTable error response.
 func (client *ExpressRouteCircuitsClient) ListRoutesTableHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -658,8 +631,8 @@ func (client *ExpressRouteCircuitsClient) BeginListRoutesTableSummary(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListRoutesTableSummaryHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.ListRoutesTableSummaryHandleError(resp)
 	}
 	result, err := client.ListRoutesTableSummaryHandleResponse(resp)
 	if err != nil {
@@ -717,9 +690,6 @@ func (client *ExpressRouteCircuitsClient) ListRoutesTableSummaryHandleResponse(r
 
 // ListRoutesTableSummaryHandleError handles the ListRoutesTableSummary error response.
 func (client *ExpressRouteCircuitsClient) ListRoutesTableSummaryHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -737,8 +707,8 @@ func (client *ExpressRouteCircuitsClient) UpdateTags(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -772,9 +742,6 @@ func (client *ExpressRouteCircuitsClient) UpdateTagsHandleResponse(resp *azcore.
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *ExpressRouteCircuitsClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits.go
@@ -79,6 +79,9 @@ func (client *ExpressRouteCircuitsClient) BeginCreateOrUpdate(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -128,14 +131,14 @@ func (client *ExpressRouteCircuitsClient) CreateOrUpdateCreateRequest(ctx contex
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ExpressRouteCircuitsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &ExpressRouteCircuitPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCircuitsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -152,6 +155,9 @@ func (client *ExpressRouteCircuitsClient) BeginDelete(ctx context.Context, resou
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -203,14 +209,14 @@ func (client *ExpressRouteCircuitsClient) DeleteCreateRequest(ctx context.Contex
 
 // DeleteHandleResponse handles the Delete response.
 func (client *ExpressRouteCircuitsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRouteCircuitsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -226,6 +232,9 @@ func (client *ExpressRouteCircuitsClient) Get(ctx context.Context, resourceGroup
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -254,15 +263,15 @@ func (client *ExpressRouteCircuitsClient) GetCreateRequest(ctx context.Context, 
 
 // GetHandleResponse handles the Get response.
 func (client *ExpressRouteCircuitsClient) GetHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ExpressRouteCircuitResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCircuit)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteCircuitsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -278,6 +287,9 @@ func (client *ExpressRouteCircuitsClient) GetPeeringStats(ctx context.Context, r
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetPeeringStatsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetPeeringStatsHandleResponse(resp)
@@ -307,15 +319,15 @@ func (client *ExpressRouteCircuitsClient) GetPeeringStatsCreateRequest(ctx conte
 
 // GetPeeringStatsHandleResponse handles the GetPeeringStats response.
 func (client *ExpressRouteCircuitsClient) GetPeeringStatsHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitStatsResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetPeeringStatsHandleError(resp)
-	}
 	result := ExpressRouteCircuitStatsResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCircuitStats)
 }
 
 // GetPeeringStatsHandleError handles the GetPeeringStats error response.
 func (client *ExpressRouteCircuitsClient) GetPeeringStatsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -331,6 +343,9 @@ func (client *ExpressRouteCircuitsClient) GetStats(ctx context.Context, resource
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetStatsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetStatsHandleResponse(resp)
@@ -359,15 +374,15 @@ func (client *ExpressRouteCircuitsClient) GetStatsCreateRequest(ctx context.Cont
 
 // GetStatsHandleResponse handles the GetStats response.
 func (client *ExpressRouteCircuitsClient) GetStatsHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitStatsResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetStatsHandleError(resp)
-	}
 	result := ExpressRouteCircuitStatsResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCircuitStats)
 }
 
 // GetStatsHandleError handles the GetStats error response.
 func (client *ExpressRouteCircuitsClient) GetStatsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -383,6 +398,7 @@ func (client *ExpressRouteCircuitsClient) List(resourceGroupName string) Express
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ExpressRouteCircuitListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteCircuitListResult.NextLink)
 		},
@@ -407,15 +423,15 @@ func (client *ExpressRouteCircuitsClient) ListCreateRequest(ctx context.Context,
 
 // ListHandleResponse handles the List response.
 func (client *ExpressRouteCircuitsClient) ListHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ExpressRouteCircuitListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCircuitListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteCircuitsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -431,6 +447,7 @@ func (client *ExpressRouteCircuitsClient) ListAll() ExpressRouteCircuitListResul
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *ExpressRouteCircuitListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteCircuitListResult.NextLink)
 		},
@@ -454,15 +471,15 @@ func (client *ExpressRouteCircuitsClient) ListAllCreateRequest(ctx context.Conte
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *ExpressRouteCircuitsClient) ListAllHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := ExpressRouteCircuitListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCircuitListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *ExpressRouteCircuitsClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -479,6 +496,9 @@ func (client *ExpressRouteCircuitsClient) BeginListArpTable(ctx context.Context,
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListArpTableHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListArpTableHandleResponse(resp)
@@ -532,14 +552,14 @@ func (client *ExpressRouteCircuitsClient) ListArpTableCreateRequest(ctx context.
 
 // ListArpTableHandleResponse handles the ListArpTable response.
 func (client *ExpressRouteCircuitsClient) ListArpTableHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitsArpTableListResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.ListArpTableHandleError(resp)
-	}
 	return &ExpressRouteCircuitsArpTableListResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // ListArpTableHandleError handles the ListArpTable error response.
 func (client *ExpressRouteCircuitsClient) ListArpTableHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -556,6 +576,9 @@ func (client *ExpressRouteCircuitsClient) BeginListRoutesTable(ctx context.Conte
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListRoutesTableHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListRoutesTableHandleResponse(resp)
@@ -609,14 +632,14 @@ func (client *ExpressRouteCircuitsClient) ListRoutesTableCreateRequest(ctx conte
 
 // ListRoutesTableHandleResponse handles the ListRoutesTable response.
 func (client *ExpressRouteCircuitsClient) ListRoutesTableHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitsRoutesTableListResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.ListRoutesTableHandleError(resp)
-	}
 	return &ExpressRouteCircuitsRoutesTableListResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // ListRoutesTableHandleError handles the ListRoutesTable error response.
 func (client *ExpressRouteCircuitsClient) ListRoutesTableHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -633,6 +656,9 @@ func (client *ExpressRouteCircuitsClient) BeginListRoutesTableSummary(ctx contex
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListRoutesTableSummaryHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListRoutesTableSummaryHandleResponse(resp)
@@ -686,14 +712,14 @@ func (client *ExpressRouteCircuitsClient) ListRoutesTableSummaryCreateRequest(ct
 
 // ListRoutesTableSummaryHandleResponse handles the ListRoutesTableSummary response.
 func (client *ExpressRouteCircuitsClient) ListRoutesTableSummaryHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitsRoutesTableSummaryListResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.ListRoutesTableSummaryHandleError(resp)
-	}
 	return &ExpressRouteCircuitsRoutesTableSummaryListResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // ListRoutesTableSummaryHandleError handles the ListRoutesTableSummary error response.
 func (client *ExpressRouteCircuitsClient) ListRoutesTableSummaryHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -709,6 +735,9 @@ func (client *ExpressRouteCircuitsClient) UpdateTags(ctx context.Context, resour
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -737,15 +766,15 @@ func (client *ExpressRouteCircuitsClient) UpdateTagsCreateRequest(ctx context.Co
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *ExpressRouteCircuitsClient) UpdateTagsHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := ExpressRouteCircuitResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCircuit)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *ExpressRouteCircuitsClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections.go
@@ -59,6 +59,9 @@ func (client *ExpressRouteConnectionsClient) BeginCreateOrUpdate(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *ExpressRouteConnectionsClient) CreateOrUpdateCreateRequest(ctx con
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ExpressRouteConnectionsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*ExpressRouteConnectionPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &ExpressRouteConnectionPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteConnectionsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *ExpressRouteConnectionsClient) BeginDelete(ctx context.Context, re
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *ExpressRouteConnectionsClient) DeleteCreateRequest(ctx context.Con
 
 // DeleteHandleResponse handles the Delete response.
 func (client *ExpressRouteConnectionsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRouteConnectionsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *ExpressRouteConnectionsClient) Get(ctx context.Context, resourceGr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *ExpressRouteConnectionsClient) GetCreateRequest(ctx context.Contex
 
 // GetHandleResponse handles the Get response.
 func (client *ExpressRouteConnectionsClient) GetHandleResponse(resp *azcore.Response) (*ExpressRouteConnectionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ExpressRouteConnectionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteConnection)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteConnectionsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,9 @@ func (client *ExpressRouteConnectionsClient) List(ctx context.Context, resourceG
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListHandleResponse(resp)
@@ -289,15 +301,15 @@ func (client *ExpressRouteConnectionsClient) ListCreateRequest(ctx context.Conte
 
 // ListHandleResponse handles the List response.
 func (client *ExpressRouteConnectionsClient) ListHandleResponse(resp *azcore.Response) (*ExpressRouteConnectionListResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ExpressRouteConnectionListResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteConnectionList)
 }
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteConnectionsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections.go
@@ -59,8 +59,8 @@ func (client *ExpressRouteConnectionsClient) BeginCreateOrUpdate(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *ExpressRouteConnectionsClient) CreateOrUpdateHandleResponse(resp *
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteConnectionsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *ExpressRouteConnectionsClient) BeginDelete(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *ExpressRouteConnectionsClient) DeleteHandleResponse(resp *azcore.R
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRouteConnectionsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *ExpressRouteConnectionsClient) Get(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *ExpressRouteConnectionsClient) GetHandleResponse(resp *azcore.Resp
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteConnectionsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -272,8 +263,8 @@ func (client *ExpressRouteConnectionsClient) List(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListHandleError(resp)
 	}
 	result, err := client.ListHandleResponse(resp)
 	if err != nil {
@@ -307,9 +298,6 @@ func (client *ExpressRouteConnectionsClient) ListHandleResponse(resp *azcore.Res
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteConnectionsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings.go
@@ -59,8 +59,8 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) BeginCreateOrUpdate(ctx
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) CreateOrUpdateHandleRes
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCrossConnectionPeeringsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) BeginDelete(ctx context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) DeleteHandleResponse(re
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRouteCrossConnectionPeeringsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) Get(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) GetHandleResponse(resp 
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteCrossConnectionPeeringsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) ListHandleResponse(resp
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteCrossConnectionPeeringsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings.go
@@ -59,6 +59,9 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) BeginCreateOrUpdate(ctx
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) CreateOrUpdateCreateReq
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ExpressRouteCrossConnectionPeeringsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*ExpressRouteCrossConnectionPeeringPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &ExpressRouteCrossConnectionPeeringPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCrossConnectionPeeringsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) BeginDelete(ctx context
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) DeleteCreateRequest(ctx
 
 // DeleteHandleResponse handles the Delete response.
 func (client *ExpressRouteCrossConnectionPeeringsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRouteCrossConnectionPeeringsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) Get(ctx context.Context
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) GetCreateRequest(ctx co
 
 // GetHandleResponse handles the Get response.
 func (client *ExpressRouteCrossConnectionPeeringsClient) GetHandleResponse(resp *azcore.Response) (*ExpressRouteCrossConnectionPeeringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ExpressRouteCrossConnectionPeeringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCrossConnectionPeering)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteCrossConnectionPeeringsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) List(resourceGroupName 
 			return client.ListCreateRequest(ctx, resourceGroupName, crossConnectionName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ExpressRouteCrossConnectionPeeringListResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteCrossConnectionPeeringList.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) ListCreateRequest(ctx c
 
 // ListHandleResponse handles the List response.
 func (client *ExpressRouteCrossConnectionPeeringsClient) ListHandleResponse(resp *azcore.Response) (*ExpressRouteCrossConnectionPeeringListResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ExpressRouteCrossConnectionPeeringListResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCrossConnectionPeeringList)
 }
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteCrossConnectionPeeringsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections.go
@@ -71,6 +71,9 @@ func (client *ExpressRouteCrossConnectionsClient) BeginCreateOrUpdate(ctx contex
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -120,14 +123,14 @@ func (client *ExpressRouteCrossConnectionsClient) CreateOrUpdateCreateRequest(ct
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ExpressRouteCrossConnectionsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*ExpressRouteCrossConnectionPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &ExpressRouteCrossConnectionPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCrossConnectionsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -143,6 +146,9 @@ func (client *ExpressRouteCrossConnectionsClient) Get(ctx context.Context, resou
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -171,15 +177,15 @@ func (client *ExpressRouteCrossConnectionsClient) GetCreateRequest(ctx context.C
 
 // GetHandleResponse handles the Get response.
 func (client *ExpressRouteCrossConnectionsClient) GetHandleResponse(resp *azcore.Response) (*ExpressRouteCrossConnectionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ExpressRouteCrossConnectionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCrossConnection)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteCrossConnectionsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -195,6 +201,7 @@ func (client *ExpressRouteCrossConnectionsClient) List() ExpressRouteCrossConnec
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ExpressRouteCrossConnectionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteCrossConnectionListResult.NextLink)
 		},
@@ -218,15 +225,15 @@ func (client *ExpressRouteCrossConnectionsClient) ListCreateRequest(ctx context.
 
 // ListHandleResponse handles the List response.
 func (client *ExpressRouteCrossConnectionsClient) ListHandleResponse(resp *azcore.Response) (*ExpressRouteCrossConnectionListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ExpressRouteCrossConnectionListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCrossConnectionListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteCrossConnectionsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -243,6 +250,9 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListArpTable(ctx context.
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListArpTableHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListArpTableHandleResponse(resp)
@@ -296,14 +306,14 @@ func (client *ExpressRouteCrossConnectionsClient) ListArpTableCreateRequest(ctx 
 
 // ListArpTableHandleResponse handles the ListArpTable response.
 func (client *ExpressRouteCrossConnectionsClient) ListArpTableHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitsArpTableListResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.ListArpTableHandleError(resp)
-	}
 	return &ExpressRouteCircuitsArpTableListResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // ListArpTableHandleError handles the ListArpTable error response.
 func (client *ExpressRouteCrossConnectionsClient) ListArpTableHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -319,6 +329,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListByResourceGroup(resourceGr
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *ExpressRouteCrossConnectionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteCrossConnectionListResult.NextLink)
 		},
@@ -343,15 +354,15 @@ func (client *ExpressRouteCrossConnectionsClient) ListByResourceGroupCreateReque
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *ExpressRouteCrossConnectionsClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*ExpressRouteCrossConnectionListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := ExpressRouteCrossConnectionListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCrossConnectionListResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *ExpressRouteCrossConnectionsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -368,6 +379,9 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTable(ctx conte
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListRoutesTableHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListRoutesTableHandleResponse(resp)
@@ -421,14 +435,14 @@ func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableCreateRequest(c
 
 // ListRoutesTableHandleResponse handles the ListRoutesTable response.
 func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableHandleResponse(resp *azcore.Response) (*ExpressRouteCircuitsRoutesTableListResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.ListRoutesTableHandleError(resp)
-	}
 	return &ExpressRouteCircuitsRoutesTableListResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // ListRoutesTableHandleError handles the ListRoutesTable error response.
 func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -445,6 +459,9 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTableSummary(ct
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListRoutesTableSummaryHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListRoutesTableSummaryHandleResponse(resp)
@@ -498,14 +515,14 @@ func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableSummaryCreateRe
 
 // ListRoutesTableSummaryHandleResponse handles the ListRoutesTableSummary response.
 func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableSummaryHandleResponse(resp *azcore.Response) (*ExpressRouteCrossConnectionsRoutesTableSummaryListResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.ListRoutesTableSummaryHandleError(resp)
-	}
 	return &ExpressRouteCrossConnectionsRoutesTableSummaryListResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // ListRoutesTableSummaryHandleError handles the ListRoutesTableSummary error response.
 func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableSummaryHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -521,6 +538,9 @@ func (client *ExpressRouteCrossConnectionsClient) UpdateTags(ctx context.Context
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -549,15 +569,15 @@ func (client *ExpressRouteCrossConnectionsClient) UpdateTagsCreateRequest(ctx co
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *ExpressRouteCrossConnectionsClient) UpdateTagsHandleResponse(resp *azcore.Response) (*ExpressRouteCrossConnectionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := ExpressRouteCrossConnectionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteCrossConnection)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *ExpressRouteCrossConnectionsClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections.go
@@ -71,8 +71,8 @@ func (client *ExpressRouteCrossConnectionsClient) BeginCreateOrUpdate(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -128,9 +128,6 @@ func (client *ExpressRouteCrossConnectionsClient) CreateOrUpdateHandleResponse(r
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCrossConnectionsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -148,8 +145,8 @@ func (client *ExpressRouteCrossConnectionsClient) Get(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -183,9 +180,6 @@ func (client *ExpressRouteCrossConnectionsClient) GetHandleResponse(resp *azcore
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteCrossConnectionsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -231,9 +225,6 @@ func (client *ExpressRouteCrossConnectionsClient) ListHandleResponse(resp *azcor
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteCrossConnectionsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -252,8 +243,8 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListArpTable(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListArpTableHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.ListArpTableHandleError(resp)
 	}
 	result, err := client.ListArpTableHandleResponse(resp)
 	if err != nil {
@@ -311,9 +302,6 @@ func (client *ExpressRouteCrossConnectionsClient) ListArpTableHandleResponse(res
 
 // ListArpTableHandleError handles the ListArpTable error response.
 func (client *ExpressRouteCrossConnectionsClient) ListArpTableHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -360,9 +348,6 @@ func (client *ExpressRouteCrossConnectionsClient) ListByResourceGroupHandleRespo
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *ExpressRouteCrossConnectionsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -381,8 +366,8 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTable(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListRoutesTableHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.ListRoutesTableHandleError(resp)
 	}
 	result, err := client.ListRoutesTableHandleResponse(resp)
 	if err != nil {
@@ -440,9 +425,6 @@ func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableHandleResponse(
 
 // ListRoutesTableHandleError handles the ListRoutesTable error response.
 func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -461,8 +443,8 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTableSummary(ct
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListRoutesTableSummaryHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.ListRoutesTableSummaryHandleError(resp)
 	}
 	result, err := client.ListRoutesTableSummaryHandleResponse(resp)
 	if err != nil {
@@ -520,9 +502,6 @@ func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableSummaryHandleRe
 
 // ListRoutesTableSummaryHandleError handles the ListRoutesTableSummary error response.
 func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableSummaryHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -540,8 +519,8 @@ func (client *ExpressRouteCrossConnectionsClient) UpdateTags(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -575,9 +554,6 @@ func (client *ExpressRouteCrossConnectionsClient) UpdateTagsHandleResponse(resp 
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *ExpressRouteCrossConnectionsClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways.go
@@ -61,8 +61,8 @@ func (client *ExpressRouteGatewaysClient) BeginCreateOrUpdate(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -118,9 +118,6 @@ func (client *ExpressRouteGatewaysClient) CreateOrUpdateHandleResponse(resp *azc
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -139,8 +136,8 @@ func (client *ExpressRouteGatewaysClient) BeginDelete(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *ExpressRouteGatewaysClient) DeleteHandleResponse(resp *azcore.Resp
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRouteGatewaysClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *ExpressRouteGatewaysClient) Get(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -251,9 +245,6 @@ func (client *ExpressRouteGatewaysClient) GetHandleResponse(resp *azcore.Respons
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteGatewaysClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -271,8 +262,8 @@ func (client *ExpressRouteGatewaysClient) ListByResourceGroup(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListByResourceGroupHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListByResourceGroupHandleError(resp)
 	}
 	result, err := client.ListByResourceGroupHandleResponse(resp)
 	if err != nil {
@@ -305,9 +296,6 @@ func (client *ExpressRouteGatewaysClient) ListByResourceGroupHandleResponse(resp
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *ExpressRouteGatewaysClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -325,8 +313,8 @@ func (client *ExpressRouteGatewaysClient) ListBySubscription(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListBySubscriptionHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListBySubscriptionHandleError(resp)
 	}
 	result, err := client.ListBySubscriptionHandleResponse(resp)
 	if err != nil {
@@ -358,9 +346,6 @@ func (client *ExpressRouteGatewaysClient) ListBySubscriptionHandleResponse(resp 
 
 // ListBySubscriptionHandleError handles the ListBySubscription error response.
 func (client *ExpressRouteGatewaysClient) ListBySubscriptionHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways.go
@@ -61,6 +61,9 @@ func (client *ExpressRouteGatewaysClient) BeginCreateOrUpdate(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -110,14 +113,14 @@ func (client *ExpressRouteGatewaysClient) CreateOrUpdateCreateRequest(ctx contex
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ExpressRouteGatewaysClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*ExpressRouteGatewayPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &ExpressRouteGatewayPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,6 +137,9 @@ func (client *ExpressRouteGatewaysClient) BeginDelete(ctx context.Context, resou
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *ExpressRouteGatewaysClient) DeleteCreateRequest(ctx context.Contex
 
 // DeleteHandleResponse handles the Delete response.
 func (client *ExpressRouteGatewaysClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRouteGatewaysClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *ExpressRouteGatewaysClient) Get(ctx context.Context, resourceGroup
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -236,15 +245,15 @@ func (client *ExpressRouteGatewaysClient) GetCreateRequest(ctx context.Context, 
 
 // GetHandleResponse handles the Get response.
 func (client *ExpressRouteGatewaysClient) GetHandleResponse(resp *azcore.Response) (*ExpressRouteGatewayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ExpressRouteGatewayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteGateway)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteGatewaysClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -260,6 +269,9 @@ func (client *ExpressRouteGatewaysClient) ListByResourceGroup(ctx context.Contex
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListByResourceGroupHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListByResourceGroupHandleResponse(resp)
@@ -287,15 +299,15 @@ func (client *ExpressRouteGatewaysClient) ListByResourceGroupCreateRequest(ctx c
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *ExpressRouteGatewaysClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*ExpressRouteGatewayListResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := ExpressRouteGatewayListResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteGatewayList)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *ExpressRouteGatewaysClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -311,6 +323,9 @@ func (client *ExpressRouteGatewaysClient) ListBySubscription(ctx context.Context
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListBySubscriptionHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListBySubscriptionHandleResponse(resp)
@@ -337,15 +352,15 @@ func (client *ExpressRouteGatewaysClient) ListBySubscriptionCreateRequest(ctx co
 
 // ListBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client *ExpressRouteGatewaysClient) ListBySubscriptionHandleResponse(resp *azcore.Response) (*ExpressRouteGatewayListResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListBySubscriptionHandleError(resp)
-	}
 	result := ExpressRouteGatewayListResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteGatewayList)
 }
 
 // ListBySubscriptionHandleError handles the ListBySubscription error response.
 func (client *ExpressRouteGatewaysClient) ListBySubscriptionHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks.go
@@ -48,8 +48,8 @@ func (client *ExpressRouteLinksClient) Get(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -84,9 +84,6 @@ func (client *ExpressRouteLinksClient) GetHandleResponse(resp *azcore.Response) 
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteLinksClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,9 +131,6 @@ func (client *ExpressRouteLinksClient) ListHandleResponse(resp *azcore.Response)
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteLinksClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks.go
@@ -48,6 +48,9 @@ func (client *ExpressRouteLinksClient) Get(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -75,15 +78,15 @@ func (client *ExpressRouteLinksClient) GetCreateRequest(ctx context.Context, res
 
 // GetHandleResponse handles the Get response.
 func (client *ExpressRouteLinksClient) GetHandleResponse(resp *azcore.Response) (*ExpressRouteLinkResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ExpressRouteLinkResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteLink)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRouteLinksClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -99,6 +102,7 @@ func (client *ExpressRouteLinksClient) List(resourceGroupName string, expressRou
 			return client.ListCreateRequest(ctx, resourceGroupName, expressRoutePortName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ExpressRouteLinkListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteLinkListResult.NextLink)
 		},
@@ -124,15 +128,15 @@ func (client *ExpressRouteLinksClient) ListCreateRequest(ctx context.Context, re
 
 // ListHandleResponse handles the List response.
 func (client *ExpressRouteLinksClient) ListHandleResponse(resp *azcore.Response) (*ExpressRouteLinkListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ExpressRouteLinkListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteLinkListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteLinksClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports.go
@@ -63,6 +63,9 @@ func (client *ExpressRoutePortsClient) BeginCreateOrUpdate(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *ExpressRoutePortsClient) CreateOrUpdateCreateRequest(ctx context.C
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ExpressRoutePortsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*ExpressRoutePortPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &ExpressRoutePortPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRoutePortsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *ExpressRoutePortsClient) BeginDelete(ctx context.Context, resource
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *ExpressRoutePortsClient) DeleteCreateRequest(ctx context.Context, 
 
 // DeleteHandleResponse handles the Delete response.
 func (client *ExpressRoutePortsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRoutePortsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *ExpressRoutePortsClient) Get(ctx context.Context, resourceGroupNam
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -238,15 +247,15 @@ func (client *ExpressRoutePortsClient) GetCreateRequest(ctx context.Context, res
 
 // GetHandleResponse handles the Get response.
 func (client *ExpressRoutePortsClient) GetHandleResponse(resp *azcore.Response) (*ExpressRoutePortResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ExpressRoutePortResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRoutePort)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRoutePortsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -262,6 +271,7 @@ func (client *ExpressRoutePortsClient) List() ExpressRoutePortListResultPager {
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ExpressRoutePortListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRoutePortListResult.NextLink)
 		},
@@ -285,15 +295,15 @@ func (client *ExpressRoutePortsClient) ListCreateRequest(ctx context.Context) (*
 
 // ListHandleResponse handles the List response.
 func (client *ExpressRoutePortsClient) ListHandleResponse(resp *azcore.Response) (*ExpressRoutePortListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ExpressRoutePortListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRoutePortListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ExpressRoutePortsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -309,6 +319,7 @@ func (client *ExpressRoutePortsClient) ListByResourceGroup(resourceGroupName str
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *ExpressRoutePortListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRoutePortListResult.NextLink)
 		},
@@ -333,15 +344,15 @@ func (client *ExpressRoutePortsClient) ListByResourceGroupCreateRequest(ctx cont
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *ExpressRoutePortsClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*ExpressRoutePortListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := ExpressRoutePortListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRoutePortListResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *ExpressRoutePortsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -357,6 +368,9 @@ func (client *ExpressRoutePortsClient) UpdateTags(ctx context.Context, resourceG
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -385,15 +399,15 @@ func (client *ExpressRoutePortsClient) UpdateTagsCreateRequest(ctx context.Conte
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *ExpressRoutePortsClient) UpdateTagsHandleResponse(resp *azcore.Response) (*ExpressRoutePortResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := ExpressRoutePortResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRoutePort)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *ExpressRoutePortsClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports.go
@@ -63,8 +63,8 @@ func (client *ExpressRoutePortsClient) BeginCreateOrUpdate(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *ExpressRoutePortsClient) CreateOrUpdateHandleResponse(resp *azcore
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRoutePortsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *ExpressRoutePortsClient) BeginDelete(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *ExpressRoutePortsClient) DeleteHandleResponse(resp *azcore.Respons
 
 // DeleteHandleError handles the Delete error response.
 func (client *ExpressRoutePortsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *ExpressRoutePortsClient) Get(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -253,9 +247,6 @@ func (client *ExpressRoutePortsClient) GetHandleResponse(resp *azcore.Response) 
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRoutePortsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -301,9 +292,6 @@ func (client *ExpressRoutePortsClient) ListHandleResponse(resp *azcore.Response)
 
 // ListHandleError handles the List error response.
 func (client *ExpressRoutePortsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -350,9 +338,6 @@ func (client *ExpressRoutePortsClient) ListByResourceGroupHandleResponse(resp *a
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *ExpressRoutePortsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -370,8 +355,8 @@ func (client *ExpressRoutePortsClient) UpdateTags(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -405,9 +390,6 @@ func (client *ExpressRoutePortsClient) UpdateTagsHandleResponse(resp *azcore.Res
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *ExpressRoutePortsClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations.go
@@ -48,8 +48,8 @@ func (client *ExpressRoutePortsLocationsClient) Get(ctx context.Context, locatio
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -82,9 +82,6 @@ func (client *ExpressRoutePortsLocationsClient) GetHandleResponse(resp *azcore.R
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRoutePortsLocationsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -130,9 +127,6 @@ func (client *ExpressRoutePortsLocationsClient) ListHandleResponse(resp *azcore.
 
 // ListHandleError handles the List error response.
 func (client *ExpressRoutePortsLocationsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations.go
@@ -48,6 +48,9 @@ func (client *ExpressRoutePortsLocationsClient) Get(ctx context.Context, locatio
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -73,15 +76,15 @@ func (client *ExpressRoutePortsLocationsClient) GetCreateRequest(ctx context.Con
 
 // GetHandleResponse handles the Get response.
 func (client *ExpressRoutePortsLocationsClient) GetHandleResponse(resp *azcore.Response) (*ExpressRoutePortsLocationResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ExpressRoutePortsLocationResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRoutePortsLocation)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ExpressRoutePortsLocationsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -97,6 +100,7 @@ func (client *ExpressRoutePortsLocationsClient) List() ExpressRoutePortsLocation
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ExpressRoutePortsLocationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRoutePortsLocationListResult.NextLink)
 		},
@@ -120,15 +124,15 @@ func (client *ExpressRoutePortsLocationsClient) ListCreateRequest(ctx context.Co
 
 // ListHandleResponse handles the List response.
 func (client *ExpressRoutePortsLocationsClient) ListHandleResponse(resp *azcore.Response) (*ExpressRoutePortsLocationListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ExpressRoutePortsLocationListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRoutePortsLocationListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ExpressRoutePortsLocationsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders.go
@@ -74,9 +74,6 @@ func (client *ExpressRouteServiceProvidersClient) ListHandleResponse(resp *azcor
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteServiceProvidersClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders.go
@@ -44,6 +44,7 @@ func (client *ExpressRouteServiceProvidersClient) List() ExpressRouteServiceProv
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ExpressRouteServiceProviderListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteServiceProviderListResult.NextLink)
 		},
@@ -67,15 +68,15 @@ func (client *ExpressRouteServiceProvidersClient) ListCreateRequest(ctx context.
 
 // ListHandleResponse handles the List response.
 func (client *ExpressRouteServiceProvidersClient) ListHandleResponse(resp *azcore.Response) (*ExpressRouteServiceProviderListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ExpressRouteServiceProviderListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ExpressRouteServiceProviderListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ExpressRouteServiceProvidersClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies.go
@@ -61,8 +61,8 @@ func (client *FirewallPoliciesClient) BeginCreateOrUpdate(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -118,9 +118,6 @@ func (client *FirewallPoliciesClient) CreateOrUpdateHandleResponse(resp *azcore.
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *FirewallPoliciesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -139,8 +136,8 @@ func (client *FirewallPoliciesClient) BeginDelete(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *FirewallPoliciesClient) DeleteHandleResponse(resp *azcore.Response
 
 // DeleteHandleError handles the Delete error response.
 func (client *FirewallPoliciesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *FirewallPoliciesClient) Get(ctx context.Context, resourceGroupName
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -254,9 +248,6 @@ func (client *FirewallPoliciesClient) GetHandleResponse(resp *azcore.Response) (
 
 // GetHandleError handles the Get error response.
 func (client *FirewallPoliciesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -303,9 +294,6 @@ func (client *FirewallPoliciesClient) ListHandleResponse(resp *azcore.Response) 
 
 // ListHandleError handles the List error response.
 func (client *FirewallPoliciesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -351,9 +339,6 @@ func (client *FirewallPoliciesClient) ListAllHandleResponse(resp *azcore.Respons
 
 // ListAllHandleError handles the ListAll error response.
 func (client *FirewallPoliciesClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies.go
@@ -61,6 +61,9 @@ func (client *FirewallPoliciesClient) BeginCreateOrUpdate(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -110,14 +113,14 @@ func (client *FirewallPoliciesClient) CreateOrUpdateCreateRequest(ctx context.Co
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *FirewallPoliciesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*FirewallPolicyPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &FirewallPolicyPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *FirewallPoliciesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,6 +137,9 @@ func (client *FirewallPoliciesClient) BeginDelete(ctx context.Context, resourceG
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *FirewallPoliciesClient) DeleteCreateRequest(ctx context.Context, r
 
 // DeleteHandleResponse handles the Delete response.
 func (client *FirewallPoliciesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *FirewallPoliciesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *FirewallPoliciesClient) Get(ctx context.Context, resourceGroupName
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -239,15 +248,15 @@ func (client *FirewallPoliciesClient) GetCreateRequest(ctx context.Context, reso
 
 // GetHandleResponse handles the Get response.
 func (client *FirewallPoliciesClient) GetHandleResponse(resp *azcore.Response) (*FirewallPolicyResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := FirewallPolicyResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.FirewallPolicy)
 }
 
 // GetHandleError handles the Get error response.
 func (client *FirewallPoliciesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -263,6 +272,7 @@ func (client *FirewallPoliciesClient) List(resourceGroupName string) FirewallPol
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *FirewallPolicyListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.FirewallPolicyListResult.NextLink)
 		},
@@ -287,15 +297,15 @@ func (client *FirewallPoliciesClient) ListCreateRequest(ctx context.Context, res
 
 // ListHandleResponse handles the List response.
 func (client *FirewallPoliciesClient) ListHandleResponse(resp *azcore.Response) (*FirewallPolicyListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := FirewallPolicyListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.FirewallPolicyListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *FirewallPoliciesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -311,6 +321,7 @@ func (client *FirewallPoliciesClient) ListAll() FirewallPolicyListResultPager {
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *FirewallPolicyListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.FirewallPolicyListResult.NextLink)
 		},
@@ -334,15 +345,15 @@ func (client *FirewallPoliciesClient) ListAllCreateRequest(ctx context.Context) 
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *FirewallPoliciesClient) ListAllHandleResponse(resp *azcore.Response) (*FirewallPolicyListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := FirewallPolicyListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.FirewallPolicyListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *FirewallPoliciesClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups.go
@@ -59,6 +59,9 @@ func (client *FirewallPolicyRuleGroupsClient) BeginCreateOrUpdate(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *FirewallPolicyRuleGroupsClient) CreateOrUpdateCreateRequest(ctx co
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *FirewallPolicyRuleGroupsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*FirewallPolicyRuleGroupPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &FirewallPolicyRuleGroupPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *FirewallPolicyRuleGroupsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *FirewallPolicyRuleGroupsClient) BeginDelete(ctx context.Context, r
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *FirewallPolicyRuleGroupsClient) DeleteCreateRequest(ctx context.Co
 
 // DeleteHandleResponse handles the Delete response.
 func (client *FirewallPolicyRuleGroupsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *FirewallPolicyRuleGroupsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *FirewallPolicyRuleGroupsClient) Get(ctx context.Context, resourceG
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *FirewallPolicyRuleGroupsClient) GetCreateRequest(ctx context.Conte
 
 // GetHandleResponse handles the Get response.
 func (client *FirewallPolicyRuleGroupsClient) GetHandleResponse(resp *azcore.Response) (*FirewallPolicyRuleGroupResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := FirewallPolicyRuleGroupResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.FirewallPolicyRuleGroup)
 }
 
 // GetHandleError handles the Get error response.
 func (client *FirewallPolicyRuleGroupsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,7 @@ func (client *FirewallPolicyRuleGroupsClient) List(resourceGroupName string, fir
 			return client.ListCreateRequest(ctx, resourceGroupName, firewallPolicyName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *FirewallPolicyRuleGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.FirewallPolicyRuleGroupListResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *FirewallPolicyRuleGroupsClient) ListCreateRequest(ctx context.Cont
 
 // ListHandleResponse handles the List response.
 func (client *FirewallPolicyRuleGroupsClient) ListHandleResponse(resp *azcore.Response) (*FirewallPolicyRuleGroupListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := FirewallPolicyRuleGroupListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.FirewallPolicyRuleGroupListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *FirewallPolicyRuleGroupsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups.go
@@ -59,8 +59,8 @@ func (client *FirewallPolicyRuleGroupsClient) BeginCreateOrUpdate(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *FirewallPolicyRuleGroupsClient) CreateOrUpdateHandleResponse(resp 
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *FirewallPolicyRuleGroupsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *FirewallPolicyRuleGroupsClient) BeginDelete(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *FirewallPolicyRuleGroupsClient) DeleteHandleResponse(resp *azcore.
 
 // DeleteHandleError handles the Delete error response.
 func (client *FirewallPolicyRuleGroupsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *FirewallPolicyRuleGroupsClient) Get(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *FirewallPolicyRuleGroupsClient) GetHandleResponse(resp *azcore.Res
 
 // GetHandleError handles the Get error response.
 func (client *FirewallPolicyRuleGroupsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *FirewallPolicyRuleGroupsClient) ListHandleResponse(resp *azcore.Re
 
 // ListHandleError handles the List error response.
 func (client *FirewallPolicyRuleGroupsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_flowlogs.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_flowlogs.go
@@ -59,8 +59,8 @@ func (client *FlowLogsClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *FlowLogsClient) CreateOrUpdateHandleResponse(resp *azcore.Response
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *FlowLogsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *FlowLogsClient) BeginDelete(ctx context.Context, resourceGroupName
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *FlowLogsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTP
 
 // DeleteHandleError handles the Delete error response.
 func (client *FlowLogsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *FlowLogsClient) Get(ctx context.Context, resourceGroupName string,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *FlowLogsClient) GetHandleResponse(resp *azcore.Response) (*FlowLog
 
 // GetHandleError handles the Get error response.
 func (client *FlowLogsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *FlowLogsClient) ListHandleResponse(resp *azcore.Response) (*FlowLo
 
 // ListHandleError handles the List error response.
 func (client *FlowLogsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_flowlogs.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_flowlogs.go
@@ -59,6 +59,9 @@ func (client *FlowLogsClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *FlowLogsClient) CreateOrUpdateCreateRequest(ctx context.Context, r
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *FlowLogsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*FlowLogPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &FlowLogPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *FlowLogsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *FlowLogsClient) BeginDelete(ctx context.Context, resourceGroupName
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *FlowLogsClient) DeleteCreateRequest(ctx context.Context, resourceG
 
 // DeleteHandleResponse handles the Delete response.
 func (client *FlowLogsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *FlowLogsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *FlowLogsClient) Get(ctx context.Context, resourceGroupName string,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *FlowLogsClient) GetCreateRequest(ctx context.Context, resourceGrou
 
 // GetHandleResponse handles the Get response.
 func (client *FlowLogsClient) GetHandleResponse(resp *azcore.Response) (*FlowLogResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := FlowLogResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.FlowLog)
 }
 
 // GetHandleError handles the Get error response.
 func (client *FlowLogsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,7 @@ func (client *FlowLogsClient) List(resourceGroupName string, networkWatcherName 
 			return client.ListCreateRequest(ctx, resourceGroupName, networkWatcherName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *FlowLogListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.FlowLogListResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *FlowLogsClient) ListCreateRequest(ctx context.Context, resourceGro
 
 // ListHandleResponse handles the List response.
 func (client *FlowLogsClient) ListHandleResponse(resp *azcore.Response) (*FlowLogListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := FlowLogListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.FlowLogListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *FlowLogsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections.go
@@ -48,6 +48,9 @@ func (client *HubVirtualNetworkConnectionsClient) Get(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -75,15 +78,15 @@ func (client *HubVirtualNetworkConnectionsClient) GetCreateRequest(ctx context.C
 
 // GetHandleResponse handles the Get response.
 func (client *HubVirtualNetworkConnectionsClient) GetHandleResponse(resp *azcore.Response) (*HubVirtualNetworkConnectionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := HubVirtualNetworkConnectionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.HubVirtualNetworkConnection)
 }
 
 // GetHandleError handles the Get error response.
 func (client *HubVirtualNetworkConnectionsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -99,6 +102,7 @@ func (client *HubVirtualNetworkConnectionsClient) List(resourceGroupName string,
 			return client.ListCreateRequest(ctx, resourceGroupName, virtualHubName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ListHubVirtualNetworkConnectionsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListHubVirtualNetworkConnectionsResult.NextLink)
 		},
@@ -124,15 +128,15 @@ func (client *HubVirtualNetworkConnectionsClient) ListCreateRequest(ctx context.
 
 // ListHandleResponse handles the List response.
 func (client *HubVirtualNetworkConnectionsClient) ListHandleResponse(resp *azcore.Response) (*ListHubVirtualNetworkConnectionsResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ListHubVirtualNetworkConnectionsResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListHubVirtualNetworkConnectionsResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *HubVirtualNetworkConnectionsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections.go
@@ -48,8 +48,8 @@ func (client *HubVirtualNetworkConnectionsClient) Get(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -84,9 +84,6 @@ func (client *HubVirtualNetworkConnectionsClient) GetHandleResponse(resp *azcore
 
 // GetHandleError handles the Get error response.
 func (client *HubVirtualNetworkConnectionsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,9 +131,6 @@ func (client *HubVirtualNetworkConnectionsClient) ListHandleResponse(resp *azcor
 
 // ListHandleError handles the List error response.
 func (client *HubVirtualNetworkConnectionsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules.go
@@ -59,6 +59,9 @@ func (client *InboundNatRulesClient) BeginCreateOrUpdate(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *InboundNatRulesClient) CreateOrUpdateCreateRequest(ctx context.Con
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *InboundNatRulesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*InboundNatRulePollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &InboundNatRulePollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *InboundNatRulesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *InboundNatRulesClient) BeginDelete(ctx context.Context, resourceGr
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *InboundNatRulesClient) DeleteCreateRequest(ctx context.Context, re
 
 // DeleteHandleResponse handles the Delete response.
 func (client *InboundNatRulesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *InboundNatRulesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *InboundNatRulesClient) Get(ctx context.Context, resourceGroupName 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -240,15 +249,15 @@ func (client *InboundNatRulesClient) GetCreateRequest(ctx context.Context, resou
 
 // GetHandleResponse handles the Get response.
 func (client *InboundNatRulesClient) GetHandleResponse(resp *azcore.Response) (*InboundNatRuleResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := InboundNatRuleResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.InboundNatRule)
 }
 
 // GetHandleError handles the Get error response.
 func (client *InboundNatRulesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -264,6 +273,7 @@ func (client *InboundNatRulesClient) List(resourceGroupName string, loadBalancer
 			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *InboundNatRuleListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.InboundNatRuleListResult.NextLink)
 		},
@@ -289,15 +299,15 @@ func (client *InboundNatRulesClient) ListCreateRequest(ctx context.Context, reso
 
 // ListHandleResponse handles the List response.
 func (client *InboundNatRulesClient) ListHandleResponse(resp *azcore.Response) (*InboundNatRuleListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := InboundNatRuleListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.InboundNatRuleListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *InboundNatRulesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules.go
@@ -59,8 +59,8 @@ func (client *InboundNatRulesClient) BeginCreateOrUpdate(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *InboundNatRulesClient) CreateOrUpdateHandleResponse(resp *azcore.R
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *InboundNatRulesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *InboundNatRulesClient) BeginDelete(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *InboundNatRulesClient) DeleteHandleResponse(resp *azcore.Response)
 
 // DeleteHandleError handles the Delete error response.
 func (client *InboundNatRulesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *InboundNatRulesClient) Get(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -255,9 +249,6 @@ func (client *InboundNatRulesClient) GetHandleResponse(resp *azcore.Response) (*
 
 // GetHandleError handles the Get error response.
 func (client *InboundNatRulesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -305,9 +296,6 @@ func (client *InboundNatRulesClient) ListHandleResponse(resp *azcore.Response) (
 
 // ListHandleError handles the List error response.
 func (client *InboundNatRulesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipallocations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipallocations.go
@@ -63,6 +63,9 @@ func (client *IPAllocationsClient) BeginCreateOrUpdate(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *IPAllocationsClient) CreateOrUpdateCreateRequest(ctx context.Conte
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *IPAllocationsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*IPAllocationPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &IPAllocationPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *IPAllocationsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *IPAllocationsClient) BeginDelete(ctx context.Context, resourceGrou
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *IPAllocationsClient) DeleteCreateRequest(ctx context.Context, reso
 
 // DeleteHandleResponse handles the Delete response.
 func (client *IPAllocationsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *IPAllocationsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *IPAllocationsClient) Get(ctx context.Context, resourceGroupName st
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -241,15 +250,15 @@ func (client *IPAllocationsClient) GetCreateRequest(ctx context.Context, resourc
 
 // GetHandleResponse handles the Get response.
 func (client *IPAllocationsClient) GetHandleResponse(resp *azcore.Response) (*IPAllocationResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := IPAllocationResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.IPAllocation)
 }
 
 // GetHandleError handles the Get error response.
 func (client *IPAllocationsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -265,6 +274,7 @@ func (client *IPAllocationsClient) List() IPAllocationListResultPager {
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *IPAllocationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.IPAllocationListResult.NextLink)
 		},
@@ -288,15 +298,15 @@ func (client *IPAllocationsClient) ListCreateRequest(ctx context.Context) (*azco
 
 // ListHandleResponse handles the List response.
 func (client *IPAllocationsClient) ListHandleResponse(resp *azcore.Response) (*IPAllocationListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := IPAllocationListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.IPAllocationListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *IPAllocationsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -312,6 +322,7 @@ func (client *IPAllocationsClient) ListByResourceGroup(resourceGroupName string)
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *IPAllocationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.IPAllocationListResult.NextLink)
 		},
@@ -336,15 +347,15 @@ func (client *IPAllocationsClient) ListByResourceGroupCreateRequest(ctx context.
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *IPAllocationsClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*IPAllocationListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := IPAllocationListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.IPAllocationListResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *IPAllocationsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -360,6 +371,9 @@ func (client *IPAllocationsClient) UpdateTags(ctx context.Context, resourceGroup
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -388,15 +402,15 @@ func (client *IPAllocationsClient) UpdateTagsCreateRequest(ctx context.Context, 
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *IPAllocationsClient) UpdateTagsHandleResponse(resp *azcore.Response) (*IPAllocationResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := IPAllocationResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.IPAllocation)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *IPAllocationsClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipallocations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipallocations.go
@@ -63,8 +63,8 @@ func (client *IPAllocationsClient) BeginCreateOrUpdate(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *IPAllocationsClient) CreateOrUpdateHandleResponse(resp *azcore.Res
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *IPAllocationsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *IPAllocationsClient) BeginDelete(ctx context.Context, resourceGrou
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *IPAllocationsClient) DeleteHandleResponse(resp *azcore.Response) (
 
 // DeleteHandleError handles the Delete error response.
 func (client *IPAllocationsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *IPAllocationsClient) Get(ctx context.Context, resourceGroupName st
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -256,9 +250,6 @@ func (client *IPAllocationsClient) GetHandleResponse(resp *azcore.Response) (*IP
 
 // GetHandleError handles the Get error response.
 func (client *IPAllocationsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -304,9 +295,6 @@ func (client *IPAllocationsClient) ListHandleResponse(resp *azcore.Response) (*I
 
 // ListHandleError handles the List error response.
 func (client *IPAllocationsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -353,9 +341,6 @@ func (client *IPAllocationsClient) ListByResourceGroupHandleResponse(resp *azcor
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *IPAllocationsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -373,8 +358,8 @@ func (client *IPAllocationsClient) UpdateTags(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -408,9 +393,6 @@ func (client *IPAllocationsClient) UpdateTagsHandleResponse(resp *azcore.Respons
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *IPAllocationsClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipgroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipgroups.go
@@ -63,6 +63,9 @@ func (client *IPGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *IPGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, r
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *IPGroupsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*IPGroupPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &IPGroupPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *IPGroupsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *IPGroupsClient) BeginDelete(ctx context.Context, resourceGroupName
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *IPGroupsClient) DeleteCreateRequest(ctx context.Context, resourceG
 
 // DeleteHandleResponse handles the Delete response.
 func (client *IPGroupsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *IPGroupsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *IPGroupsClient) Get(ctx context.Context, resourceGroupName string,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -241,15 +250,15 @@ func (client *IPGroupsClient) GetCreateRequest(ctx context.Context, resourceGrou
 
 // GetHandleResponse handles the Get response.
 func (client *IPGroupsClient) GetHandleResponse(resp *azcore.Response) (*IPGroupResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := IPGroupResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.IPGroup)
 }
 
 // GetHandleError handles the Get error response.
 func (client *IPGroupsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -265,6 +274,7 @@ func (client *IPGroupsClient) List() IPGroupListResultPager {
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *IPGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.IPGroupListResult.NextLink)
 		},
@@ -288,15 +298,15 @@ func (client *IPGroupsClient) ListCreateRequest(ctx context.Context) (*azcore.Re
 
 // ListHandleResponse handles the List response.
 func (client *IPGroupsClient) ListHandleResponse(resp *azcore.Response) (*IPGroupListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := IPGroupListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.IPGroupListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *IPGroupsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -312,6 +322,7 @@ func (client *IPGroupsClient) ListByResourceGroup(resourceGroupName string) IPGr
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *IPGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.IPGroupListResult.NextLink)
 		},
@@ -336,15 +347,15 @@ func (client *IPGroupsClient) ListByResourceGroupCreateRequest(ctx context.Conte
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *IPGroupsClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*IPGroupListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := IPGroupListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.IPGroupListResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *IPGroupsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -360,6 +371,9 @@ func (client *IPGroupsClient) UpdateGroups(ctx context.Context, resourceGroupNam
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateGroupsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateGroupsHandleResponse(resp)
@@ -388,15 +402,15 @@ func (client *IPGroupsClient) UpdateGroupsCreateRequest(ctx context.Context, res
 
 // UpdateGroupsHandleResponse handles the UpdateGroups response.
 func (client *IPGroupsClient) UpdateGroupsHandleResponse(resp *azcore.Response) (*IPGroupResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateGroupsHandleError(resp)
-	}
 	result := IPGroupResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.IPGroup)
 }
 
 // UpdateGroupsHandleError handles the UpdateGroups error response.
 func (client *IPGroupsClient) UpdateGroupsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipgroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipgroups.go
@@ -63,8 +63,8 @@ func (client *IPGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *IPGroupsClient) CreateOrUpdateHandleResponse(resp *azcore.Response
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *IPGroupsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *IPGroupsClient) BeginDelete(ctx context.Context, resourceGroupName
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *IPGroupsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTP
 
 // DeleteHandleError handles the Delete error response.
 func (client *IPGroupsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *IPGroupsClient) Get(ctx context.Context, resourceGroupName string,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -256,9 +250,6 @@ func (client *IPGroupsClient) GetHandleResponse(resp *azcore.Response) (*IPGroup
 
 // GetHandleError handles the Get error response.
 func (client *IPGroupsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -304,9 +295,6 @@ func (client *IPGroupsClient) ListHandleResponse(resp *azcore.Response) (*IPGrou
 
 // ListHandleError handles the List error response.
 func (client *IPGroupsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -353,9 +341,6 @@ func (client *IPGroupsClient) ListByResourceGroupHandleResponse(resp *azcore.Res
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *IPGroupsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -373,8 +358,8 @@ func (client *IPGroupsClient) UpdateGroups(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateGroupsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateGroupsHandleError(resp)
 	}
 	result, err := client.UpdateGroupsHandleResponse(resp)
 	if err != nil {
@@ -408,9 +393,6 @@ func (client *IPGroupsClient) UpdateGroupsHandleResponse(resp *azcore.Response) 
 
 // UpdateGroupsHandleError handles the UpdateGroups error response.
 func (client *IPGroupsClient) UpdateGroupsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools.go
@@ -48,6 +48,9 @@ func (client *LoadBalancerBackendAddressPoolsClient) Get(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -75,15 +78,15 @@ func (client *LoadBalancerBackendAddressPoolsClient) GetCreateRequest(ctx contex
 
 // GetHandleResponse handles the Get response.
 func (client *LoadBalancerBackendAddressPoolsClient) GetHandleResponse(resp *azcore.Response) (*BackendAddressPoolResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := BackendAddressPoolResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.BackendAddressPool)
 }
 
 // GetHandleError handles the Get error response.
 func (client *LoadBalancerBackendAddressPoolsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -99,6 +102,7 @@ func (client *LoadBalancerBackendAddressPoolsClient) List(resourceGroupName stri
 			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *LoadBalancerBackendAddressPoolListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LoadBalancerBackendAddressPoolListResult.NextLink)
 		},
@@ -124,15 +128,15 @@ func (client *LoadBalancerBackendAddressPoolsClient) ListCreateRequest(ctx conte
 
 // ListHandleResponse handles the List response.
 func (client *LoadBalancerBackendAddressPoolsClient) ListHandleResponse(resp *azcore.Response) (*LoadBalancerBackendAddressPoolListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := LoadBalancerBackendAddressPoolListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.LoadBalancerBackendAddressPoolListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *LoadBalancerBackendAddressPoolsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools.go
@@ -48,8 +48,8 @@ func (client *LoadBalancerBackendAddressPoolsClient) Get(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -84,9 +84,6 @@ func (client *LoadBalancerBackendAddressPoolsClient) GetHandleResponse(resp *azc
 
 // GetHandleError handles the Get error response.
 func (client *LoadBalancerBackendAddressPoolsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,9 +131,6 @@ func (client *LoadBalancerBackendAddressPoolsClient) ListHandleResponse(resp *az
 
 // ListHandleError handles the List error response.
 func (client *LoadBalancerBackendAddressPoolsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations.go
@@ -48,6 +48,9 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) Get(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -75,15 +78,15 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) GetCreateRequest(ctx c
 
 // GetHandleResponse handles the Get response.
 func (client *LoadBalancerFrontendIPConfigurationsClient) GetHandleResponse(resp *azcore.Response) (*FrontendIPConfigurationResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := FrontendIPConfigurationResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.FrontendIPConfiguration)
 }
 
 // GetHandleError handles the Get error response.
 func (client *LoadBalancerFrontendIPConfigurationsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -99,6 +102,7 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) List(resourceGroupName
 			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *LoadBalancerFrontendIPConfigurationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LoadBalancerFrontendIPConfigurationListResult.NextLink)
 		},
@@ -124,15 +128,15 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) ListCreateRequest(ctx 
 
 // ListHandleResponse handles the List response.
 func (client *LoadBalancerFrontendIPConfigurationsClient) ListHandleResponse(resp *azcore.Response) (*LoadBalancerFrontendIPConfigurationListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := LoadBalancerFrontendIPConfigurationListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.LoadBalancerFrontendIPConfigurationListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *LoadBalancerFrontendIPConfigurationsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations.go
@@ -48,8 +48,8 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) Get(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -84,9 +84,6 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) GetHandleResponse(resp
 
 // GetHandleError handles the Get error response.
 func (client *LoadBalancerFrontendIPConfigurationsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,9 +131,6 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) ListHandleResponse(res
 
 // ListHandleError handles the List error response.
 func (client *LoadBalancerFrontendIPConfigurationsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules.go
@@ -48,8 +48,8 @@ func (client *LoadBalancerLoadBalancingRulesClient) Get(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -84,9 +84,6 @@ func (client *LoadBalancerLoadBalancingRulesClient) GetHandleResponse(resp *azco
 
 // GetHandleError handles the Get error response.
 func (client *LoadBalancerLoadBalancingRulesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,9 +131,6 @@ func (client *LoadBalancerLoadBalancingRulesClient) ListHandleResponse(resp *azc
 
 // ListHandleError handles the List error response.
 func (client *LoadBalancerLoadBalancingRulesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules.go
@@ -48,6 +48,9 @@ func (client *LoadBalancerLoadBalancingRulesClient) Get(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -75,15 +78,15 @@ func (client *LoadBalancerLoadBalancingRulesClient) GetCreateRequest(ctx context
 
 // GetHandleResponse handles the Get response.
 func (client *LoadBalancerLoadBalancingRulesClient) GetHandleResponse(resp *azcore.Response) (*LoadBalancingRuleResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := LoadBalancingRuleResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.LoadBalancingRule)
 }
 
 // GetHandleError handles the Get error response.
 func (client *LoadBalancerLoadBalancingRulesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -99,6 +102,7 @@ func (client *LoadBalancerLoadBalancingRulesClient) List(resourceGroupName strin
 			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *LoadBalancerLoadBalancingRuleListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LoadBalancerLoadBalancingRuleListResult.NextLink)
 		},
@@ -124,15 +128,15 @@ func (client *LoadBalancerLoadBalancingRulesClient) ListCreateRequest(ctx contex
 
 // ListHandleResponse handles the List response.
 func (client *LoadBalancerLoadBalancingRulesClient) ListHandleResponse(resp *azcore.Response) (*LoadBalancerLoadBalancingRuleListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := LoadBalancerLoadBalancingRuleListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.LoadBalancerLoadBalancingRuleListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *LoadBalancerLoadBalancingRulesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces.go
@@ -76,9 +76,6 @@ func (client *LoadBalancerNetworkInterfacesClient) ListHandleResponse(resp *azco
 
 // ListHandleError handles the List error response.
 func (client *LoadBalancerNetworkInterfacesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces.go
@@ -44,6 +44,7 @@ func (client *LoadBalancerNetworkInterfacesClient) List(resourceGroupName string
 			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *NetworkInterfaceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceListResult.NextLink)
 		},
@@ -69,15 +70,15 @@ func (client *LoadBalancerNetworkInterfacesClient) ListCreateRequest(ctx context
 
 // ListHandleResponse handles the List response.
 func (client *LoadBalancerNetworkInterfacesClient) ListHandleResponse(resp *azcore.Response) (*NetworkInterfaceListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := NetworkInterfaceListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkInterfaceListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *LoadBalancerNetworkInterfacesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules.go
@@ -48,6 +48,9 @@ func (client *LoadBalancerOutboundRulesClient) Get(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -75,15 +78,15 @@ func (client *LoadBalancerOutboundRulesClient) GetCreateRequest(ctx context.Cont
 
 // GetHandleResponse handles the Get response.
 func (client *LoadBalancerOutboundRulesClient) GetHandleResponse(resp *azcore.Response) (*OutboundRuleResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := OutboundRuleResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.OutboundRule)
 }
 
 // GetHandleError handles the Get error response.
 func (client *LoadBalancerOutboundRulesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -99,6 +102,7 @@ func (client *LoadBalancerOutboundRulesClient) List(resourceGroupName string, lo
 			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *LoadBalancerOutboundRuleListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LoadBalancerOutboundRuleListResult.NextLink)
 		},
@@ -124,15 +128,15 @@ func (client *LoadBalancerOutboundRulesClient) ListCreateRequest(ctx context.Con
 
 // ListHandleResponse handles the List response.
 func (client *LoadBalancerOutboundRulesClient) ListHandleResponse(resp *azcore.Response) (*LoadBalancerOutboundRuleListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := LoadBalancerOutboundRuleListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.LoadBalancerOutboundRuleListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *LoadBalancerOutboundRulesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules.go
@@ -48,8 +48,8 @@ func (client *LoadBalancerOutboundRulesClient) Get(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -84,9 +84,6 @@ func (client *LoadBalancerOutboundRulesClient) GetHandleResponse(resp *azcore.Re
 
 // GetHandleError handles the Get error response.
 func (client *LoadBalancerOutboundRulesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,9 +131,6 @@ func (client *LoadBalancerOutboundRulesClient) ListHandleResponse(resp *azcore.R
 
 // ListHandleError handles the List error response.
 func (client *LoadBalancerOutboundRulesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes.go
@@ -48,8 +48,8 @@ func (client *LoadBalancerProbesClient) Get(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -84,9 +84,6 @@ func (client *LoadBalancerProbesClient) GetHandleResponse(resp *azcore.Response)
 
 // GetHandleError handles the Get error response.
 func (client *LoadBalancerProbesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,9 +131,6 @@ func (client *LoadBalancerProbesClient) ListHandleResponse(resp *azcore.Response
 
 // ListHandleError handles the List error response.
 func (client *LoadBalancerProbesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes.go
@@ -48,6 +48,9 @@ func (client *LoadBalancerProbesClient) Get(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -75,15 +78,15 @@ func (client *LoadBalancerProbesClient) GetCreateRequest(ctx context.Context, re
 
 // GetHandleResponse handles the Get response.
 func (client *LoadBalancerProbesClient) GetHandleResponse(resp *azcore.Response) (*ProbeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ProbeResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Probe)
 }
 
 // GetHandleError handles the Get error response.
 func (client *LoadBalancerProbesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -99,6 +102,7 @@ func (client *LoadBalancerProbesClient) List(resourceGroupName string, loadBalan
 			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *LoadBalancerProbeListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LoadBalancerProbeListResult.NextLink)
 		},
@@ -124,15 +128,15 @@ func (client *LoadBalancerProbesClient) ListCreateRequest(ctx context.Context, r
 
 // ListHandleResponse handles the List response.
 func (client *LoadBalancerProbesClient) ListHandleResponse(resp *azcore.Response) (*LoadBalancerProbeListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := LoadBalancerProbeListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.LoadBalancerProbeListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *LoadBalancerProbesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers.go
@@ -63,8 +63,8 @@ func (client *LoadBalancersClient) BeginCreateOrUpdate(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *LoadBalancersClient) CreateOrUpdateHandleResponse(resp *azcore.Res
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *LoadBalancersClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *LoadBalancersClient) BeginDelete(ctx context.Context, resourceGrou
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *LoadBalancersClient) DeleteHandleResponse(resp *azcore.Response) (
 
 // DeleteHandleError handles the Delete error response.
 func (client *LoadBalancersClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *LoadBalancersClient) Get(ctx context.Context, resourceGroupName st
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -256,9 +250,6 @@ func (client *LoadBalancersClient) GetHandleResponse(resp *azcore.Response) (*Lo
 
 // GetHandleError handles the Get error response.
 func (client *LoadBalancersClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -305,9 +296,6 @@ func (client *LoadBalancersClient) ListHandleResponse(resp *azcore.Response) (*L
 
 // ListHandleError handles the List error response.
 func (client *LoadBalancersClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -353,9 +341,6 @@ func (client *LoadBalancersClient) ListAllHandleResponse(resp *azcore.Response) 
 
 // ListAllHandleError handles the ListAll error response.
 func (client *LoadBalancersClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -373,8 +358,8 @@ func (client *LoadBalancersClient) UpdateTags(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -408,9 +393,6 @@ func (client *LoadBalancersClient) UpdateTagsHandleResponse(resp *azcore.Respons
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *LoadBalancersClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers.go
@@ -63,6 +63,9 @@ func (client *LoadBalancersClient) BeginCreateOrUpdate(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *LoadBalancersClient) CreateOrUpdateCreateRequest(ctx context.Conte
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *LoadBalancersClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*LoadBalancerPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &LoadBalancerPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *LoadBalancersClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *LoadBalancersClient) BeginDelete(ctx context.Context, resourceGrou
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *LoadBalancersClient) DeleteCreateRequest(ctx context.Context, reso
 
 // DeleteHandleResponse handles the Delete response.
 func (client *LoadBalancersClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *LoadBalancersClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *LoadBalancersClient) Get(ctx context.Context, resourceGroupName st
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -241,15 +250,15 @@ func (client *LoadBalancersClient) GetCreateRequest(ctx context.Context, resourc
 
 // GetHandleResponse handles the Get response.
 func (client *LoadBalancersClient) GetHandleResponse(resp *azcore.Response) (*LoadBalancerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := LoadBalancerResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.LoadBalancer)
 }
 
 // GetHandleError handles the Get error response.
 func (client *LoadBalancersClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -265,6 +274,7 @@ func (client *LoadBalancersClient) List(resourceGroupName string) LoadBalancerLi
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *LoadBalancerListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LoadBalancerListResult.NextLink)
 		},
@@ -289,15 +299,15 @@ func (client *LoadBalancersClient) ListCreateRequest(ctx context.Context, resour
 
 // ListHandleResponse handles the List response.
 func (client *LoadBalancersClient) ListHandleResponse(resp *azcore.Response) (*LoadBalancerListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := LoadBalancerListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.LoadBalancerListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *LoadBalancersClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -313,6 +323,7 @@ func (client *LoadBalancersClient) ListAll() LoadBalancerListResultPager {
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *LoadBalancerListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LoadBalancerListResult.NextLink)
 		},
@@ -336,15 +347,15 @@ func (client *LoadBalancersClient) ListAllCreateRequest(ctx context.Context) (*a
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *LoadBalancersClient) ListAllHandleResponse(resp *azcore.Response) (*LoadBalancerListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := LoadBalancerListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.LoadBalancerListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *LoadBalancersClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -360,6 +371,9 @@ func (client *LoadBalancersClient) UpdateTags(ctx context.Context, resourceGroup
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -388,15 +402,15 @@ func (client *LoadBalancersClient) UpdateTagsCreateRequest(ctx context.Context, 
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *LoadBalancersClient) UpdateTagsHandleResponse(resp *azcore.Response) (*LoadBalancerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := LoadBalancerResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.LoadBalancer)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *LoadBalancersClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways.go
@@ -61,6 +61,9 @@ func (client *LocalNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -110,14 +113,14 @@ func (client *LocalNetworkGatewaysClient) CreateOrUpdateCreateRequest(ctx contex
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *LocalNetworkGatewaysClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*LocalNetworkGatewayPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &LocalNetworkGatewayPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *LocalNetworkGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,6 +137,9 @@ func (client *LocalNetworkGatewaysClient) BeginDelete(ctx context.Context, resou
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *LocalNetworkGatewaysClient) DeleteCreateRequest(ctx context.Contex
 
 // DeleteHandleResponse handles the Delete response.
 func (client *LocalNetworkGatewaysClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *LocalNetworkGatewaysClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *LocalNetworkGatewaysClient) Get(ctx context.Context, resourceGroup
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -236,15 +245,15 @@ func (client *LocalNetworkGatewaysClient) GetCreateRequest(ctx context.Context, 
 
 // GetHandleResponse handles the Get response.
 func (client *LocalNetworkGatewaysClient) GetHandleResponse(resp *azcore.Response) (*LocalNetworkGatewayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := LocalNetworkGatewayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.LocalNetworkGateway)
 }
 
 // GetHandleError handles the Get error response.
 func (client *LocalNetworkGatewaysClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -260,6 +269,7 @@ func (client *LocalNetworkGatewaysClient) List(resourceGroupName string) LocalNe
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *LocalNetworkGatewayListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LocalNetworkGatewayListResult.NextLink)
 		},
@@ -284,15 +294,15 @@ func (client *LocalNetworkGatewaysClient) ListCreateRequest(ctx context.Context,
 
 // ListHandleResponse handles the List response.
 func (client *LocalNetworkGatewaysClient) ListHandleResponse(resp *azcore.Response) (*LocalNetworkGatewayListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := LocalNetworkGatewayListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.LocalNetworkGatewayListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *LocalNetworkGatewaysClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -308,6 +318,9 @@ func (client *LocalNetworkGatewaysClient) UpdateTags(ctx context.Context, resour
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -336,15 +349,15 @@ func (client *LocalNetworkGatewaysClient) UpdateTagsCreateRequest(ctx context.Co
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *LocalNetworkGatewaysClient) UpdateTagsHandleResponse(resp *azcore.Response) (*LocalNetworkGatewayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := LocalNetworkGatewayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.LocalNetworkGateway)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *LocalNetworkGatewaysClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways.go
@@ -61,8 +61,8 @@ func (client *LocalNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -118,9 +118,6 @@ func (client *LocalNetworkGatewaysClient) CreateOrUpdateHandleResponse(resp *azc
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *LocalNetworkGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -139,8 +136,8 @@ func (client *LocalNetworkGatewaysClient) BeginDelete(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *LocalNetworkGatewaysClient) DeleteHandleResponse(resp *azcore.Resp
 
 // DeleteHandleError handles the Delete error response.
 func (client *LocalNetworkGatewaysClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *LocalNetworkGatewaysClient) Get(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -251,9 +245,6 @@ func (client *LocalNetworkGatewaysClient) GetHandleResponse(resp *azcore.Respons
 
 // GetHandleError handles the Get error response.
 func (client *LocalNetworkGatewaysClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -300,9 +291,6 @@ func (client *LocalNetworkGatewaysClient) ListHandleResponse(resp *azcore.Respon
 
 // ListHandleError handles the List error response.
 func (client *LocalNetworkGatewaysClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -320,8 +308,8 @@ func (client *LocalNetworkGatewaysClient) UpdateTags(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -355,9 +343,6 @@ func (client *LocalNetworkGatewaysClient) UpdateTagsHandleResponse(resp *azcore.
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *LocalNetworkGatewaysClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_natgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_natgateways.go
@@ -63,8 +63,8 @@ func (client *NatGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *NatGatewaysClient) CreateOrUpdateHandleResponse(resp *azcore.Respo
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NatGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *NatGatewaysClient) BeginDelete(ctx context.Context, resourceGroupN
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *NatGatewaysClient) DeleteHandleResponse(resp *azcore.Response) (*H
 
 // DeleteHandleError handles the Delete error response.
 func (client *NatGatewaysClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *NatGatewaysClient) Get(ctx context.Context, resourceGroupName stri
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -256,9 +250,6 @@ func (client *NatGatewaysClient) GetHandleResponse(resp *azcore.Response) (*NatG
 
 // GetHandleError handles the Get error response.
 func (client *NatGatewaysClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -305,9 +296,6 @@ func (client *NatGatewaysClient) ListHandleResponse(resp *azcore.Response) (*Nat
 
 // ListHandleError handles the List error response.
 func (client *NatGatewaysClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -353,9 +341,6 @@ func (client *NatGatewaysClient) ListAllHandleResponse(resp *azcore.Response) (*
 
 // ListAllHandleError handles the ListAll error response.
 func (client *NatGatewaysClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -373,8 +358,8 @@ func (client *NatGatewaysClient) UpdateTags(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -408,9 +393,6 @@ func (client *NatGatewaysClient) UpdateTagsHandleResponse(resp *azcore.Response)
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *NatGatewaysClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_natgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_natgateways.go
@@ -63,6 +63,9 @@ func (client *NatGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *NatGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *NatGatewaysClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*NatGatewayPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &NatGatewayPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NatGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *NatGatewaysClient) BeginDelete(ctx context.Context, resourceGroupN
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *NatGatewaysClient) DeleteCreateRequest(ctx context.Context, resour
 
 // DeleteHandleResponse handles the Delete response.
 func (client *NatGatewaysClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *NatGatewaysClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *NatGatewaysClient) Get(ctx context.Context, resourceGroupName stri
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -241,15 +250,15 @@ func (client *NatGatewaysClient) GetCreateRequest(ctx context.Context, resourceG
 
 // GetHandleResponse handles the Get response.
 func (client *NatGatewaysClient) GetHandleResponse(resp *azcore.Response) (*NatGatewayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := NatGatewayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NatGateway)
 }
 
 // GetHandleError handles the Get error response.
 func (client *NatGatewaysClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -265,6 +274,7 @@ func (client *NatGatewaysClient) List(resourceGroupName string) NatGatewayListRe
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *NatGatewayListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NatGatewayListResult.NextLink)
 		},
@@ -289,15 +299,15 @@ func (client *NatGatewaysClient) ListCreateRequest(ctx context.Context, resource
 
 // ListHandleResponse handles the List response.
 func (client *NatGatewaysClient) ListHandleResponse(resp *azcore.Response) (*NatGatewayListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := NatGatewayListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NatGatewayListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *NatGatewaysClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -313,6 +323,7 @@ func (client *NatGatewaysClient) ListAll() NatGatewayListResultPager {
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *NatGatewayListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NatGatewayListResult.NextLink)
 		},
@@ -336,15 +347,15 @@ func (client *NatGatewaysClient) ListAllCreateRequest(ctx context.Context) (*azc
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *NatGatewaysClient) ListAllHandleResponse(resp *azcore.Response) (*NatGatewayListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := NatGatewayListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NatGatewayListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *NatGatewaysClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -360,6 +371,9 @@ func (client *NatGatewaysClient) UpdateTags(ctx context.Context, resourceGroupNa
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -388,15 +402,15 @@ func (client *NatGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, re
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *NatGatewaysClient) UpdateTagsHandleResponse(resp *azcore.Response) (*NatGatewayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := NatGatewayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NatGateway)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *NatGatewaysClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations.go
@@ -48,8 +48,8 @@ func (client *NetworkInterfaceIPConfigurationsClient) Get(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -84,9 +84,6 @@ func (client *NetworkInterfaceIPConfigurationsClient) GetHandleResponse(resp *az
 
 // GetHandleError handles the Get error response.
 func (client *NetworkInterfaceIPConfigurationsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,9 +131,6 @@ func (client *NetworkInterfaceIPConfigurationsClient) ListHandleResponse(resp *a
 
 // ListHandleError handles the List error response.
 func (client *NetworkInterfaceIPConfigurationsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations.go
@@ -48,6 +48,9 @@ func (client *NetworkInterfaceIPConfigurationsClient) Get(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -75,15 +78,15 @@ func (client *NetworkInterfaceIPConfigurationsClient) GetCreateRequest(ctx conte
 
 // GetHandleResponse handles the Get response.
 func (client *NetworkInterfaceIPConfigurationsClient) GetHandleResponse(resp *azcore.Response) (*NetworkInterfaceIPConfigurationResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := NetworkInterfaceIPConfigurationResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkInterfaceIPConfiguration)
 }
 
 // GetHandleError handles the Get error response.
 func (client *NetworkInterfaceIPConfigurationsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -99,6 +102,7 @@ func (client *NetworkInterfaceIPConfigurationsClient) List(resourceGroupName str
 			return client.ListCreateRequest(ctx, resourceGroupName, networkInterfaceName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *NetworkInterfaceIPConfigurationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceIPConfigurationListResult.NextLink)
 		},
@@ -124,15 +128,15 @@ func (client *NetworkInterfaceIPConfigurationsClient) ListCreateRequest(ctx cont
 
 // ListHandleResponse handles the List response.
 func (client *NetworkInterfaceIPConfigurationsClient) ListHandleResponse(resp *azcore.Response) (*NetworkInterfaceIPConfigurationListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := NetworkInterfaceIPConfigurationListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkInterfaceIPConfigurationListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *NetworkInterfaceIPConfigurationsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers.go
@@ -44,6 +44,7 @@ func (client *NetworkInterfaceLoadBalancersClient) List(resourceGroupName string
 			return client.ListCreateRequest(ctx, resourceGroupName, networkInterfaceName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *NetworkInterfaceLoadBalancerListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceLoadBalancerListResult.NextLink)
 		},
@@ -69,15 +70,15 @@ func (client *NetworkInterfaceLoadBalancersClient) ListCreateRequest(ctx context
 
 // ListHandleResponse handles the List response.
 func (client *NetworkInterfaceLoadBalancersClient) ListHandleResponse(resp *azcore.Response) (*NetworkInterfaceLoadBalancerListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := NetworkInterfaceLoadBalancerListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkInterfaceLoadBalancerListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *NetworkInterfaceLoadBalancersClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers.go
@@ -76,9 +76,6 @@ func (client *NetworkInterfaceLoadBalancersClient) ListHandleResponse(resp *azco
 
 // ListHandleError handles the List error response.
 func (client *NetworkInterfaceLoadBalancersClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces.go
@@ -81,6 +81,9 @@ func (client *NetworkInterfacesClient) BeginCreateOrUpdate(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -130,14 +133,14 @@ func (client *NetworkInterfacesClient) CreateOrUpdateCreateRequest(ctx context.C
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *NetworkInterfacesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*NetworkInterfacePollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &NetworkInterfacePollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkInterfacesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -154,6 +157,9 @@ func (client *NetworkInterfacesClient) BeginDelete(ctx context.Context, resource
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -205,14 +211,14 @@ func (client *NetworkInterfacesClient) DeleteCreateRequest(ctx context.Context, 
 
 // DeleteHandleResponse handles the Delete response.
 func (client *NetworkInterfacesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *NetworkInterfacesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -228,6 +234,9 @@ func (client *NetworkInterfacesClient) Get(ctx context.Context, resourceGroupNam
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -259,15 +268,15 @@ func (client *NetworkInterfacesClient) GetCreateRequest(ctx context.Context, res
 
 // GetHandleResponse handles the Get response.
 func (client *NetworkInterfacesClient) GetHandleResponse(resp *azcore.Response) (*NetworkInterfaceResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := NetworkInterfaceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkInterface)
 }
 
 // GetHandleError handles the Get error response.
 func (client *NetworkInterfacesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -284,6 +293,9 @@ func (client *NetworkInterfacesClient) BeginGetEffectiveRouteTable(ctx context.C
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetEffectiveRouteTableHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetEffectiveRouteTableHandleResponse(resp)
@@ -335,14 +347,14 @@ func (client *NetworkInterfacesClient) GetEffectiveRouteTableCreateRequest(ctx c
 
 // GetEffectiveRouteTableHandleResponse handles the GetEffectiveRouteTable response.
 func (client *NetworkInterfacesClient) GetEffectiveRouteTableHandleResponse(resp *azcore.Response) (*EffectiveRouteListResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetEffectiveRouteTableHandleError(resp)
-	}
 	return &EffectiveRouteListResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetEffectiveRouteTableHandleError handles the GetEffectiveRouteTable error response.
 func (client *NetworkInterfacesClient) GetEffectiveRouteTableHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -358,6 +370,9 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfiguration(
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetVirtualMachineScaleSetIPConfigurationHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetVirtualMachineScaleSetIPConfigurationHandleResponse(resp)
@@ -392,15 +407,15 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfigurationC
 
 // GetVirtualMachineScaleSetIPConfigurationHandleResponse handles the GetVirtualMachineScaleSetIPConfiguration response.
 func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfigurationHandleResponse(resp *azcore.Response) (*NetworkInterfaceIPConfigurationResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetVirtualMachineScaleSetIPConfigurationHandleError(resp)
-	}
 	result := NetworkInterfaceIPConfigurationResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkInterfaceIPConfiguration)
 }
 
 // GetVirtualMachineScaleSetIPConfigurationHandleError handles the GetVirtualMachineScaleSetIPConfiguration error response.
 func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfigurationHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -416,6 +431,9 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterface
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetVirtualMachineScaleSetNetworkInterfaceHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetVirtualMachineScaleSetNetworkInterfaceHandleResponse(resp)
@@ -449,15 +467,15 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterface
 
 // GetVirtualMachineScaleSetNetworkInterfaceHandleResponse handles the GetVirtualMachineScaleSetNetworkInterface response.
 func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterfaceHandleResponse(resp *azcore.Response) (*NetworkInterfaceResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetVirtualMachineScaleSetNetworkInterfaceHandleError(resp)
-	}
 	result := NetworkInterfaceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkInterface)
 }
 
 // GetVirtualMachineScaleSetNetworkInterfaceHandleError handles the GetVirtualMachineScaleSetNetworkInterface error response.
 func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterfaceHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -473,6 +491,7 @@ func (client *NetworkInterfacesClient) List(resourceGroupName string) NetworkInt
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *NetworkInterfaceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceListResult.NextLink)
 		},
@@ -497,15 +516,15 @@ func (client *NetworkInterfacesClient) ListCreateRequest(ctx context.Context, re
 
 // ListHandleResponse handles the List response.
 func (client *NetworkInterfacesClient) ListHandleResponse(resp *azcore.Response) (*NetworkInterfaceListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := NetworkInterfaceListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkInterfaceListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *NetworkInterfacesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -521,6 +540,7 @@ func (client *NetworkInterfacesClient) ListAll() NetworkInterfaceListResultPager
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *NetworkInterfaceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceListResult.NextLink)
 		},
@@ -544,15 +564,15 @@ func (client *NetworkInterfacesClient) ListAllCreateRequest(ctx context.Context)
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *NetworkInterfacesClient) ListAllHandleResponse(resp *azcore.Response) (*NetworkInterfaceListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := NetworkInterfaceListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkInterfaceListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *NetworkInterfacesClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -569,6 +589,9 @@ func (client *NetworkInterfacesClient) BeginListEffectiveNetworkSecurityGroups(c
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListEffectiveNetworkSecurityGroupsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListEffectiveNetworkSecurityGroupsHandleResponse(resp)
@@ -620,14 +643,14 @@ func (client *NetworkInterfacesClient) ListEffectiveNetworkSecurityGroupsCreateR
 
 // ListEffectiveNetworkSecurityGroupsHandleResponse handles the ListEffectiveNetworkSecurityGroups response.
 func (client *NetworkInterfacesClient) ListEffectiveNetworkSecurityGroupsHandleResponse(resp *azcore.Response) (*EffectiveNetworkSecurityGroupListResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.ListEffectiveNetworkSecurityGroupsHandleError(resp)
-	}
 	return &EffectiveNetworkSecurityGroupListResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // ListEffectiveNetworkSecurityGroupsHandleError handles the ListEffectiveNetworkSecurityGroups error response.
 func (client *NetworkInterfacesClient) ListEffectiveNetworkSecurityGroupsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -643,6 +666,7 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfiguration
 			return client.ListVirtualMachineScaleSetIPConfigurationsCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, networkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions)
 		},
 		responder: client.ListVirtualMachineScaleSetIPConfigurationsHandleResponse,
+		errorer:   client.ListVirtualMachineScaleSetIPConfigurationsHandleError,
 		advancer: func(ctx context.Context, resp *NetworkInterfaceIPConfigurationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceIPConfigurationListResult.NextLink)
 		},
@@ -673,15 +697,15 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfiguration
 
 // ListVirtualMachineScaleSetIPConfigurationsHandleResponse handles the ListVirtualMachineScaleSetIPConfigurations response.
 func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfigurationsHandleResponse(resp *azcore.Response) (*NetworkInterfaceIPConfigurationListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListVirtualMachineScaleSetIPConfigurationsHandleError(resp)
-	}
 	result := NetworkInterfaceIPConfigurationListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkInterfaceIPConfigurationListResult)
 }
 
 // ListVirtualMachineScaleSetIPConfigurationsHandleError handles the ListVirtualMachineScaleSetIPConfigurations error response.
 func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfigurationsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -697,6 +721,7 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfac
 			return client.ListVirtualMachineScaleSetNetworkInterfacesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName)
 		},
 		responder: client.ListVirtualMachineScaleSetNetworkInterfacesHandleResponse,
+		errorer:   client.ListVirtualMachineScaleSetNetworkInterfacesHandleError,
 		advancer: func(ctx context.Context, resp *NetworkInterfaceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceListResult.NextLink)
 		},
@@ -722,15 +747,15 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfac
 
 // ListVirtualMachineScaleSetNetworkInterfacesHandleResponse handles the ListVirtualMachineScaleSetNetworkInterfaces response.
 func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfacesHandleResponse(resp *azcore.Response) (*NetworkInterfaceListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListVirtualMachineScaleSetNetworkInterfacesHandleError(resp)
-	}
 	result := NetworkInterfaceListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkInterfaceListResult)
 }
 
 // ListVirtualMachineScaleSetNetworkInterfacesHandleError handles the ListVirtualMachineScaleSetNetworkInterfaces error response.
 func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfacesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -746,6 +771,7 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterf
 			return client.ListVirtualMachineScaleSetVMNetworkInterfacesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex)
 		},
 		responder: client.ListVirtualMachineScaleSetVMNetworkInterfacesHandleResponse,
+		errorer:   client.ListVirtualMachineScaleSetVMNetworkInterfacesHandleError,
 		advancer: func(ctx context.Context, resp *NetworkInterfaceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceListResult.NextLink)
 		},
@@ -772,15 +798,15 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterf
 
 // ListVirtualMachineScaleSetVMNetworkInterfacesHandleResponse handles the ListVirtualMachineScaleSetVMNetworkInterfaces response.
 func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfacesHandleResponse(resp *azcore.Response) (*NetworkInterfaceListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListVirtualMachineScaleSetVMNetworkInterfacesHandleError(resp)
-	}
 	result := NetworkInterfaceListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkInterfaceListResult)
 }
 
 // ListVirtualMachineScaleSetVMNetworkInterfacesHandleError handles the ListVirtualMachineScaleSetVMNetworkInterfaces error response.
 func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfacesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -796,6 +822,9 @@ func (client *NetworkInterfacesClient) UpdateTags(ctx context.Context, resourceG
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -824,15 +853,15 @@ func (client *NetworkInterfacesClient) UpdateTagsCreateRequest(ctx context.Conte
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *NetworkInterfacesClient) UpdateTagsHandleResponse(resp *azcore.Response) (*NetworkInterfaceResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := NetworkInterfaceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkInterface)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *NetworkInterfacesClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces.go
@@ -81,8 +81,8 @@ func (client *NetworkInterfacesClient) BeginCreateOrUpdate(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -138,9 +138,6 @@ func (client *NetworkInterfacesClient) CreateOrUpdateHandleResponse(resp *azcore
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkInterfacesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -159,8 +156,8 @@ func (client *NetworkInterfacesClient) BeginDelete(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -216,9 +213,6 @@ func (client *NetworkInterfacesClient) DeleteHandleResponse(resp *azcore.Respons
 
 // DeleteHandleError handles the Delete error response.
 func (client *NetworkInterfacesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -236,8 +230,8 @@ func (client *NetworkInterfacesClient) Get(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -274,9 +268,6 @@ func (client *NetworkInterfacesClient) GetHandleResponse(resp *azcore.Response) 
 
 // GetHandleError handles the Get error response.
 func (client *NetworkInterfacesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -295,8 +286,8 @@ func (client *NetworkInterfacesClient) BeginGetEffectiveRouteTable(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetEffectiveRouteTableHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetEffectiveRouteTableHandleError(resp)
 	}
 	result, err := client.GetEffectiveRouteTableHandleResponse(resp)
 	if err != nil {
@@ -352,9 +343,6 @@ func (client *NetworkInterfacesClient) GetEffectiveRouteTableHandleResponse(resp
 
 // GetEffectiveRouteTableHandleError handles the GetEffectiveRouteTable error response.
 func (client *NetworkInterfacesClient) GetEffectiveRouteTableHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -372,8 +360,8 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfiguration(
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetVirtualMachineScaleSetIPConfigurationHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetVirtualMachineScaleSetIPConfigurationHandleError(resp)
 	}
 	result, err := client.GetVirtualMachineScaleSetIPConfigurationHandleResponse(resp)
 	if err != nil {
@@ -413,9 +401,6 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfigurationH
 
 // GetVirtualMachineScaleSetIPConfigurationHandleError handles the GetVirtualMachineScaleSetIPConfiguration error response.
 func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfigurationHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -433,8 +418,8 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterface
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetVirtualMachineScaleSetNetworkInterfaceHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetVirtualMachineScaleSetNetworkInterfaceHandleError(resp)
 	}
 	result, err := client.GetVirtualMachineScaleSetNetworkInterfaceHandleResponse(resp)
 	if err != nil {
@@ -473,9 +458,6 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterface
 
 // GetVirtualMachineScaleSetNetworkInterfaceHandleError handles the GetVirtualMachineScaleSetNetworkInterface error response.
 func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterfaceHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -522,9 +504,6 @@ func (client *NetworkInterfacesClient) ListHandleResponse(resp *azcore.Response)
 
 // ListHandleError handles the List error response.
 func (client *NetworkInterfacesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -570,9 +549,6 @@ func (client *NetworkInterfacesClient) ListAllHandleResponse(resp *azcore.Respon
 
 // ListAllHandleError handles the ListAll error response.
 func (client *NetworkInterfacesClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -591,8 +567,8 @@ func (client *NetworkInterfacesClient) BeginListEffectiveNetworkSecurityGroups(c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListEffectiveNetworkSecurityGroupsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.ListEffectiveNetworkSecurityGroupsHandleError(resp)
 	}
 	result, err := client.ListEffectiveNetworkSecurityGroupsHandleResponse(resp)
 	if err != nil {
@@ -648,9 +624,6 @@ func (client *NetworkInterfacesClient) ListEffectiveNetworkSecurityGroupsHandleR
 
 // ListEffectiveNetworkSecurityGroupsHandleError handles the ListEffectiveNetworkSecurityGroups error response.
 func (client *NetworkInterfacesClient) ListEffectiveNetworkSecurityGroupsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -703,9 +676,6 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfiguration
 
 // ListVirtualMachineScaleSetIPConfigurationsHandleError handles the ListVirtualMachineScaleSetIPConfigurations error response.
 func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfigurationsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -753,9 +723,6 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfac
 
 // ListVirtualMachineScaleSetNetworkInterfacesHandleError handles the ListVirtualMachineScaleSetNetworkInterfaces error response.
 func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfacesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -804,9 +771,6 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterf
 
 // ListVirtualMachineScaleSetVMNetworkInterfacesHandleError handles the ListVirtualMachineScaleSetVMNetworkInterfaces error response.
 func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfacesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -824,8 +788,8 @@ func (client *NetworkInterfacesClient) UpdateTags(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -859,9 +823,6 @@ func (client *NetworkInterfacesClient) UpdateTagsHandleResponse(resp *azcore.Res
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *NetworkInterfacesClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations.go
@@ -59,6 +59,9 @@ func (client *NetworkInterfaceTapConfigurationsClient) BeginCreateOrUpdate(ctx c
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *NetworkInterfaceTapConfigurationsClient) CreateOrUpdateCreateReque
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *NetworkInterfaceTapConfigurationsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*NetworkInterfaceTapConfigurationPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &NetworkInterfaceTapConfigurationPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkInterfaceTapConfigurationsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *NetworkInterfaceTapConfigurationsClient) BeginDelete(ctx context.C
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *NetworkInterfaceTapConfigurationsClient) DeleteCreateRequest(ctx c
 
 // DeleteHandleResponse handles the Delete response.
 func (client *NetworkInterfaceTapConfigurationsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *NetworkInterfaceTapConfigurationsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *NetworkInterfaceTapConfigurationsClient) Get(ctx context.Context, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *NetworkInterfaceTapConfigurationsClient) GetCreateRequest(ctx cont
 
 // GetHandleResponse handles the Get response.
 func (client *NetworkInterfaceTapConfigurationsClient) GetHandleResponse(resp *azcore.Response) (*NetworkInterfaceTapConfigurationResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := NetworkInterfaceTapConfigurationResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkInterfaceTapConfiguration)
 }
 
 // GetHandleError handles the Get error response.
 func (client *NetworkInterfaceTapConfigurationsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) List(resourceGroupName st
 			return client.ListCreateRequest(ctx, resourceGroupName, networkInterfaceName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *NetworkInterfaceTapConfigurationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceTapConfigurationListResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *NetworkInterfaceTapConfigurationsClient) ListCreateRequest(ctx con
 
 // ListHandleResponse handles the List response.
 func (client *NetworkInterfaceTapConfigurationsClient) ListHandleResponse(resp *azcore.Response) (*NetworkInterfaceTapConfigurationListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := NetworkInterfaceTapConfigurationListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkInterfaceTapConfigurationListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *NetworkInterfaceTapConfigurationsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations.go
@@ -59,8 +59,8 @@ func (client *NetworkInterfaceTapConfigurationsClient) BeginCreateOrUpdate(ctx c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *NetworkInterfaceTapConfigurationsClient) CreateOrUpdateHandleRespo
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkInterfaceTapConfigurationsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *NetworkInterfaceTapConfigurationsClient) BeginDelete(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *NetworkInterfaceTapConfigurationsClient) DeleteHandleResponse(resp
 
 // DeleteHandleError handles the Delete error response.
 func (client *NetworkInterfaceTapConfigurationsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *NetworkInterfaceTapConfigurationsClient) Get(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *NetworkInterfaceTapConfigurationsClient) GetHandleResponse(resp *a
 
 // GetHandleError handles the Get error response.
 func (client *NetworkInterfaceTapConfigurationsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *NetworkInterfaceTapConfigurationsClient) ListHandleResponse(resp *
 
 // ListHandleError handles the List error response.
 func (client *NetworkInterfaceTapConfigurationsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient.go
@@ -70,8 +70,8 @@ func (client *NetworkManagementClient) CheckDNSNameAvailability(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CheckDNSNameAvailabilityHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.CheckDNSNameAvailabilityHandleError(resp)
 	}
 	result, err := client.CheckDNSNameAvailabilityHandleResponse(resp)
 	if err != nil {
@@ -105,9 +105,6 @@ func (client *NetworkManagementClient) CheckDNSNameAvailabilityHandleResponse(re
 
 // CheckDNSNameAvailabilityHandleError handles the CheckDNSNameAvailability error response.
 func (client *NetworkManagementClient) CheckDNSNameAvailabilityHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -126,8 +123,8 @@ func (client *NetworkManagementClient) BeginDeleteBastionShareableLink(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteBastionShareableLinkHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.DeleteBastionShareableLinkHandleError(resp)
 	}
 	result, err := client.DeleteBastionShareableLinkHandleResponse(resp)
 	if err != nil {
@@ -183,9 +180,6 @@ func (client *NetworkManagementClient) DeleteBastionShareableLinkHandleResponse(
 
 // DeleteBastionShareableLinkHandleError handles the DeleteBastionShareableLink error response.
 func (client *NetworkManagementClient) DeleteBastionShareableLinkHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -233,9 +227,6 @@ func (client *NetworkManagementClient) DisconnectActiveSessionsHandleResponse(re
 
 // DisconnectActiveSessionsHandleError handles the DisconnectActiveSessions error response.
 func (client *NetworkManagementClient) DisconnectActiveSessionsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -254,8 +245,8 @@ func (client *NetworkManagementClient) BeginGeneratevirtualwanvpnserverconfigura
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GeneratevirtualwanvpnserverconfigurationvpnprofileHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GeneratevirtualwanvpnserverconfigurationvpnprofileHandleError(resp)
 	}
 	result, err := client.GeneratevirtualwanvpnserverconfigurationvpnprofileHandleResponse(resp)
 	if err != nil {
@@ -311,9 +302,6 @@ func (client *NetworkManagementClient) Generatevirtualwanvpnserverconfigurationv
 
 // GeneratevirtualwanvpnserverconfigurationvpnprofileHandleError handles the Generatevirtualwanvpnserverconfigurationvpnprofile error response.
 func (client *NetworkManagementClient) GeneratevirtualwanvpnserverconfigurationvpnprofileHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -332,8 +320,8 @@ func (client *NetworkManagementClient) BeginGetActiveSessions(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetActiveSessionsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetActiveSessionsHandleError(resp)
 	}
 	result, err := client.GetActiveSessionsHandleResponse(resp)
 	if err != nil {
@@ -351,7 +339,7 @@ func (client *NetworkManagementClient) BeginGetActiveSessions(ctx context.Contex
 			}
 			return client.GetActiveSessionsHandleError(resp)
 		},
-		respHandler: func(resp *azcore.Response) (*ProductResultResponse, error) {
+		respHandler: func(resp *azcore.Response) (*BastionActiveSessionListResultResponse, error) {
 			result := BastionActiveSessionListResultResponse{RawResponse: resp.Response}
 			return &result, resp.UnmarshalAsJSON(&result.BastionActiveSessionListResult)
 		},
@@ -399,9 +387,6 @@ func (client *NetworkManagementClient) GetActiveSessionsHandleResponse(resp *azc
 
 // GetActiveSessionsHandleError handles the GetActiveSessions error response.
 func (client *NetworkManagementClient) GetActiveSessionsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -449,9 +434,6 @@ func (client *NetworkManagementClient) GetBastionShareableLinkHandleResponse(res
 
 // GetBastionShareableLinkHandleError handles the GetBastionShareableLink error response.
 func (client *NetworkManagementClient) GetBastionShareableLinkHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -470,8 +452,8 @@ func (client *NetworkManagementClient) BeginPutBastionShareableLink(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PutBastionShareableLinkHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.PutBastionShareableLinkHandleError(resp)
 	}
 	result, err := client.PutBastionShareableLinkHandleResponse(resp)
 	if err != nil {
@@ -489,7 +471,7 @@ func (client *NetworkManagementClient) BeginPutBastionShareableLink(ctx context.
 			}
 			return client.PutBastionShareableLinkHandleError(resp)
 		},
-		respHandler: func(resp *azcore.Response) (*ProductResultResponse, error) {
+		respHandler: func(resp *azcore.Response) (*BastionShareableLinkListResultResponse, error) {
 			result := BastionShareableLinkListResultResponse{RawResponse: resp.Response}
 			return &result, resp.UnmarshalAsJSON(&result.BastionShareableLinkListResult)
 		},
@@ -537,9 +519,6 @@ func (client *NetworkManagementClient) PutBastionShareableLinkHandleResponse(res
 
 // PutBastionShareableLinkHandleError handles the PutBastionShareableLink error response.
 func (client *NetworkManagementClient) PutBastionShareableLinkHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -557,8 +536,8 @@ func (client *NetworkManagementClient) SupportedSecurityProviders(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.SupportedSecurityProvidersHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.SupportedSecurityProvidersHandleError(resp)
 	}
 	result, err := client.SupportedSecurityProvidersHandleResponse(resp)
 	if err != nil {
@@ -592,9 +571,6 @@ func (client *NetworkManagementClient) SupportedSecurityProvidersHandleResponse(
 
 // SupportedSecurityProvidersHandleError handles the SupportedSecurityProviders error response.
 func (client *NetworkManagementClient) SupportedSecurityProvidersHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient.go
@@ -70,6 +70,9 @@ func (client *NetworkManagementClient) CheckDNSNameAvailability(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CheckDNSNameAvailabilityHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CheckDNSNameAvailabilityHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -96,15 +99,15 @@ func (client *NetworkManagementClient) CheckDNSNameAvailabilityCreateRequest(ctx
 
 // CheckDNSNameAvailabilityHandleResponse handles the CheckDNSNameAvailability response.
 func (client *NetworkManagementClient) CheckDNSNameAvailabilityHandleResponse(resp *azcore.Response) (*DNSNameAvailabilityResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.CheckDNSNameAvailabilityHandleError(resp)
-	}
 	result := DNSNameAvailabilityResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.DNSNameAvailabilityResult)
 }
 
 // CheckDNSNameAvailabilityHandleError handles the CheckDNSNameAvailability error response.
 func (client *NetworkManagementClient) CheckDNSNameAvailabilityHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -121,6 +124,9 @@ func (client *NetworkManagementClient) BeginDeleteBastionShareableLink(ctx conte
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteBastionShareableLinkHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteBastionShareableLinkHandleResponse(resp)
@@ -172,14 +178,14 @@ func (client *NetworkManagementClient) DeleteBastionShareableLinkCreateRequest(c
 
 // DeleteBastionShareableLinkHandleResponse handles the DeleteBastionShareableLink response.
 func (client *NetworkManagementClient) DeleteBastionShareableLinkHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteBastionShareableLinkHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteBastionShareableLinkHandleError handles the DeleteBastionShareableLink error response.
 func (client *NetworkManagementClient) DeleteBastionShareableLinkHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -195,6 +201,7 @@ func (client *NetworkManagementClient) DisconnectActiveSessions(resourceGroupNam
 			return client.DisconnectActiveSessionsCreateRequest(ctx, resourceGroupName, bastionHostName, sessionIds)
 		},
 		responder: client.DisconnectActiveSessionsHandleResponse,
+		errorer:   client.DisconnectActiveSessionsHandleError,
 		advancer: func(ctx context.Context, resp *BastionSessionDeleteResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.BastionSessionDeleteResult.NextLink)
 		},
@@ -220,15 +227,15 @@ func (client *NetworkManagementClient) DisconnectActiveSessionsCreateRequest(ctx
 
 // DisconnectActiveSessionsHandleResponse handles the DisconnectActiveSessions response.
 func (client *NetworkManagementClient) DisconnectActiveSessionsHandleResponse(resp *azcore.Response) (*BastionSessionDeleteResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.DisconnectActiveSessionsHandleError(resp)
-	}
 	result := BastionSessionDeleteResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.BastionSessionDeleteResult)
 }
 
 // DisconnectActiveSessionsHandleError handles the DisconnectActiveSessions error response.
 func (client *NetworkManagementClient) DisconnectActiveSessionsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -245,6 +252,9 @@ func (client *NetworkManagementClient) BeginGeneratevirtualwanvpnserverconfigura
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GeneratevirtualwanvpnserverconfigurationvpnprofileHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GeneratevirtualwanvpnserverconfigurationvpnprofileHandleResponse(resp)
@@ -296,14 +306,14 @@ func (client *NetworkManagementClient) Generatevirtualwanvpnserverconfigurationv
 
 // GeneratevirtualwanvpnserverconfigurationvpnprofileHandleResponse handles the Generatevirtualwanvpnserverconfigurationvpnprofile response.
 func (client *NetworkManagementClient) GeneratevirtualwanvpnserverconfigurationvpnprofileHandleResponse(resp *azcore.Response) (*VpnProfileResponsePollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GeneratevirtualwanvpnserverconfigurationvpnprofileHandleError(resp)
-	}
 	return &VpnProfileResponsePollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GeneratevirtualwanvpnserverconfigurationvpnprofileHandleError handles the Generatevirtualwanvpnserverconfigurationvpnprofile error response.
 func (client *NetworkManagementClient) GeneratevirtualwanvpnserverconfigurationvpnprofileHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -322,6 +332,9 @@ func (client *NetworkManagementClient) BeginGetActiveSessions(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetActiveSessionsHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetActiveSessionsHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -331,9 +344,18 @@ func (client *NetworkManagementClient) BeginGetActiveSessions(ctx context.Contex
 		return nil, err
 	}
 	poller := &bastionActiveSessionListResultPagerPoller{
-		pt:          pt,
-		respHandler: client.bastionActiveSessionListResultPagerHandleResponse,
-		pipeline:    client.p,
+		pt: pt,
+		errHandler: func(resp *azcore.Response) error {
+			if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+				return nil
+			}
+			return client.GetActiveSessionsHandleError(resp)
+		},
+		respHandler: func(resp *azcore.Response) (*ProductResultResponse, error) {
+			result := BastionActiveSessionListResultResponse{RawResponse: resp.Response}
+			return &result, resp.UnmarshalAsJSON(&result.BastionActiveSessionListResult)
+		},
+		pipeline: client.p,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (BastionActiveSessionListResultPager, error) {
@@ -372,23 +394,14 @@ func (client *NetworkManagementClient) GetActiveSessionsCreateRequest(ctx contex
 
 // GetActiveSessionsHandleResponse handles the GetActiveSessions response.
 func (client *NetworkManagementClient) GetActiveSessionsHandleResponse(resp *azcore.Response) (*BastionActiveSessionListResultPagerPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetActiveSessionsHandleError(resp)
-	}
 	return &BastionActiveSessionListResultPagerPollerResponse{RawResponse: resp.Response}, nil
-}
-
-// GetActiveSessionsHandleResponse handles the GetActiveSessions response.
-func (client *NetworkManagementClient) bastionActiveSessionListResultPagerHandleResponse(resp *azcore.Response) (*BastionActiveSessionListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusOK) {
-		return nil, client.GetActiveSessionsHandleError(resp)
-	}
-	result := BastionActiveSessionListResultResponse{RawResponse: resp.Response}
-	return &result, resp.UnmarshalAsJSON(&result.BastionActiveSessionListResult)
 }
 
 // GetActiveSessionsHandleError handles the GetActiveSessions error response.
 func (client *NetworkManagementClient) GetActiveSessionsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -404,6 +417,7 @@ func (client *NetworkManagementClient) GetBastionShareableLink(resourceGroupName
 			return client.GetBastionShareableLinkCreateRequest(ctx, resourceGroupName, bastionHostName, bslRequest)
 		},
 		responder: client.GetBastionShareableLinkHandleResponse,
+		errorer:   client.GetBastionShareableLinkHandleError,
 		advancer: func(ctx context.Context, resp *BastionShareableLinkListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.BastionShareableLinkListResult.NextLink)
 		},
@@ -429,15 +443,15 @@ func (client *NetworkManagementClient) GetBastionShareableLinkCreateRequest(ctx 
 
 // GetBastionShareableLinkHandleResponse handles the GetBastionShareableLink response.
 func (client *NetworkManagementClient) GetBastionShareableLinkHandleResponse(resp *azcore.Response) (*BastionShareableLinkListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBastionShareableLinkHandleError(resp)
-	}
 	result := BastionShareableLinkListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.BastionShareableLinkListResult)
 }
 
 // GetBastionShareableLinkHandleError handles the GetBastionShareableLink error response.
 func (client *NetworkManagementClient) GetBastionShareableLinkHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -456,6 +470,9 @@ func (client *NetworkManagementClient) BeginPutBastionShareableLink(ctx context.
 	if err != nil {
 		return nil, err
 	}
+	if err := client.PutBastionShareableLinkHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.PutBastionShareableLinkHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -465,9 +482,18 @@ func (client *NetworkManagementClient) BeginPutBastionShareableLink(ctx context.
 		return nil, err
 	}
 	poller := &bastionShareableLinkListResultPagerPoller{
-		pt:          pt,
-		respHandler: client.bastionShareableLinkListResultPagerHandleResponse,
-		pipeline:    client.p,
+		pt: pt,
+		errHandler: func(resp *azcore.Response) error {
+			if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+				return nil
+			}
+			return client.PutBastionShareableLinkHandleError(resp)
+		},
+		respHandler: func(resp *azcore.Response) (*ProductResultResponse, error) {
+			result := BastionShareableLinkListResultResponse{RawResponse: resp.Response}
+			return &result, resp.UnmarshalAsJSON(&result.BastionShareableLinkListResult)
+		},
+		pipeline: client.p,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (BastionShareableLinkListResultPager, error) {
@@ -506,23 +532,14 @@ func (client *NetworkManagementClient) PutBastionShareableLinkCreateRequest(ctx 
 
 // PutBastionShareableLinkHandleResponse handles the PutBastionShareableLink response.
 func (client *NetworkManagementClient) PutBastionShareableLinkHandleResponse(resp *azcore.Response) (*BastionShareableLinkListResultPagerPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PutBastionShareableLinkHandleError(resp)
-	}
 	return &BastionShareableLinkListResultPagerPollerResponse{RawResponse: resp.Response}, nil
-}
-
-// PutBastionShareableLinkHandleResponse handles the PutBastionShareableLink response.
-func (client *NetworkManagementClient) bastionShareableLinkListResultPagerHandleResponse(resp *azcore.Response) (*BastionShareableLinkListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusOK) {
-		return nil, client.PutBastionShareableLinkHandleError(resp)
-	}
-	result := BastionShareableLinkListResultResponse{RawResponse: resp.Response}
-	return &result, resp.UnmarshalAsJSON(&result.BastionShareableLinkListResult)
 }
 
 // PutBastionShareableLinkHandleError handles the PutBastionShareableLink error response.
 func (client *NetworkManagementClient) PutBastionShareableLinkHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -538,6 +555,9 @@ func (client *NetworkManagementClient) SupportedSecurityProviders(ctx context.Co
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.SupportedSecurityProvidersHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.SupportedSecurityProvidersHandleResponse(resp)
@@ -566,15 +586,15 @@ func (client *NetworkManagementClient) SupportedSecurityProvidersCreateRequest(c
 
 // SupportedSecurityProvidersHandleResponse handles the SupportedSecurityProviders response.
 func (client *NetworkManagementClient) SupportedSecurityProvidersHandleResponse(resp *azcore.Response) (*VirtualWanSecurityProvidersResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.SupportedSecurityProvidersHandleError(resp)
-	}
 	result := VirtualWanSecurityProvidersResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualWanSecurityProviders)
 }
 
 // SupportedSecurityProvidersHandleError handles the SupportedSecurityProviders error response.
 func (client *NetworkManagementClient) SupportedSecurityProvidersHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles.go
@@ -60,6 +60,9 @@ func (client *NetworkProfilesClient) CreateOrUpdate(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -86,15 +89,15 @@ func (client *NetworkProfilesClient) CreateOrUpdateCreateRequest(ctx context.Con
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *NetworkProfilesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*NetworkProfileResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	result := NetworkProfileResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkProfile)
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkProfilesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -111,6 +114,9 @@ func (client *NetworkProfilesClient) BeginDelete(ctx context.Context, resourceGr
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -162,14 +168,14 @@ func (client *NetworkProfilesClient) DeleteCreateRequest(ctx context.Context, re
 
 // DeleteHandleResponse handles the Delete response.
 func (client *NetworkProfilesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *NetworkProfilesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -185,6 +191,9 @@ func (client *NetworkProfilesClient) Get(ctx context.Context, resourceGroupName 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -216,15 +225,15 @@ func (client *NetworkProfilesClient) GetCreateRequest(ctx context.Context, resou
 
 // GetHandleResponse handles the Get response.
 func (client *NetworkProfilesClient) GetHandleResponse(resp *azcore.Response) (*NetworkProfileResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := NetworkProfileResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkProfile)
 }
 
 // GetHandleError handles the Get error response.
 func (client *NetworkProfilesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -240,6 +249,7 @@ func (client *NetworkProfilesClient) List(resourceGroupName string) NetworkProfi
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *NetworkProfileListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkProfileListResult.NextLink)
 		},
@@ -264,15 +274,15 @@ func (client *NetworkProfilesClient) ListCreateRequest(ctx context.Context, reso
 
 // ListHandleResponse handles the List response.
 func (client *NetworkProfilesClient) ListHandleResponse(resp *azcore.Response) (*NetworkProfileListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := NetworkProfileListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkProfileListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *NetworkProfilesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -288,6 +298,7 @@ func (client *NetworkProfilesClient) ListAll() NetworkProfileListResultPager {
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *NetworkProfileListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkProfileListResult.NextLink)
 		},
@@ -311,15 +322,15 @@ func (client *NetworkProfilesClient) ListAllCreateRequest(ctx context.Context) (
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *NetworkProfilesClient) ListAllHandleResponse(resp *azcore.Response) (*NetworkProfileListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := NetworkProfileListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkProfileListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *NetworkProfilesClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -335,6 +346,9 @@ func (client *NetworkProfilesClient) UpdateTags(ctx context.Context, resourceGro
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -363,15 +377,15 @@ func (client *NetworkProfilesClient) UpdateTagsCreateRequest(ctx context.Context
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *NetworkProfilesClient) UpdateTagsHandleResponse(resp *azcore.Response) (*NetworkProfileResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := NetworkProfileResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkProfile)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *NetworkProfilesClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles.go
@@ -60,8 +60,8 @@ func (client *NetworkProfilesClient) CreateOrUpdate(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -95,9 +95,6 @@ func (client *NetworkProfilesClient) CreateOrUpdateHandleResponse(resp *azcore.R
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkProfilesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -116,8 +113,8 @@ func (client *NetworkProfilesClient) BeginDelete(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -173,9 +170,6 @@ func (client *NetworkProfilesClient) DeleteHandleResponse(resp *azcore.Response)
 
 // DeleteHandleError handles the Delete error response.
 func (client *NetworkProfilesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -193,8 +187,8 @@ func (client *NetworkProfilesClient) Get(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -231,9 +225,6 @@ func (client *NetworkProfilesClient) GetHandleResponse(resp *azcore.Response) (*
 
 // GetHandleError handles the Get error response.
 func (client *NetworkProfilesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -280,9 +271,6 @@ func (client *NetworkProfilesClient) ListHandleResponse(resp *azcore.Response) (
 
 // ListHandleError handles the List error response.
 func (client *NetworkProfilesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -328,9 +316,6 @@ func (client *NetworkProfilesClient) ListAllHandleResponse(resp *azcore.Response
 
 // ListAllHandleError handles the ListAll error response.
 func (client *NetworkProfilesClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -348,8 +333,8 @@ func (client *NetworkProfilesClient) UpdateTags(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -383,9 +368,6 @@ func (client *NetworkProfilesClient) UpdateTagsHandleResponse(resp *azcore.Respo
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *NetworkProfilesClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups.go
@@ -63,6 +63,9 @@ func (client *NetworkSecurityGroupsClient) BeginCreateOrUpdate(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *NetworkSecurityGroupsClient) CreateOrUpdateCreateRequest(ctx conte
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *NetworkSecurityGroupsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*NetworkSecurityGroupPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &NetworkSecurityGroupPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkSecurityGroupsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *NetworkSecurityGroupsClient) BeginDelete(ctx context.Context, reso
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *NetworkSecurityGroupsClient) DeleteCreateRequest(ctx context.Conte
 
 // DeleteHandleResponse handles the Delete response.
 func (client *NetworkSecurityGroupsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *NetworkSecurityGroupsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *NetworkSecurityGroupsClient) Get(ctx context.Context, resourceGrou
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -241,15 +250,15 @@ func (client *NetworkSecurityGroupsClient) GetCreateRequest(ctx context.Context,
 
 // GetHandleResponse handles the Get response.
 func (client *NetworkSecurityGroupsClient) GetHandleResponse(resp *azcore.Response) (*NetworkSecurityGroupResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := NetworkSecurityGroupResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkSecurityGroup)
 }
 
 // GetHandleError handles the Get error response.
 func (client *NetworkSecurityGroupsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -265,6 +274,7 @@ func (client *NetworkSecurityGroupsClient) List(resourceGroupName string) Networ
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *NetworkSecurityGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkSecurityGroupListResult.NextLink)
 		},
@@ -289,15 +299,15 @@ func (client *NetworkSecurityGroupsClient) ListCreateRequest(ctx context.Context
 
 // ListHandleResponse handles the List response.
 func (client *NetworkSecurityGroupsClient) ListHandleResponse(resp *azcore.Response) (*NetworkSecurityGroupListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := NetworkSecurityGroupListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkSecurityGroupListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *NetworkSecurityGroupsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -313,6 +323,7 @@ func (client *NetworkSecurityGroupsClient) ListAll() NetworkSecurityGroupListRes
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *NetworkSecurityGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkSecurityGroupListResult.NextLink)
 		},
@@ -336,15 +347,15 @@ func (client *NetworkSecurityGroupsClient) ListAllCreateRequest(ctx context.Cont
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *NetworkSecurityGroupsClient) ListAllHandleResponse(resp *azcore.Response) (*NetworkSecurityGroupListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := NetworkSecurityGroupListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkSecurityGroupListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *NetworkSecurityGroupsClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -360,6 +371,9 @@ func (client *NetworkSecurityGroupsClient) UpdateTags(ctx context.Context, resou
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -388,15 +402,15 @@ func (client *NetworkSecurityGroupsClient) UpdateTagsCreateRequest(ctx context.C
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *NetworkSecurityGroupsClient) UpdateTagsHandleResponse(resp *azcore.Response) (*NetworkSecurityGroupResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := NetworkSecurityGroupResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkSecurityGroup)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *NetworkSecurityGroupsClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups.go
@@ -63,8 +63,8 @@ func (client *NetworkSecurityGroupsClient) BeginCreateOrUpdate(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *NetworkSecurityGroupsClient) CreateOrUpdateHandleResponse(resp *az
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkSecurityGroupsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *NetworkSecurityGroupsClient) BeginDelete(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *NetworkSecurityGroupsClient) DeleteHandleResponse(resp *azcore.Res
 
 // DeleteHandleError handles the Delete error response.
 func (client *NetworkSecurityGroupsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *NetworkSecurityGroupsClient) Get(ctx context.Context, resourceGrou
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -256,9 +250,6 @@ func (client *NetworkSecurityGroupsClient) GetHandleResponse(resp *azcore.Respon
 
 // GetHandleError handles the Get error response.
 func (client *NetworkSecurityGroupsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -305,9 +296,6 @@ func (client *NetworkSecurityGroupsClient) ListHandleResponse(resp *azcore.Respo
 
 // ListHandleError handles the List error response.
 func (client *NetworkSecurityGroupsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -353,9 +341,6 @@ func (client *NetworkSecurityGroupsClient) ListAllHandleResponse(resp *azcore.Re
 
 // ListAllHandleError handles the ListAll error response.
 func (client *NetworkSecurityGroupsClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -373,8 +358,8 @@ func (client *NetworkSecurityGroupsClient) UpdateTags(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -408,9 +393,6 @@ func (client *NetworkSecurityGroupsClient) UpdateTagsHandleResponse(resp *azcore
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *NetworkSecurityGroupsClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances.go
@@ -63,6 +63,9 @@ func (client *NetworkVirtualAppliancesClient) BeginCreateOrUpdate(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *NetworkVirtualAppliancesClient) CreateOrUpdateCreateRequest(ctx co
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *NetworkVirtualAppliancesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*NetworkVirtualAppliancePollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &NetworkVirtualAppliancePollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkVirtualAppliancesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *NetworkVirtualAppliancesClient) BeginDelete(ctx context.Context, r
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *NetworkVirtualAppliancesClient) DeleteCreateRequest(ctx context.Co
 
 // DeleteHandleResponse handles the Delete response.
 func (client *NetworkVirtualAppliancesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *NetworkVirtualAppliancesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *NetworkVirtualAppliancesClient) Get(ctx context.Context, resourceG
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -241,15 +250,15 @@ func (client *NetworkVirtualAppliancesClient) GetCreateRequest(ctx context.Conte
 
 // GetHandleResponse handles the Get response.
 func (client *NetworkVirtualAppliancesClient) GetHandleResponse(resp *azcore.Response) (*NetworkVirtualApplianceResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := NetworkVirtualApplianceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkVirtualAppliance)
 }
 
 // GetHandleError handles the Get error response.
 func (client *NetworkVirtualAppliancesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -265,6 +274,7 @@ func (client *NetworkVirtualAppliancesClient) List() NetworkVirtualApplianceList
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *NetworkVirtualApplianceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkVirtualApplianceListResult.NextLink)
 		},
@@ -288,15 +298,15 @@ func (client *NetworkVirtualAppliancesClient) ListCreateRequest(ctx context.Cont
 
 // ListHandleResponse handles the List response.
 func (client *NetworkVirtualAppliancesClient) ListHandleResponse(resp *azcore.Response) (*NetworkVirtualApplianceListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := NetworkVirtualApplianceListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkVirtualApplianceListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *NetworkVirtualAppliancesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -312,6 +322,7 @@ func (client *NetworkVirtualAppliancesClient) ListByResourceGroup(resourceGroupN
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *NetworkVirtualApplianceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkVirtualApplianceListResult.NextLink)
 		},
@@ -336,15 +347,15 @@ func (client *NetworkVirtualAppliancesClient) ListByResourceGroupCreateRequest(c
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *NetworkVirtualAppliancesClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*NetworkVirtualApplianceListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := NetworkVirtualApplianceListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkVirtualApplianceListResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *NetworkVirtualAppliancesClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -360,6 +371,9 @@ func (client *NetworkVirtualAppliancesClient) UpdateTags(ctx context.Context, re
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -388,15 +402,15 @@ func (client *NetworkVirtualAppliancesClient) UpdateTagsCreateRequest(ctx contex
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *NetworkVirtualAppliancesClient) UpdateTagsHandleResponse(resp *azcore.Response) (*NetworkVirtualApplianceResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := NetworkVirtualApplianceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkVirtualAppliance)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *NetworkVirtualAppliancesClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances.go
@@ -63,8 +63,8 @@ func (client *NetworkVirtualAppliancesClient) BeginCreateOrUpdate(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *NetworkVirtualAppliancesClient) CreateOrUpdateHandleResponse(resp 
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkVirtualAppliancesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *NetworkVirtualAppliancesClient) BeginDelete(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *NetworkVirtualAppliancesClient) DeleteHandleResponse(resp *azcore.
 
 // DeleteHandleError handles the Delete error response.
 func (client *NetworkVirtualAppliancesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *NetworkVirtualAppliancesClient) Get(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -256,9 +250,6 @@ func (client *NetworkVirtualAppliancesClient) GetHandleResponse(resp *azcore.Res
 
 // GetHandleError handles the Get error response.
 func (client *NetworkVirtualAppliancesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -304,9 +295,6 @@ func (client *NetworkVirtualAppliancesClient) ListHandleResponse(resp *azcore.Re
 
 // ListHandleError handles the List error response.
 func (client *NetworkVirtualAppliancesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -353,9 +341,6 @@ func (client *NetworkVirtualAppliancesClient) ListByResourceGroupHandleResponse(
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *NetworkVirtualAppliancesClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -373,8 +358,8 @@ func (client *NetworkVirtualAppliancesClient) UpdateTags(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -408,9 +393,6 @@ func (client *NetworkVirtualAppliancesClient) UpdateTagsHandleResponse(resp *azc
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *NetworkVirtualAppliancesClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers.go
@@ -107,8 +107,8 @@ func (client *NetworkWatchersClient) BeginCheckConnectivity(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CheckConnectivityHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.CheckConnectivityHandleError(resp)
 	}
 	result, err := client.CheckConnectivityHandleResponse(resp)
 	if err != nil {
@@ -164,9 +164,6 @@ func (client *NetworkWatchersClient) CheckConnectivityHandleResponse(resp *azcor
 
 // CheckConnectivityHandleError handles the CheckConnectivity error response.
 func (client *NetworkWatchersClient) CheckConnectivityHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -184,8 +181,8 @@ func (client *NetworkWatchersClient) CreateOrUpdate(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -219,9 +216,6 @@ func (client *NetworkWatchersClient) CreateOrUpdateHandleResponse(resp *azcore.R
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkWatchersClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -240,8 +234,8 @@ func (client *NetworkWatchersClient) BeginDelete(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -297,9 +291,6 @@ func (client *NetworkWatchersClient) DeleteHandleResponse(resp *azcore.Response)
 
 // DeleteHandleError handles the Delete error response.
 func (client *NetworkWatchersClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -317,8 +308,8 @@ func (client *NetworkWatchersClient) Get(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -352,9 +343,6 @@ func (client *NetworkWatchersClient) GetHandleResponse(resp *azcore.Response) (*
 
 // GetHandleError handles the Get error response.
 func (client *NetworkWatchersClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -373,8 +361,8 @@ func (client *NetworkWatchersClient) BeginGetAzureReachabilityReport(ctx context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetAzureReachabilityReportHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetAzureReachabilityReportHandleError(resp)
 	}
 	result, err := client.GetAzureReachabilityReportHandleResponse(resp)
 	if err != nil {
@@ -430,9 +418,6 @@ func (client *NetworkWatchersClient) GetAzureReachabilityReportHandleResponse(re
 
 // GetAzureReachabilityReportHandleError handles the GetAzureReachabilityReport error response.
 func (client *NetworkWatchersClient) GetAzureReachabilityReportHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -451,8 +436,8 @@ func (client *NetworkWatchersClient) BeginGetFlowLogStatus(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetFlowLogStatusHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetFlowLogStatusHandleError(resp)
 	}
 	result, err := client.GetFlowLogStatusHandleResponse(resp)
 	if err != nil {
@@ -508,9 +493,6 @@ func (client *NetworkWatchersClient) GetFlowLogStatusHandleResponse(resp *azcore
 
 // GetFlowLogStatusHandleError handles the GetFlowLogStatus error response.
 func (client *NetworkWatchersClient) GetFlowLogStatusHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -529,8 +511,8 @@ func (client *NetworkWatchersClient) BeginGetNetworkConfigurationDiagnostic(ctx 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNetworkConfigurationDiagnosticHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetNetworkConfigurationDiagnosticHandleError(resp)
 	}
 	result, err := client.GetNetworkConfigurationDiagnosticHandleResponse(resp)
 	if err != nil {
@@ -586,9 +568,6 @@ func (client *NetworkWatchersClient) GetNetworkConfigurationDiagnosticHandleResp
 
 // GetNetworkConfigurationDiagnosticHandleError handles the GetNetworkConfigurationDiagnostic error response.
 func (client *NetworkWatchersClient) GetNetworkConfigurationDiagnosticHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -607,8 +586,8 @@ func (client *NetworkWatchersClient) BeginGetNextHop(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetNextHopHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetNextHopHandleError(resp)
 	}
 	result, err := client.GetNextHopHandleResponse(resp)
 	if err != nil {
@@ -664,9 +643,6 @@ func (client *NetworkWatchersClient) GetNextHopHandleResponse(resp *azcore.Respo
 
 // GetNextHopHandleError handles the GetNextHop error response.
 func (client *NetworkWatchersClient) GetNextHopHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -684,8 +660,8 @@ func (client *NetworkWatchersClient) GetTopology(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetTopologyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetTopologyHandleError(resp)
 	}
 	result, err := client.GetTopologyHandleResponse(resp)
 	if err != nil {
@@ -719,9 +695,6 @@ func (client *NetworkWatchersClient) GetTopologyHandleResponse(resp *azcore.Resp
 
 // GetTopologyHandleError handles the GetTopology error response.
 func (client *NetworkWatchersClient) GetTopologyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -740,8 +713,8 @@ func (client *NetworkWatchersClient) BeginGetTroubleshooting(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetTroubleshootingHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetTroubleshootingHandleError(resp)
 	}
 	result, err := client.GetTroubleshootingHandleResponse(resp)
 	if err != nil {
@@ -797,9 +770,6 @@ func (client *NetworkWatchersClient) GetTroubleshootingHandleResponse(resp *azco
 
 // GetTroubleshootingHandleError handles the GetTroubleshooting error response.
 func (client *NetworkWatchersClient) GetTroubleshootingHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -818,8 +788,8 @@ func (client *NetworkWatchersClient) BeginGetTroubleshootingResult(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetTroubleshootingResultHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetTroubleshootingResultHandleError(resp)
 	}
 	result, err := client.GetTroubleshootingResultHandleResponse(resp)
 	if err != nil {
@@ -875,9 +845,6 @@ func (client *NetworkWatchersClient) GetTroubleshootingResultHandleResponse(resp
 
 // GetTroubleshootingResultHandleError handles the GetTroubleshootingResult error response.
 func (client *NetworkWatchersClient) GetTroubleshootingResultHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -896,8 +863,8 @@ func (client *NetworkWatchersClient) BeginGetVMSecurityRules(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetVMSecurityRulesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetVMSecurityRulesHandleError(resp)
 	}
 	result, err := client.GetVMSecurityRulesHandleResponse(resp)
 	if err != nil {
@@ -953,9 +920,6 @@ func (client *NetworkWatchersClient) GetVMSecurityRulesHandleResponse(resp *azco
 
 // GetVMSecurityRulesHandleError handles the GetVMSecurityRules error response.
 func (client *NetworkWatchersClient) GetVMSecurityRulesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -973,8 +937,8 @@ func (client *NetworkWatchersClient) List(ctx context.Context, resourceGroupName
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListHandleError(resp)
 	}
 	result, err := client.ListHandleResponse(resp)
 	if err != nil {
@@ -1007,9 +971,6 @@ func (client *NetworkWatchersClient) ListHandleResponse(resp *azcore.Response) (
 
 // ListHandleError handles the List error response.
 func (client *NetworkWatchersClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1027,8 +988,8 @@ func (client *NetworkWatchersClient) ListAll(ctx context.Context) (*NetworkWatch
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListAllHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListAllHandleError(resp)
 	}
 	result, err := client.ListAllHandleResponse(resp)
 	if err != nil {
@@ -1060,9 +1021,6 @@ func (client *NetworkWatchersClient) ListAllHandleResponse(resp *azcore.Response
 
 // ListAllHandleError handles the ListAll error response.
 func (client *NetworkWatchersClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1081,8 +1039,8 @@ func (client *NetworkWatchersClient) BeginListAvailableProviders(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListAvailableProvidersHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.ListAvailableProvidersHandleError(resp)
 	}
 	result, err := client.ListAvailableProvidersHandleResponse(resp)
 	if err != nil {
@@ -1138,9 +1096,6 @@ func (client *NetworkWatchersClient) ListAvailableProvidersHandleResponse(resp *
 
 // ListAvailableProvidersHandleError handles the ListAvailableProviders error response.
 func (client *NetworkWatchersClient) ListAvailableProvidersHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1159,8 +1114,8 @@ func (client *NetworkWatchersClient) BeginSetFlowLogConfiguration(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.SetFlowLogConfigurationHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.SetFlowLogConfigurationHandleError(resp)
 	}
 	result, err := client.SetFlowLogConfigurationHandleResponse(resp)
 	if err != nil {
@@ -1216,9 +1171,6 @@ func (client *NetworkWatchersClient) SetFlowLogConfigurationHandleResponse(resp 
 
 // SetFlowLogConfigurationHandleError handles the SetFlowLogConfiguration error response.
 func (client *NetworkWatchersClient) SetFlowLogConfigurationHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1236,8 +1188,8 @@ func (client *NetworkWatchersClient) UpdateTags(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -1271,9 +1223,6 @@ func (client *NetworkWatchersClient) UpdateTagsHandleResponse(resp *azcore.Respo
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *NetworkWatchersClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1292,8 +1241,8 @@ func (client *NetworkWatchersClient) BeginVerifyIPFlow(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	if err := client.VerifyIPFlowHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.VerifyIPFlowHandleError(resp)
 	}
 	result, err := client.VerifyIPFlowHandleResponse(resp)
 	if err != nil {
@@ -1349,9 +1298,6 @@ func (client *NetworkWatchersClient) VerifyIPFlowHandleResponse(resp *azcore.Res
 
 // VerifyIPFlowHandleError handles the VerifyIPFlow error response.
 func (client *NetworkWatchersClient) VerifyIPFlowHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers.go
@@ -107,6 +107,9 @@ func (client *NetworkWatchersClient) BeginCheckConnectivity(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CheckConnectivityHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CheckConnectivityHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -156,14 +159,14 @@ func (client *NetworkWatchersClient) CheckConnectivityCreateRequest(ctx context.
 
 // CheckConnectivityHandleResponse handles the CheckConnectivity response.
 func (client *NetworkWatchersClient) CheckConnectivityHandleResponse(resp *azcore.Response) (*ConnectivityInformationPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.CheckConnectivityHandleError(resp)
-	}
 	return &ConnectivityInformationPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CheckConnectivityHandleError handles the CheckConnectivity error response.
 func (client *NetworkWatchersClient) CheckConnectivityHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -179,6 +182,9 @@ func (client *NetworkWatchersClient) CreateOrUpdate(ctx context.Context, resourc
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
@@ -207,15 +213,15 @@ func (client *NetworkWatchersClient) CreateOrUpdateCreateRequest(ctx context.Con
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *NetworkWatchersClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*NetworkWatcherResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	result := NetworkWatcherResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkWatcher)
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkWatchersClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -232,6 +238,9 @@ func (client *NetworkWatchersClient) BeginDelete(ctx context.Context, resourceGr
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -283,14 +292,14 @@ func (client *NetworkWatchersClient) DeleteCreateRequest(ctx context.Context, re
 
 // DeleteHandleResponse handles the Delete response.
 func (client *NetworkWatchersClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *NetworkWatchersClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -306,6 +315,9 @@ func (client *NetworkWatchersClient) Get(ctx context.Context, resourceGroupName 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -334,15 +346,15 @@ func (client *NetworkWatchersClient) GetCreateRequest(ctx context.Context, resou
 
 // GetHandleResponse handles the Get response.
 func (client *NetworkWatchersClient) GetHandleResponse(resp *azcore.Response) (*NetworkWatcherResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := NetworkWatcherResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkWatcher)
 }
 
 // GetHandleError handles the Get error response.
 func (client *NetworkWatchersClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -359,6 +371,9 @@ func (client *NetworkWatchersClient) BeginGetAzureReachabilityReport(ctx context
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetAzureReachabilityReportHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetAzureReachabilityReportHandleResponse(resp)
@@ -410,14 +425,14 @@ func (client *NetworkWatchersClient) GetAzureReachabilityReportCreateRequest(ctx
 
 // GetAzureReachabilityReportHandleResponse handles the GetAzureReachabilityReport response.
 func (client *NetworkWatchersClient) GetAzureReachabilityReportHandleResponse(resp *azcore.Response) (*AzureReachabilityReportPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetAzureReachabilityReportHandleError(resp)
-	}
 	return &AzureReachabilityReportPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetAzureReachabilityReportHandleError handles the GetAzureReachabilityReport error response.
 func (client *NetworkWatchersClient) GetAzureReachabilityReportHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -434,6 +449,9 @@ func (client *NetworkWatchersClient) BeginGetFlowLogStatus(ctx context.Context, 
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetFlowLogStatusHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetFlowLogStatusHandleResponse(resp)
@@ -485,14 +503,14 @@ func (client *NetworkWatchersClient) GetFlowLogStatusCreateRequest(ctx context.C
 
 // GetFlowLogStatusHandleResponse handles the GetFlowLogStatus response.
 func (client *NetworkWatchersClient) GetFlowLogStatusHandleResponse(resp *azcore.Response) (*FlowLogInformationPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetFlowLogStatusHandleError(resp)
-	}
 	return &FlowLogInformationPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetFlowLogStatusHandleError handles the GetFlowLogStatus error response.
 func (client *NetworkWatchersClient) GetFlowLogStatusHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -509,6 +527,9 @@ func (client *NetworkWatchersClient) BeginGetNetworkConfigurationDiagnostic(ctx 
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNetworkConfigurationDiagnosticHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNetworkConfigurationDiagnosticHandleResponse(resp)
@@ -560,14 +581,14 @@ func (client *NetworkWatchersClient) GetNetworkConfigurationDiagnosticCreateRequ
 
 // GetNetworkConfigurationDiagnosticHandleResponse handles the GetNetworkConfigurationDiagnostic response.
 func (client *NetworkWatchersClient) GetNetworkConfigurationDiagnosticHandleResponse(resp *azcore.Response) (*NetworkConfigurationDiagnosticResponsePollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetNetworkConfigurationDiagnosticHandleError(resp)
-	}
 	return &NetworkConfigurationDiagnosticResponsePollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetNetworkConfigurationDiagnosticHandleError handles the GetNetworkConfigurationDiagnostic error response.
 func (client *NetworkWatchersClient) GetNetworkConfigurationDiagnosticHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -584,6 +605,9 @@ func (client *NetworkWatchersClient) BeginGetNextHop(ctx context.Context, resour
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetNextHopHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetNextHopHandleResponse(resp)
@@ -635,14 +659,14 @@ func (client *NetworkWatchersClient) GetNextHopCreateRequest(ctx context.Context
 
 // GetNextHopHandleResponse handles the GetNextHop response.
 func (client *NetworkWatchersClient) GetNextHopHandleResponse(resp *azcore.Response) (*NextHopResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetNextHopHandleError(resp)
-	}
 	return &NextHopResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetNextHopHandleError handles the GetNextHop error response.
 func (client *NetworkWatchersClient) GetNextHopHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -658,6 +682,9 @@ func (client *NetworkWatchersClient) GetTopology(ctx context.Context, resourceGr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetTopologyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetTopologyHandleResponse(resp)
@@ -686,15 +713,15 @@ func (client *NetworkWatchersClient) GetTopologyCreateRequest(ctx context.Contex
 
 // GetTopologyHandleResponse handles the GetTopology response.
 func (client *NetworkWatchersClient) GetTopologyHandleResponse(resp *azcore.Response) (*TopologyResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetTopologyHandleError(resp)
-	}
 	result := TopologyResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Topology)
 }
 
 // GetTopologyHandleError handles the GetTopology error response.
 func (client *NetworkWatchersClient) GetTopologyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -711,6 +738,9 @@ func (client *NetworkWatchersClient) BeginGetTroubleshooting(ctx context.Context
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetTroubleshootingHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetTroubleshootingHandleResponse(resp)
@@ -762,14 +792,14 @@ func (client *NetworkWatchersClient) GetTroubleshootingCreateRequest(ctx context
 
 // GetTroubleshootingHandleResponse handles the GetTroubleshooting response.
 func (client *NetworkWatchersClient) GetTroubleshootingHandleResponse(resp *azcore.Response) (*TroubleshootingResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetTroubleshootingHandleError(resp)
-	}
 	return &TroubleshootingResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetTroubleshootingHandleError handles the GetTroubleshooting error response.
 func (client *NetworkWatchersClient) GetTroubleshootingHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -786,6 +816,9 @@ func (client *NetworkWatchersClient) BeginGetTroubleshootingResult(ctx context.C
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetTroubleshootingResultHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetTroubleshootingResultHandleResponse(resp)
@@ -837,14 +870,14 @@ func (client *NetworkWatchersClient) GetTroubleshootingResultCreateRequest(ctx c
 
 // GetTroubleshootingResultHandleResponse handles the GetTroubleshootingResult response.
 func (client *NetworkWatchersClient) GetTroubleshootingResultHandleResponse(resp *azcore.Response) (*TroubleshootingResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetTroubleshootingResultHandleError(resp)
-	}
 	return &TroubleshootingResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetTroubleshootingResultHandleError handles the GetTroubleshootingResult error response.
 func (client *NetworkWatchersClient) GetTroubleshootingResultHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -861,6 +894,9 @@ func (client *NetworkWatchersClient) BeginGetVMSecurityRules(ctx context.Context
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetVMSecurityRulesHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetVMSecurityRulesHandleResponse(resp)
@@ -912,14 +948,14 @@ func (client *NetworkWatchersClient) GetVMSecurityRulesCreateRequest(ctx context
 
 // GetVMSecurityRulesHandleResponse handles the GetVMSecurityRules response.
 func (client *NetworkWatchersClient) GetVMSecurityRulesHandleResponse(resp *azcore.Response) (*SecurityGroupViewResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetVMSecurityRulesHandleError(resp)
-	}
 	return &SecurityGroupViewResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetVMSecurityRulesHandleError handles the GetVMSecurityRules error response.
 func (client *NetworkWatchersClient) GetVMSecurityRulesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -935,6 +971,9 @@ func (client *NetworkWatchersClient) List(ctx context.Context, resourceGroupName
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListHandleResponse(resp)
@@ -962,15 +1001,15 @@ func (client *NetworkWatchersClient) ListCreateRequest(ctx context.Context, reso
 
 // ListHandleResponse handles the List response.
 func (client *NetworkWatchersClient) ListHandleResponse(resp *azcore.Response) (*NetworkWatcherListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := NetworkWatcherListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkWatcherListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *NetworkWatchersClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -986,6 +1025,9 @@ func (client *NetworkWatchersClient) ListAll(ctx context.Context) (*NetworkWatch
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListAllHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListAllHandleResponse(resp)
@@ -1012,15 +1054,15 @@ func (client *NetworkWatchersClient) ListAllCreateRequest(ctx context.Context) (
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *NetworkWatchersClient) ListAllHandleResponse(resp *azcore.Response) (*NetworkWatcherListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := NetworkWatcherListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkWatcherListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *NetworkWatchersClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1037,6 +1079,9 @@ func (client *NetworkWatchersClient) BeginListAvailableProviders(ctx context.Con
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListAvailableProvidersHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListAvailableProvidersHandleResponse(resp)
@@ -1088,14 +1133,14 @@ func (client *NetworkWatchersClient) ListAvailableProvidersCreateRequest(ctx con
 
 // ListAvailableProvidersHandleResponse handles the ListAvailableProviders response.
 func (client *NetworkWatchersClient) ListAvailableProvidersHandleResponse(resp *azcore.Response) (*AvailableProvidersListPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.ListAvailableProvidersHandleError(resp)
-	}
 	return &AvailableProvidersListPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // ListAvailableProvidersHandleError handles the ListAvailableProviders error response.
 func (client *NetworkWatchersClient) ListAvailableProvidersHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1112,6 +1157,9 @@ func (client *NetworkWatchersClient) BeginSetFlowLogConfiguration(ctx context.Co
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.SetFlowLogConfigurationHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.SetFlowLogConfigurationHandleResponse(resp)
@@ -1163,14 +1211,14 @@ func (client *NetworkWatchersClient) SetFlowLogConfigurationCreateRequest(ctx co
 
 // SetFlowLogConfigurationHandleResponse handles the SetFlowLogConfiguration response.
 func (client *NetworkWatchersClient) SetFlowLogConfigurationHandleResponse(resp *azcore.Response) (*FlowLogInformationPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.SetFlowLogConfigurationHandleError(resp)
-	}
 	return &FlowLogInformationPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // SetFlowLogConfigurationHandleError handles the SetFlowLogConfiguration error response.
 func (client *NetworkWatchersClient) SetFlowLogConfigurationHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1186,6 +1234,9 @@ func (client *NetworkWatchersClient) UpdateTags(ctx context.Context, resourceGro
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -1214,15 +1265,15 @@ func (client *NetworkWatchersClient) UpdateTagsCreateRequest(ctx context.Context
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *NetworkWatchersClient) UpdateTagsHandleResponse(resp *azcore.Response) (*NetworkWatcherResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := NetworkWatcherResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.NetworkWatcher)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *NetworkWatchersClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1239,6 +1290,9 @@ func (client *NetworkWatchersClient) BeginVerifyIPFlow(ctx context.Context, reso
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.VerifyIPFlowHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.VerifyIPFlowHandleResponse(resp)
@@ -1290,14 +1344,14 @@ func (client *NetworkWatchersClient) VerifyIPFlowCreateRequest(ctx context.Conte
 
 // VerifyIPFlowHandleResponse handles the VerifyIPFlow response.
 func (client *NetworkWatchersClient) VerifyIPFlowHandleResponse(resp *azcore.Response) (*VerificationIPFlowResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.VerifyIPFlowHandleError(resp)
-	}
 	return &VerificationIPFlowResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // VerifyIPFlowHandleError handles the VerifyIPFlow error response.
 func (client *NetworkWatchersClient) VerifyIPFlowHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_operations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_operations.go
@@ -70,9 +70,6 @@ func (client *OperationsClient) ListHandleResponse(resp *azcore.Response) (*Oper
 
 // ListHandleError handles the List error response.
 func (client *OperationsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_operations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_operations.go
@@ -41,6 +41,7 @@ func (client *OperationsClient) List() OperationListResultPager {
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *OperationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.OperationListResult.NextLink)
 		},
@@ -63,15 +64,15 @@ func (client *OperationsClient) ListCreateRequest(ctx context.Context) (*azcore.
 
 // ListHandleResponse handles the List response.
 func (client *OperationsClient) ListHandleResponse(resp *azcore.Response) (*OperationListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := OperationListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.OperationListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *OperationsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways.go
@@ -79,6 +79,9 @@ func (client *P2SVpnGatewaysClient) BeginCreateOrUpdate(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -128,14 +131,14 @@ func (client *P2SVpnGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Cont
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *P2SVpnGatewaysClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*P2SVpnGatewayPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &P2SVpnGatewayPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *P2SVpnGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -152,6 +155,9 @@ func (client *P2SVpnGatewaysClient) BeginDelete(ctx context.Context, resourceGro
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -203,14 +209,14 @@ func (client *P2SVpnGatewaysClient) DeleteCreateRequest(ctx context.Context, res
 
 // DeleteHandleResponse handles the Delete response.
 func (client *P2SVpnGatewaysClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *P2SVpnGatewaysClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -227,6 +233,9 @@ func (client *P2SVpnGatewaysClient) BeginDisconnectP2SVpnConnections(ctx context
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DisconnectP2SVpnConnectionsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DisconnectP2SVpnConnectionsHandleResponse(resp)
@@ -278,14 +287,14 @@ func (client *P2SVpnGatewaysClient) DisconnectP2SVpnConnectionsCreateRequest(ctx
 
 // DisconnectP2SVpnConnectionsHandleResponse handles the DisconnectP2SVpnConnections response.
 func (client *P2SVpnGatewaysClient) DisconnectP2SVpnConnectionsHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DisconnectP2SVpnConnectionsHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DisconnectP2SVpnConnectionsHandleError handles the DisconnectP2SVpnConnections error response.
 func (client *P2SVpnGatewaysClient) DisconnectP2SVpnConnectionsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,6 +311,9 @@ func (client *P2SVpnGatewaysClient) BeginGenerateVpnProfile(ctx context.Context,
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GenerateVpnProfileHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GenerateVpnProfileHandleResponse(resp)
@@ -353,14 +365,14 @@ func (client *P2SVpnGatewaysClient) GenerateVpnProfileCreateRequest(ctx context.
 
 // GenerateVpnProfileHandleResponse handles the GenerateVpnProfile response.
 func (client *P2SVpnGatewaysClient) GenerateVpnProfileHandleResponse(resp *azcore.Response) (*VpnProfileResponsePollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GenerateVpnProfileHandleError(resp)
-	}
 	return &VpnProfileResponsePollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GenerateVpnProfileHandleError handles the GenerateVpnProfile error response.
 func (client *P2SVpnGatewaysClient) GenerateVpnProfileHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -376,6 +388,9 @@ func (client *P2SVpnGatewaysClient) Get(ctx context.Context, resourceGroupName s
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -404,15 +419,15 @@ func (client *P2SVpnGatewaysClient) GetCreateRequest(ctx context.Context, resour
 
 // GetHandleResponse handles the Get response.
 func (client *P2SVpnGatewaysClient) GetHandleResponse(resp *azcore.Response) (*P2SVpnGatewayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := P2SVpnGatewayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.P2SVpnGateway)
 }
 
 // GetHandleError handles the Get error response.
 func (client *P2SVpnGatewaysClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -429,6 +444,9 @@ func (client *P2SVpnGatewaysClient) BeginGetP2SVpnConnectionHealth(ctx context.C
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetP2SVpnConnectionHealthHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetP2SVpnConnectionHealthHandleResponse(resp)
@@ -480,14 +498,14 @@ func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthCreateRequest(ctx c
 
 // GetP2SVpnConnectionHealthHandleResponse handles the GetP2SVpnConnectionHealth response.
 func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthHandleResponse(resp *azcore.Response) (*P2SVpnGatewayPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetP2SVpnConnectionHealthHandleError(resp)
-	}
 	return &P2SVpnGatewayPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetP2SVpnConnectionHealthHandleError handles the GetP2SVpnConnectionHealth error response.
 func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -504,6 +522,9 @@ func (client *P2SVpnGatewaysClient) BeginGetP2SVpnConnectionHealthDetailed(ctx c
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetP2SVpnConnectionHealthDetailedHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetP2SVpnConnectionHealthDetailedHandleResponse(resp)
@@ -555,14 +576,14 @@ func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthDetailedCreateReque
 
 // GetP2SVpnConnectionHealthDetailedHandleResponse handles the GetP2SVpnConnectionHealthDetailed response.
 func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthDetailedHandleResponse(resp *azcore.Response) (*P2SVpnConnectionHealthPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetP2SVpnConnectionHealthDetailedHandleError(resp)
-	}
 	return &P2SVpnConnectionHealthPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetP2SVpnConnectionHealthDetailedHandleError handles the GetP2SVpnConnectionHealthDetailed error response.
 func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthDetailedHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -578,6 +599,7 @@ func (client *P2SVpnGatewaysClient) List() ListP2SVpnGatewaysResultPager {
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ListP2SVpnGatewaysResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListP2SVpnGatewaysResult.NextLink)
 		},
@@ -601,15 +623,15 @@ func (client *P2SVpnGatewaysClient) ListCreateRequest(ctx context.Context) (*azc
 
 // ListHandleResponse handles the List response.
 func (client *P2SVpnGatewaysClient) ListHandleResponse(resp *azcore.Response) (*ListP2SVpnGatewaysResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ListP2SVpnGatewaysResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListP2SVpnGatewaysResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *P2SVpnGatewaysClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -625,6 +647,7 @@ func (client *P2SVpnGatewaysClient) ListByResourceGroup(resourceGroupName string
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *ListP2SVpnGatewaysResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListP2SVpnGatewaysResult.NextLink)
 		},
@@ -649,15 +672,15 @@ func (client *P2SVpnGatewaysClient) ListByResourceGroupCreateRequest(ctx context
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *P2SVpnGatewaysClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*ListP2SVpnGatewaysResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := ListP2SVpnGatewaysResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListP2SVpnGatewaysResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *P2SVpnGatewaysClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -673,6 +696,9 @@ func (client *P2SVpnGatewaysClient) UpdateTags(ctx context.Context, resourceGrou
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -701,15 +727,15 @@ func (client *P2SVpnGatewaysClient) UpdateTagsCreateRequest(ctx context.Context,
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *P2SVpnGatewaysClient) UpdateTagsHandleResponse(resp *azcore.Response) (*P2SVpnGatewayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := P2SVpnGatewayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.P2SVpnGateway)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *P2SVpnGatewaysClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways.go
@@ -79,8 +79,8 @@ func (client *P2SVpnGatewaysClient) BeginCreateOrUpdate(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -136,9 +136,6 @@ func (client *P2SVpnGatewaysClient) CreateOrUpdateHandleResponse(resp *azcore.Re
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *P2SVpnGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -157,8 +154,8 @@ func (client *P2SVpnGatewaysClient) BeginDelete(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -214,9 +211,6 @@ func (client *P2SVpnGatewaysClient) DeleteHandleResponse(resp *azcore.Response) 
 
 // DeleteHandleError handles the Delete error response.
 func (client *P2SVpnGatewaysClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -235,8 +229,8 @@ func (client *P2SVpnGatewaysClient) BeginDisconnectP2SVpnConnections(ctx context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DisconnectP2SVpnConnectionsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.DisconnectP2SVpnConnectionsHandleError(resp)
 	}
 	result, err := client.DisconnectP2SVpnConnectionsHandleResponse(resp)
 	if err != nil {
@@ -292,9 +286,6 @@ func (client *P2SVpnGatewaysClient) DisconnectP2SVpnConnectionsHandleResponse(re
 
 // DisconnectP2SVpnConnectionsHandleError handles the DisconnectP2SVpnConnections error response.
 func (client *P2SVpnGatewaysClient) DisconnectP2SVpnConnectionsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -313,8 +304,8 @@ func (client *P2SVpnGatewaysClient) BeginGenerateVpnProfile(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GenerateVpnProfileHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GenerateVpnProfileHandleError(resp)
 	}
 	result, err := client.GenerateVpnProfileHandleResponse(resp)
 	if err != nil {
@@ -370,9 +361,6 @@ func (client *P2SVpnGatewaysClient) GenerateVpnProfileHandleResponse(resp *azcor
 
 // GenerateVpnProfileHandleError handles the GenerateVpnProfile error response.
 func (client *P2SVpnGatewaysClient) GenerateVpnProfileHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -390,8 +378,8 @@ func (client *P2SVpnGatewaysClient) Get(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -425,9 +413,6 @@ func (client *P2SVpnGatewaysClient) GetHandleResponse(resp *azcore.Response) (*P
 
 // GetHandleError handles the Get error response.
 func (client *P2SVpnGatewaysClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -446,8 +431,8 @@ func (client *P2SVpnGatewaysClient) BeginGetP2SVpnConnectionHealth(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetP2SVpnConnectionHealthHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetP2SVpnConnectionHealthHandleError(resp)
 	}
 	result, err := client.GetP2SVpnConnectionHealthHandleResponse(resp)
 	if err != nil {
@@ -503,9 +488,6 @@ func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthHandleResponse(resp
 
 // GetP2SVpnConnectionHealthHandleError handles the GetP2SVpnConnectionHealth error response.
 func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -524,8 +506,8 @@ func (client *P2SVpnGatewaysClient) BeginGetP2SVpnConnectionHealthDetailed(ctx c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetP2SVpnConnectionHealthDetailedHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetP2SVpnConnectionHealthDetailedHandleError(resp)
 	}
 	result, err := client.GetP2SVpnConnectionHealthDetailedHandleResponse(resp)
 	if err != nil {
@@ -581,9 +563,6 @@ func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthDetailedHandleRespo
 
 // GetP2SVpnConnectionHealthDetailedHandleError handles the GetP2SVpnConnectionHealthDetailed error response.
 func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthDetailedHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -629,9 +608,6 @@ func (client *P2SVpnGatewaysClient) ListHandleResponse(resp *azcore.Response) (*
 
 // ListHandleError handles the List error response.
 func (client *P2SVpnGatewaysClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -678,9 +654,6 @@ func (client *P2SVpnGatewaysClient) ListByResourceGroupHandleResponse(resp *azco
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *P2SVpnGatewaysClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -698,8 +671,8 @@ func (client *P2SVpnGatewaysClient) UpdateTags(ctx context.Context, resourceGrou
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -733,9 +706,6 @@ func (client *P2SVpnGatewaysClient) UpdateTagsHandleResponse(resp *azcore.Respon
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *P2SVpnGatewaysClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures.go
@@ -67,8 +67,8 @@ func (client *PacketCapturesClient) BeginCreate(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.CreateHandleError(resp)
 	}
 	result, err := client.CreateHandleResponse(resp)
 	if err != nil {
@@ -125,9 +125,6 @@ func (client *PacketCapturesClient) CreateHandleResponse(resp *azcore.Response) 
 
 // CreateHandleError handles the Create error response.
 func (client *PacketCapturesClient) CreateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -146,8 +143,8 @@ func (client *PacketCapturesClient) BeginDelete(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -204,9 +201,6 @@ func (client *PacketCapturesClient) DeleteHandleResponse(resp *azcore.Response) 
 
 // DeleteHandleError handles the Delete error response.
 func (client *PacketCapturesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -224,8 +218,8 @@ func (client *PacketCapturesClient) Get(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -260,9 +254,6 @@ func (client *PacketCapturesClient) GetHandleResponse(resp *azcore.Response) (*P
 
 // GetHandleError handles the Get error response.
 func (client *PacketCapturesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -281,8 +272,8 @@ func (client *PacketCapturesClient) BeginGetStatus(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetStatusHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetStatusHandleError(resp)
 	}
 	result, err := client.GetStatusHandleResponse(resp)
 	if err != nil {
@@ -339,9 +330,6 @@ func (client *PacketCapturesClient) GetStatusHandleResponse(resp *azcore.Respons
 
 // GetStatusHandleError handles the GetStatus error response.
 func (client *PacketCapturesClient) GetStatusHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -359,8 +347,8 @@ func (client *PacketCapturesClient) List(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListHandleError(resp)
 	}
 	result, err := client.ListHandleResponse(resp)
 	if err != nil {
@@ -394,9 +382,6 @@ func (client *PacketCapturesClient) ListHandleResponse(resp *azcore.Response) (*
 
 // ListHandleError handles the List error response.
 func (client *PacketCapturesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -415,8 +400,8 @@ func (client *PacketCapturesClient) BeginStop(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StopHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.StopHandleError(resp)
 	}
 	result, err := client.StopHandleResponse(resp)
 	if err != nil {
@@ -473,9 +458,6 @@ func (client *PacketCapturesClient) StopHandleResponse(resp *azcore.Response) (*
 
 // StopHandleError handles the Stop error response.
 func (client *PacketCapturesClient) StopHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures.go
@@ -67,6 +67,9 @@ func (client *PacketCapturesClient) BeginCreate(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -117,14 +120,14 @@ func (client *PacketCapturesClient) CreateCreateRequest(ctx context.Context, res
 
 // CreateHandleResponse handles the Create response.
 func (client *PacketCapturesClient) CreateHandleResponse(resp *azcore.Response) (*PacketCaptureResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateHandleError(resp)
-	}
 	return &PacketCaptureResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateHandleError handles the Create error response.
 func (client *PacketCapturesClient) CreateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,6 +144,9 @@ func (client *PacketCapturesClient) BeginDelete(ctx context.Context, resourceGro
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -193,14 +199,14 @@ func (client *PacketCapturesClient) DeleteCreateRequest(ctx context.Context, res
 
 // DeleteHandleResponse handles the Delete response.
 func (client *PacketCapturesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *PacketCapturesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,6 +222,9 @@ func (client *PacketCapturesClient) Get(ctx context.Context, resourceGroupName s
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -245,15 +254,15 @@ func (client *PacketCapturesClient) GetCreateRequest(ctx context.Context, resour
 
 // GetHandleResponse handles the Get response.
 func (client *PacketCapturesClient) GetHandleResponse(resp *azcore.Response) (*PacketCaptureResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := PacketCaptureResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PacketCaptureResult)
 }
 
 // GetHandleError handles the Get error response.
 func (client *PacketCapturesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -270,6 +279,9 @@ func (client *PacketCapturesClient) BeginGetStatus(ctx context.Context, resource
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetStatusHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetStatusHandleResponse(resp)
@@ -322,14 +334,14 @@ func (client *PacketCapturesClient) GetStatusCreateRequest(ctx context.Context, 
 
 // GetStatusHandleResponse handles the GetStatus response.
 func (client *PacketCapturesClient) GetStatusHandleResponse(resp *azcore.Response) (*PacketCaptureQueryStatusResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetStatusHandleError(resp)
-	}
 	return &PacketCaptureQueryStatusResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetStatusHandleError handles the GetStatus error response.
 func (client *PacketCapturesClient) GetStatusHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -345,6 +357,9 @@ func (client *PacketCapturesClient) List(ctx context.Context, resourceGroupName 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ListHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ListHandleResponse(resp)
@@ -373,15 +388,15 @@ func (client *PacketCapturesClient) ListCreateRequest(ctx context.Context, resou
 
 // ListHandleResponse handles the List response.
 func (client *PacketCapturesClient) ListHandleResponse(resp *azcore.Response) (*PacketCaptureListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := PacketCaptureListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PacketCaptureListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *PacketCapturesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -398,6 +413,9 @@ func (client *PacketCapturesClient) BeginStop(ctx context.Context, resourceGroup
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.StopHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.StopHandleResponse(resp)
@@ -450,14 +468,14 @@ func (client *PacketCapturesClient) StopCreateRequest(ctx context.Context, resou
 
 // StopHandleResponse handles the Stop response.
 func (client *PacketCapturesClient) StopHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.StopHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // StopHandleError handles the Stop error response.
 func (client *PacketCapturesClient) StopHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err ErrorResponse
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
@@ -25,6 +25,8 @@ type ApplicationGatewayAvailableSslPredefinedPoliciesPager interface {
 
 type applicationGatewayAvailableSslPredefinedPoliciesCreateRequest func(context.Context) (*azcore.Request, error)
 
+type applicationGatewayAvailableSslPredefinedPoliciesHandleError func(*azcore.Response) error
+
 type applicationGatewayAvailableSslPredefinedPoliciesHandleResponse func(*azcore.Response) (*ApplicationGatewayAvailableSslPredefinedPoliciesResponse, error)
 
 type applicationGatewayAvailableSslPredefinedPoliciesAdvancePage func(context.Context, *ApplicationGatewayAvailableSslPredefinedPoliciesResponse) (*azcore.Request, error)
@@ -34,6 +36,8 @@ type applicationGatewayAvailableSslPredefinedPoliciesPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester applicationGatewayAvailableSslPredefinedPoliciesCreateRequest
+	// callback for handling response errors
+	errorer applicationGatewayAvailableSslPredefinedPoliciesHandleError
 	// callback for handling the HTTP response
 	responder applicationGatewayAvailableSslPredefinedPoliciesHandleResponse
 	// callback for advancing to the next page
@@ -64,6 +68,13 @@ func (p *applicationGatewayAvailableSslPredefinedPoliciesPager) NextPage(ctx con
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -92,6 +103,8 @@ type ApplicationGatewayListResultPager interface {
 
 type applicationGatewayListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type applicationGatewayListResultHandleError func(*azcore.Response) error
+
 type applicationGatewayListResultHandleResponse func(*azcore.Response) (*ApplicationGatewayListResultResponse, error)
 
 type applicationGatewayListResultAdvancePage func(context.Context, *ApplicationGatewayListResultResponse) (*azcore.Request, error)
@@ -101,6 +114,8 @@ type applicationGatewayListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester applicationGatewayListResultCreateRequest
+	// callback for handling response errors
+	errorer applicationGatewayListResultHandleError
 	// callback for handling the HTTP response
 	responder applicationGatewayListResultHandleResponse
 	// callback for advancing to the next page
@@ -131,6 +146,13 @@ func (p *applicationGatewayListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -159,6 +181,8 @@ type ApplicationSecurityGroupListResultPager interface {
 
 type applicationSecurityGroupListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type applicationSecurityGroupListResultHandleError func(*azcore.Response) error
+
 type applicationSecurityGroupListResultHandleResponse func(*azcore.Response) (*ApplicationSecurityGroupListResultResponse, error)
 
 type applicationSecurityGroupListResultAdvancePage func(context.Context, *ApplicationSecurityGroupListResultResponse) (*azcore.Request, error)
@@ -168,6 +192,8 @@ type applicationSecurityGroupListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester applicationSecurityGroupListResultCreateRequest
+	// callback for handling response errors
+	errorer applicationSecurityGroupListResultHandleError
 	// callback for handling the HTTP response
 	responder applicationSecurityGroupListResultHandleResponse
 	// callback for advancing to the next page
@@ -198,6 +224,13 @@ func (p *applicationSecurityGroupListResultPager) NextPage(ctx context.Context) 
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -226,6 +259,8 @@ type AuthorizationListResultPager interface {
 
 type authorizationListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type authorizationListResultHandleError func(*azcore.Response) error
+
 type authorizationListResultHandleResponse func(*azcore.Response) (*AuthorizationListResultResponse, error)
 
 type authorizationListResultAdvancePage func(context.Context, *AuthorizationListResultResponse) (*azcore.Request, error)
@@ -235,6 +270,8 @@ type authorizationListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester authorizationListResultCreateRequest
+	// callback for handling response errors
+	errorer authorizationListResultHandleError
 	// callback for handling the HTTP response
 	responder authorizationListResultHandleResponse
 	// callback for advancing to the next page
@@ -265,6 +302,13 @@ func (p *authorizationListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -293,6 +337,8 @@ type AutoApprovedPrivateLinkServicesResultPager interface {
 
 type autoApprovedPrivateLinkServicesResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type autoApprovedPrivateLinkServicesResultHandleError func(*azcore.Response) error
+
 type autoApprovedPrivateLinkServicesResultHandleResponse func(*azcore.Response) (*AutoApprovedPrivateLinkServicesResultResponse, error)
 
 type autoApprovedPrivateLinkServicesResultAdvancePage func(context.Context, *AutoApprovedPrivateLinkServicesResultResponse) (*azcore.Request, error)
@@ -302,6 +348,8 @@ type autoApprovedPrivateLinkServicesResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester autoApprovedPrivateLinkServicesResultCreateRequest
+	// callback for handling response errors
+	errorer autoApprovedPrivateLinkServicesResultHandleError
 	// callback for handling the HTTP response
 	responder autoApprovedPrivateLinkServicesResultHandleResponse
 	// callback for advancing to the next page
@@ -332,6 +380,13 @@ func (p *autoApprovedPrivateLinkServicesResultPager) NextPage(ctx context.Contex
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -360,6 +415,8 @@ type AvailableDelegationsResultPager interface {
 
 type availableDelegationsResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type availableDelegationsResultHandleError func(*azcore.Response) error
+
 type availableDelegationsResultHandleResponse func(*azcore.Response) (*AvailableDelegationsResultResponse, error)
 
 type availableDelegationsResultAdvancePage func(context.Context, *AvailableDelegationsResultResponse) (*azcore.Request, error)
@@ -369,6 +426,8 @@ type availableDelegationsResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester availableDelegationsResultCreateRequest
+	// callback for handling response errors
+	errorer availableDelegationsResultHandleError
 	// callback for handling the HTTP response
 	responder availableDelegationsResultHandleResponse
 	// callback for advancing to the next page
@@ -399,6 +458,13 @@ func (p *availableDelegationsResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -427,6 +493,8 @@ type AvailablePrivateEndpointTypesResultPager interface {
 
 type availablePrivateEndpointTypesResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type availablePrivateEndpointTypesResultHandleError func(*azcore.Response) error
+
 type availablePrivateEndpointTypesResultHandleResponse func(*azcore.Response) (*AvailablePrivateEndpointTypesResultResponse, error)
 
 type availablePrivateEndpointTypesResultAdvancePage func(context.Context, *AvailablePrivateEndpointTypesResultResponse) (*azcore.Request, error)
@@ -436,6 +504,8 @@ type availablePrivateEndpointTypesResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester availablePrivateEndpointTypesResultCreateRequest
+	// callback for handling response errors
+	errorer availablePrivateEndpointTypesResultHandleError
 	// callback for handling the HTTP response
 	responder availablePrivateEndpointTypesResultHandleResponse
 	// callback for advancing to the next page
@@ -466,6 +536,13 @@ func (p *availablePrivateEndpointTypesResultPager) NextPage(ctx context.Context)
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -494,6 +571,8 @@ type AvailableServiceAliasesResultPager interface {
 
 type availableServiceAliasesResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type availableServiceAliasesResultHandleError func(*azcore.Response) error
+
 type availableServiceAliasesResultHandleResponse func(*azcore.Response) (*AvailableServiceAliasesResultResponse, error)
 
 type availableServiceAliasesResultAdvancePage func(context.Context, *AvailableServiceAliasesResultResponse) (*azcore.Request, error)
@@ -503,6 +582,8 @@ type availableServiceAliasesResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester availableServiceAliasesResultCreateRequest
+	// callback for handling response errors
+	errorer availableServiceAliasesResultHandleError
 	// callback for handling the HTTP response
 	responder availableServiceAliasesResultHandleResponse
 	// callback for advancing to the next page
@@ -533,6 +614,13 @@ func (p *availableServiceAliasesResultPager) NextPage(ctx context.Context) bool 
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -561,6 +649,8 @@ type AzureFirewallFqdnTagListResultPager interface {
 
 type azureFirewallFqdnTagListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type azureFirewallFqdnTagListResultHandleError func(*azcore.Response) error
+
 type azureFirewallFqdnTagListResultHandleResponse func(*azcore.Response) (*AzureFirewallFqdnTagListResultResponse, error)
 
 type azureFirewallFqdnTagListResultAdvancePage func(context.Context, *AzureFirewallFqdnTagListResultResponse) (*azcore.Request, error)
@@ -570,6 +660,8 @@ type azureFirewallFqdnTagListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester azureFirewallFqdnTagListResultCreateRequest
+	// callback for handling response errors
+	errorer azureFirewallFqdnTagListResultHandleError
 	// callback for handling the HTTP response
 	responder azureFirewallFqdnTagListResultHandleResponse
 	// callback for advancing to the next page
@@ -600,6 +692,13 @@ func (p *azureFirewallFqdnTagListResultPager) NextPage(ctx context.Context) bool
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -628,6 +727,8 @@ type AzureFirewallListResultPager interface {
 
 type azureFirewallListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type azureFirewallListResultHandleError func(*azcore.Response) error
+
 type azureFirewallListResultHandleResponse func(*azcore.Response) (*AzureFirewallListResultResponse, error)
 
 type azureFirewallListResultAdvancePage func(context.Context, *AzureFirewallListResultResponse) (*azcore.Request, error)
@@ -637,6 +738,8 @@ type azureFirewallListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester azureFirewallListResultCreateRequest
+	// callback for handling response errors
+	errorer azureFirewallListResultHandleError
 	// callback for handling the HTTP response
 	responder azureFirewallListResultHandleResponse
 	// callback for advancing to the next page
@@ -667,6 +770,13 @@ func (p *azureFirewallListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -695,6 +805,8 @@ type BastionActiveSessionListResultPager interface {
 
 type bastionActiveSessionListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type bastionActiveSessionListResultHandleError func(*azcore.Response) error
+
 type bastionActiveSessionListResultHandleResponse func(*azcore.Response) (*BastionActiveSessionListResultResponse, error)
 
 type bastionActiveSessionListResultAdvancePage func(context.Context, *BastionActiveSessionListResultResponse) (*azcore.Request, error)
@@ -704,6 +816,8 @@ type bastionActiveSessionListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester bastionActiveSessionListResultCreateRequest
+	// callback for handling response errors
+	errorer bastionActiveSessionListResultHandleError
 	// callback for handling the HTTP response
 	responder bastionActiveSessionListResultHandleResponse
 	// callback for advancing to the next page
@@ -741,6 +855,13 @@ func (p *bastionActiveSessionListResultPager) NextPage(ctx context.Context) bool
 	} else {
 		p.resp = nil
 	}
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -769,6 +890,8 @@ type BastionHostListResultPager interface {
 
 type bastionHostListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type bastionHostListResultHandleError func(*azcore.Response) error
+
 type bastionHostListResultHandleResponse func(*azcore.Response) (*BastionHostListResultResponse, error)
 
 type bastionHostListResultAdvancePage func(context.Context, *BastionHostListResultResponse) (*azcore.Request, error)
@@ -778,6 +901,8 @@ type bastionHostListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester bastionHostListResultCreateRequest
+	// callback for handling response errors
+	errorer bastionHostListResultHandleError
 	// callback for handling the HTTP response
 	responder bastionHostListResultHandleResponse
 	// callback for advancing to the next page
@@ -808,6 +933,13 @@ func (p *bastionHostListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -836,6 +968,8 @@ type BastionSessionDeleteResultPager interface {
 
 type bastionSessionDeleteResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type bastionSessionDeleteResultHandleError func(*azcore.Response) error
+
 type bastionSessionDeleteResultHandleResponse func(*azcore.Response) (*BastionSessionDeleteResultResponse, error)
 
 type bastionSessionDeleteResultAdvancePage func(context.Context, *BastionSessionDeleteResultResponse) (*azcore.Request, error)
@@ -845,6 +979,8 @@ type bastionSessionDeleteResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester bastionSessionDeleteResultCreateRequest
+	// callback for handling response errors
+	errorer bastionSessionDeleteResultHandleError
 	// callback for handling the HTTP response
 	responder bastionSessionDeleteResultHandleResponse
 	// callback for advancing to the next page
@@ -875,6 +1011,13 @@ func (p *bastionSessionDeleteResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -903,6 +1046,8 @@ type BastionShareableLinkListResultPager interface {
 
 type bastionShareableLinkListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type bastionShareableLinkListResultHandleError func(*azcore.Response) error
+
 type bastionShareableLinkListResultHandleResponse func(*azcore.Response) (*BastionShareableLinkListResultResponse, error)
 
 type bastionShareableLinkListResultAdvancePage func(context.Context, *BastionShareableLinkListResultResponse) (*azcore.Request, error)
@@ -912,6 +1057,8 @@ type bastionShareableLinkListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester bastionShareableLinkListResultCreateRequest
+	// callback for handling response errors
+	errorer bastionShareableLinkListResultHandleError
 	// callback for handling the HTTP response
 	responder bastionShareableLinkListResultHandleResponse
 	// callback for advancing to the next page
@@ -949,6 +1096,13 @@ func (p *bastionShareableLinkListResultPager) NextPage(ctx context.Context) bool
 	} else {
 		p.resp = nil
 	}
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -977,6 +1131,8 @@ type BgpServiceCommunityListResultPager interface {
 
 type bgpServiceCommunityListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type bgpServiceCommunityListResultHandleError func(*azcore.Response) error
+
 type bgpServiceCommunityListResultHandleResponse func(*azcore.Response) (*BgpServiceCommunityListResultResponse, error)
 
 type bgpServiceCommunityListResultAdvancePage func(context.Context, *BgpServiceCommunityListResultResponse) (*azcore.Request, error)
@@ -986,6 +1142,8 @@ type bgpServiceCommunityListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester bgpServiceCommunityListResultCreateRequest
+	// callback for handling response errors
+	errorer bgpServiceCommunityListResultHandleError
 	// callback for handling the HTTP response
 	responder bgpServiceCommunityListResultHandleResponse
 	// callback for advancing to the next page
@@ -1016,6 +1174,13 @@ func (p *bgpServiceCommunityListResultPager) NextPage(ctx context.Context) bool 
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -1044,6 +1209,8 @@ type DdosProtectionPlanListResultPager interface {
 
 type ddosProtectionPlanListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type ddosProtectionPlanListResultHandleError func(*azcore.Response) error
+
 type ddosProtectionPlanListResultHandleResponse func(*azcore.Response) (*DdosProtectionPlanListResultResponse, error)
 
 type ddosProtectionPlanListResultAdvancePage func(context.Context, *DdosProtectionPlanListResultResponse) (*azcore.Request, error)
@@ -1053,6 +1220,8 @@ type ddosProtectionPlanListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester ddosProtectionPlanListResultCreateRequest
+	// callback for handling response errors
+	errorer ddosProtectionPlanListResultHandleError
 	// callback for handling the HTTP response
 	responder ddosProtectionPlanListResultHandleResponse
 	// callback for advancing to the next page
@@ -1083,6 +1252,13 @@ func (p *ddosProtectionPlanListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -1111,6 +1287,8 @@ type EndpointServicesListResultPager interface {
 
 type endpointServicesListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type endpointServicesListResultHandleError func(*azcore.Response) error
+
 type endpointServicesListResultHandleResponse func(*azcore.Response) (*EndpointServicesListResultResponse, error)
 
 type endpointServicesListResultAdvancePage func(context.Context, *EndpointServicesListResultResponse) (*azcore.Request, error)
@@ -1120,6 +1298,8 @@ type endpointServicesListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester endpointServicesListResultCreateRequest
+	// callback for handling response errors
+	errorer endpointServicesListResultHandleError
 	// callback for handling the HTTP response
 	responder endpointServicesListResultHandleResponse
 	// callback for advancing to the next page
@@ -1150,6 +1330,13 @@ func (p *endpointServicesListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -1178,6 +1365,8 @@ type ExpressRouteCircuitConnectionListResultPager interface {
 
 type expressRouteCircuitConnectionListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type expressRouteCircuitConnectionListResultHandleError func(*azcore.Response) error
+
 type expressRouteCircuitConnectionListResultHandleResponse func(*azcore.Response) (*ExpressRouteCircuitConnectionListResultResponse, error)
 
 type expressRouteCircuitConnectionListResultAdvancePage func(context.Context, *ExpressRouteCircuitConnectionListResultResponse) (*azcore.Request, error)
@@ -1187,6 +1376,8 @@ type expressRouteCircuitConnectionListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester expressRouteCircuitConnectionListResultCreateRequest
+	// callback for handling response errors
+	errorer expressRouteCircuitConnectionListResultHandleError
 	// callback for handling the HTTP response
 	responder expressRouteCircuitConnectionListResultHandleResponse
 	// callback for advancing to the next page
@@ -1217,6 +1408,13 @@ func (p *expressRouteCircuitConnectionListResultPager) NextPage(ctx context.Cont
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -1245,6 +1443,8 @@ type ExpressRouteCircuitListResultPager interface {
 
 type expressRouteCircuitListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type expressRouteCircuitListResultHandleError func(*azcore.Response) error
+
 type expressRouteCircuitListResultHandleResponse func(*azcore.Response) (*ExpressRouteCircuitListResultResponse, error)
 
 type expressRouteCircuitListResultAdvancePage func(context.Context, *ExpressRouteCircuitListResultResponse) (*azcore.Request, error)
@@ -1254,6 +1454,8 @@ type expressRouteCircuitListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester expressRouteCircuitListResultCreateRequest
+	// callback for handling response errors
+	errorer expressRouteCircuitListResultHandleError
 	// callback for handling the HTTP response
 	responder expressRouteCircuitListResultHandleResponse
 	// callback for advancing to the next page
@@ -1284,6 +1486,13 @@ func (p *expressRouteCircuitListResultPager) NextPage(ctx context.Context) bool 
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -1312,6 +1521,8 @@ type ExpressRouteCircuitPeeringListResultPager interface {
 
 type expressRouteCircuitPeeringListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type expressRouteCircuitPeeringListResultHandleError func(*azcore.Response) error
+
 type expressRouteCircuitPeeringListResultHandleResponse func(*azcore.Response) (*ExpressRouteCircuitPeeringListResultResponse, error)
 
 type expressRouteCircuitPeeringListResultAdvancePage func(context.Context, *ExpressRouteCircuitPeeringListResultResponse) (*azcore.Request, error)
@@ -1321,6 +1532,8 @@ type expressRouteCircuitPeeringListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester expressRouteCircuitPeeringListResultCreateRequest
+	// callback for handling response errors
+	errorer expressRouteCircuitPeeringListResultHandleError
 	// callback for handling the HTTP response
 	responder expressRouteCircuitPeeringListResultHandleResponse
 	// callback for advancing to the next page
@@ -1351,6 +1564,13 @@ func (p *expressRouteCircuitPeeringListResultPager) NextPage(ctx context.Context
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -1379,6 +1599,8 @@ type ExpressRouteCrossConnectionListResultPager interface {
 
 type expressRouteCrossConnectionListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type expressRouteCrossConnectionListResultHandleError func(*azcore.Response) error
+
 type expressRouteCrossConnectionListResultHandleResponse func(*azcore.Response) (*ExpressRouteCrossConnectionListResultResponse, error)
 
 type expressRouteCrossConnectionListResultAdvancePage func(context.Context, *ExpressRouteCrossConnectionListResultResponse) (*azcore.Request, error)
@@ -1388,6 +1610,8 @@ type expressRouteCrossConnectionListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester expressRouteCrossConnectionListResultCreateRequest
+	// callback for handling response errors
+	errorer expressRouteCrossConnectionListResultHandleError
 	// callback for handling the HTTP response
 	responder expressRouteCrossConnectionListResultHandleResponse
 	// callback for advancing to the next page
@@ -1418,6 +1642,13 @@ func (p *expressRouteCrossConnectionListResultPager) NextPage(ctx context.Contex
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -1446,6 +1677,8 @@ type ExpressRouteCrossConnectionPeeringListPager interface {
 
 type expressRouteCrossConnectionPeeringListCreateRequest func(context.Context) (*azcore.Request, error)
 
+type expressRouteCrossConnectionPeeringListHandleError func(*azcore.Response) error
+
 type expressRouteCrossConnectionPeeringListHandleResponse func(*azcore.Response) (*ExpressRouteCrossConnectionPeeringListResponse, error)
 
 type expressRouteCrossConnectionPeeringListAdvancePage func(context.Context, *ExpressRouteCrossConnectionPeeringListResponse) (*azcore.Request, error)
@@ -1455,6 +1688,8 @@ type expressRouteCrossConnectionPeeringListPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester expressRouteCrossConnectionPeeringListCreateRequest
+	// callback for handling response errors
+	errorer expressRouteCrossConnectionPeeringListHandleError
 	// callback for handling the HTTP response
 	responder expressRouteCrossConnectionPeeringListHandleResponse
 	// callback for advancing to the next page
@@ -1485,6 +1720,13 @@ func (p *expressRouteCrossConnectionPeeringListPager) NextPage(ctx context.Conte
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -1513,6 +1755,8 @@ type ExpressRouteLinkListResultPager interface {
 
 type expressRouteLinkListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type expressRouteLinkListResultHandleError func(*azcore.Response) error
+
 type expressRouteLinkListResultHandleResponse func(*azcore.Response) (*ExpressRouteLinkListResultResponse, error)
 
 type expressRouteLinkListResultAdvancePage func(context.Context, *ExpressRouteLinkListResultResponse) (*azcore.Request, error)
@@ -1522,6 +1766,8 @@ type expressRouteLinkListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester expressRouteLinkListResultCreateRequest
+	// callback for handling response errors
+	errorer expressRouteLinkListResultHandleError
 	// callback for handling the HTTP response
 	responder expressRouteLinkListResultHandleResponse
 	// callback for advancing to the next page
@@ -1552,6 +1798,13 @@ func (p *expressRouteLinkListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -1580,6 +1833,8 @@ type ExpressRoutePortListResultPager interface {
 
 type expressRoutePortListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type expressRoutePortListResultHandleError func(*azcore.Response) error
+
 type expressRoutePortListResultHandleResponse func(*azcore.Response) (*ExpressRoutePortListResultResponse, error)
 
 type expressRoutePortListResultAdvancePage func(context.Context, *ExpressRoutePortListResultResponse) (*azcore.Request, error)
@@ -1589,6 +1844,8 @@ type expressRoutePortListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester expressRoutePortListResultCreateRequest
+	// callback for handling response errors
+	errorer expressRoutePortListResultHandleError
 	// callback for handling the HTTP response
 	responder expressRoutePortListResultHandleResponse
 	// callback for advancing to the next page
@@ -1619,6 +1876,13 @@ func (p *expressRoutePortListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -1647,6 +1911,8 @@ type ExpressRoutePortsLocationListResultPager interface {
 
 type expressRoutePortsLocationListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type expressRoutePortsLocationListResultHandleError func(*azcore.Response) error
+
 type expressRoutePortsLocationListResultHandleResponse func(*azcore.Response) (*ExpressRoutePortsLocationListResultResponse, error)
 
 type expressRoutePortsLocationListResultAdvancePage func(context.Context, *ExpressRoutePortsLocationListResultResponse) (*azcore.Request, error)
@@ -1656,6 +1922,8 @@ type expressRoutePortsLocationListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester expressRoutePortsLocationListResultCreateRequest
+	// callback for handling response errors
+	errorer expressRoutePortsLocationListResultHandleError
 	// callback for handling the HTTP response
 	responder expressRoutePortsLocationListResultHandleResponse
 	// callback for advancing to the next page
@@ -1686,6 +1954,13 @@ func (p *expressRoutePortsLocationListResultPager) NextPage(ctx context.Context)
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -1714,6 +1989,8 @@ type ExpressRouteServiceProviderListResultPager interface {
 
 type expressRouteServiceProviderListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type expressRouteServiceProviderListResultHandleError func(*azcore.Response) error
+
 type expressRouteServiceProviderListResultHandleResponse func(*azcore.Response) (*ExpressRouteServiceProviderListResultResponse, error)
 
 type expressRouteServiceProviderListResultAdvancePage func(context.Context, *ExpressRouteServiceProviderListResultResponse) (*azcore.Request, error)
@@ -1723,6 +2000,8 @@ type expressRouteServiceProviderListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester expressRouteServiceProviderListResultCreateRequest
+	// callback for handling response errors
+	errorer expressRouteServiceProviderListResultHandleError
 	// callback for handling the HTTP response
 	responder expressRouteServiceProviderListResultHandleResponse
 	// callback for advancing to the next page
@@ -1753,6 +2032,13 @@ func (p *expressRouteServiceProviderListResultPager) NextPage(ctx context.Contex
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -1781,6 +2067,8 @@ type FirewallPolicyListResultPager interface {
 
 type firewallPolicyListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type firewallPolicyListResultHandleError func(*azcore.Response) error
+
 type firewallPolicyListResultHandleResponse func(*azcore.Response) (*FirewallPolicyListResultResponse, error)
 
 type firewallPolicyListResultAdvancePage func(context.Context, *FirewallPolicyListResultResponse) (*azcore.Request, error)
@@ -1790,6 +2078,8 @@ type firewallPolicyListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester firewallPolicyListResultCreateRequest
+	// callback for handling response errors
+	errorer firewallPolicyListResultHandleError
 	// callback for handling the HTTP response
 	responder firewallPolicyListResultHandleResponse
 	// callback for advancing to the next page
@@ -1820,6 +2110,13 @@ func (p *firewallPolicyListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -1848,6 +2145,8 @@ type FirewallPolicyRuleGroupListResultPager interface {
 
 type firewallPolicyRuleGroupListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type firewallPolicyRuleGroupListResultHandleError func(*azcore.Response) error
+
 type firewallPolicyRuleGroupListResultHandleResponse func(*azcore.Response) (*FirewallPolicyRuleGroupListResultResponse, error)
 
 type firewallPolicyRuleGroupListResultAdvancePage func(context.Context, *FirewallPolicyRuleGroupListResultResponse) (*azcore.Request, error)
@@ -1857,6 +2156,8 @@ type firewallPolicyRuleGroupListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester firewallPolicyRuleGroupListResultCreateRequest
+	// callback for handling response errors
+	errorer firewallPolicyRuleGroupListResultHandleError
 	// callback for handling the HTTP response
 	responder firewallPolicyRuleGroupListResultHandleResponse
 	// callback for advancing to the next page
@@ -1887,6 +2188,13 @@ func (p *firewallPolicyRuleGroupListResultPager) NextPage(ctx context.Context) b
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -1915,6 +2223,8 @@ type FlowLogListResultPager interface {
 
 type flowLogListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type flowLogListResultHandleError func(*azcore.Response) error
+
 type flowLogListResultHandleResponse func(*azcore.Response) (*FlowLogListResultResponse, error)
 
 type flowLogListResultAdvancePage func(context.Context, *FlowLogListResultResponse) (*azcore.Request, error)
@@ -1924,6 +2234,8 @@ type flowLogListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester flowLogListResultCreateRequest
+	// callback for handling response errors
+	errorer flowLogListResultHandleError
 	// callback for handling the HTTP response
 	responder flowLogListResultHandleResponse
 	// callback for advancing to the next page
@@ -1954,6 +2266,13 @@ func (p *flowLogListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -1982,6 +2301,8 @@ type IPAllocationListResultPager interface {
 
 type ipAllocationListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type ipAllocationListResultHandleError func(*azcore.Response) error
+
 type ipAllocationListResultHandleResponse func(*azcore.Response) (*IPAllocationListResultResponse, error)
 
 type ipAllocationListResultAdvancePage func(context.Context, *IPAllocationListResultResponse) (*azcore.Request, error)
@@ -1991,6 +2312,8 @@ type ipAllocationListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester ipAllocationListResultCreateRequest
+	// callback for handling response errors
+	errorer ipAllocationListResultHandleError
 	// callback for handling the HTTP response
 	responder ipAllocationListResultHandleResponse
 	// callback for advancing to the next page
@@ -2021,6 +2344,13 @@ func (p *ipAllocationListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -2049,6 +2379,8 @@ type IPGroupListResultPager interface {
 
 type ipGroupListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type ipGroupListResultHandleError func(*azcore.Response) error
+
 type ipGroupListResultHandleResponse func(*azcore.Response) (*IPGroupListResultResponse, error)
 
 type ipGroupListResultAdvancePage func(context.Context, *IPGroupListResultResponse) (*azcore.Request, error)
@@ -2058,6 +2390,8 @@ type ipGroupListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester ipGroupListResultCreateRequest
+	// callback for handling response errors
+	errorer ipGroupListResultHandleError
 	// callback for handling the HTTP response
 	responder ipGroupListResultHandleResponse
 	// callback for advancing to the next page
@@ -2088,6 +2422,13 @@ func (p *ipGroupListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -2116,6 +2457,8 @@ type InboundNatRuleListResultPager interface {
 
 type inboundNatRuleListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type inboundNatRuleListResultHandleError func(*azcore.Response) error
+
 type inboundNatRuleListResultHandleResponse func(*azcore.Response) (*InboundNatRuleListResultResponse, error)
 
 type inboundNatRuleListResultAdvancePage func(context.Context, *InboundNatRuleListResultResponse) (*azcore.Request, error)
@@ -2125,6 +2468,8 @@ type inboundNatRuleListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester inboundNatRuleListResultCreateRequest
+	// callback for handling response errors
+	errorer inboundNatRuleListResultHandleError
 	// callback for handling the HTTP response
 	responder inboundNatRuleListResultHandleResponse
 	// callback for advancing to the next page
@@ -2155,6 +2500,13 @@ func (p *inboundNatRuleListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -2183,6 +2535,8 @@ type ListHubVirtualNetworkConnectionsResultPager interface {
 
 type listHubVirtualNetworkConnectionsResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type listHubVirtualNetworkConnectionsResultHandleError func(*azcore.Response) error
+
 type listHubVirtualNetworkConnectionsResultHandleResponse func(*azcore.Response) (*ListHubVirtualNetworkConnectionsResultResponse, error)
 
 type listHubVirtualNetworkConnectionsResultAdvancePage func(context.Context, *ListHubVirtualNetworkConnectionsResultResponse) (*azcore.Request, error)
@@ -2192,6 +2546,8 @@ type listHubVirtualNetworkConnectionsResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester listHubVirtualNetworkConnectionsResultCreateRequest
+	// callback for handling response errors
+	errorer listHubVirtualNetworkConnectionsResultHandleError
 	// callback for handling the HTTP response
 	responder listHubVirtualNetworkConnectionsResultHandleResponse
 	// callback for advancing to the next page
@@ -2222,6 +2578,13 @@ func (p *listHubVirtualNetworkConnectionsResultPager) NextPage(ctx context.Conte
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -2250,6 +2613,8 @@ type ListP2SVpnGatewaysResultPager interface {
 
 type listP2SVpnGatewaysResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type listP2SVpnGatewaysResultHandleError func(*azcore.Response) error
+
 type listP2SVpnGatewaysResultHandleResponse func(*azcore.Response) (*ListP2SVpnGatewaysResultResponse, error)
 
 type listP2SVpnGatewaysResultAdvancePage func(context.Context, *ListP2SVpnGatewaysResultResponse) (*azcore.Request, error)
@@ -2259,6 +2624,8 @@ type listP2SVpnGatewaysResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester listP2SVpnGatewaysResultCreateRequest
+	// callback for handling response errors
+	errorer listP2SVpnGatewaysResultHandleError
 	// callback for handling the HTTP response
 	responder listP2SVpnGatewaysResultHandleResponse
 	// callback for advancing to the next page
@@ -2289,6 +2656,13 @@ func (p *listP2SVpnGatewaysResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -2317,6 +2691,8 @@ type ListVirtualHubRouteTableV2SResultPager interface {
 
 type listVirtualHubRouteTableV2SResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type listVirtualHubRouteTableV2SResultHandleError func(*azcore.Response) error
+
 type listVirtualHubRouteTableV2SResultHandleResponse func(*azcore.Response) (*ListVirtualHubRouteTableV2SResultResponse, error)
 
 type listVirtualHubRouteTableV2SResultAdvancePage func(context.Context, *ListVirtualHubRouteTableV2SResultResponse) (*azcore.Request, error)
@@ -2326,6 +2702,8 @@ type listVirtualHubRouteTableV2SResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester listVirtualHubRouteTableV2SResultCreateRequest
+	// callback for handling response errors
+	errorer listVirtualHubRouteTableV2SResultHandleError
 	// callback for handling the HTTP response
 	responder listVirtualHubRouteTableV2SResultHandleResponse
 	// callback for advancing to the next page
@@ -2356,6 +2734,13 @@ func (p *listVirtualHubRouteTableV2SResultPager) NextPage(ctx context.Context) b
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -2384,6 +2769,8 @@ type ListVirtualHubsResultPager interface {
 
 type listVirtualHubsResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type listVirtualHubsResultHandleError func(*azcore.Response) error
+
 type listVirtualHubsResultHandleResponse func(*azcore.Response) (*ListVirtualHubsResultResponse, error)
 
 type listVirtualHubsResultAdvancePage func(context.Context, *ListVirtualHubsResultResponse) (*azcore.Request, error)
@@ -2393,6 +2780,8 @@ type listVirtualHubsResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester listVirtualHubsResultCreateRequest
+	// callback for handling response errors
+	errorer listVirtualHubsResultHandleError
 	// callback for handling the HTTP response
 	responder listVirtualHubsResultHandleResponse
 	// callback for advancing to the next page
@@ -2423,6 +2812,13 @@ func (p *listVirtualHubsResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -2451,6 +2847,8 @@ type ListVirtualWaNsResultPager interface {
 
 type listVirtualWaNsResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type listVirtualWaNsResultHandleError func(*azcore.Response) error
+
 type listVirtualWaNsResultHandleResponse func(*azcore.Response) (*ListVirtualWaNsResultResponse, error)
 
 type listVirtualWaNsResultAdvancePage func(context.Context, *ListVirtualWaNsResultResponse) (*azcore.Request, error)
@@ -2460,6 +2858,8 @@ type listVirtualWaNsResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester listVirtualWaNsResultCreateRequest
+	// callback for handling response errors
+	errorer listVirtualWaNsResultHandleError
 	// callback for handling the HTTP response
 	responder listVirtualWaNsResultHandleResponse
 	// callback for advancing to the next page
@@ -2490,6 +2890,13 @@ func (p *listVirtualWaNsResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -2518,6 +2925,8 @@ type ListVpnConnectionsResultPager interface {
 
 type listVpnConnectionsResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type listVpnConnectionsResultHandleError func(*azcore.Response) error
+
 type listVpnConnectionsResultHandleResponse func(*azcore.Response) (*ListVpnConnectionsResultResponse, error)
 
 type listVpnConnectionsResultAdvancePage func(context.Context, *ListVpnConnectionsResultResponse) (*azcore.Request, error)
@@ -2527,6 +2936,8 @@ type listVpnConnectionsResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester listVpnConnectionsResultCreateRequest
+	// callback for handling response errors
+	errorer listVpnConnectionsResultHandleError
 	// callback for handling the HTTP response
 	responder listVpnConnectionsResultHandleResponse
 	// callback for advancing to the next page
@@ -2557,6 +2968,13 @@ func (p *listVpnConnectionsResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -2585,6 +3003,8 @@ type ListVpnGatewaysResultPager interface {
 
 type listVpnGatewaysResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type listVpnGatewaysResultHandleError func(*azcore.Response) error
+
 type listVpnGatewaysResultHandleResponse func(*azcore.Response) (*ListVpnGatewaysResultResponse, error)
 
 type listVpnGatewaysResultAdvancePage func(context.Context, *ListVpnGatewaysResultResponse) (*azcore.Request, error)
@@ -2594,6 +3014,8 @@ type listVpnGatewaysResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester listVpnGatewaysResultCreateRequest
+	// callback for handling response errors
+	errorer listVpnGatewaysResultHandleError
 	// callback for handling the HTTP response
 	responder listVpnGatewaysResultHandleResponse
 	// callback for advancing to the next page
@@ -2624,6 +3046,13 @@ func (p *listVpnGatewaysResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -2652,6 +3081,8 @@ type ListVpnServerConfigurationsResultPager interface {
 
 type listVpnServerConfigurationsResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type listVpnServerConfigurationsResultHandleError func(*azcore.Response) error
+
 type listVpnServerConfigurationsResultHandleResponse func(*azcore.Response) (*ListVpnServerConfigurationsResultResponse, error)
 
 type listVpnServerConfigurationsResultAdvancePage func(context.Context, *ListVpnServerConfigurationsResultResponse) (*azcore.Request, error)
@@ -2661,6 +3092,8 @@ type listVpnServerConfigurationsResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester listVpnServerConfigurationsResultCreateRequest
+	// callback for handling response errors
+	errorer listVpnServerConfigurationsResultHandleError
 	// callback for handling the HTTP response
 	responder listVpnServerConfigurationsResultHandleResponse
 	// callback for advancing to the next page
@@ -2691,6 +3124,13 @@ func (p *listVpnServerConfigurationsResultPager) NextPage(ctx context.Context) b
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -2719,6 +3159,8 @@ type ListVpnSiteLinkConnectionsResultPager interface {
 
 type listVpnSiteLinkConnectionsResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type listVpnSiteLinkConnectionsResultHandleError func(*azcore.Response) error
+
 type listVpnSiteLinkConnectionsResultHandleResponse func(*azcore.Response) (*ListVpnSiteLinkConnectionsResultResponse, error)
 
 type listVpnSiteLinkConnectionsResultAdvancePage func(context.Context, *ListVpnSiteLinkConnectionsResultResponse) (*azcore.Request, error)
@@ -2728,6 +3170,8 @@ type listVpnSiteLinkConnectionsResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester listVpnSiteLinkConnectionsResultCreateRequest
+	// callback for handling response errors
+	errorer listVpnSiteLinkConnectionsResultHandleError
 	// callback for handling the HTTP response
 	responder listVpnSiteLinkConnectionsResultHandleResponse
 	// callback for advancing to the next page
@@ -2758,6 +3202,13 @@ func (p *listVpnSiteLinkConnectionsResultPager) NextPage(ctx context.Context) bo
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -2786,6 +3237,8 @@ type ListVpnSiteLinksResultPager interface {
 
 type listVpnSiteLinksResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type listVpnSiteLinksResultHandleError func(*azcore.Response) error
+
 type listVpnSiteLinksResultHandleResponse func(*azcore.Response) (*ListVpnSiteLinksResultResponse, error)
 
 type listVpnSiteLinksResultAdvancePage func(context.Context, *ListVpnSiteLinksResultResponse) (*azcore.Request, error)
@@ -2795,6 +3248,8 @@ type listVpnSiteLinksResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester listVpnSiteLinksResultCreateRequest
+	// callback for handling response errors
+	errorer listVpnSiteLinksResultHandleError
 	// callback for handling the HTTP response
 	responder listVpnSiteLinksResultHandleResponse
 	// callback for advancing to the next page
@@ -2825,6 +3280,13 @@ func (p *listVpnSiteLinksResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -2853,6 +3315,8 @@ type ListVpnSitesResultPager interface {
 
 type listVpnSitesResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type listVpnSitesResultHandleError func(*azcore.Response) error
+
 type listVpnSitesResultHandleResponse func(*azcore.Response) (*ListVpnSitesResultResponse, error)
 
 type listVpnSitesResultAdvancePage func(context.Context, *ListVpnSitesResultResponse) (*azcore.Request, error)
@@ -2862,6 +3326,8 @@ type listVpnSitesResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester listVpnSitesResultCreateRequest
+	// callback for handling response errors
+	errorer listVpnSitesResultHandleError
 	// callback for handling the HTTP response
 	responder listVpnSitesResultHandleResponse
 	// callback for advancing to the next page
@@ -2892,6 +3358,13 @@ func (p *listVpnSitesResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -2920,6 +3393,8 @@ type LoadBalancerBackendAddressPoolListResultPager interface {
 
 type loadBalancerBackendAddressPoolListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type loadBalancerBackendAddressPoolListResultHandleError func(*azcore.Response) error
+
 type loadBalancerBackendAddressPoolListResultHandleResponse func(*azcore.Response) (*LoadBalancerBackendAddressPoolListResultResponse, error)
 
 type loadBalancerBackendAddressPoolListResultAdvancePage func(context.Context, *LoadBalancerBackendAddressPoolListResultResponse) (*azcore.Request, error)
@@ -2929,6 +3404,8 @@ type loadBalancerBackendAddressPoolListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester loadBalancerBackendAddressPoolListResultCreateRequest
+	// callback for handling response errors
+	errorer loadBalancerBackendAddressPoolListResultHandleError
 	// callback for handling the HTTP response
 	responder loadBalancerBackendAddressPoolListResultHandleResponse
 	// callback for advancing to the next page
@@ -2959,6 +3436,13 @@ func (p *loadBalancerBackendAddressPoolListResultPager) NextPage(ctx context.Con
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -2987,6 +3471,8 @@ type LoadBalancerFrontendIPConfigurationListResultPager interface {
 
 type loadBalancerFrontendIPConfigurationListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type loadBalancerFrontendIPConfigurationListResultHandleError func(*azcore.Response) error
+
 type loadBalancerFrontendIPConfigurationListResultHandleResponse func(*azcore.Response) (*LoadBalancerFrontendIPConfigurationListResultResponse, error)
 
 type loadBalancerFrontendIPConfigurationListResultAdvancePage func(context.Context, *LoadBalancerFrontendIPConfigurationListResultResponse) (*azcore.Request, error)
@@ -2996,6 +3482,8 @@ type loadBalancerFrontendIPConfigurationListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester loadBalancerFrontendIPConfigurationListResultCreateRequest
+	// callback for handling response errors
+	errorer loadBalancerFrontendIPConfigurationListResultHandleError
 	// callback for handling the HTTP response
 	responder loadBalancerFrontendIPConfigurationListResultHandleResponse
 	// callback for advancing to the next page
@@ -3026,6 +3514,13 @@ func (p *loadBalancerFrontendIPConfigurationListResultPager) NextPage(ctx contex
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -3054,6 +3549,8 @@ type LoadBalancerListResultPager interface {
 
 type loadBalancerListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type loadBalancerListResultHandleError func(*azcore.Response) error
+
 type loadBalancerListResultHandleResponse func(*azcore.Response) (*LoadBalancerListResultResponse, error)
 
 type loadBalancerListResultAdvancePage func(context.Context, *LoadBalancerListResultResponse) (*azcore.Request, error)
@@ -3063,6 +3560,8 @@ type loadBalancerListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester loadBalancerListResultCreateRequest
+	// callback for handling response errors
+	errorer loadBalancerListResultHandleError
 	// callback for handling the HTTP response
 	responder loadBalancerListResultHandleResponse
 	// callback for advancing to the next page
@@ -3093,6 +3592,13 @@ func (p *loadBalancerListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -3121,6 +3627,8 @@ type LoadBalancerLoadBalancingRuleListResultPager interface {
 
 type loadBalancerLoadBalancingRuleListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type loadBalancerLoadBalancingRuleListResultHandleError func(*azcore.Response) error
+
 type loadBalancerLoadBalancingRuleListResultHandleResponse func(*azcore.Response) (*LoadBalancerLoadBalancingRuleListResultResponse, error)
 
 type loadBalancerLoadBalancingRuleListResultAdvancePage func(context.Context, *LoadBalancerLoadBalancingRuleListResultResponse) (*azcore.Request, error)
@@ -3130,6 +3638,8 @@ type loadBalancerLoadBalancingRuleListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester loadBalancerLoadBalancingRuleListResultCreateRequest
+	// callback for handling response errors
+	errorer loadBalancerLoadBalancingRuleListResultHandleError
 	// callback for handling the HTTP response
 	responder loadBalancerLoadBalancingRuleListResultHandleResponse
 	// callback for advancing to the next page
@@ -3160,6 +3670,13 @@ func (p *loadBalancerLoadBalancingRuleListResultPager) NextPage(ctx context.Cont
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -3188,6 +3705,8 @@ type LoadBalancerOutboundRuleListResultPager interface {
 
 type loadBalancerOutboundRuleListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type loadBalancerOutboundRuleListResultHandleError func(*azcore.Response) error
+
 type loadBalancerOutboundRuleListResultHandleResponse func(*azcore.Response) (*LoadBalancerOutboundRuleListResultResponse, error)
 
 type loadBalancerOutboundRuleListResultAdvancePage func(context.Context, *LoadBalancerOutboundRuleListResultResponse) (*azcore.Request, error)
@@ -3197,6 +3716,8 @@ type loadBalancerOutboundRuleListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester loadBalancerOutboundRuleListResultCreateRequest
+	// callback for handling response errors
+	errorer loadBalancerOutboundRuleListResultHandleError
 	// callback for handling the HTTP response
 	responder loadBalancerOutboundRuleListResultHandleResponse
 	// callback for advancing to the next page
@@ -3227,6 +3748,13 @@ func (p *loadBalancerOutboundRuleListResultPager) NextPage(ctx context.Context) 
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -3255,6 +3783,8 @@ type LoadBalancerProbeListResultPager interface {
 
 type loadBalancerProbeListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type loadBalancerProbeListResultHandleError func(*azcore.Response) error
+
 type loadBalancerProbeListResultHandleResponse func(*azcore.Response) (*LoadBalancerProbeListResultResponse, error)
 
 type loadBalancerProbeListResultAdvancePage func(context.Context, *LoadBalancerProbeListResultResponse) (*azcore.Request, error)
@@ -3264,6 +3794,8 @@ type loadBalancerProbeListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester loadBalancerProbeListResultCreateRequest
+	// callback for handling response errors
+	errorer loadBalancerProbeListResultHandleError
 	// callback for handling the HTTP response
 	responder loadBalancerProbeListResultHandleResponse
 	// callback for advancing to the next page
@@ -3294,6 +3826,13 @@ func (p *loadBalancerProbeListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -3322,6 +3861,8 @@ type LocalNetworkGatewayListResultPager interface {
 
 type localNetworkGatewayListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type localNetworkGatewayListResultHandleError func(*azcore.Response) error
+
 type localNetworkGatewayListResultHandleResponse func(*azcore.Response) (*LocalNetworkGatewayListResultResponse, error)
 
 type localNetworkGatewayListResultAdvancePage func(context.Context, *LocalNetworkGatewayListResultResponse) (*azcore.Request, error)
@@ -3331,6 +3872,8 @@ type localNetworkGatewayListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester localNetworkGatewayListResultCreateRequest
+	// callback for handling response errors
+	errorer localNetworkGatewayListResultHandleError
 	// callback for handling the HTTP response
 	responder localNetworkGatewayListResultHandleResponse
 	// callback for advancing to the next page
@@ -3361,6 +3904,13 @@ func (p *localNetworkGatewayListResultPager) NextPage(ctx context.Context) bool 
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -3389,6 +3939,8 @@ type NatGatewayListResultPager interface {
 
 type natGatewayListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type natGatewayListResultHandleError func(*azcore.Response) error
+
 type natGatewayListResultHandleResponse func(*azcore.Response) (*NatGatewayListResultResponse, error)
 
 type natGatewayListResultAdvancePage func(context.Context, *NatGatewayListResultResponse) (*azcore.Request, error)
@@ -3398,6 +3950,8 @@ type natGatewayListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester natGatewayListResultCreateRequest
+	// callback for handling response errors
+	errorer natGatewayListResultHandleError
 	// callback for handling the HTTP response
 	responder natGatewayListResultHandleResponse
 	// callback for advancing to the next page
@@ -3428,6 +3982,13 @@ func (p *natGatewayListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -3456,6 +4017,8 @@ type NetworkInterfaceIPConfigurationListResultPager interface {
 
 type networkInterfaceIPConfigurationListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type networkInterfaceIPConfigurationListResultHandleError func(*azcore.Response) error
+
 type networkInterfaceIPConfigurationListResultHandleResponse func(*azcore.Response) (*NetworkInterfaceIPConfigurationListResultResponse, error)
 
 type networkInterfaceIPConfigurationListResultAdvancePage func(context.Context, *NetworkInterfaceIPConfigurationListResultResponse) (*azcore.Request, error)
@@ -3465,6 +4028,8 @@ type networkInterfaceIPConfigurationListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester networkInterfaceIPConfigurationListResultCreateRequest
+	// callback for handling response errors
+	errorer networkInterfaceIPConfigurationListResultHandleError
 	// callback for handling the HTTP response
 	responder networkInterfaceIPConfigurationListResultHandleResponse
 	// callback for advancing to the next page
@@ -3495,6 +4060,13 @@ func (p *networkInterfaceIPConfigurationListResultPager) NextPage(ctx context.Co
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -3523,6 +4095,8 @@ type NetworkInterfaceListResultPager interface {
 
 type networkInterfaceListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type networkInterfaceListResultHandleError func(*azcore.Response) error
+
 type networkInterfaceListResultHandleResponse func(*azcore.Response) (*NetworkInterfaceListResultResponse, error)
 
 type networkInterfaceListResultAdvancePage func(context.Context, *NetworkInterfaceListResultResponse) (*azcore.Request, error)
@@ -3532,6 +4106,8 @@ type networkInterfaceListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester networkInterfaceListResultCreateRequest
+	// callback for handling response errors
+	errorer networkInterfaceListResultHandleError
 	// callback for handling the HTTP response
 	responder networkInterfaceListResultHandleResponse
 	// callback for advancing to the next page
@@ -3562,6 +4138,13 @@ func (p *networkInterfaceListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -3590,6 +4173,8 @@ type NetworkInterfaceLoadBalancerListResultPager interface {
 
 type networkInterfaceLoadBalancerListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type networkInterfaceLoadBalancerListResultHandleError func(*azcore.Response) error
+
 type networkInterfaceLoadBalancerListResultHandleResponse func(*azcore.Response) (*NetworkInterfaceLoadBalancerListResultResponse, error)
 
 type networkInterfaceLoadBalancerListResultAdvancePage func(context.Context, *NetworkInterfaceLoadBalancerListResultResponse) (*azcore.Request, error)
@@ -3599,6 +4184,8 @@ type networkInterfaceLoadBalancerListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester networkInterfaceLoadBalancerListResultCreateRequest
+	// callback for handling response errors
+	errorer networkInterfaceLoadBalancerListResultHandleError
 	// callback for handling the HTTP response
 	responder networkInterfaceLoadBalancerListResultHandleResponse
 	// callback for advancing to the next page
@@ -3629,6 +4216,13 @@ func (p *networkInterfaceLoadBalancerListResultPager) NextPage(ctx context.Conte
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -3657,6 +4251,8 @@ type NetworkInterfaceTapConfigurationListResultPager interface {
 
 type networkInterfaceTapConfigurationListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type networkInterfaceTapConfigurationListResultHandleError func(*azcore.Response) error
+
 type networkInterfaceTapConfigurationListResultHandleResponse func(*azcore.Response) (*NetworkInterfaceTapConfigurationListResultResponse, error)
 
 type networkInterfaceTapConfigurationListResultAdvancePage func(context.Context, *NetworkInterfaceTapConfigurationListResultResponse) (*azcore.Request, error)
@@ -3666,6 +4262,8 @@ type networkInterfaceTapConfigurationListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester networkInterfaceTapConfigurationListResultCreateRequest
+	// callback for handling response errors
+	errorer networkInterfaceTapConfigurationListResultHandleError
 	// callback for handling the HTTP response
 	responder networkInterfaceTapConfigurationListResultHandleResponse
 	// callback for advancing to the next page
@@ -3696,6 +4294,13 @@ func (p *networkInterfaceTapConfigurationListResultPager) NextPage(ctx context.C
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -3724,6 +4329,8 @@ type NetworkProfileListResultPager interface {
 
 type networkProfileListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type networkProfileListResultHandleError func(*azcore.Response) error
+
 type networkProfileListResultHandleResponse func(*azcore.Response) (*NetworkProfileListResultResponse, error)
 
 type networkProfileListResultAdvancePage func(context.Context, *NetworkProfileListResultResponse) (*azcore.Request, error)
@@ -3733,6 +4340,8 @@ type networkProfileListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester networkProfileListResultCreateRequest
+	// callback for handling response errors
+	errorer networkProfileListResultHandleError
 	// callback for handling the HTTP response
 	responder networkProfileListResultHandleResponse
 	// callback for advancing to the next page
@@ -3763,6 +4372,13 @@ func (p *networkProfileListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -3791,6 +4407,8 @@ type NetworkSecurityGroupListResultPager interface {
 
 type networkSecurityGroupListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type networkSecurityGroupListResultHandleError func(*azcore.Response) error
+
 type networkSecurityGroupListResultHandleResponse func(*azcore.Response) (*NetworkSecurityGroupListResultResponse, error)
 
 type networkSecurityGroupListResultAdvancePage func(context.Context, *NetworkSecurityGroupListResultResponse) (*azcore.Request, error)
@@ -3800,6 +4418,8 @@ type networkSecurityGroupListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester networkSecurityGroupListResultCreateRequest
+	// callback for handling response errors
+	errorer networkSecurityGroupListResultHandleError
 	// callback for handling the HTTP response
 	responder networkSecurityGroupListResultHandleResponse
 	// callback for advancing to the next page
@@ -3830,6 +4450,13 @@ func (p *networkSecurityGroupListResultPager) NextPage(ctx context.Context) bool
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -3858,6 +4485,8 @@ type NetworkVirtualApplianceListResultPager interface {
 
 type networkVirtualApplianceListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type networkVirtualApplianceListResultHandleError func(*azcore.Response) error
+
 type networkVirtualApplianceListResultHandleResponse func(*azcore.Response) (*NetworkVirtualApplianceListResultResponse, error)
 
 type networkVirtualApplianceListResultAdvancePage func(context.Context, *NetworkVirtualApplianceListResultResponse) (*azcore.Request, error)
@@ -3867,6 +4496,8 @@ type networkVirtualApplianceListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester networkVirtualApplianceListResultCreateRequest
+	// callback for handling response errors
+	errorer networkVirtualApplianceListResultHandleError
 	// callback for handling the HTTP response
 	responder networkVirtualApplianceListResultHandleResponse
 	// callback for advancing to the next page
@@ -3897,6 +4528,13 @@ func (p *networkVirtualApplianceListResultPager) NextPage(ctx context.Context) b
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -3925,6 +4563,8 @@ type OperationListResultPager interface {
 
 type operationListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type operationListResultHandleError func(*azcore.Response) error
+
 type operationListResultHandleResponse func(*azcore.Response) (*OperationListResultResponse, error)
 
 type operationListResultAdvancePage func(context.Context, *OperationListResultResponse) (*azcore.Request, error)
@@ -3934,6 +4574,8 @@ type operationListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester operationListResultCreateRequest
+	// callback for handling response errors
+	errorer operationListResultHandleError
 	// callback for handling the HTTP response
 	responder operationListResultHandleResponse
 	// callback for advancing to the next page
@@ -3964,6 +4606,13 @@ func (p *operationListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -3992,6 +4641,8 @@ type PeerExpressRouteCircuitConnectionListResultPager interface {
 
 type peerExpressRouteCircuitConnectionListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type peerExpressRouteCircuitConnectionListResultHandleError func(*azcore.Response) error
+
 type peerExpressRouteCircuitConnectionListResultHandleResponse func(*azcore.Response) (*PeerExpressRouteCircuitConnectionListResultResponse, error)
 
 type peerExpressRouteCircuitConnectionListResultAdvancePage func(context.Context, *PeerExpressRouteCircuitConnectionListResultResponse) (*azcore.Request, error)
@@ -4001,6 +4652,8 @@ type peerExpressRouteCircuitConnectionListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester peerExpressRouteCircuitConnectionListResultCreateRequest
+	// callback for handling response errors
+	errorer peerExpressRouteCircuitConnectionListResultHandleError
 	// callback for handling the HTTP response
 	responder peerExpressRouteCircuitConnectionListResultHandleResponse
 	// callback for advancing to the next page
@@ -4031,6 +4684,13 @@ func (p *peerExpressRouteCircuitConnectionListResultPager) NextPage(ctx context.
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -4059,6 +4719,8 @@ type PrivateDNSZoneGroupListResultPager interface {
 
 type privateDnsZoneGroupListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type privateDnsZoneGroupListResultHandleError func(*azcore.Response) error
+
 type privateDnsZoneGroupListResultHandleResponse func(*azcore.Response) (*PrivateDNSZoneGroupListResultResponse, error)
 
 type privateDnsZoneGroupListResultAdvancePage func(context.Context, *PrivateDNSZoneGroupListResultResponse) (*azcore.Request, error)
@@ -4068,6 +4730,8 @@ type privateDnsZoneGroupListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester privateDnsZoneGroupListResultCreateRequest
+	// callback for handling response errors
+	errorer privateDnsZoneGroupListResultHandleError
 	// callback for handling the HTTP response
 	responder privateDnsZoneGroupListResultHandleResponse
 	// callback for advancing to the next page
@@ -4098,6 +4762,13 @@ func (p *privateDnsZoneGroupListResultPager) NextPage(ctx context.Context) bool 
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -4126,6 +4797,8 @@ type PrivateEndpointConnectionListResultPager interface {
 
 type privateEndpointConnectionListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type privateEndpointConnectionListResultHandleError func(*azcore.Response) error
+
 type privateEndpointConnectionListResultHandleResponse func(*azcore.Response) (*PrivateEndpointConnectionListResultResponse, error)
 
 type privateEndpointConnectionListResultAdvancePage func(context.Context, *PrivateEndpointConnectionListResultResponse) (*azcore.Request, error)
@@ -4135,6 +4808,8 @@ type privateEndpointConnectionListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester privateEndpointConnectionListResultCreateRequest
+	// callback for handling response errors
+	errorer privateEndpointConnectionListResultHandleError
 	// callback for handling the HTTP response
 	responder privateEndpointConnectionListResultHandleResponse
 	// callback for advancing to the next page
@@ -4165,6 +4840,13 @@ func (p *privateEndpointConnectionListResultPager) NextPage(ctx context.Context)
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -4193,6 +4875,8 @@ type PrivateEndpointListResultPager interface {
 
 type privateEndpointListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type privateEndpointListResultHandleError func(*azcore.Response) error
+
 type privateEndpointListResultHandleResponse func(*azcore.Response) (*PrivateEndpointListResultResponse, error)
 
 type privateEndpointListResultAdvancePage func(context.Context, *PrivateEndpointListResultResponse) (*azcore.Request, error)
@@ -4202,6 +4886,8 @@ type privateEndpointListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester privateEndpointListResultCreateRequest
+	// callback for handling response errors
+	errorer privateEndpointListResultHandleError
 	// callback for handling the HTTP response
 	responder privateEndpointListResultHandleResponse
 	// callback for advancing to the next page
@@ -4232,6 +4918,13 @@ func (p *privateEndpointListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -4260,6 +4953,8 @@ type PrivateLinkServiceListResultPager interface {
 
 type privateLinkServiceListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type privateLinkServiceListResultHandleError func(*azcore.Response) error
+
 type privateLinkServiceListResultHandleResponse func(*azcore.Response) (*PrivateLinkServiceListResultResponse, error)
 
 type privateLinkServiceListResultAdvancePage func(context.Context, *PrivateLinkServiceListResultResponse) (*azcore.Request, error)
@@ -4269,6 +4964,8 @@ type privateLinkServiceListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester privateLinkServiceListResultCreateRequest
+	// callback for handling response errors
+	errorer privateLinkServiceListResultHandleError
 	// callback for handling the HTTP response
 	responder privateLinkServiceListResultHandleResponse
 	// callback for advancing to the next page
@@ -4299,6 +4996,13 @@ func (p *privateLinkServiceListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -4327,6 +5031,8 @@ type PublicIPAddressListResultPager interface {
 
 type publicIPAddressListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type publicIPAddressListResultHandleError func(*azcore.Response) error
+
 type publicIPAddressListResultHandleResponse func(*azcore.Response) (*PublicIPAddressListResultResponse, error)
 
 type publicIPAddressListResultAdvancePage func(context.Context, *PublicIPAddressListResultResponse) (*azcore.Request, error)
@@ -4336,6 +5042,8 @@ type publicIPAddressListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester publicIPAddressListResultCreateRequest
+	// callback for handling response errors
+	errorer publicIPAddressListResultHandleError
 	// callback for handling the HTTP response
 	responder publicIPAddressListResultHandleResponse
 	// callback for advancing to the next page
@@ -4366,6 +5074,13 @@ func (p *publicIPAddressListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -4394,6 +5109,8 @@ type PublicIPPrefixListResultPager interface {
 
 type publicIPPrefixListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type publicIPPrefixListResultHandleError func(*azcore.Response) error
+
 type publicIPPrefixListResultHandleResponse func(*azcore.Response) (*PublicIPPrefixListResultResponse, error)
 
 type publicIPPrefixListResultAdvancePage func(context.Context, *PublicIPPrefixListResultResponse) (*azcore.Request, error)
@@ -4403,6 +5120,8 @@ type publicIPPrefixListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester publicIPPrefixListResultCreateRequest
+	// callback for handling response errors
+	errorer publicIPPrefixListResultHandleError
 	// callback for handling the HTTP response
 	responder publicIPPrefixListResultHandleResponse
 	// callback for advancing to the next page
@@ -4433,6 +5152,13 @@ func (p *publicIPPrefixListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -4461,6 +5187,8 @@ type RouteFilterListResultPager interface {
 
 type routeFilterListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type routeFilterListResultHandleError func(*azcore.Response) error
+
 type routeFilterListResultHandleResponse func(*azcore.Response) (*RouteFilterListResultResponse, error)
 
 type routeFilterListResultAdvancePage func(context.Context, *RouteFilterListResultResponse) (*azcore.Request, error)
@@ -4470,6 +5198,8 @@ type routeFilterListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester routeFilterListResultCreateRequest
+	// callback for handling response errors
+	errorer routeFilterListResultHandleError
 	// callback for handling the HTTP response
 	responder routeFilterListResultHandleResponse
 	// callback for advancing to the next page
@@ -4500,6 +5230,13 @@ func (p *routeFilterListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -4528,6 +5265,8 @@ type RouteFilterRuleListResultPager interface {
 
 type routeFilterRuleListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type routeFilterRuleListResultHandleError func(*azcore.Response) error
+
 type routeFilterRuleListResultHandleResponse func(*azcore.Response) (*RouteFilterRuleListResultResponse, error)
 
 type routeFilterRuleListResultAdvancePage func(context.Context, *RouteFilterRuleListResultResponse) (*azcore.Request, error)
@@ -4537,6 +5276,8 @@ type routeFilterRuleListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester routeFilterRuleListResultCreateRequest
+	// callback for handling response errors
+	errorer routeFilterRuleListResultHandleError
 	// callback for handling the HTTP response
 	responder routeFilterRuleListResultHandleResponse
 	// callback for advancing to the next page
@@ -4567,6 +5308,13 @@ func (p *routeFilterRuleListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -4595,6 +5343,8 @@ type RouteListResultPager interface {
 
 type routeListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type routeListResultHandleError func(*azcore.Response) error
+
 type routeListResultHandleResponse func(*azcore.Response) (*RouteListResultResponse, error)
 
 type routeListResultAdvancePage func(context.Context, *RouteListResultResponse) (*azcore.Request, error)
@@ -4604,6 +5354,8 @@ type routeListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester routeListResultCreateRequest
+	// callback for handling response errors
+	errorer routeListResultHandleError
 	// callback for handling the HTTP response
 	responder routeListResultHandleResponse
 	// callback for advancing to the next page
@@ -4634,6 +5386,13 @@ func (p *routeListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -4662,6 +5421,8 @@ type RouteTableListResultPager interface {
 
 type routeTableListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type routeTableListResultHandleError func(*azcore.Response) error
+
 type routeTableListResultHandleResponse func(*azcore.Response) (*RouteTableListResultResponse, error)
 
 type routeTableListResultAdvancePage func(context.Context, *RouteTableListResultResponse) (*azcore.Request, error)
@@ -4671,6 +5432,8 @@ type routeTableListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester routeTableListResultCreateRequest
+	// callback for handling response errors
+	errorer routeTableListResultHandleError
 	// callback for handling the HTTP response
 	responder routeTableListResultHandleResponse
 	// callback for advancing to the next page
@@ -4701,6 +5464,13 @@ func (p *routeTableListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -4729,6 +5499,8 @@ type SecurityPartnerProviderListResultPager interface {
 
 type securityPartnerProviderListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type securityPartnerProviderListResultHandleError func(*azcore.Response) error
+
 type securityPartnerProviderListResultHandleResponse func(*azcore.Response) (*SecurityPartnerProviderListResultResponse, error)
 
 type securityPartnerProviderListResultAdvancePage func(context.Context, *SecurityPartnerProviderListResultResponse) (*azcore.Request, error)
@@ -4738,6 +5510,8 @@ type securityPartnerProviderListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester securityPartnerProviderListResultCreateRequest
+	// callback for handling response errors
+	errorer securityPartnerProviderListResultHandleError
 	// callback for handling the HTTP response
 	responder securityPartnerProviderListResultHandleResponse
 	// callback for advancing to the next page
@@ -4768,6 +5542,13 @@ func (p *securityPartnerProviderListResultPager) NextPage(ctx context.Context) b
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -4796,6 +5577,8 @@ type SecurityRuleListResultPager interface {
 
 type securityRuleListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type securityRuleListResultHandleError func(*azcore.Response) error
+
 type securityRuleListResultHandleResponse func(*azcore.Response) (*SecurityRuleListResultResponse, error)
 
 type securityRuleListResultAdvancePage func(context.Context, *SecurityRuleListResultResponse) (*azcore.Request, error)
@@ -4805,6 +5588,8 @@ type securityRuleListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester securityRuleListResultCreateRequest
+	// callback for handling response errors
+	errorer securityRuleListResultHandleError
 	// callback for handling the HTTP response
 	responder securityRuleListResultHandleResponse
 	// callback for advancing to the next page
@@ -4835,6 +5620,13 @@ func (p *securityRuleListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -4863,6 +5655,8 @@ type ServiceEndpointPolicyDefinitionListResultPager interface {
 
 type serviceEndpointPolicyDefinitionListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type serviceEndpointPolicyDefinitionListResultHandleError func(*azcore.Response) error
+
 type serviceEndpointPolicyDefinitionListResultHandleResponse func(*azcore.Response) (*ServiceEndpointPolicyDefinitionListResultResponse, error)
 
 type serviceEndpointPolicyDefinitionListResultAdvancePage func(context.Context, *ServiceEndpointPolicyDefinitionListResultResponse) (*azcore.Request, error)
@@ -4872,6 +5666,8 @@ type serviceEndpointPolicyDefinitionListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester serviceEndpointPolicyDefinitionListResultCreateRequest
+	// callback for handling response errors
+	errorer serviceEndpointPolicyDefinitionListResultHandleError
 	// callback for handling the HTTP response
 	responder serviceEndpointPolicyDefinitionListResultHandleResponse
 	// callback for advancing to the next page
@@ -4902,6 +5698,13 @@ func (p *serviceEndpointPolicyDefinitionListResultPager) NextPage(ctx context.Co
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -4930,6 +5733,8 @@ type ServiceEndpointPolicyListResultPager interface {
 
 type serviceEndpointPolicyListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type serviceEndpointPolicyListResultHandleError func(*azcore.Response) error
+
 type serviceEndpointPolicyListResultHandleResponse func(*azcore.Response) (*ServiceEndpointPolicyListResultResponse, error)
 
 type serviceEndpointPolicyListResultAdvancePage func(context.Context, *ServiceEndpointPolicyListResultResponse) (*azcore.Request, error)
@@ -4939,6 +5744,8 @@ type serviceEndpointPolicyListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester serviceEndpointPolicyListResultCreateRequest
+	// callback for handling response errors
+	errorer serviceEndpointPolicyListResultHandleError
 	// callback for handling the HTTP response
 	responder serviceEndpointPolicyListResultHandleResponse
 	// callback for advancing to the next page
@@ -4969,6 +5776,13 @@ func (p *serviceEndpointPolicyListResultPager) NextPage(ctx context.Context) boo
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -4997,6 +5811,8 @@ type SubnetListResultPager interface {
 
 type subnetListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type subnetListResultHandleError func(*azcore.Response) error
+
 type subnetListResultHandleResponse func(*azcore.Response) (*SubnetListResultResponse, error)
 
 type subnetListResultAdvancePage func(context.Context, *SubnetListResultResponse) (*azcore.Request, error)
@@ -5006,6 +5822,8 @@ type subnetListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester subnetListResultCreateRequest
+	// callback for handling response errors
+	errorer subnetListResultHandleError
 	// callback for handling the HTTP response
 	responder subnetListResultHandleResponse
 	// callback for advancing to the next page
@@ -5036,6 +5854,13 @@ func (p *subnetListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -5064,6 +5889,8 @@ type UsagesListResultPager interface {
 
 type usagesListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type usagesListResultHandleError func(*azcore.Response) error
+
 type usagesListResultHandleResponse func(*azcore.Response) (*UsagesListResultResponse, error)
 
 type usagesListResultAdvancePage func(context.Context, *UsagesListResultResponse) (*azcore.Request, error)
@@ -5073,6 +5900,8 @@ type usagesListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester usagesListResultCreateRequest
+	// callback for handling response errors
+	errorer usagesListResultHandleError
 	// callback for handling the HTTP response
 	responder usagesListResultHandleResponse
 	// callback for advancing to the next page
@@ -5103,6 +5932,13 @@ func (p *usagesListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -5131,6 +5967,8 @@ type VirtualNetworkGatewayConnectionListResultPager interface {
 
 type virtualNetworkGatewayConnectionListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type virtualNetworkGatewayConnectionListResultHandleError func(*azcore.Response) error
+
 type virtualNetworkGatewayConnectionListResultHandleResponse func(*azcore.Response) (*VirtualNetworkGatewayConnectionListResultResponse, error)
 
 type virtualNetworkGatewayConnectionListResultAdvancePage func(context.Context, *VirtualNetworkGatewayConnectionListResultResponse) (*azcore.Request, error)
@@ -5140,6 +5978,8 @@ type virtualNetworkGatewayConnectionListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester virtualNetworkGatewayConnectionListResultCreateRequest
+	// callback for handling response errors
+	errorer virtualNetworkGatewayConnectionListResultHandleError
 	// callback for handling the HTTP response
 	responder virtualNetworkGatewayConnectionListResultHandleResponse
 	// callback for advancing to the next page
@@ -5170,6 +6010,13 @@ func (p *virtualNetworkGatewayConnectionListResultPager) NextPage(ctx context.Co
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -5198,6 +6045,8 @@ type VirtualNetworkGatewayListConnectionsResultPager interface {
 
 type virtualNetworkGatewayListConnectionsResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type virtualNetworkGatewayListConnectionsResultHandleError func(*azcore.Response) error
+
 type virtualNetworkGatewayListConnectionsResultHandleResponse func(*azcore.Response) (*VirtualNetworkGatewayListConnectionsResultResponse, error)
 
 type virtualNetworkGatewayListConnectionsResultAdvancePage func(context.Context, *VirtualNetworkGatewayListConnectionsResultResponse) (*azcore.Request, error)
@@ -5207,6 +6056,8 @@ type virtualNetworkGatewayListConnectionsResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester virtualNetworkGatewayListConnectionsResultCreateRequest
+	// callback for handling response errors
+	errorer virtualNetworkGatewayListConnectionsResultHandleError
 	// callback for handling the HTTP response
 	responder virtualNetworkGatewayListConnectionsResultHandleResponse
 	// callback for advancing to the next page
@@ -5237,6 +6088,13 @@ func (p *virtualNetworkGatewayListConnectionsResultPager) NextPage(ctx context.C
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -5265,6 +6123,8 @@ type VirtualNetworkGatewayListResultPager interface {
 
 type virtualNetworkGatewayListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type virtualNetworkGatewayListResultHandleError func(*azcore.Response) error
+
 type virtualNetworkGatewayListResultHandleResponse func(*azcore.Response) (*VirtualNetworkGatewayListResultResponse, error)
 
 type virtualNetworkGatewayListResultAdvancePage func(context.Context, *VirtualNetworkGatewayListResultResponse) (*azcore.Request, error)
@@ -5274,6 +6134,8 @@ type virtualNetworkGatewayListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester virtualNetworkGatewayListResultCreateRequest
+	// callback for handling response errors
+	errorer virtualNetworkGatewayListResultHandleError
 	// callback for handling the HTTP response
 	responder virtualNetworkGatewayListResultHandleResponse
 	// callback for advancing to the next page
@@ -5304,6 +6166,13 @@ func (p *virtualNetworkGatewayListResultPager) NextPage(ctx context.Context) boo
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -5332,6 +6201,8 @@ type VirtualNetworkListResultPager interface {
 
 type virtualNetworkListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type virtualNetworkListResultHandleError func(*azcore.Response) error
+
 type virtualNetworkListResultHandleResponse func(*azcore.Response) (*VirtualNetworkListResultResponse, error)
 
 type virtualNetworkListResultAdvancePage func(context.Context, *VirtualNetworkListResultResponse) (*azcore.Request, error)
@@ -5341,6 +6212,8 @@ type virtualNetworkListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester virtualNetworkListResultCreateRequest
+	// callback for handling response errors
+	errorer virtualNetworkListResultHandleError
 	// callback for handling the HTTP response
 	responder virtualNetworkListResultHandleResponse
 	// callback for advancing to the next page
@@ -5371,6 +6244,13 @@ func (p *virtualNetworkListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -5399,6 +6279,8 @@ type VirtualNetworkListUsageResultPager interface {
 
 type virtualNetworkListUsageResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type virtualNetworkListUsageResultHandleError func(*azcore.Response) error
+
 type virtualNetworkListUsageResultHandleResponse func(*azcore.Response) (*VirtualNetworkListUsageResultResponse, error)
 
 type virtualNetworkListUsageResultAdvancePage func(context.Context, *VirtualNetworkListUsageResultResponse) (*azcore.Request, error)
@@ -5408,6 +6290,8 @@ type virtualNetworkListUsageResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester virtualNetworkListUsageResultCreateRequest
+	// callback for handling response errors
+	errorer virtualNetworkListUsageResultHandleError
 	// callback for handling the HTTP response
 	responder virtualNetworkListUsageResultHandleResponse
 	// callback for advancing to the next page
@@ -5438,6 +6322,13 @@ func (p *virtualNetworkListUsageResultPager) NextPage(ctx context.Context) bool 
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -5466,6 +6357,8 @@ type VirtualNetworkPeeringListResultPager interface {
 
 type virtualNetworkPeeringListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type virtualNetworkPeeringListResultHandleError func(*azcore.Response) error
+
 type virtualNetworkPeeringListResultHandleResponse func(*azcore.Response) (*VirtualNetworkPeeringListResultResponse, error)
 
 type virtualNetworkPeeringListResultAdvancePage func(context.Context, *VirtualNetworkPeeringListResultResponse) (*azcore.Request, error)
@@ -5475,6 +6368,8 @@ type virtualNetworkPeeringListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester virtualNetworkPeeringListResultCreateRequest
+	// callback for handling response errors
+	errorer virtualNetworkPeeringListResultHandleError
 	// callback for handling the HTTP response
 	responder virtualNetworkPeeringListResultHandleResponse
 	// callback for advancing to the next page
@@ -5505,6 +6400,13 @@ func (p *virtualNetworkPeeringListResultPager) NextPage(ctx context.Context) boo
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -5533,6 +6435,8 @@ type VirtualNetworkTapListResultPager interface {
 
 type virtualNetworkTapListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type virtualNetworkTapListResultHandleError func(*azcore.Response) error
+
 type virtualNetworkTapListResultHandleResponse func(*azcore.Response) (*VirtualNetworkTapListResultResponse, error)
 
 type virtualNetworkTapListResultAdvancePage func(context.Context, *VirtualNetworkTapListResultResponse) (*azcore.Request, error)
@@ -5542,6 +6446,8 @@ type virtualNetworkTapListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester virtualNetworkTapListResultCreateRequest
+	// callback for handling response errors
+	errorer virtualNetworkTapListResultHandleError
 	// callback for handling the HTTP response
 	responder virtualNetworkTapListResultHandleResponse
 	// callback for advancing to the next page
@@ -5572,6 +6478,13 @@ func (p *virtualNetworkTapListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -5600,6 +6513,8 @@ type VirtualRouterListResultPager interface {
 
 type virtualRouterListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type virtualRouterListResultHandleError func(*azcore.Response) error
+
 type virtualRouterListResultHandleResponse func(*azcore.Response) (*VirtualRouterListResultResponse, error)
 
 type virtualRouterListResultAdvancePage func(context.Context, *VirtualRouterListResultResponse) (*azcore.Request, error)
@@ -5609,6 +6524,8 @@ type virtualRouterListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester virtualRouterListResultCreateRequest
+	// callback for handling response errors
+	errorer virtualRouterListResultHandleError
 	// callback for handling the HTTP response
 	responder virtualRouterListResultHandleResponse
 	// callback for advancing to the next page
@@ -5639,6 +6556,13 @@ func (p *virtualRouterListResultPager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -5667,6 +6591,8 @@ type VirtualRouterPeeringListResultPager interface {
 
 type virtualRouterPeeringListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type virtualRouterPeeringListResultHandleError func(*azcore.Response) error
+
 type virtualRouterPeeringListResultHandleResponse func(*azcore.Response) (*VirtualRouterPeeringListResultResponse, error)
 
 type virtualRouterPeeringListResultAdvancePage func(context.Context, *VirtualRouterPeeringListResultResponse) (*azcore.Request, error)
@@ -5676,6 +6602,8 @@ type virtualRouterPeeringListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester virtualRouterPeeringListResultCreateRequest
+	// callback for handling response errors
+	errorer virtualRouterPeeringListResultHandleError
 	// callback for handling the HTTP response
 	responder virtualRouterPeeringListResultHandleResponse
 	// callback for advancing to the next page
@@ -5706,6 +6634,13 @@ func (p *virtualRouterPeeringListResultPager) NextPage(ctx context.Context) bool
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -5734,6 +6669,8 @@ type WebApplicationFirewallPolicyListResultPager interface {
 
 type webApplicationFirewallPolicyListResultCreateRequest func(context.Context) (*azcore.Request, error)
 
+type webApplicationFirewallPolicyListResultHandleError func(*azcore.Response) error
+
 type webApplicationFirewallPolicyListResultHandleResponse func(*azcore.Response) (*WebApplicationFirewallPolicyListResultResponse, error)
 
 type webApplicationFirewallPolicyListResultAdvancePage func(context.Context, *WebApplicationFirewallPolicyListResultResponse) (*azcore.Request, error)
@@ -5743,6 +6680,8 @@ type webApplicationFirewallPolicyListResultPager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester webApplicationFirewallPolicyListResultCreateRequest
+	// callback for handling response errors
+	errorer webApplicationFirewallPolicyListResultHandleError
 	// callback for handling the HTTP response
 	responder webApplicationFirewallPolicyListResultHandleResponse
 	// callback for advancing to the next page
@@ -5773,6 +6712,13 @@ func (p *webApplicationFirewallPolicyListResultPager) NextPage(ctx context.Conte
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err

--- a/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
@@ -8,6 +8,7 @@ package armnetwork
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"net/http"
 )
 
 // ApplicationGatewayAvailableSslPredefinedPoliciesPager provides iteration over ApplicationGatewayAvailableSslPredefinedPolicies pages.
@@ -72,7 +73,8 @@ func (p *applicationGatewayAvailableSslPredefinedPoliciesPager) NextPage(ctx con
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -150,7 +152,8 @@ func (p *applicationGatewayListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -228,7 +231,8 @@ func (p *applicationSecurityGroupListResultPager) NextPage(ctx context.Context) 
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -306,7 +310,8 @@ func (p *authorizationListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -384,7 +389,8 @@ func (p *autoApprovedPrivateLinkServicesResultPager) NextPage(ctx context.Contex
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -462,7 +468,8 @@ func (p *availableDelegationsResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -540,7 +547,8 @@ func (p *availablePrivateEndpointTypesResultPager) NextPage(ctx context.Context)
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -618,7 +626,8 @@ func (p *availableServiceAliasesResultPager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -696,7 +705,8 @@ func (p *azureFirewallFqdnTagListResultPager) NextPage(ctx context.Context) bool
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -774,7 +784,8 @@ func (p *azureFirewallListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -859,7 +870,8 @@ func (p *bastionActiveSessionListResultPager) NextPage(ctx context.Context) bool
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -937,7 +949,8 @@ func (p *bastionHostListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -1015,7 +1028,8 @@ func (p *bastionSessionDeleteResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -1100,7 +1114,8 @@ func (p *bastionShareableLinkListResultPager) NextPage(ctx context.Context) bool
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -1178,7 +1193,8 @@ func (p *bgpServiceCommunityListResultPager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -1256,7 +1272,8 @@ func (p *ddosProtectionPlanListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -1334,7 +1351,8 @@ func (p *endpointServicesListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -1412,7 +1430,8 @@ func (p *expressRouteCircuitConnectionListResultPager) NextPage(ctx context.Cont
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -1490,7 +1509,8 @@ func (p *expressRouteCircuitListResultPager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -1568,7 +1588,8 @@ func (p *expressRouteCircuitPeeringListResultPager) NextPage(ctx context.Context
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -1646,7 +1667,8 @@ func (p *expressRouteCrossConnectionListResultPager) NextPage(ctx context.Contex
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -1724,7 +1746,8 @@ func (p *expressRouteCrossConnectionPeeringListPager) NextPage(ctx context.Conte
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -1802,7 +1825,8 @@ func (p *expressRouteLinkListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -1880,7 +1904,8 @@ func (p *expressRoutePortListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -1958,7 +1983,8 @@ func (p *expressRoutePortsLocationListResultPager) NextPage(ctx context.Context)
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -2036,7 +2062,8 @@ func (p *expressRouteServiceProviderListResultPager) NextPage(ctx context.Contex
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -2114,7 +2141,8 @@ func (p *firewallPolicyListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -2192,7 +2220,8 @@ func (p *firewallPolicyRuleGroupListResultPager) NextPage(ctx context.Context) b
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -2270,7 +2299,8 @@ func (p *flowLogListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -2348,7 +2378,8 @@ func (p *ipAllocationListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -2426,7 +2457,8 @@ func (p *ipGroupListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -2504,7 +2536,8 @@ func (p *inboundNatRuleListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -2582,7 +2615,8 @@ func (p *listHubVirtualNetworkConnectionsResultPager) NextPage(ctx context.Conte
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -2660,7 +2694,8 @@ func (p *listP2SVpnGatewaysResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -2738,7 +2773,8 @@ func (p *listVirtualHubRouteTableV2SResultPager) NextPage(ctx context.Context) b
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -2816,7 +2852,8 @@ func (p *listVirtualHubsResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -2894,7 +2931,8 @@ func (p *listVirtualWaNsResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -2972,7 +3010,8 @@ func (p *listVpnConnectionsResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -3050,7 +3089,8 @@ func (p *listVpnGatewaysResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -3128,7 +3168,8 @@ func (p *listVpnServerConfigurationsResultPager) NextPage(ctx context.Context) b
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -3206,7 +3247,8 @@ func (p *listVpnSiteLinkConnectionsResultPager) NextPage(ctx context.Context) bo
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -3284,7 +3326,8 @@ func (p *listVpnSiteLinksResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -3362,7 +3405,8 @@ func (p *listVpnSitesResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -3440,7 +3484,8 @@ func (p *loadBalancerBackendAddressPoolListResultPager) NextPage(ctx context.Con
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -3518,7 +3563,8 @@ func (p *loadBalancerFrontendIPConfigurationListResultPager) NextPage(ctx contex
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -3596,7 +3642,8 @@ func (p *loadBalancerListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -3674,7 +3721,8 @@ func (p *loadBalancerLoadBalancingRuleListResultPager) NextPage(ctx context.Cont
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -3752,7 +3800,8 @@ func (p *loadBalancerOutboundRuleListResultPager) NextPage(ctx context.Context) 
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -3830,7 +3879,8 @@ func (p *loadBalancerProbeListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -3908,7 +3958,8 @@ func (p *localNetworkGatewayListResultPager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -3986,7 +4037,8 @@ func (p *natGatewayListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -4064,7 +4116,8 @@ func (p *networkInterfaceIPConfigurationListResultPager) NextPage(ctx context.Co
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -4142,7 +4195,8 @@ func (p *networkInterfaceListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -4220,7 +4274,8 @@ func (p *networkInterfaceLoadBalancerListResultPager) NextPage(ctx context.Conte
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -4298,7 +4353,8 @@ func (p *networkInterfaceTapConfigurationListResultPager) NextPage(ctx context.C
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -4376,7 +4432,8 @@ func (p *networkProfileListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -4454,7 +4511,8 @@ func (p *networkSecurityGroupListResultPager) NextPage(ctx context.Context) bool
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -4532,7 +4590,8 @@ func (p *networkVirtualApplianceListResultPager) NextPage(ctx context.Context) b
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -4610,7 +4669,8 @@ func (p *operationListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -4688,7 +4748,8 @@ func (p *peerExpressRouteCircuitConnectionListResultPager) NextPage(ctx context.
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -4766,7 +4827,8 @@ func (p *privateDnsZoneGroupListResultPager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -4844,7 +4906,8 @@ func (p *privateEndpointConnectionListResultPager) NextPage(ctx context.Context)
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -4922,7 +4985,8 @@ func (p *privateEndpointListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -5000,7 +5064,8 @@ func (p *privateLinkServiceListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -5078,7 +5143,8 @@ func (p *publicIPAddressListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -5156,7 +5222,8 @@ func (p *publicIPPrefixListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -5234,7 +5301,8 @@ func (p *routeFilterListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -5312,7 +5380,8 @@ func (p *routeFilterRuleListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -5390,7 +5459,8 @@ func (p *routeListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -5468,7 +5538,8 @@ func (p *routeTableListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -5546,7 +5617,8 @@ func (p *securityPartnerProviderListResultPager) NextPage(ctx context.Context) b
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -5624,7 +5696,8 @@ func (p *securityRuleListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -5702,7 +5775,8 @@ func (p *serviceEndpointPolicyDefinitionListResultPager) NextPage(ctx context.Co
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -5780,7 +5854,8 @@ func (p *serviceEndpointPolicyListResultPager) NextPage(ctx context.Context) boo
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -5858,7 +5933,8 @@ func (p *subnetListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -5936,7 +6012,8 @@ func (p *usagesListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -6014,7 +6091,8 @@ func (p *virtualNetworkGatewayConnectionListResultPager) NextPage(ctx context.Co
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -6092,7 +6170,8 @@ func (p *virtualNetworkGatewayListConnectionsResultPager) NextPage(ctx context.C
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -6170,7 +6249,8 @@ func (p *virtualNetworkGatewayListResultPager) NextPage(ctx context.Context) boo
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -6248,7 +6328,8 @@ func (p *virtualNetworkListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -6326,7 +6407,8 @@ func (p *virtualNetworkListUsageResultPager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -6404,7 +6486,8 @@ func (p *virtualNetworkPeeringListResultPager) NextPage(ctx context.Context) boo
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -6482,7 +6565,8 @@ func (p *virtualNetworkTapListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -6560,7 +6644,8 @@ func (p *virtualRouterListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -6638,7 +6723,8 @@ func (p *virtualRouterPeeringListResultPager) NextPage(ctx context.Context) bool
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -6716,7 +6802,8 @@ func (p *webApplicationFirewallPolicyListResultPager) NextPage(ctx context.Conte
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)

--- a/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections.go
@@ -48,8 +48,8 @@ func (client *PeerExpressRouteCircuitConnectionsClient) Get(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -85,9 +85,6 @@ func (client *PeerExpressRouteCircuitConnectionsClient) GetHandleResponse(resp *
 
 // GetHandleError handles the Get error response.
 func (client *PeerExpressRouteCircuitConnectionsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,9 +133,6 @@ func (client *PeerExpressRouteCircuitConnectionsClient) ListHandleResponse(resp 
 
 // ListHandleError handles the List error response.
 func (client *PeerExpressRouteCircuitConnectionsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections.go
@@ -48,6 +48,9 @@ func (client *PeerExpressRouteCircuitConnectionsClient) Get(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -76,15 +79,15 @@ func (client *PeerExpressRouteCircuitConnectionsClient) GetCreateRequest(ctx con
 
 // GetHandleResponse handles the Get response.
 func (client *PeerExpressRouteCircuitConnectionsClient) GetHandleResponse(resp *azcore.Response) (*PeerExpressRouteCircuitConnectionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := PeerExpressRouteCircuitConnectionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PeerExpressRouteCircuitConnection)
 }
 
 // GetHandleError handles the Get error response.
 func (client *PeerExpressRouteCircuitConnectionsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -100,6 +103,7 @@ func (client *PeerExpressRouteCircuitConnectionsClient) List(resourceGroupName s
 			return client.ListCreateRequest(ctx, resourceGroupName, circuitName, peeringName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *PeerExpressRouteCircuitConnectionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PeerExpressRouteCircuitConnectionListResult.NextLink)
 		},
@@ -126,15 +130,15 @@ func (client *PeerExpressRouteCircuitConnectionsClient) ListCreateRequest(ctx co
 
 // ListHandleResponse handles the List response.
 func (client *PeerExpressRouteCircuitConnectionsClient) ListHandleResponse(resp *azcore.Response) (*PeerExpressRouteCircuitConnectionListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := PeerExpressRouteCircuitConnectionListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PeerExpressRouteCircuitConnectionListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *PeerExpressRouteCircuitConnectionsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
@@ -395,7 +395,7 @@ func (p *bastionActiveSessionListResultPagerPoller) FinalResponse(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	return p.handleResponse(&azcore.Response{resp})
+	return p.handleResponse(&azcore.Response{Response: resp})
 }
 
 // ResumeToken generates the string token that can be used with the ResumeBastionActiveSessionListResultPagerPoller method
@@ -410,7 +410,7 @@ func (p *bastionActiveSessionListResultPagerPoller) pollUntilDone(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	return p.handleResponse(&azcore.Response{resp})
+	return p.handleResponse(&azcore.Response{Response: resp})
 }
 
 func (p *bastionActiveSessionListResultPagerPoller) handleResponse(resp *azcore.Response) (BastionActiveSessionListResultPager, error) {
@@ -507,7 +507,7 @@ func (p *bastionShareableLinkListResultPagerPoller) FinalResponse(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	return p.handleResponse(&azcore.Response{resp})
+	return p.handleResponse(&azcore.Response{Response: resp})
 }
 
 // ResumeToken generates the string token that can be used with the ResumeBastionShareableLinkListResultPagerPoller method
@@ -522,7 +522,7 @@ func (p *bastionShareableLinkListResultPagerPoller) pollUntilDone(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	return p.handleResponse(&azcore.Response{resp})
+	return p.handleResponse(&azcore.Response{Response: resp})
 }
 
 func (p *bastionShareableLinkListResultPagerPoller) handleResponse(resp *azcore.Response) (BastionShareableLinkListResultPager, error) {

--- a/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
@@ -374,6 +374,7 @@ type BastionActiveSessionListResultPagerPoller interface {
 type bastionActiveSessionListResultPagerPoller struct {
 	// the client for making the request
 	pipeline    azcore.Pipeline
+	errHandler  bastionActiveSessionListResultHandleError
 	respHandler bastionActiveSessionListResultHandleResponse
 	pt          armcore.Poller
 }
@@ -416,6 +417,7 @@ func (p *bastionActiveSessionListResultPagerPoller) handleResponse(resp *azcore.
 	return &bastionActiveSessionListResultPager{
 		pipeline:  p.pipeline,
 		resp:      resp,
+		errorer:   p.errHandler,
 		responder: p.respHandler,
 		advancer: func(ctx context.Context, resp *BastionActiveSessionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.BastionActiveSessionListResult.NextLink)
@@ -484,6 +486,7 @@ type BastionShareableLinkListResultPagerPoller interface {
 type bastionShareableLinkListResultPagerPoller struct {
 	// the client for making the request
 	pipeline    azcore.Pipeline
+	errHandler  bastionShareableLinkListResultHandleError
 	respHandler bastionShareableLinkListResultHandleResponse
 	pt          armcore.Poller
 }
@@ -526,6 +529,7 @@ func (p *bastionShareableLinkListResultPagerPoller) handleResponse(resp *azcore.
 	return &bastionShareableLinkListResultPager{
 		pipeline:  p.pipeline,
 		resp:      resp,
+		errorer:   p.errHandler,
 		responder: p.respHandler,
 		advancer: func(ctx context.Context, resp *BastionShareableLinkListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.BastionShareableLinkListResult.NextLink)

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups.go
@@ -59,8 +59,8 @@ func (client *PrivateDNSZoneGroupsClient) BeginCreateOrUpdate(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *PrivateDNSZoneGroupsClient) CreateOrUpdateHandleResponse(resp *azc
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *PrivateDNSZoneGroupsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *PrivateDNSZoneGroupsClient) BeginDelete(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *PrivateDNSZoneGroupsClient) DeleteHandleResponse(resp *azcore.Resp
 
 // DeleteHandleError handles the Delete error response.
 func (client *PrivateDNSZoneGroupsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *PrivateDNSZoneGroupsClient) Get(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *PrivateDNSZoneGroupsClient) GetHandleResponse(resp *azcore.Respons
 
 // GetHandleError handles the Get error response.
 func (client *PrivateDNSZoneGroupsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *PrivateDNSZoneGroupsClient) ListHandleResponse(resp *azcore.Respon
 
 // ListHandleError handles the List error response.
 func (client *PrivateDNSZoneGroupsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups.go
@@ -59,6 +59,9 @@ func (client *PrivateDNSZoneGroupsClient) BeginCreateOrUpdate(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *PrivateDNSZoneGroupsClient) CreateOrUpdateCreateRequest(ctx contex
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *PrivateDNSZoneGroupsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*PrivateDNSZoneGroupPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &PrivateDNSZoneGroupPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *PrivateDNSZoneGroupsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *PrivateDNSZoneGroupsClient) BeginDelete(ctx context.Context, resou
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *PrivateDNSZoneGroupsClient) DeleteCreateRequest(ctx context.Contex
 
 // DeleteHandleResponse handles the Delete response.
 func (client *PrivateDNSZoneGroupsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *PrivateDNSZoneGroupsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *PrivateDNSZoneGroupsClient) Get(ctx context.Context, resourceGroup
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *PrivateDNSZoneGroupsClient) GetCreateRequest(ctx context.Context, 
 
 // GetHandleResponse handles the Get response.
 func (client *PrivateDNSZoneGroupsClient) GetHandleResponse(resp *azcore.Response) (*PrivateDNSZoneGroupResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := PrivateDNSZoneGroupResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PrivateDNSZoneGroup)
 }
 
 // GetHandleError handles the Get error response.
 func (client *PrivateDNSZoneGroupsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,7 @@ func (client *PrivateDNSZoneGroupsClient) List(privateEndpointName string, resou
 			return client.ListCreateRequest(ctx, privateEndpointName, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *PrivateDNSZoneGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PrivateDNSZoneGroupListResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *PrivateDNSZoneGroupsClient) ListCreateRequest(ctx context.Context,
 
 // ListHandleResponse handles the List response.
 func (client *PrivateDNSZoneGroupsClient) ListHandleResponse(resp *azcore.Response) (*PrivateDNSZoneGroupListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := PrivateDNSZoneGroupListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PrivateDNSZoneGroupListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *PrivateDNSZoneGroupsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints.go
@@ -61,8 +61,8 @@ func (client *PrivateEndpointsClient) BeginCreateOrUpdate(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -118,9 +118,6 @@ func (client *PrivateEndpointsClient) CreateOrUpdateHandleResponse(resp *azcore.
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *PrivateEndpointsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -139,8 +136,8 @@ func (client *PrivateEndpointsClient) BeginDelete(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *PrivateEndpointsClient) DeleteHandleResponse(resp *azcore.Response
 
 // DeleteHandleError handles the Delete error response.
 func (client *PrivateEndpointsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *PrivateEndpointsClient) Get(ctx context.Context, resourceGroupName
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -254,9 +248,6 @@ func (client *PrivateEndpointsClient) GetHandleResponse(resp *azcore.Response) (
 
 // GetHandleError handles the Get error response.
 func (client *PrivateEndpointsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -303,9 +294,6 @@ func (client *PrivateEndpointsClient) ListHandleResponse(resp *azcore.Response) 
 
 // ListHandleError handles the List error response.
 func (client *PrivateEndpointsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -351,9 +339,6 @@ func (client *PrivateEndpointsClient) ListBySubscriptionHandleResponse(resp *azc
 
 // ListBySubscriptionHandleError handles the ListBySubscription error response.
 func (client *PrivateEndpointsClient) ListBySubscriptionHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints.go
@@ -61,6 +61,9 @@ func (client *PrivateEndpointsClient) BeginCreateOrUpdate(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -110,14 +113,14 @@ func (client *PrivateEndpointsClient) CreateOrUpdateCreateRequest(ctx context.Co
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *PrivateEndpointsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*PrivateEndpointPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &PrivateEndpointPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *PrivateEndpointsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,6 +137,9 @@ func (client *PrivateEndpointsClient) BeginDelete(ctx context.Context, resourceG
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *PrivateEndpointsClient) DeleteCreateRequest(ctx context.Context, r
 
 // DeleteHandleResponse handles the Delete response.
 func (client *PrivateEndpointsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *PrivateEndpointsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *PrivateEndpointsClient) Get(ctx context.Context, resourceGroupName
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -239,15 +248,15 @@ func (client *PrivateEndpointsClient) GetCreateRequest(ctx context.Context, reso
 
 // GetHandleResponse handles the Get response.
 func (client *PrivateEndpointsClient) GetHandleResponse(resp *azcore.Response) (*PrivateEndpointResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := PrivateEndpointResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PrivateEndpoint)
 }
 
 // GetHandleError handles the Get error response.
 func (client *PrivateEndpointsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -263,6 +272,7 @@ func (client *PrivateEndpointsClient) List(resourceGroupName string) PrivateEndp
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *PrivateEndpointListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PrivateEndpointListResult.NextLink)
 		},
@@ -287,15 +297,15 @@ func (client *PrivateEndpointsClient) ListCreateRequest(ctx context.Context, res
 
 // ListHandleResponse handles the List response.
 func (client *PrivateEndpointsClient) ListHandleResponse(resp *azcore.Response) (*PrivateEndpointListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := PrivateEndpointListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PrivateEndpointListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *PrivateEndpointsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -311,6 +321,7 @@ func (client *PrivateEndpointsClient) ListBySubscription() PrivateEndpointListRe
 			return client.ListBySubscriptionCreateRequest(ctx)
 		},
 		responder: client.ListBySubscriptionHandleResponse,
+		errorer:   client.ListBySubscriptionHandleError,
 		advancer: func(ctx context.Context, resp *PrivateEndpointListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PrivateEndpointListResult.NextLink)
 		},
@@ -334,15 +345,15 @@ func (client *PrivateEndpointsClient) ListBySubscriptionCreateRequest(ctx contex
 
 // ListBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client *PrivateEndpointsClient) ListBySubscriptionHandleResponse(resp *azcore.Response) (*PrivateEndpointListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListBySubscriptionHandleError(resp)
-	}
 	result := PrivateEndpointListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PrivateEndpointListResult)
 }
 
 // ListBySubscriptionHandleError handles the ListBySubscription error response.
 func (client *PrivateEndpointsClient) ListBySubscriptionHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices.go
@@ -83,8 +83,8 @@ func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibility(
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CheckPrivateLinkServiceVisibilityHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.CheckPrivateLinkServiceVisibilityHandleError(resp)
 	}
 	result, err := client.CheckPrivateLinkServiceVisibilityHandleResponse(resp)
 	if err != nil {
@@ -139,9 +139,6 @@ func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityHandle
 
 // CheckPrivateLinkServiceVisibilityHandleError handles the CheckPrivateLinkServiceVisibility error response.
 func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -160,8 +157,8 @@ func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibilityB
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CheckPrivateLinkServiceVisibilityByResourceGroupHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.CheckPrivateLinkServiceVisibilityByResourceGroupHandleError(resp)
 	}
 	result, err := client.CheckPrivateLinkServiceVisibilityByResourceGroupHandleResponse(resp)
 	if err != nil {
@@ -217,9 +214,6 @@ func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityByReso
 
 // CheckPrivateLinkServiceVisibilityByResourceGroupHandleError handles the CheckPrivateLinkServiceVisibilityByResourceGroup error response.
 func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -238,8 +232,8 @@ func (client *PrivateLinkServicesClient) BeginCreateOrUpdate(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -295,9 +289,6 @@ func (client *PrivateLinkServicesClient) CreateOrUpdateHandleResponse(resp *azco
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *PrivateLinkServicesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -316,8 +307,8 @@ func (client *PrivateLinkServicesClient) BeginDelete(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -373,9 +364,6 @@ func (client *PrivateLinkServicesClient) DeleteHandleResponse(resp *azcore.Respo
 
 // DeleteHandleError handles the Delete error response.
 func (client *PrivateLinkServicesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -394,8 +382,8 @@ func (client *PrivateLinkServicesClient) BeginDeletePrivateEndpointConnection(ct
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeletePrivateEndpointConnectionHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeletePrivateEndpointConnectionHandleError(resp)
 	}
 	result, err := client.DeletePrivateEndpointConnectionHandleResponse(resp)
 	if err != nil {
@@ -452,9 +440,6 @@ func (client *PrivateLinkServicesClient) DeletePrivateEndpointConnectionHandleRe
 
 // DeletePrivateEndpointConnectionHandleError handles the DeletePrivateEndpointConnection error response.
 func (client *PrivateLinkServicesClient) DeletePrivateEndpointConnectionHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -472,8 +457,8 @@ func (client *PrivateLinkServicesClient) Get(ctx context.Context, resourceGroupN
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -510,9 +495,6 @@ func (client *PrivateLinkServicesClient) GetHandleResponse(resp *azcore.Response
 
 // GetHandleError handles the Get error response.
 func (client *PrivateLinkServicesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -530,8 +512,8 @@ func (client *PrivateLinkServicesClient) GetPrivateEndpointConnection(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetPrivateEndpointConnectionHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetPrivateEndpointConnectionHandleError(resp)
 	}
 	result, err := client.GetPrivateEndpointConnectionHandleResponse(resp)
 	if err != nil {
@@ -569,9 +551,6 @@ func (client *PrivateLinkServicesClient) GetPrivateEndpointConnectionHandleRespo
 
 // GetPrivateEndpointConnectionHandleError handles the GetPrivateEndpointConnection error response.
 func (client *PrivateLinkServicesClient) GetPrivateEndpointConnectionHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -618,9 +597,6 @@ func (client *PrivateLinkServicesClient) ListHandleResponse(resp *azcore.Respons
 
 // ListHandleError handles the List error response.
 func (client *PrivateLinkServicesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -667,9 +643,6 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesHand
 
 // ListAutoApprovedPrivateLinkServicesHandleError handles the ListAutoApprovedPrivateLinkServices error response.
 func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -717,9 +690,6 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesByRe
 
 // ListAutoApprovedPrivateLinkServicesByResourceGroupHandleError handles the ListAutoApprovedPrivateLinkServicesByResourceGroup error response.
 func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -765,9 +735,6 @@ func (client *PrivateLinkServicesClient) ListBySubscriptionHandleResponse(resp *
 
 // ListBySubscriptionHandleError handles the ListBySubscription error response.
 func (client *PrivateLinkServicesClient) ListBySubscriptionHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -815,9 +782,6 @@ func (client *PrivateLinkServicesClient) ListPrivateEndpointConnectionsHandleRes
 
 // ListPrivateEndpointConnectionsHandleError handles the ListPrivateEndpointConnections error response.
 func (client *PrivateLinkServicesClient) ListPrivateEndpointConnectionsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -835,8 +799,8 @@ func (client *PrivateLinkServicesClient) UpdatePrivateEndpointConnection(ctx con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdatePrivateEndpointConnectionHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdatePrivateEndpointConnectionHandleError(resp)
 	}
 	result, err := client.UpdatePrivateEndpointConnectionHandleResponse(resp)
 	if err != nil {
@@ -871,9 +835,6 @@ func (client *PrivateLinkServicesClient) UpdatePrivateEndpointConnectionHandleRe
 
 // UpdatePrivateEndpointConnectionHandleError handles the UpdatePrivateEndpointConnection error response.
 func (client *PrivateLinkServicesClient) UpdatePrivateEndpointConnectionHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices.go
@@ -83,6 +83,9 @@ func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibility(
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CheckPrivateLinkServiceVisibilityHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CheckPrivateLinkServiceVisibilityHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -131,14 +134,14 @@ func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityCreate
 
 // CheckPrivateLinkServiceVisibilityHandleResponse handles the CheckPrivateLinkServiceVisibility response.
 func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityHandleResponse(resp *azcore.Response) (*PrivateLinkServiceVisibilityPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.CheckPrivateLinkServiceVisibilityHandleError(resp)
-	}
 	return &PrivateLinkServiceVisibilityPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CheckPrivateLinkServiceVisibilityHandleError handles the CheckPrivateLinkServiceVisibility error response.
 func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -155,6 +158,9 @@ func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibilityB
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CheckPrivateLinkServiceVisibilityByResourceGroupHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CheckPrivateLinkServiceVisibilityByResourceGroupHandleResponse(resp)
@@ -206,14 +212,14 @@ func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityByReso
 
 // CheckPrivateLinkServiceVisibilityByResourceGroupHandleResponse handles the CheckPrivateLinkServiceVisibilityByResourceGroup response.
 func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityByResourceGroupHandleResponse(resp *azcore.Response) (*PrivateLinkServiceVisibilityPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.CheckPrivateLinkServiceVisibilityByResourceGroupHandleError(resp)
-	}
 	return &PrivateLinkServiceVisibilityPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CheckPrivateLinkServiceVisibilityByResourceGroupHandleError handles the CheckPrivateLinkServiceVisibilityByResourceGroup error response.
 func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -230,6 +236,9 @@ func (client *PrivateLinkServicesClient) BeginCreateOrUpdate(ctx context.Context
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
@@ -281,14 +290,14 @@ func (client *PrivateLinkServicesClient) CreateOrUpdateCreateRequest(ctx context
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *PrivateLinkServicesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*PrivateLinkServicePollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &PrivateLinkServicePollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *PrivateLinkServicesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -305,6 +314,9 @@ func (client *PrivateLinkServicesClient) BeginDelete(ctx context.Context, resour
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -356,14 +368,14 @@ func (client *PrivateLinkServicesClient) DeleteCreateRequest(ctx context.Context
 
 // DeleteHandleResponse handles the Delete response.
 func (client *PrivateLinkServicesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *PrivateLinkServicesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -380,6 +392,9 @@ func (client *PrivateLinkServicesClient) BeginDeletePrivateEndpointConnection(ct
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeletePrivateEndpointConnectionHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeletePrivateEndpointConnectionHandleResponse(resp)
@@ -432,14 +447,14 @@ func (client *PrivateLinkServicesClient) DeletePrivateEndpointConnectionCreateRe
 
 // DeletePrivateEndpointConnectionHandleResponse handles the DeletePrivateEndpointConnection response.
 func (client *PrivateLinkServicesClient) DeletePrivateEndpointConnectionHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeletePrivateEndpointConnectionHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeletePrivateEndpointConnectionHandleError handles the DeletePrivateEndpointConnection error response.
 func (client *PrivateLinkServicesClient) DeletePrivateEndpointConnectionHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -455,6 +470,9 @@ func (client *PrivateLinkServicesClient) Get(ctx context.Context, resourceGroupN
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -486,15 +504,15 @@ func (client *PrivateLinkServicesClient) GetCreateRequest(ctx context.Context, r
 
 // GetHandleResponse handles the Get response.
 func (client *PrivateLinkServicesClient) GetHandleResponse(resp *azcore.Response) (*PrivateLinkServiceResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := PrivateLinkServiceResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PrivateLinkService)
 }
 
 // GetHandleError handles the Get error response.
 func (client *PrivateLinkServicesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -510,6 +528,9 @@ func (client *PrivateLinkServicesClient) GetPrivateEndpointConnection(ctx contex
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetPrivateEndpointConnectionHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetPrivateEndpointConnectionHandleResponse(resp)
@@ -542,15 +563,15 @@ func (client *PrivateLinkServicesClient) GetPrivateEndpointConnectionCreateReque
 
 // GetPrivateEndpointConnectionHandleResponse handles the GetPrivateEndpointConnection response.
 func (client *PrivateLinkServicesClient) GetPrivateEndpointConnectionHandleResponse(resp *azcore.Response) (*PrivateEndpointConnectionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetPrivateEndpointConnectionHandleError(resp)
-	}
 	result := PrivateEndpointConnectionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PrivateEndpointConnection)
 }
 
 // GetPrivateEndpointConnectionHandleError handles the GetPrivateEndpointConnection error response.
 func (client *PrivateLinkServicesClient) GetPrivateEndpointConnectionHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -566,6 +587,7 @@ func (client *PrivateLinkServicesClient) List(resourceGroupName string) PrivateL
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *PrivateLinkServiceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PrivateLinkServiceListResult.NextLink)
 		},
@@ -590,15 +612,15 @@ func (client *PrivateLinkServicesClient) ListCreateRequest(ctx context.Context, 
 
 // ListHandleResponse handles the List response.
 func (client *PrivateLinkServicesClient) ListHandleResponse(resp *azcore.Response) (*PrivateLinkServiceListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := PrivateLinkServiceListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PrivateLinkServiceListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *PrivateLinkServicesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -614,6 +636,7 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServices(loc
 			return client.ListAutoApprovedPrivateLinkServicesCreateRequest(ctx, location)
 		},
 		responder: client.ListAutoApprovedPrivateLinkServicesHandleResponse,
+		errorer:   client.ListAutoApprovedPrivateLinkServicesHandleError,
 		advancer: func(ctx context.Context, resp *AutoApprovedPrivateLinkServicesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AutoApprovedPrivateLinkServicesResult.NextLink)
 		},
@@ -638,15 +661,15 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesCrea
 
 // ListAutoApprovedPrivateLinkServicesHandleResponse handles the ListAutoApprovedPrivateLinkServices response.
 func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesHandleResponse(resp *azcore.Response) (*AutoApprovedPrivateLinkServicesResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAutoApprovedPrivateLinkServicesHandleError(resp)
-	}
 	result := AutoApprovedPrivateLinkServicesResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.AutoApprovedPrivateLinkServicesResult)
 }
 
 // ListAutoApprovedPrivateLinkServicesHandleError handles the ListAutoApprovedPrivateLinkServices error response.
 func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -662,6 +685,7 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesByRe
 			return client.ListAutoApprovedPrivateLinkServicesByResourceGroupCreateRequest(ctx, location, resourceGroupName)
 		},
 		responder: client.ListAutoApprovedPrivateLinkServicesByResourceGroupHandleResponse,
+		errorer:   client.ListAutoApprovedPrivateLinkServicesByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *AutoApprovedPrivateLinkServicesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AutoApprovedPrivateLinkServicesResult.NextLink)
 		},
@@ -687,15 +711,15 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesByRe
 
 // ListAutoApprovedPrivateLinkServicesByResourceGroupHandleResponse handles the ListAutoApprovedPrivateLinkServicesByResourceGroup response.
 func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesByResourceGroupHandleResponse(resp *azcore.Response) (*AutoApprovedPrivateLinkServicesResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAutoApprovedPrivateLinkServicesByResourceGroupHandleError(resp)
-	}
 	result := AutoApprovedPrivateLinkServicesResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.AutoApprovedPrivateLinkServicesResult)
 }
 
 // ListAutoApprovedPrivateLinkServicesByResourceGroupHandleError handles the ListAutoApprovedPrivateLinkServicesByResourceGroup error response.
 func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -711,6 +735,7 @@ func (client *PrivateLinkServicesClient) ListBySubscription() PrivateLinkService
 			return client.ListBySubscriptionCreateRequest(ctx)
 		},
 		responder: client.ListBySubscriptionHandleResponse,
+		errorer:   client.ListBySubscriptionHandleError,
 		advancer: func(ctx context.Context, resp *PrivateLinkServiceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PrivateLinkServiceListResult.NextLink)
 		},
@@ -734,15 +759,15 @@ func (client *PrivateLinkServicesClient) ListBySubscriptionCreateRequest(ctx con
 
 // ListBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client *PrivateLinkServicesClient) ListBySubscriptionHandleResponse(resp *azcore.Response) (*PrivateLinkServiceListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListBySubscriptionHandleError(resp)
-	}
 	result := PrivateLinkServiceListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PrivateLinkServiceListResult)
 }
 
 // ListBySubscriptionHandleError handles the ListBySubscription error response.
 func (client *PrivateLinkServicesClient) ListBySubscriptionHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -758,6 +783,7 @@ func (client *PrivateLinkServicesClient) ListPrivateEndpointConnections(resource
 			return client.ListPrivateEndpointConnectionsCreateRequest(ctx, resourceGroupName, serviceName)
 		},
 		responder: client.ListPrivateEndpointConnectionsHandleResponse,
+		errorer:   client.ListPrivateEndpointConnectionsHandleError,
 		advancer: func(ctx context.Context, resp *PrivateEndpointConnectionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PrivateEndpointConnectionListResult.NextLink)
 		},
@@ -783,15 +809,15 @@ func (client *PrivateLinkServicesClient) ListPrivateEndpointConnectionsCreateReq
 
 // ListPrivateEndpointConnectionsHandleResponse handles the ListPrivateEndpointConnections response.
 func (client *PrivateLinkServicesClient) ListPrivateEndpointConnectionsHandleResponse(resp *azcore.Response) (*PrivateEndpointConnectionListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListPrivateEndpointConnectionsHandleError(resp)
-	}
 	result := PrivateEndpointConnectionListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PrivateEndpointConnectionListResult)
 }
 
 // ListPrivateEndpointConnectionsHandleError handles the ListPrivateEndpointConnections error response.
 func (client *PrivateLinkServicesClient) ListPrivateEndpointConnectionsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -807,6 +833,9 @@ func (client *PrivateLinkServicesClient) UpdatePrivateEndpointConnection(ctx con
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdatePrivateEndpointConnectionHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdatePrivateEndpointConnectionHandleResponse(resp)
@@ -836,15 +865,15 @@ func (client *PrivateLinkServicesClient) UpdatePrivateEndpointConnectionCreateRe
 
 // UpdatePrivateEndpointConnectionHandleResponse handles the UpdatePrivateEndpointConnection response.
 func (client *PrivateLinkServicesClient) UpdatePrivateEndpointConnectionHandleResponse(resp *azcore.Response) (*PrivateEndpointConnectionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdatePrivateEndpointConnectionHandleError(resp)
-	}
 	result := PrivateEndpointConnectionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PrivateEndpointConnection)
 }
 
 // UpdatePrivateEndpointConnectionHandleError handles the UpdatePrivateEndpointConnection error response.
 func (client *PrivateLinkServicesClient) UpdatePrivateEndpointConnectionHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses.go
@@ -69,8 +69,8 @@ func (client *PublicIPAddressesClient) BeginCreateOrUpdate(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -126,9 +126,6 @@ func (client *PublicIPAddressesClient) CreateOrUpdateHandleResponse(resp *azcore
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *PublicIPAddressesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -147,8 +144,8 @@ func (client *PublicIPAddressesClient) BeginDelete(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -204,9 +201,6 @@ func (client *PublicIPAddressesClient) DeleteHandleResponse(resp *azcore.Respons
 
 // DeleteHandleError handles the Delete error response.
 func (client *PublicIPAddressesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -224,8 +218,8 @@ func (client *PublicIPAddressesClient) Get(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -262,9 +256,6 @@ func (client *PublicIPAddressesClient) GetHandleResponse(resp *azcore.Response) 
 
 // GetHandleError handles the Get error response.
 func (client *PublicIPAddressesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -282,8 +273,8 @@ func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddress(
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetVirtualMachineScaleSetPublicIPAddressHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetVirtualMachineScaleSetPublicIPAddressHandleError(resp)
 	}
 	result, err := client.GetVirtualMachineScaleSetPublicIPAddressHandleResponse(resp)
 	if err != nil {
@@ -324,9 +315,6 @@ func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddressH
 
 // GetVirtualMachineScaleSetPublicIPAddressHandleError handles the GetVirtualMachineScaleSetPublicIPAddress error response.
 func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddressHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -373,9 +361,6 @@ func (client *PublicIPAddressesClient) ListHandleResponse(resp *azcore.Response)
 
 // ListHandleError handles the List error response.
 func (client *PublicIPAddressesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -421,9 +406,6 @@ func (client *PublicIPAddressesClient) ListAllHandleResponse(resp *azcore.Respon
 
 // ListAllHandleError handles the ListAll error response.
 func (client *PublicIPAddressesClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -471,9 +453,6 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetPublicIPAddress
 
 // ListVirtualMachineScaleSetPublicIPAddressesHandleError handles the ListVirtualMachineScaleSetPublicIPAddresses error response.
 func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetPublicIPAddressesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -524,9 +503,6 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetVMPublicIPaddre
 
 // ListVirtualMachineScaleSetVMPublicIPaddressesHandleError handles the ListVirtualMachineScaleSetVMPublicIPaddresses error response.
 func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetVMPublicIPaddressesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -544,8 +520,8 @@ func (client *PublicIPAddressesClient) UpdateTags(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -579,9 +555,6 @@ func (client *PublicIPAddressesClient) UpdateTagsHandleResponse(resp *azcore.Res
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *PublicIPAddressesClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses.go
@@ -69,6 +69,9 @@ func (client *PublicIPAddressesClient) BeginCreateOrUpdate(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -118,14 +121,14 @@ func (client *PublicIPAddressesClient) CreateOrUpdateCreateRequest(ctx context.C
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *PublicIPAddressesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*PublicIPAddressPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &PublicIPAddressPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *PublicIPAddressesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -142,6 +145,9 @@ func (client *PublicIPAddressesClient) BeginDelete(ctx context.Context, resource
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -193,14 +199,14 @@ func (client *PublicIPAddressesClient) DeleteCreateRequest(ctx context.Context, 
 
 // DeleteHandleResponse handles the Delete response.
 func (client *PublicIPAddressesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *PublicIPAddressesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,6 +222,9 @@ func (client *PublicIPAddressesClient) Get(ctx context.Context, resourceGroupNam
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -247,15 +256,15 @@ func (client *PublicIPAddressesClient) GetCreateRequest(ctx context.Context, res
 
 // GetHandleResponse handles the Get response.
 func (client *PublicIPAddressesClient) GetHandleResponse(resp *azcore.Response) (*PublicIPAddressResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := PublicIPAddressResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PublicIPAddress)
 }
 
 // GetHandleError handles the Get error response.
 func (client *PublicIPAddressesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -271,6 +280,9 @@ func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddress(
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetVirtualMachineScaleSetPublicIPAddressHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetVirtualMachineScaleSetPublicIPAddressHandleResponse(resp)
@@ -306,15 +318,15 @@ func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddressC
 
 // GetVirtualMachineScaleSetPublicIPAddressHandleResponse handles the GetVirtualMachineScaleSetPublicIPAddress response.
 func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddressHandleResponse(resp *azcore.Response) (*PublicIPAddressResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetVirtualMachineScaleSetPublicIPAddressHandleError(resp)
-	}
 	result := PublicIPAddressResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PublicIPAddress)
 }
 
 // GetVirtualMachineScaleSetPublicIPAddressHandleError handles the GetVirtualMachineScaleSetPublicIPAddress error response.
 func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddressHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -330,6 +342,7 @@ func (client *PublicIPAddressesClient) List(resourceGroupName string) PublicIPAd
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *PublicIPAddressListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PublicIPAddressListResult.NextLink)
 		},
@@ -354,15 +367,15 @@ func (client *PublicIPAddressesClient) ListCreateRequest(ctx context.Context, re
 
 // ListHandleResponse handles the List response.
 func (client *PublicIPAddressesClient) ListHandleResponse(resp *azcore.Response) (*PublicIPAddressListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := PublicIPAddressListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PublicIPAddressListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *PublicIPAddressesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -378,6 +391,7 @@ func (client *PublicIPAddressesClient) ListAll() PublicIPAddressListResultPager 
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *PublicIPAddressListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PublicIPAddressListResult.NextLink)
 		},
@@ -401,15 +415,15 @@ func (client *PublicIPAddressesClient) ListAllCreateRequest(ctx context.Context)
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *PublicIPAddressesClient) ListAllHandleResponse(resp *azcore.Response) (*PublicIPAddressListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := PublicIPAddressListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PublicIPAddressListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *PublicIPAddressesClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -425,6 +439,7 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetPublicIPAddress
 			return client.ListVirtualMachineScaleSetPublicIPAddressesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName)
 		},
 		responder: client.ListVirtualMachineScaleSetPublicIPAddressesHandleResponse,
+		errorer:   client.ListVirtualMachineScaleSetPublicIPAddressesHandleError,
 		advancer: func(ctx context.Context, resp *PublicIPAddressListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PublicIPAddressListResult.NextLink)
 		},
@@ -450,15 +465,15 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetPublicIPAddress
 
 // ListVirtualMachineScaleSetPublicIPAddressesHandleResponse handles the ListVirtualMachineScaleSetPublicIPAddresses response.
 func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetPublicIPAddressesHandleResponse(resp *azcore.Response) (*PublicIPAddressListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListVirtualMachineScaleSetPublicIPAddressesHandleError(resp)
-	}
 	result := PublicIPAddressListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PublicIPAddressListResult)
 }
 
 // ListVirtualMachineScaleSetPublicIPAddressesHandleError handles the ListVirtualMachineScaleSetPublicIPAddresses error response.
 func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetPublicIPAddressesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -474,6 +489,7 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetVMPublicIPaddre
 			return client.ListVirtualMachineScaleSetVMPublicIPaddressesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, ipConfigurationName)
 		},
 		responder: client.ListVirtualMachineScaleSetVMPublicIPaddressesHandleResponse,
+		errorer:   client.ListVirtualMachineScaleSetVMPublicIPaddressesHandleError,
 		advancer: func(ctx context.Context, resp *PublicIPAddressListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PublicIPAddressListResult.NextLink)
 		},
@@ -502,15 +518,15 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetVMPublicIPaddre
 
 // ListVirtualMachineScaleSetVMPublicIPaddressesHandleResponse handles the ListVirtualMachineScaleSetVMPublicIPaddresses response.
 func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetVMPublicIPaddressesHandleResponse(resp *azcore.Response) (*PublicIPAddressListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListVirtualMachineScaleSetVMPublicIPaddressesHandleError(resp)
-	}
 	result := PublicIPAddressListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PublicIPAddressListResult)
 }
 
 // ListVirtualMachineScaleSetVMPublicIPaddressesHandleError handles the ListVirtualMachineScaleSetVMPublicIPaddresses error response.
 func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetVMPublicIPaddressesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -526,6 +542,9 @@ func (client *PublicIPAddressesClient) UpdateTags(ctx context.Context, resourceG
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -554,15 +573,15 @@ func (client *PublicIPAddressesClient) UpdateTagsCreateRequest(ctx context.Conte
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *PublicIPAddressesClient) UpdateTagsHandleResponse(resp *azcore.Response) (*PublicIPAddressResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := PublicIPAddressResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PublicIPAddress)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *PublicIPAddressesClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes.go
@@ -63,6 +63,9 @@ func (client *PublicIPPrefixesClient) BeginCreateOrUpdate(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *PublicIPPrefixesClient) CreateOrUpdateCreateRequest(ctx context.Co
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *PublicIPPrefixesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*PublicIPPrefixPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &PublicIPPrefixPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *PublicIPPrefixesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *PublicIPPrefixesClient) BeginDelete(ctx context.Context, resourceG
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *PublicIPPrefixesClient) DeleteCreateRequest(ctx context.Context, r
 
 // DeleteHandleResponse handles the Delete response.
 func (client *PublicIPPrefixesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *PublicIPPrefixesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *PublicIPPrefixesClient) Get(ctx context.Context, resourceGroupName
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -241,15 +250,15 @@ func (client *PublicIPPrefixesClient) GetCreateRequest(ctx context.Context, reso
 
 // GetHandleResponse handles the Get response.
 func (client *PublicIPPrefixesClient) GetHandleResponse(resp *azcore.Response) (*PublicIPPrefixResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := PublicIPPrefixResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PublicIPPrefix)
 }
 
 // GetHandleError handles the Get error response.
 func (client *PublicIPPrefixesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -265,6 +274,7 @@ func (client *PublicIPPrefixesClient) List(resourceGroupName string) PublicIPPre
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *PublicIPPrefixListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PublicIPPrefixListResult.NextLink)
 		},
@@ -289,15 +299,15 @@ func (client *PublicIPPrefixesClient) ListCreateRequest(ctx context.Context, res
 
 // ListHandleResponse handles the List response.
 func (client *PublicIPPrefixesClient) ListHandleResponse(resp *azcore.Response) (*PublicIPPrefixListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := PublicIPPrefixListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PublicIPPrefixListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *PublicIPPrefixesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -313,6 +323,7 @@ func (client *PublicIPPrefixesClient) ListAll() PublicIPPrefixListResultPager {
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *PublicIPPrefixListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PublicIPPrefixListResult.NextLink)
 		},
@@ -336,15 +347,15 @@ func (client *PublicIPPrefixesClient) ListAllCreateRequest(ctx context.Context) 
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *PublicIPPrefixesClient) ListAllHandleResponse(resp *azcore.Response) (*PublicIPPrefixListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := PublicIPPrefixListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PublicIPPrefixListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *PublicIPPrefixesClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -360,6 +371,9 @@ func (client *PublicIPPrefixesClient) UpdateTags(ctx context.Context, resourceGr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -388,15 +402,15 @@ func (client *PublicIPPrefixesClient) UpdateTagsCreateRequest(ctx context.Contex
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *PublicIPPrefixesClient) UpdateTagsHandleResponse(resp *azcore.Response) (*PublicIPPrefixResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := PublicIPPrefixResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.PublicIPPrefix)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *PublicIPPrefixesClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes.go
@@ -63,8 +63,8 @@ func (client *PublicIPPrefixesClient) BeginCreateOrUpdate(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *PublicIPPrefixesClient) CreateOrUpdateHandleResponse(resp *azcore.
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *PublicIPPrefixesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *PublicIPPrefixesClient) BeginDelete(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *PublicIPPrefixesClient) DeleteHandleResponse(resp *azcore.Response
 
 // DeleteHandleError handles the Delete error response.
 func (client *PublicIPPrefixesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *PublicIPPrefixesClient) Get(ctx context.Context, resourceGroupName
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -256,9 +250,6 @@ func (client *PublicIPPrefixesClient) GetHandleResponse(resp *azcore.Response) (
 
 // GetHandleError handles the Get error response.
 func (client *PublicIPPrefixesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -305,9 +296,6 @@ func (client *PublicIPPrefixesClient) ListHandleResponse(resp *azcore.Response) 
 
 // ListHandleError handles the List error response.
 func (client *PublicIPPrefixesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -353,9 +341,6 @@ func (client *PublicIPPrefixesClient) ListAllHandleResponse(resp *azcore.Respons
 
 // ListAllHandleError handles the ListAll error response.
 func (client *PublicIPPrefixesClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -373,8 +358,8 @@ func (client *PublicIPPrefixesClient) UpdateTags(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -408,9 +393,6 @@ func (client *PublicIPPrefixesClient) UpdateTagsHandleResponse(resp *azcore.Resp
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *PublicIPPrefixesClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks.go
@@ -46,8 +46,8 @@ func (client *ResourceNavigationLinksClient) List(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListHandleError(resp)
 	}
 	result, err := client.ListHandleResponse(resp)
 	if err != nil {
@@ -82,9 +82,6 @@ func (client *ResourceNavigationLinksClient) ListHandleResponse(resp *azcore.Res
 
 // ListHandleError handles the List error response.
 func (client *ResourceNavigationLinksClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks.go
@@ -46,6 +46,9 @@ func (client *ResourceNavigationLinksClient) List(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
+	if err := client.ListHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.ListHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -73,15 +76,15 @@ func (client *ResourceNavigationLinksClient) ListCreateRequest(ctx context.Conte
 
 // ListHandleResponse handles the List response.
 func (client *ResourceNavigationLinksClient) ListHandleResponse(resp *azcore.Response) (*ResourceNavigationLinksListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ResourceNavigationLinksListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ResourceNavigationLinksListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ResourceNavigationLinksClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules.go
@@ -59,8 +59,8 @@ func (client *RouteFilterRulesClient) BeginCreateOrUpdate(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *RouteFilterRulesClient) CreateOrUpdateHandleResponse(resp *azcore.
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *RouteFilterRulesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *RouteFilterRulesClient) BeginDelete(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *RouteFilterRulesClient) DeleteHandleResponse(resp *azcore.Response
 
 // DeleteHandleError handles the Delete error response.
 func (client *RouteFilterRulesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *RouteFilterRulesClient) Get(ctx context.Context, resourceGroupName
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *RouteFilterRulesClient) GetHandleResponse(resp *azcore.Response) (
 
 // GetHandleError handles the Get error response.
 func (client *RouteFilterRulesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *RouteFilterRulesClient) ListByRouteFilterHandleResponse(resp *azco
 
 // ListByRouteFilterHandleError handles the ListByRouteFilter error response.
 func (client *RouteFilterRulesClient) ListByRouteFilterHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules.go
@@ -59,6 +59,9 @@ func (client *RouteFilterRulesClient) BeginCreateOrUpdate(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *RouteFilterRulesClient) CreateOrUpdateCreateRequest(ctx context.Co
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *RouteFilterRulesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*RouteFilterRulePollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &RouteFilterRulePollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *RouteFilterRulesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *RouteFilterRulesClient) BeginDelete(ctx context.Context, resourceG
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *RouteFilterRulesClient) DeleteCreateRequest(ctx context.Context, r
 
 // DeleteHandleResponse handles the Delete response.
 func (client *RouteFilterRulesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *RouteFilterRulesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *RouteFilterRulesClient) Get(ctx context.Context, resourceGroupName
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *RouteFilterRulesClient) GetCreateRequest(ctx context.Context, reso
 
 // GetHandleResponse handles the Get response.
 func (client *RouteFilterRulesClient) GetHandleResponse(resp *azcore.Response) (*RouteFilterRuleResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := RouteFilterRuleResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.RouteFilterRule)
 }
 
 // GetHandleError handles the Get error response.
 func (client *RouteFilterRulesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,7 @@ func (client *RouteFilterRulesClient) ListByRouteFilter(resourceGroupName string
 			return client.ListByRouteFilterCreateRequest(ctx, resourceGroupName, routeFilterName)
 		},
 		responder: client.ListByRouteFilterHandleResponse,
+		errorer:   client.ListByRouteFilterHandleError,
 		advancer: func(ctx context.Context, resp *RouteFilterRuleListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.RouteFilterRuleListResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *RouteFilterRulesClient) ListByRouteFilterCreateRequest(ctx context
 
 // ListByRouteFilterHandleResponse handles the ListByRouteFilter response.
 func (client *RouteFilterRulesClient) ListByRouteFilterHandleResponse(resp *azcore.Response) (*RouteFilterRuleListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByRouteFilterHandleError(resp)
-	}
 	result := RouteFilterRuleListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.RouteFilterRuleListResult)
 }
 
 // ListByRouteFilterHandleError handles the ListByRouteFilter error response.
 func (client *RouteFilterRulesClient) ListByRouteFilterHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilters.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilters.go
@@ -63,8 +63,8 @@ func (client *RouteFiltersClient) BeginCreateOrUpdate(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *RouteFiltersClient) CreateOrUpdateHandleResponse(resp *azcore.Resp
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *RouteFiltersClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *RouteFiltersClient) BeginDelete(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *RouteFiltersClient) DeleteHandleResponse(resp *azcore.Response) (*
 
 // DeleteHandleError handles the Delete error response.
 func (client *RouteFiltersClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *RouteFiltersClient) Get(ctx context.Context, resourceGroupName str
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -256,9 +250,6 @@ func (client *RouteFiltersClient) GetHandleResponse(resp *azcore.Response) (*Rou
 
 // GetHandleError handles the Get error response.
 func (client *RouteFiltersClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -304,9 +295,6 @@ func (client *RouteFiltersClient) ListHandleResponse(resp *azcore.Response) (*Ro
 
 // ListHandleError handles the List error response.
 func (client *RouteFiltersClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -353,9 +341,6 @@ func (client *RouteFiltersClient) ListByResourceGroupHandleResponse(resp *azcore
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *RouteFiltersClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -373,8 +358,8 @@ func (client *RouteFiltersClient) UpdateTags(ctx context.Context, resourceGroupN
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -408,9 +393,6 @@ func (client *RouteFiltersClient) UpdateTagsHandleResponse(resp *azcore.Response
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *RouteFiltersClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilters.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilters.go
@@ -63,6 +63,9 @@ func (client *RouteFiltersClient) BeginCreateOrUpdate(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *RouteFiltersClient) CreateOrUpdateCreateRequest(ctx context.Contex
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *RouteFiltersClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*RouteFilterPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &RouteFilterPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *RouteFiltersClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *RouteFiltersClient) BeginDelete(ctx context.Context, resourceGroup
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *RouteFiltersClient) DeleteCreateRequest(ctx context.Context, resou
 
 // DeleteHandleResponse handles the Delete response.
 func (client *RouteFiltersClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *RouteFiltersClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *RouteFiltersClient) Get(ctx context.Context, resourceGroupName str
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -241,15 +250,15 @@ func (client *RouteFiltersClient) GetCreateRequest(ctx context.Context, resource
 
 // GetHandleResponse handles the Get response.
 func (client *RouteFiltersClient) GetHandleResponse(resp *azcore.Response) (*RouteFilterResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := RouteFilterResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.RouteFilter)
 }
 
 // GetHandleError handles the Get error response.
 func (client *RouteFiltersClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -265,6 +274,7 @@ func (client *RouteFiltersClient) List() RouteFilterListResultPager {
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *RouteFilterListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.RouteFilterListResult.NextLink)
 		},
@@ -288,15 +298,15 @@ func (client *RouteFiltersClient) ListCreateRequest(ctx context.Context) (*azcor
 
 // ListHandleResponse handles the List response.
 func (client *RouteFiltersClient) ListHandleResponse(resp *azcore.Response) (*RouteFilterListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := RouteFilterListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.RouteFilterListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *RouteFiltersClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -312,6 +322,7 @@ func (client *RouteFiltersClient) ListByResourceGroup(resourceGroupName string) 
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *RouteFilterListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.RouteFilterListResult.NextLink)
 		},
@@ -336,15 +347,15 @@ func (client *RouteFiltersClient) ListByResourceGroupCreateRequest(ctx context.C
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *RouteFiltersClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*RouteFilterListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := RouteFilterListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.RouteFilterListResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *RouteFiltersClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -360,6 +371,9 @@ func (client *RouteFiltersClient) UpdateTags(ctx context.Context, resourceGroupN
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -388,15 +402,15 @@ func (client *RouteFiltersClient) UpdateTagsCreateRequest(ctx context.Context, r
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *RouteFiltersClient) UpdateTagsHandleResponse(resp *azcore.Response) (*RouteFilterResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := RouteFilterResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.RouteFilter)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *RouteFiltersClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_routes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routes.go
@@ -59,8 +59,8 @@ func (client *RoutesClient) BeginCreateOrUpdate(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *RoutesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) 
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *RoutesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *RoutesClient) BeginDelete(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *RoutesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPo
 
 // DeleteHandleError handles the Delete error response.
 func (client *RoutesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *RoutesClient) Get(ctx context.Context, resourceGroupName string, r
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *RoutesClient) GetHandleResponse(resp *azcore.Response) (*RouteResp
 
 // GetHandleError handles the Get error response.
 func (client *RoutesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *RoutesClient) ListHandleResponse(resp *azcore.Response) (*RouteLis
 
 // ListHandleError handles the List error response.
 func (client *RoutesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_routes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routes.go
@@ -59,6 +59,9 @@ func (client *RoutesClient) BeginCreateOrUpdate(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *RoutesClient) CreateOrUpdateCreateRequest(ctx context.Context, res
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *RoutesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*RoutePollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &RoutePollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *RoutesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *RoutesClient) BeginDelete(ctx context.Context, resourceGroupName s
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *RoutesClient) DeleteCreateRequest(ctx context.Context, resourceGro
 
 // DeleteHandleResponse handles the Delete response.
 func (client *RoutesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *RoutesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *RoutesClient) Get(ctx context.Context, resourceGroupName string, r
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *RoutesClient) GetCreateRequest(ctx context.Context, resourceGroupN
 
 // GetHandleResponse handles the Get response.
 func (client *RoutesClient) GetHandleResponse(resp *azcore.Response) (*RouteResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := RouteResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Route)
 }
 
 // GetHandleError handles the Get error response.
 func (client *RoutesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,7 @@ func (client *RoutesClient) List(resourceGroupName string, routeTableName string
 			return client.ListCreateRequest(ctx, resourceGroupName, routeTableName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *RouteListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.RouteListResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *RoutesClient) ListCreateRequest(ctx context.Context, resourceGroup
 
 // ListHandleResponse handles the List response.
 func (client *RoutesClient) ListHandleResponse(resp *azcore.Response) (*RouteListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := RouteListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.RouteListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *RoutesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_routetables.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routetables.go
@@ -63,8 +63,8 @@ func (client *RouteTablesClient) BeginCreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *RouteTablesClient) CreateOrUpdateHandleResponse(resp *azcore.Respo
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *RouteTablesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *RouteTablesClient) BeginDelete(ctx context.Context, resourceGroupN
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *RouteTablesClient) DeleteHandleResponse(resp *azcore.Response) (*H
 
 // DeleteHandleError handles the Delete error response.
 func (client *RouteTablesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *RouteTablesClient) Get(ctx context.Context, resourceGroupName stri
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -256,9 +250,6 @@ func (client *RouteTablesClient) GetHandleResponse(resp *azcore.Response) (*Rout
 
 // GetHandleError handles the Get error response.
 func (client *RouteTablesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -305,9 +296,6 @@ func (client *RouteTablesClient) ListHandleResponse(resp *azcore.Response) (*Rou
 
 // ListHandleError handles the List error response.
 func (client *RouteTablesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -353,9 +341,6 @@ func (client *RouteTablesClient) ListAllHandleResponse(resp *azcore.Response) (*
 
 // ListAllHandleError handles the ListAll error response.
 func (client *RouteTablesClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -373,8 +358,8 @@ func (client *RouteTablesClient) UpdateTags(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -408,9 +393,6 @@ func (client *RouteTablesClient) UpdateTagsHandleResponse(resp *azcore.Response)
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *RouteTablesClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_routetables.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routetables.go
@@ -63,6 +63,9 @@ func (client *RouteTablesClient) BeginCreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *RouteTablesClient) CreateOrUpdateCreateRequest(ctx context.Context
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *RouteTablesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*RouteTablePollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &RouteTablePollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *RouteTablesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *RouteTablesClient) BeginDelete(ctx context.Context, resourceGroupN
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *RouteTablesClient) DeleteCreateRequest(ctx context.Context, resour
 
 // DeleteHandleResponse handles the Delete response.
 func (client *RouteTablesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *RouteTablesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *RouteTablesClient) Get(ctx context.Context, resourceGroupName stri
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -241,15 +250,15 @@ func (client *RouteTablesClient) GetCreateRequest(ctx context.Context, resourceG
 
 // GetHandleResponse handles the Get response.
 func (client *RouteTablesClient) GetHandleResponse(resp *azcore.Response) (*RouteTableResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := RouteTableResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.RouteTable)
 }
 
 // GetHandleError handles the Get error response.
 func (client *RouteTablesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -265,6 +274,7 @@ func (client *RouteTablesClient) List(resourceGroupName string) RouteTableListRe
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *RouteTableListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.RouteTableListResult.NextLink)
 		},
@@ -289,15 +299,15 @@ func (client *RouteTablesClient) ListCreateRequest(ctx context.Context, resource
 
 // ListHandleResponse handles the List response.
 func (client *RouteTablesClient) ListHandleResponse(resp *azcore.Response) (*RouteTableListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := RouteTableListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.RouteTableListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *RouteTablesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -313,6 +323,7 @@ func (client *RouteTablesClient) ListAll() RouteTableListResultPager {
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *RouteTableListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.RouteTableListResult.NextLink)
 		},
@@ -336,15 +347,15 @@ func (client *RouteTablesClient) ListAllCreateRequest(ctx context.Context) (*azc
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *RouteTablesClient) ListAllHandleResponse(resp *azcore.Response) (*RouteTableListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := RouteTableListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.RouteTableListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *RouteTablesClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -360,6 +371,9 @@ func (client *RouteTablesClient) UpdateTags(ctx context.Context, resourceGroupNa
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -388,15 +402,15 @@ func (client *RouteTablesClient) UpdateTagsCreateRequest(ctx context.Context, re
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *RouteTablesClient) UpdateTagsHandleResponse(resp *azcore.Response) (*RouteTableResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := RouteTableResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.RouteTable)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *RouteTablesClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders.go
@@ -63,6 +63,9 @@ func (client *SecurityPartnerProvidersClient) BeginCreateOrUpdate(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *SecurityPartnerProvidersClient) CreateOrUpdateCreateRequest(ctx co
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *SecurityPartnerProvidersClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*SecurityPartnerProviderPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &SecurityPartnerProviderPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *SecurityPartnerProvidersClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *SecurityPartnerProvidersClient) BeginDelete(ctx context.Context, r
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *SecurityPartnerProvidersClient) DeleteCreateRequest(ctx context.Co
 
 // DeleteHandleResponse handles the Delete response.
 func (client *SecurityPartnerProvidersClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *SecurityPartnerProvidersClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *SecurityPartnerProvidersClient) Get(ctx context.Context, resourceG
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -238,15 +247,15 @@ func (client *SecurityPartnerProvidersClient) GetCreateRequest(ctx context.Conte
 
 // GetHandleResponse handles the Get response.
 func (client *SecurityPartnerProvidersClient) GetHandleResponse(resp *azcore.Response) (*SecurityPartnerProviderResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := SecurityPartnerProviderResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.SecurityPartnerProvider)
 }
 
 // GetHandleError handles the Get error response.
 func (client *SecurityPartnerProvidersClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -262,6 +271,7 @@ func (client *SecurityPartnerProvidersClient) List() SecurityPartnerProviderList
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *SecurityPartnerProviderListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SecurityPartnerProviderListResult.NextLink)
 		},
@@ -285,15 +295,15 @@ func (client *SecurityPartnerProvidersClient) ListCreateRequest(ctx context.Cont
 
 // ListHandleResponse handles the List response.
 func (client *SecurityPartnerProvidersClient) ListHandleResponse(resp *azcore.Response) (*SecurityPartnerProviderListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := SecurityPartnerProviderListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.SecurityPartnerProviderListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *SecurityPartnerProvidersClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -309,6 +319,7 @@ func (client *SecurityPartnerProvidersClient) ListByResourceGroup(resourceGroupN
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *SecurityPartnerProviderListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SecurityPartnerProviderListResult.NextLink)
 		},
@@ -333,15 +344,15 @@ func (client *SecurityPartnerProvidersClient) ListByResourceGroupCreateRequest(c
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *SecurityPartnerProvidersClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*SecurityPartnerProviderListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := SecurityPartnerProviderListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.SecurityPartnerProviderListResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *SecurityPartnerProvidersClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -357,6 +368,9 @@ func (client *SecurityPartnerProvidersClient) UpdateTags(ctx context.Context, re
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -385,15 +399,15 @@ func (client *SecurityPartnerProvidersClient) UpdateTagsCreateRequest(ctx contex
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *SecurityPartnerProvidersClient) UpdateTagsHandleResponse(resp *azcore.Response) (*SecurityPartnerProviderResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := SecurityPartnerProviderResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.SecurityPartnerProvider)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *SecurityPartnerProvidersClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders.go
@@ -63,8 +63,8 @@ func (client *SecurityPartnerProvidersClient) BeginCreateOrUpdate(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *SecurityPartnerProvidersClient) CreateOrUpdateHandleResponse(resp 
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *SecurityPartnerProvidersClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *SecurityPartnerProvidersClient) BeginDelete(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *SecurityPartnerProvidersClient) DeleteHandleResponse(resp *azcore.
 
 // DeleteHandleError handles the Delete error response.
 func (client *SecurityPartnerProvidersClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *SecurityPartnerProvidersClient) Get(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -253,9 +247,6 @@ func (client *SecurityPartnerProvidersClient) GetHandleResponse(resp *azcore.Res
 
 // GetHandleError handles the Get error response.
 func (client *SecurityPartnerProvidersClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -301,9 +292,6 @@ func (client *SecurityPartnerProvidersClient) ListHandleResponse(resp *azcore.Re
 
 // ListHandleError handles the List error response.
 func (client *SecurityPartnerProvidersClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -350,9 +338,6 @@ func (client *SecurityPartnerProvidersClient) ListByResourceGroupHandleResponse(
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *SecurityPartnerProvidersClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -370,8 +355,8 @@ func (client *SecurityPartnerProvidersClient) UpdateTags(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -405,9 +390,6 @@ func (client *SecurityPartnerProvidersClient) UpdateTagsHandleResponse(resp *azc
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *SecurityPartnerProvidersClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_securityrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securityrules.go
@@ -59,8 +59,8 @@ func (client *SecurityRulesClient) BeginCreateOrUpdate(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *SecurityRulesClient) CreateOrUpdateHandleResponse(resp *azcore.Res
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *SecurityRulesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *SecurityRulesClient) BeginDelete(ctx context.Context, resourceGrou
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *SecurityRulesClient) DeleteHandleResponse(resp *azcore.Response) (
 
 // DeleteHandleError handles the Delete error response.
 func (client *SecurityRulesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *SecurityRulesClient) Get(ctx context.Context, resourceGroupName st
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *SecurityRulesClient) GetHandleResponse(resp *azcore.Response) (*Se
 
 // GetHandleError handles the Get error response.
 func (client *SecurityRulesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *SecurityRulesClient) ListHandleResponse(resp *azcore.Response) (*S
 
 // ListHandleError handles the List error response.
 func (client *SecurityRulesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_securityrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securityrules.go
@@ -59,6 +59,9 @@ func (client *SecurityRulesClient) BeginCreateOrUpdate(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *SecurityRulesClient) CreateOrUpdateCreateRequest(ctx context.Conte
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *SecurityRulesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*SecurityRulePollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &SecurityRulePollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *SecurityRulesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *SecurityRulesClient) BeginDelete(ctx context.Context, resourceGrou
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *SecurityRulesClient) DeleteCreateRequest(ctx context.Context, reso
 
 // DeleteHandleResponse handles the Delete response.
 func (client *SecurityRulesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *SecurityRulesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *SecurityRulesClient) Get(ctx context.Context, resourceGroupName st
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *SecurityRulesClient) GetCreateRequest(ctx context.Context, resourc
 
 // GetHandleResponse handles the Get response.
 func (client *SecurityRulesClient) GetHandleResponse(resp *azcore.Response) (*SecurityRuleResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := SecurityRuleResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.SecurityRule)
 }
 
 // GetHandleError handles the Get error response.
 func (client *SecurityRulesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,7 @@ func (client *SecurityRulesClient) List(resourceGroupName string, networkSecurit
 			return client.ListCreateRequest(ctx, resourceGroupName, networkSecurityGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *SecurityRuleListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SecurityRuleListResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *SecurityRulesClient) ListCreateRequest(ctx context.Context, resour
 
 // ListHandleResponse handles the List response.
 func (client *SecurityRulesClient) ListHandleResponse(resp *azcore.Response) (*SecurityRuleListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := SecurityRuleListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.SecurityRuleListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *SecurityRulesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks.go
@@ -46,6 +46,9 @@ func (client *ServiceAssociationLinksClient) List(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
+	if err := client.ListHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.ListHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -73,15 +76,15 @@ func (client *ServiceAssociationLinksClient) ListCreateRequest(ctx context.Conte
 
 // ListHandleResponse handles the List response.
 func (client *ServiceAssociationLinksClient) ListHandleResponse(resp *azcore.Response) (*ServiceAssociationLinksListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ServiceAssociationLinksListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ServiceAssociationLinksListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ServiceAssociationLinksClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks.go
@@ -46,8 +46,8 @@ func (client *ServiceAssociationLinksClient) List(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListHandleError(resp)
 	}
 	result, err := client.ListHandleResponse(resp)
 	if err != nil {
@@ -82,9 +82,6 @@ func (client *ServiceAssociationLinksClient) ListHandleResponse(resp *azcore.Res
 
 // ListHandleError handles the List error response.
 func (client *ServiceAssociationLinksClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies.go
@@ -63,8 +63,8 @@ func (client *ServiceEndpointPoliciesClient) BeginCreateOrUpdate(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *ServiceEndpointPoliciesClient) CreateOrUpdateHandleResponse(resp *
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ServiceEndpointPoliciesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *ServiceEndpointPoliciesClient) BeginDelete(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *ServiceEndpointPoliciesClient) DeleteHandleResponse(resp *azcore.R
 
 // DeleteHandleError handles the Delete error response.
 func (client *ServiceEndpointPoliciesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *ServiceEndpointPoliciesClient) Get(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -256,9 +250,6 @@ func (client *ServiceEndpointPoliciesClient) GetHandleResponse(resp *azcore.Resp
 
 // GetHandleError handles the Get error response.
 func (client *ServiceEndpointPoliciesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -304,9 +295,6 @@ func (client *ServiceEndpointPoliciesClient) ListHandleResponse(resp *azcore.Res
 
 // ListHandleError handles the List error response.
 func (client *ServiceEndpointPoliciesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -353,9 +341,6 @@ func (client *ServiceEndpointPoliciesClient) ListByResourceGroupHandleResponse(r
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *ServiceEndpointPoliciesClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -373,8 +358,8 @@ func (client *ServiceEndpointPoliciesClient) UpdateTags(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -408,9 +393,6 @@ func (client *ServiceEndpointPoliciesClient) UpdateTagsHandleResponse(resp *azco
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *ServiceEndpointPoliciesClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies.go
@@ -63,6 +63,9 @@ func (client *ServiceEndpointPoliciesClient) BeginCreateOrUpdate(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *ServiceEndpointPoliciesClient) CreateOrUpdateCreateRequest(ctx con
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ServiceEndpointPoliciesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*ServiceEndpointPolicyPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &ServiceEndpointPolicyPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ServiceEndpointPoliciesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *ServiceEndpointPoliciesClient) BeginDelete(ctx context.Context, re
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *ServiceEndpointPoliciesClient) DeleteCreateRequest(ctx context.Con
 
 // DeleteHandleResponse handles the Delete response.
 func (client *ServiceEndpointPoliciesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *ServiceEndpointPoliciesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *ServiceEndpointPoliciesClient) Get(ctx context.Context, resourceGr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -241,15 +250,15 @@ func (client *ServiceEndpointPoliciesClient) GetCreateRequest(ctx context.Contex
 
 // GetHandleResponse handles the Get response.
 func (client *ServiceEndpointPoliciesClient) GetHandleResponse(resp *azcore.Response) (*ServiceEndpointPolicyResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ServiceEndpointPolicyResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ServiceEndpointPolicy)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ServiceEndpointPoliciesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -265,6 +274,7 @@ func (client *ServiceEndpointPoliciesClient) List() ServiceEndpointPolicyListRes
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ServiceEndpointPolicyListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ServiceEndpointPolicyListResult.NextLink)
 		},
@@ -288,15 +298,15 @@ func (client *ServiceEndpointPoliciesClient) ListCreateRequest(ctx context.Conte
 
 // ListHandleResponse handles the List response.
 func (client *ServiceEndpointPoliciesClient) ListHandleResponse(resp *azcore.Response) (*ServiceEndpointPolicyListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ServiceEndpointPolicyListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ServiceEndpointPolicyListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ServiceEndpointPoliciesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -312,6 +322,7 @@ func (client *ServiceEndpointPoliciesClient) ListByResourceGroup(resourceGroupNa
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *ServiceEndpointPolicyListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ServiceEndpointPolicyListResult.NextLink)
 		},
@@ -336,15 +347,15 @@ func (client *ServiceEndpointPoliciesClient) ListByResourceGroupCreateRequest(ct
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *ServiceEndpointPoliciesClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*ServiceEndpointPolicyListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := ServiceEndpointPolicyListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ServiceEndpointPolicyListResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *ServiceEndpointPoliciesClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -360,6 +371,9 @@ func (client *ServiceEndpointPoliciesClient) UpdateTags(ctx context.Context, res
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -388,15 +402,15 @@ func (client *ServiceEndpointPoliciesClient) UpdateTagsCreateRequest(ctx context
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *ServiceEndpointPoliciesClient) UpdateTagsHandleResponse(resp *azcore.Response) (*ServiceEndpointPolicyResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := ServiceEndpointPolicyResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ServiceEndpointPolicy)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *ServiceEndpointPoliciesClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions.go
@@ -59,6 +59,9 @@ func (client *ServiceEndpointPolicyDefinitionsClient) BeginCreateOrUpdate(ctx co
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *ServiceEndpointPolicyDefinitionsClient) CreateOrUpdateCreateReques
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ServiceEndpointPolicyDefinitionsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*ServiceEndpointPolicyDefinitionPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &ServiceEndpointPolicyDefinitionPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ServiceEndpointPolicyDefinitionsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *ServiceEndpointPolicyDefinitionsClient) BeginDelete(ctx context.Co
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *ServiceEndpointPolicyDefinitionsClient) DeleteCreateRequest(ctx co
 
 // DeleteHandleResponse handles the Delete response.
 func (client *ServiceEndpointPolicyDefinitionsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *ServiceEndpointPolicyDefinitionsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *ServiceEndpointPolicyDefinitionsClient) Get(ctx context.Context, r
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *ServiceEndpointPolicyDefinitionsClient) GetCreateRequest(ctx conte
 
 // GetHandleResponse handles the Get response.
 func (client *ServiceEndpointPolicyDefinitionsClient) GetHandleResponse(resp *azcore.Response) (*ServiceEndpointPolicyDefinitionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := ServiceEndpointPolicyDefinitionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ServiceEndpointPolicyDefinition)
 }
 
 // GetHandleError handles the Get error response.
 func (client *ServiceEndpointPolicyDefinitionsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) ListByResourceGroup(resour
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *ServiceEndpointPolicyDefinitionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ServiceEndpointPolicyDefinitionListResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *ServiceEndpointPolicyDefinitionsClient) ListByResourceGroupCreateR
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *ServiceEndpointPolicyDefinitionsClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*ServiceEndpointPolicyDefinitionListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := ServiceEndpointPolicyDefinitionListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ServiceEndpointPolicyDefinitionListResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *ServiceEndpointPolicyDefinitionsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions.go
@@ -59,8 +59,8 @@ func (client *ServiceEndpointPolicyDefinitionsClient) BeginCreateOrUpdate(ctx co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *ServiceEndpointPolicyDefinitionsClient) CreateOrUpdateHandleRespon
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ServiceEndpointPolicyDefinitionsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *ServiceEndpointPolicyDefinitionsClient) BeginDelete(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *ServiceEndpointPolicyDefinitionsClient) DeleteHandleResponse(resp 
 
 // DeleteHandleError handles the Delete error response.
 func (client *ServiceEndpointPolicyDefinitionsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *ServiceEndpointPolicyDefinitionsClient) Get(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *ServiceEndpointPolicyDefinitionsClient) GetHandleResponse(resp *az
 
 // GetHandleError handles the Get error response.
 func (client *ServiceEndpointPolicyDefinitionsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *ServiceEndpointPolicyDefinitionsClient) ListByResourceGroupHandleR
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *ServiceEndpointPolicyDefinitionsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_servicetags.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_servicetags.go
@@ -46,6 +46,9 @@ func (client *ServiceTagsClient) List(ctx context.Context, location string) (*Se
 	if err != nil {
 		return nil, err
 	}
+	if err := client.ListHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.ListHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -71,15 +74,15 @@ func (client *ServiceTagsClient) ListCreateRequest(ctx context.Context, location
 
 // ListHandleResponse handles the List response.
 func (client *ServiceTagsClient) ListHandleResponse(resp *azcore.Response) (*ServiceTagsListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ServiceTagsListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ServiceTagsListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *ServiceTagsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_servicetags.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_servicetags.go
@@ -46,8 +46,8 @@ func (client *ServiceTagsClient) List(ctx context.Context, location string) (*Se
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ListHandleError(resp)
 	}
 	result, err := client.ListHandleResponse(resp)
 	if err != nil {
@@ -80,9 +80,6 @@ func (client *ServiceTagsClient) ListHandleResponse(resp *azcore.Response) (*Ser
 
 // ListHandleError handles the List error response.
 func (client *ServiceTagsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_subnets.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_subnets.go
@@ -67,6 +67,9 @@ func (client *SubnetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -117,14 +120,14 @@ func (client *SubnetsClient) CreateOrUpdateCreateRequest(ctx context.Context, re
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *SubnetsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*SubnetPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &SubnetPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *SubnetsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,6 +144,9 @@ func (client *SubnetsClient) BeginDelete(ctx context.Context, resourceGroupName 
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -193,14 +199,14 @@ func (client *SubnetsClient) DeleteCreateRequest(ctx context.Context, resourceGr
 
 // DeleteHandleResponse handles the Delete response.
 func (client *SubnetsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *SubnetsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,6 +222,9 @@ func (client *SubnetsClient) Get(ctx context.Context, resourceGroupName string, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -248,15 +257,15 @@ func (client *SubnetsClient) GetCreateRequest(ctx context.Context, resourceGroup
 
 // GetHandleResponse handles the Get response.
 func (client *SubnetsClient) GetHandleResponse(resp *azcore.Response) (*SubnetResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := SubnetResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Subnet)
 }
 
 // GetHandleError handles the Get error response.
 func (client *SubnetsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -272,6 +281,7 @@ func (client *SubnetsClient) List(resourceGroupName string, virtualNetworkName s
 			return client.ListCreateRequest(ctx, resourceGroupName, virtualNetworkName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *SubnetListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SubnetListResult.NextLink)
 		},
@@ -297,15 +307,15 @@ func (client *SubnetsClient) ListCreateRequest(ctx context.Context, resourceGrou
 
 // ListHandleResponse handles the List response.
 func (client *SubnetsClient) ListHandleResponse(resp *azcore.Response) (*SubnetListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := SubnetListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.SubnetListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *SubnetsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -322,6 +332,9 @@ func (client *SubnetsClient) BeginPrepareNetworkPolicies(ctx context.Context, re
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.PrepareNetworkPoliciesHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.PrepareNetworkPoliciesHandleResponse(resp)
@@ -374,14 +387,14 @@ func (client *SubnetsClient) PrepareNetworkPoliciesCreateRequest(ctx context.Con
 
 // PrepareNetworkPoliciesHandleResponse handles the PrepareNetworkPolicies response.
 func (client *SubnetsClient) PrepareNetworkPoliciesHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.PrepareNetworkPoliciesHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // PrepareNetworkPoliciesHandleError handles the PrepareNetworkPolicies error response.
 func (client *SubnetsClient) PrepareNetworkPoliciesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -398,6 +411,9 @@ func (client *SubnetsClient) BeginUnprepareNetworkPolicies(ctx context.Context, 
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UnprepareNetworkPoliciesHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UnprepareNetworkPoliciesHandleResponse(resp)
@@ -450,14 +466,14 @@ func (client *SubnetsClient) UnprepareNetworkPoliciesCreateRequest(ctx context.C
 
 // UnprepareNetworkPoliciesHandleResponse handles the UnprepareNetworkPolicies response.
 func (client *SubnetsClient) UnprepareNetworkPoliciesHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.UnprepareNetworkPoliciesHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // UnprepareNetworkPoliciesHandleError handles the UnprepareNetworkPolicies error response.
 func (client *SubnetsClient) UnprepareNetworkPoliciesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_subnets.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_subnets.go
@@ -67,8 +67,8 @@ func (client *SubnetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -125,9 +125,6 @@ func (client *SubnetsClient) CreateOrUpdateHandleResponse(resp *azcore.Response)
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *SubnetsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -146,8 +143,8 @@ func (client *SubnetsClient) BeginDelete(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -204,9 +201,6 @@ func (client *SubnetsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPP
 
 // DeleteHandleError handles the Delete error response.
 func (client *SubnetsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -224,8 +218,8 @@ func (client *SubnetsClient) Get(ctx context.Context, resourceGroupName string, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -263,9 +257,6 @@ func (client *SubnetsClient) GetHandleResponse(resp *azcore.Response) (*SubnetRe
 
 // GetHandleError handles the Get error response.
 func (client *SubnetsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -313,9 +304,6 @@ func (client *SubnetsClient) ListHandleResponse(resp *azcore.Response) (*SubnetL
 
 // ListHandleError handles the List error response.
 func (client *SubnetsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -334,8 +322,8 @@ func (client *SubnetsClient) BeginPrepareNetworkPolicies(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	if err := client.PrepareNetworkPoliciesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.PrepareNetworkPoliciesHandleError(resp)
 	}
 	result, err := client.PrepareNetworkPoliciesHandleResponse(resp)
 	if err != nil {
@@ -392,9 +380,6 @@ func (client *SubnetsClient) PrepareNetworkPoliciesHandleResponse(resp *azcore.R
 
 // PrepareNetworkPoliciesHandleError handles the PrepareNetworkPolicies error response.
 func (client *SubnetsClient) PrepareNetworkPoliciesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -413,8 +398,8 @@ func (client *SubnetsClient) BeginUnprepareNetworkPolicies(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UnprepareNetworkPoliciesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.UnprepareNetworkPoliciesHandleError(resp)
 	}
 	result, err := client.UnprepareNetworkPoliciesHandleResponse(resp)
 	if err != nil {
@@ -471,9 +456,6 @@ func (client *SubnetsClient) UnprepareNetworkPoliciesHandleResponse(resp *azcore
 
 // UnprepareNetworkPoliciesHandleError handles the UnprepareNetworkPolicies error response.
 func (client *SubnetsClient) UnprepareNetworkPoliciesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_usages.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_usages.go
@@ -44,6 +44,7 @@ func (client *UsagesClient) List(location string) UsagesListResultPager {
 			return client.ListCreateRequest(ctx, location)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *UsagesListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.UsagesListResult.NextLink)
 		},
@@ -68,15 +69,15 @@ func (client *UsagesClient) ListCreateRequest(ctx context.Context, location stri
 
 // ListHandleResponse handles the List response.
 func (client *UsagesClient) ListHandleResponse(resp *azcore.Response) (*UsagesListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := UsagesListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.UsagesListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *UsagesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_usages.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_usages.go
@@ -75,9 +75,6 @@ func (client *UsagesClient) ListHandleResponse(resp *azcore.Response) (*UsagesLi
 
 // ListHandleError handles the List error response.
 func (client *UsagesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s.go
@@ -59,8 +59,8 @@ func (client *VirtualHubRouteTableV2SClient) BeginCreateOrUpdate(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *VirtualHubRouteTableV2SClient) CreateOrUpdateHandleResponse(resp *
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualHubRouteTableV2SClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *VirtualHubRouteTableV2SClient) BeginDelete(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *VirtualHubRouteTableV2SClient) DeleteHandleResponse(resp *azcore.R
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualHubRouteTableV2SClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *VirtualHubRouteTableV2SClient) Get(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *VirtualHubRouteTableV2SClient) GetHandleResponse(resp *azcore.Resp
 
 // GetHandleError handles the Get error response.
 func (client *VirtualHubRouteTableV2SClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *VirtualHubRouteTableV2SClient) ListHandleResponse(resp *azcore.Res
 
 // ListHandleError handles the List error response.
 func (client *VirtualHubRouteTableV2SClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s.go
@@ -59,6 +59,9 @@ func (client *VirtualHubRouteTableV2SClient) BeginCreateOrUpdate(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *VirtualHubRouteTableV2SClient) CreateOrUpdateCreateRequest(ctx con
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *VirtualHubRouteTableV2SClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*VirtualHubRouteTableV2PollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &VirtualHubRouteTableV2PollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualHubRouteTableV2SClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *VirtualHubRouteTableV2SClient) BeginDelete(ctx context.Context, re
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *VirtualHubRouteTableV2SClient) DeleteCreateRequest(ctx context.Con
 
 // DeleteHandleResponse handles the Delete response.
 func (client *VirtualHubRouteTableV2SClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualHubRouteTableV2SClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *VirtualHubRouteTableV2SClient) Get(ctx context.Context, resourceGr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *VirtualHubRouteTableV2SClient) GetCreateRequest(ctx context.Contex
 
 // GetHandleResponse handles the Get response.
 func (client *VirtualHubRouteTableV2SClient) GetHandleResponse(resp *azcore.Response) (*VirtualHubRouteTableV2Response, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VirtualHubRouteTableV2Response{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualHubRouteTableV2)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VirtualHubRouteTableV2SClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,7 @@ func (client *VirtualHubRouteTableV2SClient) List(resourceGroupName string, virt
 			return client.ListCreateRequest(ctx, resourceGroupName, virtualHubName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ListVirtualHubRouteTableV2SResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVirtualHubRouteTableV2SResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *VirtualHubRouteTableV2SClient) ListCreateRequest(ctx context.Conte
 
 // ListHandleResponse handles the List response.
 func (client *VirtualHubRouteTableV2SClient) ListHandleResponse(resp *azcore.Response) (*ListVirtualHubRouteTableV2SResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ListVirtualHubRouteTableV2SResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListVirtualHubRouteTableV2SResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *VirtualHubRouteTableV2SClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs.go
@@ -63,8 +63,8 @@ func (client *VirtualHubsClient) BeginCreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *VirtualHubsClient) CreateOrUpdateHandleResponse(resp *azcore.Respo
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualHubsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *VirtualHubsClient) BeginDelete(ctx context.Context, resourceGroupN
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *VirtualHubsClient) DeleteHandleResponse(resp *azcore.Response) (*H
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualHubsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *VirtualHubsClient) Get(ctx context.Context, resourceGroupName stri
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -253,9 +247,6 @@ func (client *VirtualHubsClient) GetHandleResponse(resp *azcore.Response) (*Virt
 
 // GetHandleError handles the Get error response.
 func (client *VirtualHubsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -301,9 +292,6 @@ func (client *VirtualHubsClient) ListHandleResponse(resp *azcore.Response) (*Lis
 
 // ListHandleError handles the List error response.
 func (client *VirtualHubsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -350,9 +338,6 @@ func (client *VirtualHubsClient) ListByResourceGroupHandleResponse(resp *azcore.
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *VirtualHubsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -370,8 +355,8 @@ func (client *VirtualHubsClient) UpdateTags(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -405,9 +390,6 @@ func (client *VirtualHubsClient) UpdateTagsHandleResponse(resp *azcore.Response)
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VirtualHubsClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs.go
@@ -63,6 +63,9 @@ func (client *VirtualHubsClient) BeginCreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *VirtualHubsClient) CreateOrUpdateCreateRequest(ctx context.Context
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *VirtualHubsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*VirtualHubPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &VirtualHubPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualHubsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *VirtualHubsClient) BeginDelete(ctx context.Context, resourceGroupN
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *VirtualHubsClient) DeleteCreateRequest(ctx context.Context, resour
 
 // DeleteHandleResponse handles the Delete response.
 func (client *VirtualHubsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualHubsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *VirtualHubsClient) Get(ctx context.Context, resourceGroupName stri
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -238,15 +247,15 @@ func (client *VirtualHubsClient) GetCreateRequest(ctx context.Context, resourceG
 
 // GetHandleResponse handles the Get response.
 func (client *VirtualHubsClient) GetHandleResponse(resp *azcore.Response) (*VirtualHubResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VirtualHubResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualHub)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VirtualHubsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -262,6 +271,7 @@ func (client *VirtualHubsClient) List() ListVirtualHubsResultPager {
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ListVirtualHubsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVirtualHubsResult.NextLink)
 		},
@@ -285,15 +295,15 @@ func (client *VirtualHubsClient) ListCreateRequest(ctx context.Context) (*azcore
 
 // ListHandleResponse handles the List response.
 func (client *VirtualHubsClient) ListHandleResponse(resp *azcore.Response) (*ListVirtualHubsResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ListVirtualHubsResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListVirtualHubsResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *VirtualHubsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -309,6 +319,7 @@ func (client *VirtualHubsClient) ListByResourceGroup(resourceGroupName string) L
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *ListVirtualHubsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVirtualHubsResult.NextLink)
 		},
@@ -333,15 +344,15 @@ func (client *VirtualHubsClient) ListByResourceGroupCreateRequest(ctx context.Co
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *VirtualHubsClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*ListVirtualHubsResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := ListVirtualHubsResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListVirtualHubsResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *VirtualHubsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -357,6 +368,9 @@ func (client *VirtualHubsClient) UpdateTags(ctx context.Context, resourceGroupNa
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -385,15 +399,15 @@ func (client *VirtualHubsClient) UpdateTagsCreateRequest(ctx context.Context, re
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *VirtualHubsClient) UpdateTagsHandleResponse(resp *azcore.Response) (*VirtualHubResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := VirtualHubResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualHub)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VirtualHubsClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
@@ -81,8 +81,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginCreateOrUpdate(ctx co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -138,9 +138,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) CreateOrUpdateHandleRespon
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualNetworkGatewayConnectionsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -159,8 +156,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginDelete(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -216,9 +213,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) DeleteHandleResponse(resp 
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualNetworkGatewayConnectionsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -236,8 +230,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) Get(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -271,9 +265,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) GetHandleResponse(resp *az
 
 // GetHandleError handles the Get error response.
 func (client *VirtualNetworkGatewayConnectionsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -291,8 +282,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKey(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetSharedKeyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetSharedKeyHandleError(resp)
 	}
 	result, err := client.GetSharedKeyHandleResponse(resp)
 	if err != nil {
@@ -326,9 +317,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKeyHandleResponse
 
 // GetSharedKeyHandleError handles the GetSharedKey error response.
 func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKeyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -375,9 +363,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) ListHandleResponse(resp *a
 
 // ListHandleError handles the List error response.
 func (client *VirtualNetworkGatewayConnectionsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -396,8 +381,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginResetSharedKey(ctx co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResetSharedKeyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.ResetSharedKeyHandleError(resp)
 	}
 	result, err := client.ResetSharedKeyHandleResponse(resp)
 	if err != nil {
@@ -453,9 +438,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) ResetSharedKeyHandleRespon
 
 // ResetSharedKeyHandleError handles the ResetSharedKey error response.
 func (client *VirtualNetworkGatewayConnectionsClient) ResetSharedKeyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -474,8 +456,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginSetSharedKey(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.SetSharedKeyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.SetSharedKeyHandleError(resp)
 	}
 	result, err := client.SetSharedKeyHandleResponse(resp)
 	if err != nil {
@@ -531,9 +513,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) SetSharedKeyHandleResponse
 
 // SetSharedKeyHandleError handles the SetSharedKey error response.
 func (client *VirtualNetworkGatewayConnectionsClient) SetSharedKeyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -552,8 +531,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginStartPacketCapture(ct
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StartPacketCaptureHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.StartPacketCaptureHandleError(resp)
 	}
 	result, err := client.StartPacketCaptureHandleResponse(resp)
 	if err != nil {
@@ -612,9 +591,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) StartPacketCaptureHandleRe
 
 // StartPacketCaptureHandleError handles the StartPacketCapture error response.
 func (client *VirtualNetworkGatewayConnectionsClient) StartPacketCaptureHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -633,8 +609,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginStopPacketCapture(ctx
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StopPacketCaptureHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.StopPacketCaptureHandleError(resp)
 	}
 	result, err := client.StopPacketCaptureHandleResponse(resp)
 	if err != nil {
@@ -690,9 +666,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) StopPacketCaptureHandleRes
 
 // StopPacketCaptureHandleError handles the StopPacketCapture error response.
 func (client *VirtualNetworkGatewayConnectionsClient) StopPacketCaptureHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -711,8 +684,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginUpdateTags(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -768,9 +741,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) UpdateTagsHandleResponse(r
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VirtualNetworkGatewayConnectionsClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
@@ -81,6 +81,9 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginCreateOrUpdate(ctx co
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -130,14 +133,14 @@ func (client *VirtualNetworkGatewayConnectionsClient) CreateOrUpdateCreateReques
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *VirtualNetworkGatewayConnectionsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*VirtualNetworkGatewayConnectionPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &VirtualNetworkGatewayConnectionPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualNetworkGatewayConnectionsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -154,6 +157,9 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginDelete(ctx context.Co
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -205,14 +211,14 @@ func (client *VirtualNetworkGatewayConnectionsClient) DeleteCreateRequest(ctx co
 
 // DeleteHandleResponse handles the Delete response.
 func (client *VirtualNetworkGatewayConnectionsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualNetworkGatewayConnectionsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -228,6 +234,9 @@ func (client *VirtualNetworkGatewayConnectionsClient) Get(ctx context.Context, r
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -256,15 +265,15 @@ func (client *VirtualNetworkGatewayConnectionsClient) GetCreateRequest(ctx conte
 
 // GetHandleResponse handles the Get response.
 func (client *VirtualNetworkGatewayConnectionsClient) GetHandleResponse(resp *azcore.Response) (*VirtualNetworkGatewayConnectionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VirtualNetworkGatewayConnectionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetworkGatewayConnection)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VirtualNetworkGatewayConnectionsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -280,6 +289,9 @@ func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKey(ctx context.C
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetSharedKeyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetSharedKeyHandleResponse(resp)
@@ -308,15 +320,15 @@ func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKeyCreateRequest(
 
 // GetSharedKeyHandleResponse handles the GetSharedKey response.
 func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKeyHandleResponse(resp *azcore.Response) (*ConnectionSharedKeyResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetSharedKeyHandleError(resp)
-	}
 	result := ConnectionSharedKeyResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ConnectionSharedKey)
 }
 
 // GetSharedKeyHandleError handles the GetSharedKey error response.
 func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKeyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -332,6 +344,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) List(resourceGroupName str
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *VirtualNetworkGatewayConnectionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkGatewayConnectionListResult.NextLink)
 		},
@@ -356,15 +369,15 @@ func (client *VirtualNetworkGatewayConnectionsClient) ListCreateRequest(ctx cont
 
 // ListHandleResponse handles the List response.
 func (client *VirtualNetworkGatewayConnectionsClient) ListHandleResponse(resp *azcore.Response) (*VirtualNetworkGatewayConnectionListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := VirtualNetworkGatewayConnectionListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetworkGatewayConnectionListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *VirtualNetworkGatewayConnectionsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -381,6 +394,9 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginResetSharedKey(ctx co
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResetSharedKeyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResetSharedKeyHandleResponse(resp)
@@ -432,14 +448,14 @@ func (client *VirtualNetworkGatewayConnectionsClient) ResetSharedKeyCreateReques
 
 // ResetSharedKeyHandleResponse handles the ResetSharedKey response.
 func (client *VirtualNetworkGatewayConnectionsClient) ResetSharedKeyHandleResponse(resp *azcore.Response) (*ConnectionResetSharedKeyPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.ResetSharedKeyHandleError(resp)
-	}
 	return &ConnectionResetSharedKeyPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // ResetSharedKeyHandleError handles the ResetSharedKey error response.
 func (client *VirtualNetworkGatewayConnectionsClient) ResetSharedKeyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -456,6 +472,9 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginSetSharedKey(ctx cont
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.SetSharedKeyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.SetSharedKeyHandleResponse(resp)
@@ -507,14 +526,14 @@ func (client *VirtualNetworkGatewayConnectionsClient) SetSharedKeyCreateRequest(
 
 // SetSharedKeyHandleResponse handles the SetSharedKey response.
 func (client *VirtualNetworkGatewayConnectionsClient) SetSharedKeyHandleResponse(resp *azcore.Response) (*ConnectionSharedKeyPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.SetSharedKeyHandleError(resp)
-	}
 	return &ConnectionSharedKeyPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // SetSharedKeyHandleError handles the SetSharedKey error response.
 func (client *VirtualNetworkGatewayConnectionsClient) SetSharedKeyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -531,6 +550,9 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginStartPacketCapture(ct
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.StartPacketCaptureHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.StartPacketCaptureHandleResponse(resp)
@@ -585,14 +607,14 @@ func (client *VirtualNetworkGatewayConnectionsClient) StartPacketCaptureCreateRe
 
 // StartPacketCaptureHandleResponse handles the StartPacketCapture response.
 func (client *VirtualNetworkGatewayConnectionsClient) StartPacketCaptureHandleResponse(resp *azcore.Response) (*StringPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.StartPacketCaptureHandleError(resp)
-	}
 	return &StringPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // StartPacketCaptureHandleError handles the StartPacketCapture error response.
 func (client *VirtualNetworkGatewayConnectionsClient) StartPacketCaptureHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -609,6 +631,9 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginStopPacketCapture(ctx
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.StopPacketCaptureHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.StopPacketCaptureHandleResponse(resp)
@@ -660,14 +685,14 @@ func (client *VirtualNetworkGatewayConnectionsClient) StopPacketCaptureCreateReq
 
 // StopPacketCaptureHandleResponse handles the StopPacketCapture response.
 func (client *VirtualNetworkGatewayConnectionsClient) StopPacketCaptureHandleResponse(resp *azcore.Response) (*StringPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.StopPacketCaptureHandleError(resp)
-	}
 	return &StringPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // StopPacketCaptureHandleError handles the StopPacketCapture error response.
 func (client *VirtualNetworkGatewayConnectionsClient) StopPacketCaptureHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -684,6 +709,9 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginUpdateTags(ctx contex
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -735,14 +763,14 @@ func (client *VirtualNetworkGatewayConnectionsClient) UpdateTagsCreateRequest(ct
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *VirtualNetworkGatewayConnectionsClient) UpdateTagsHandleResponse(resp *azcore.Response) (*VirtualNetworkGatewayConnectionPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	return &VirtualNetworkGatewayConnectionPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VirtualNetworkGatewayConnectionsClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
@@ -125,6 +125,9 @@ func (client *VirtualNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -174,14 +177,14 @@ func (client *VirtualNetworkGatewaysClient) CreateOrUpdateCreateRequest(ctx cont
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *VirtualNetworkGatewaysClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*VirtualNetworkGatewayPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &VirtualNetworkGatewayPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualNetworkGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -198,6 +201,9 @@ func (client *VirtualNetworkGatewaysClient) BeginDelete(ctx context.Context, res
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -249,14 +255,14 @@ func (client *VirtualNetworkGatewaysClient) DeleteCreateRequest(ctx context.Cont
 
 // DeleteHandleResponse handles the Delete response.
 func (client *VirtualNetworkGatewaysClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualNetworkGatewaysClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -273,6 +279,9 @@ func (client *VirtualNetworkGatewaysClient) BeginDisconnectVirtualNetworkGateway
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DisconnectVirtualNetworkGatewayVpnConnectionsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DisconnectVirtualNetworkGatewayVpnConnectionsHandleResponse(resp)
@@ -324,14 +333,14 @@ func (client *VirtualNetworkGatewaysClient) DisconnectVirtualNetworkGatewayVpnCo
 
 // DisconnectVirtualNetworkGatewayVpnConnectionsHandleResponse handles the DisconnectVirtualNetworkGatewayVpnConnections response.
 func (client *VirtualNetworkGatewaysClient) DisconnectVirtualNetworkGatewayVpnConnectionsHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DisconnectVirtualNetworkGatewayVpnConnectionsHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DisconnectVirtualNetworkGatewayVpnConnectionsHandleError handles the DisconnectVirtualNetworkGatewayVpnConnections error response.
 func (client *VirtualNetworkGatewaysClient) DisconnectVirtualNetworkGatewayVpnConnectionsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -348,6 +357,9 @@ func (client *VirtualNetworkGatewaysClient) BeginGenerateVpnProfile(ctx context.
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GenerateVpnProfileHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GenerateVpnProfileHandleResponse(resp)
@@ -399,14 +411,14 @@ func (client *VirtualNetworkGatewaysClient) GenerateVpnProfileCreateRequest(ctx 
 
 // GenerateVpnProfileHandleResponse handles the GenerateVpnProfile response.
 func (client *VirtualNetworkGatewaysClient) GenerateVpnProfileHandleResponse(resp *azcore.Response) (*StringPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GenerateVpnProfileHandleError(resp)
-	}
 	return &StringPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GenerateVpnProfileHandleError handles the GenerateVpnProfile error response.
 func (client *VirtualNetworkGatewaysClient) GenerateVpnProfileHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -423,6 +435,9 @@ func (client *VirtualNetworkGatewaysClient) BeginGeneratevpnclientpackage(ctx co
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GeneratevpnclientpackageHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GeneratevpnclientpackageHandleResponse(resp)
@@ -474,14 +489,14 @@ func (client *VirtualNetworkGatewaysClient) GeneratevpnclientpackageCreateReques
 
 // GeneratevpnclientpackageHandleResponse handles the Generatevpnclientpackage response.
 func (client *VirtualNetworkGatewaysClient) GeneratevpnclientpackageHandleResponse(resp *azcore.Response) (*StringPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GeneratevpnclientpackageHandleError(resp)
-	}
 	return &StringPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GeneratevpnclientpackageHandleError handles the Generatevpnclientpackage error response.
 func (client *VirtualNetworkGatewaysClient) GeneratevpnclientpackageHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -497,6 +512,9 @@ func (client *VirtualNetworkGatewaysClient) Get(ctx context.Context, resourceGro
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -525,15 +543,15 @@ func (client *VirtualNetworkGatewaysClient) GetCreateRequest(ctx context.Context
 
 // GetHandleResponse handles the Get response.
 func (client *VirtualNetworkGatewaysClient) GetHandleResponse(resp *azcore.Response) (*VirtualNetworkGatewayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VirtualNetworkGatewayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetworkGateway)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VirtualNetworkGatewaysClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -550,6 +568,9 @@ func (client *VirtualNetworkGatewaysClient) BeginGetAdvertisedRoutes(ctx context
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetAdvertisedRoutesHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetAdvertisedRoutesHandleResponse(resp)
@@ -602,14 +623,14 @@ func (client *VirtualNetworkGatewaysClient) GetAdvertisedRoutesCreateRequest(ctx
 
 // GetAdvertisedRoutesHandleResponse handles the GetAdvertisedRoutes response.
 func (client *VirtualNetworkGatewaysClient) GetAdvertisedRoutesHandleResponse(resp *azcore.Response) (*GatewayRouteListResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetAdvertisedRoutesHandleError(resp)
-	}
 	return &GatewayRouteListResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetAdvertisedRoutesHandleError handles the GetAdvertisedRoutes error response.
 func (client *VirtualNetworkGatewaysClient) GetAdvertisedRoutesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -626,6 +647,9 @@ func (client *VirtualNetworkGatewaysClient) BeginGetBgpPeerStatus(ctx context.Co
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBgpPeerStatusHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBgpPeerStatusHandleResponse(resp)
@@ -680,14 +704,14 @@ func (client *VirtualNetworkGatewaysClient) GetBgpPeerStatusCreateRequest(ctx co
 
 // GetBgpPeerStatusHandleResponse handles the GetBgpPeerStatus response.
 func (client *VirtualNetworkGatewaysClient) GetBgpPeerStatusHandleResponse(resp *azcore.Response) (*BgpPeerStatusListResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetBgpPeerStatusHandleError(resp)
-	}
 	return &BgpPeerStatusListResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetBgpPeerStatusHandleError handles the GetBgpPeerStatus error response.
 func (client *VirtualNetworkGatewaysClient) GetBgpPeerStatusHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -704,6 +728,9 @@ func (client *VirtualNetworkGatewaysClient) BeginGetLearnedRoutes(ctx context.Co
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetLearnedRoutesHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetLearnedRoutesHandleResponse(resp)
@@ -755,14 +782,14 @@ func (client *VirtualNetworkGatewaysClient) GetLearnedRoutesCreateRequest(ctx co
 
 // GetLearnedRoutesHandleResponse handles the GetLearnedRoutes response.
 func (client *VirtualNetworkGatewaysClient) GetLearnedRoutesHandleResponse(resp *azcore.Response) (*GatewayRouteListResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetLearnedRoutesHandleError(resp)
-	}
 	return &GatewayRouteListResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetLearnedRoutesHandleError handles the GetLearnedRoutes error response.
 func (client *VirtualNetworkGatewaysClient) GetLearnedRoutesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -779,6 +806,9 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVpnProfilePackageURL(ctx con
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetVpnProfilePackageURLHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetVpnProfilePackageURLHandleResponse(resp)
@@ -830,14 +860,14 @@ func (client *VirtualNetworkGatewaysClient) GetVpnProfilePackageURLCreateRequest
 
 // GetVpnProfilePackageURLHandleResponse handles the GetVpnProfilePackageURL response.
 func (client *VirtualNetworkGatewaysClient) GetVpnProfilePackageURLHandleResponse(resp *azcore.Response) (*StringPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetVpnProfilePackageURLHandleError(resp)
-	}
 	return &StringPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetVpnProfilePackageURLHandleError handles the GetVpnProfilePackageURL error response.
 func (client *VirtualNetworkGatewaysClient) GetVpnProfilePackageURLHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -854,6 +884,9 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientConnectionHealth(ct
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetVpnclientConnectionHealthHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetVpnclientConnectionHealthHandleResponse(resp)
@@ -905,14 +938,14 @@ func (client *VirtualNetworkGatewaysClient) GetVpnclientConnectionHealthCreateRe
 
 // GetVpnclientConnectionHealthHandleResponse handles the GetVpnclientConnectionHealth response.
 func (client *VirtualNetworkGatewaysClient) GetVpnclientConnectionHealthHandleResponse(resp *azcore.Response) (*VpnClientConnectionHealthDetailListResultPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.GetVpnclientConnectionHealthHandleError(resp)
-	}
 	return &VpnClientConnectionHealthDetailListResultPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetVpnclientConnectionHealthHandleError handles the GetVpnclientConnectionHealth error response.
 func (client *VirtualNetworkGatewaysClient) GetVpnclientConnectionHealthHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -929,6 +962,9 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientIPsecParameters(ctx
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetVpnclientIPsecParametersHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetVpnclientIPsecParametersHandleResponse(resp)
@@ -980,14 +1016,14 @@ func (client *VirtualNetworkGatewaysClient) GetVpnclientIPsecParametersCreateReq
 
 // GetVpnclientIPsecParametersHandleResponse handles the GetVpnclientIPsecParameters response.
 func (client *VirtualNetworkGatewaysClient) GetVpnclientIPsecParametersHandleResponse(resp *azcore.Response) (*VpnClientIPsecParametersPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil, client.GetVpnclientIPsecParametersHandleError(resp)
-	}
 	return &VpnClientIPsecParametersPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // GetVpnclientIPsecParametersHandleError handles the GetVpnclientIPsecParameters error response.
 func (client *VirtualNetworkGatewaysClient) GetVpnclientIPsecParametersHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1003,6 +1039,7 @@ func (client *VirtualNetworkGatewaysClient) List(resourceGroupName string) Virtu
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *VirtualNetworkGatewayListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkGatewayListResult.NextLink)
 		},
@@ -1027,15 +1064,15 @@ func (client *VirtualNetworkGatewaysClient) ListCreateRequest(ctx context.Contex
 
 // ListHandleResponse handles the List response.
 func (client *VirtualNetworkGatewaysClient) ListHandleResponse(resp *azcore.Response) (*VirtualNetworkGatewayListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := VirtualNetworkGatewayListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetworkGatewayListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *VirtualNetworkGatewaysClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1051,6 +1088,7 @@ func (client *VirtualNetworkGatewaysClient) ListConnections(resourceGroupName st
 			return client.ListConnectionsCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName)
 		},
 		responder: client.ListConnectionsHandleResponse,
+		errorer:   client.ListConnectionsHandleError,
 		advancer: func(ctx context.Context, resp *VirtualNetworkGatewayListConnectionsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkGatewayListConnectionsResult.NextLink)
 		},
@@ -1076,15 +1114,15 @@ func (client *VirtualNetworkGatewaysClient) ListConnectionsCreateRequest(ctx con
 
 // ListConnectionsHandleResponse handles the ListConnections response.
 func (client *VirtualNetworkGatewaysClient) ListConnectionsHandleResponse(resp *azcore.Response) (*VirtualNetworkGatewayListConnectionsResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListConnectionsHandleError(resp)
-	}
 	result := VirtualNetworkGatewayListConnectionsResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetworkGatewayListConnectionsResult)
 }
 
 // ListConnectionsHandleError handles the ListConnections error response.
 func (client *VirtualNetworkGatewaysClient) ListConnectionsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1101,6 +1139,9 @@ func (client *VirtualNetworkGatewaysClient) BeginReset(ctx context.Context, reso
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResetHandleResponse(resp)
@@ -1155,14 +1196,14 @@ func (client *VirtualNetworkGatewaysClient) ResetCreateRequest(ctx context.Conte
 
 // ResetHandleResponse handles the Reset response.
 func (client *VirtualNetworkGatewaysClient) ResetHandleResponse(resp *azcore.Response) (*VirtualNetworkGatewayPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.ResetHandleError(resp)
-	}
 	return &VirtualNetworkGatewayPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // ResetHandleError handles the Reset error response.
 func (client *VirtualNetworkGatewaysClient) ResetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1179,6 +1220,9 @@ func (client *VirtualNetworkGatewaysClient) BeginResetVpnClientSharedKey(ctx con
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResetVpnClientSharedKeyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResetVpnClientSharedKeyHandleResponse(resp)
@@ -1230,14 +1274,14 @@ func (client *VirtualNetworkGatewaysClient) ResetVpnClientSharedKeyCreateRequest
 
 // ResetVpnClientSharedKeyHandleResponse handles the ResetVpnClientSharedKey response.
 func (client *VirtualNetworkGatewaysClient) ResetVpnClientSharedKeyHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.ResetVpnClientSharedKeyHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // ResetVpnClientSharedKeyHandleError handles the ResetVpnClientSharedKey error response.
 func (client *VirtualNetworkGatewaysClient) ResetVpnClientSharedKeyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1254,6 +1298,9 @@ func (client *VirtualNetworkGatewaysClient) BeginSetVpnclientIPsecParameters(ctx
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.SetVpnclientIPsecParametersHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.SetVpnclientIPsecParametersHandleResponse(resp)
@@ -1305,14 +1352,14 @@ func (client *VirtualNetworkGatewaysClient) SetVpnclientIPsecParametersCreateReq
 
 // SetVpnclientIPsecParametersHandleResponse handles the SetVpnclientIPsecParameters response.
 func (client *VirtualNetworkGatewaysClient) SetVpnclientIPsecParametersHandleResponse(resp *azcore.Response) (*VpnClientIPsecParametersPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.SetVpnclientIPsecParametersHandleError(resp)
-	}
 	return &VpnClientIPsecParametersPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // SetVpnclientIPsecParametersHandleError handles the SetVpnclientIPsecParameters error response.
 func (client *VirtualNetworkGatewaysClient) SetVpnclientIPsecParametersHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1329,6 +1376,9 @@ func (client *VirtualNetworkGatewaysClient) BeginStartPacketCapture(ctx context.
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.StartPacketCaptureHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.StartPacketCaptureHandleResponse(resp)
@@ -1383,14 +1433,14 @@ func (client *VirtualNetworkGatewaysClient) StartPacketCaptureCreateRequest(ctx 
 
 // StartPacketCaptureHandleResponse handles the StartPacketCapture response.
 func (client *VirtualNetworkGatewaysClient) StartPacketCaptureHandleResponse(resp *azcore.Response) (*StringPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.StartPacketCaptureHandleError(resp)
-	}
 	return &StringPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // StartPacketCaptureHandleError handles the StartPacketCapture error response.
 func (client *VirtualNetworkGatewaysClient) StartPacketCaptureHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1407,6 +1457,9 @@ func (client *VirtualNetworkGatewaysClient) BeginStopPacketCapture(ctx context.C
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.StopPacketCaptureHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.StopPacketCaptureHandleResponse(resp)
@@ -1458,14 +1511,14 @@ func (client *VirtualNetworkGatewaysClient) StopPacketCaptureCreateRequest(ctx c
 
 // StopPacketCaptureHandleResponse handles the StopPacketCapture response.
 func (client *VirtualNetworkGatewaysClient) StopPacketCaptureHandleResponse(resp *azcore.Response) (*StringPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.StopPacketCaptureHandleError(resp)
-	}
 	return &StringPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // StopPacketCaptureHandleError handles the StopPacketCapture error response.
 func (client *VirtualNetworkGatewaysClient) StopPacketCaptureHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1481,6 +1534,9 @@ func (client *VirtualNetworkGatewaysClient) SupportedVpnDevices(ctx context.Cont
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.SupportedVpnDevicesHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.SupportedVpnDevicesHandleResponse(resp)
@@ -1509,15 +1565,15 @@ func (client *VirtualNetworkGatewaysClient) SupportedVpnDevicesCreateRequest(ctx
 
 // SupportedVpnDevicesHandleResponse handles the SupportedVpnDevices response.
 func (client *VirtualNetworkGatewaysClient) SupportedVpnDevicesHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.SupportedVpnDevicesHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // SupportedVpnDevicesHandleError handles the SupportedVpnDevices error response.
 func (client *VirtualNetworkGatewaysClient) SupportedVpnDevicesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1534,6 +1590,9 @@ func (client *VirtualNetworkGatewaysClient) BeginUpdateTags(ctx context.Context,
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -1585,14 +1644,14 @@ func (client *VirtualNetworkGatewaysClient) UpdateTagsCreateRequest(ctx context.
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *VirtualNetworkGatewaysClient) UpdateTagsHandleResponse(resp *azcore.Response) (*VirtualNetworkGatewayPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	return &VirtualNetworkGatewayPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VirtualNetworkGatewaysClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1608,6 +1667,9 @@ func (client *VirtualNetworkGatewaysClient) VpnDeviceConfigurationScript(ctx con
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.VpnDeviceConfigurationScriptHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.VpnDeviceConfigurationScriptHandleResponse(resp)
@@ -1636,15 +1698,15 @@ func (client *VirtualNetworkGatewaysClient) VpnDeviceConfigurationScriptCreateRe
 
 // VpnDeviceConfigurationScriptHandleResponse handles the VpnDeviceConfigurationScript response.
 func (client *VirtualNetworkGatewaysClient) VpnDeviceConfigurationScriptHandleResponse(resp *azcore.Response) (*StringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.VpnDeviceConfigurationScriptHandleError(resp)
-	}
 	result := StringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.Value)
 }
 
 // VpnDeviceConfigurationScriptHandleError handles the VpnDeviceConfigurationScript error response.
 func (client *VirtualNetworkGatewaysClient) VpnDeviceConfigurationScriptHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
@@ -125,8 +125,8 @@ func (client *VirtualNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -182,9 +182,6 @@ func (client *VirtualNetworkGatewaysClient) CreateOrUpdateHandleResponse(resp *a
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualNetworkGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -203,8 +200,8 @@ func (client *VirtualNetworkGatewaysClient) BeginDelete(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -260,9 +257,6 @@ func (client *VirtualNetworkGatewaysClient) DeleteHandleResponse(resp *azcore.Re
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualNetworkGatewaysClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -281,8 +275,8 @@ func (client *VirtualNetworkGatewaysClient) BeginDisconnectVirtualNetworkGateway
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DisconnectVirtualNetworkGatewayVpnConnectionsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.DisconnectVirtualNetworkGatewayVpnConnectionsHandleError(resp)
 	}
 	result, err := client.DisconnectVirtualNetworkGatewayVpnConnectionsHandleResponse(resp)
 	if err != nil {
@@ -338,9 +332,6 @@ func (client *VirtualNetworkGatewaysClient) DisconnectVirtualNetworkGatewayVpnCo
 
 // DisconnectVirtualNetworkGatewayVpnConnectionsHandleError handles the DisconnectVirtualNetworkGatewayVpnConnections error response.
 func (client *VirtualNetworkGatewaysClient) DisconnectVirtualNetworkGatewayVpnConnectionsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -359,8 +350,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGenerateVpnProfile(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GenerateVpnProfileHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GenerateVpnProfileHandleError(resp)
 	}
 	result, err := client.GenerateVpnProfileHandleResponse(resp)
 	if err != nil {
@@ -416,9 +407,6 @@ func (client *VirtualNetworkGatewaysClient) GenerateVpnProfileHandleResponse(res
 
 // GenerateVpnProfileHandleError handles the GenerateVpnProfile error response.
 func (client *VirtualNetworkGatewaysClient) GenerateVpnProfileHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -437,8 +425,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGeneratevpnclientpackage(ctx co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GeneratevpnclientpackageHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GeneratevpnclientpackageHandleError(resp)
 	}
 	result, err := client.GeneratevpnclientpackageHandleResponse(resp)
 	if err != nil {
@@ -494,9 +482,6 @@ func (client *VirtualNetworkGatewaysClient) GeneratevpnclientpackageHandleRespon
 
 // GeneratevpnclientpackageHandleError handles the Generatevpnclientpackage error response.
 func (client *VirtualNetworkGatewaysClient) GeneratevpnclientpackageHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -514,8 +499,8 @@ func (client *VirtualNetworkGatewaysClient) Get(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -549,9 +534,6 @@ func (client *VirtualNetworkGatewaysClient) GetHandleResponse(resp *azcore.Respo
 
 // GetHandleError handles the Get error response.
 func (client *VirtualNetworkGatewaysClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -570,8 +552,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGetAdvertisedRoutes(ctx context
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetAdvertisedRoutesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetAdvertisedRoutesHandleError(resp)
 	}
 	result, err := client.GetAdvertisedRoutesHandleResponse(resp)
 	if err != nil {
@@ -628,9 +610,6 @@ func (client *VirtualNetworkGatewaysClient) GetAdvertisedRoutesHandleResponse(re
 
 // GetAdvertisedRoutesHandleError handles the GetAdvertisedRoutes error response.
 func (client *VirtualNetworkGatewaysClient) GetAdvertisedRoutesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -649,8 +628,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGetBgpPeerStatus(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBgpPeerStatusHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetBgpPeerStatusHandleError(resp)
 	}
 	result, err := client.GetBgpPeerStatusHandleResponse(resp)
 	if err != nil {
@@ -709,9 +688,6 @@ func (client *VirtualNetworkGatewaysClient) GetBgpPeerStatusHandleResponse(resp 
 
 // GetBgpPeerStatusHandleError handles the GetBgpPeerStatus error response.
 func (client *VirtualNetworkGatewaysClient) GetBgpPeerStatusHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -730,8 +706,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGetLearnedRoutes(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetLearnedRoutesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetLearnedRoutesHandleError(resp)
 	}
 	result, err := client.GetLearnedRoutesHandleResponse(resp)
 	if err != nil {
@@ -787,9 +763,6 @@ func (client *VirtualNetworkGatewaysClient) GetLearnedRoutesHandleResponse(resp 
 
 // GetLearnedRoutesHandleError handles the GetLearnedRoutes error response.
 func (client *VirtualNetworkGatewaysClient) GetLearnedRoutesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -808,8 +781,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVpnProfilePackageURL(ctx con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetVpnProfilePackageURLHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetVpnProfilePackageURLHandleError(resp)
 	}
 	result, err := client.GetVpnProfilePackageURLHandleResponse(resp)
 	if err != nil {
@@ -865,9 +838,6 @@ func (client *VirtualNetworkGatewaysClient) GetVpnProfilePackageURLHandleRespons
 
 // GetVpnProfilePackageURLHandleError handles the GetVpnProfilePackageURL error response.
 func (client *VirtualNetworkGatewaysClient) GetVpnProfilePackageURLHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -886,8 +856,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientConnectionHealth(ct
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetVpnclientConnectionHealthHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.GetVpnclientConnectionHealthHandleError(resp)
 	}
 	result, err := client.GetVpnclientConnectionHealthHandleResponse(resp)
 	if err != nil {
@@ -943,9 +913,6 @@ func (client *VirtualNetworkGatewaysClient) GetVpnclientConnectionHealthHandleRe
 
 // GetVpnclientConnectionHealthHandleError handles the GetVpnclientConnectionHealth error response.
 func (client *VirtualNetworkGatewaysClient) GetVpnclientConnectionHealthHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -964,8 +931,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientIPsecParameters(ctx
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetVpnclientIPsecParametersHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetVpnclientIPsecParametersHandleError(resp)
 	}
 	result, err := client.GetVpnclientIPsecParametersHandleResponse(resp)
 	if err != nil {
@@ -1021,9 +988,6 @@ func (client *VirtualNetworkGatewaysClient) GetVpnclientIPsecParametersHandleRes
 
 // GetVpnclientIPsecParametersHandleError handles the GetVpnclientIPsecParameters error response.
 func (client *VirtualNetworkGatewaysClient) GetVpnclientIPsecParametersHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1070,9 +1034,6 @@ func (client *VirtualNetworkGatewaysClient) ListHandleResponse(resp *azcore.Resp
 
 // ListHandleError handles the List error response.
 func (client *VirtualNetworkGatewaysClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1120,9 +1081,6 @@ func (client *VirtualNetworkGatewaysClient) ListConnectionsHandleResponse(resp *
 
 // ListConnectionsHandleError handles the ListConnections error response.
 func (client *VirtualNetworkGatewaysClient) ListConnectionsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1141,8 +1099,8 @@ func (client *VirtualNetworkGatewaysClient) BeginReset(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.ResetHandleError(resp)
 	}
 	result, err := client.ResetHandleResponse(resp)
 	if err != nil {
@@ -1201,9 +1159,6 @@ func (client *VirtualNetworkGatewaysClient) ResetHandleResponse(resp *azcore.Res
 
 // ResetHandleError handles the Reset error response.
 func (client *VirtualNetworkGatewaysClient) ResetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1222,8 +1177,8 @@ func (client *VirtualNetworkGatewaysClient) BeginResetVpnClientSharedKey(ctx con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResetVpnClientSharedKeyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.ResetVpnClientSharedKeyHandleError(resp)
 	}
 	result, err := client.ResetVpnClientSharedKeyHandleResponse(resp)
 	if err != nil {
@@ -1279,9 +1234,6 @@ func (client *VirtualNetworkGatewaysClient) ResetVpnClientSharedKeyHandleRespons
 
 // ResetVpnClientSharedKeyHandleError handles the ResetVpnClientSharedKey error response.
 func (client *VirtualNetworkGatewaysClient) ResetVpnClientSharedKeyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1300,8 +1252,8 @@ func (client *VirtualNetworkGatewaysClient) BeginSetVpnclientIPsecParameters(ctx
 	if err != nil {
 		return nil, err
 	}
-	if err := client.SetVpnclientIPsecParametersHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.SetVpnclientIPsecParametersHandleError(resp)
 	}
 	result, err := client.SetVpnclientIPsecParametersHandleResponse(resp)
 	if err != nil {
@@ -1357,9 +1309,6 @@ func (client *VirtualNetworkGatewaysClient) SetVpnclientIPsecParametersHandleRes
 
 // SetVpnclientIPsecParametersHandleError handles the SetVpnclientIPsecParameters error response.
 func (client *VirtualNetworkGatewaysClient) SetVpnclientIPsecParametersHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1378,8 +1327,8 @@ func (client *VirtualNetworkGatewaysClient) BeginStartPacketCapture(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StartPacketCaptureHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.StartPacketCaptureHandleError(resp)
 	}
 	result, err := client.StartPacketCaptureHandleResponse(resp)
 	if err != nil {
@@ -1438,9 +1387,6 @@ func (client *VirtualNetworkGatewaysClient) StartPacketCaptureHandleResponse(res
 
 // StartPacketCaptureHandleError handles the StartPacketCapture error response.
 func (client *VirtualNetworkGatewaysClient) StartPacketCaptureHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1459,8 +1405,8 @@ func (client *VirtualNetworkGatewaysClient) BeginStopPacketCapture(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StopPacketCaptureHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.StopPacketCaptureHandleError(resp)
 	}
 	result, err := client.StopPacketCaptureHandleResponse(resp)
 	if err != nil {
@@ -1516,9 +1462,6 @@ func (client *VirtualNetworkGatewaysClient) StopPacketCaptureHandleResponse(resp
 
 // StopPacketCaptureHandleError handles the StopPacketCapture error response.
 func (client *VirtualNetworkGatewaysClient) StopPacketCaptureHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1536,8 +1479,8 @@ func (client *VirtualNetworkGatewaysClient) SupportedVpnDevices(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.SupportedVpnDevicesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.SupportedVpnDevicesHandleError(resp)
 	}
 	result, err := client.SupportedVpnDevicesHandleResponse(resp)
 	if err != nil {
@@ -1571,9 +1514,6 @@ func (client *VirtualNetworkGatewaysClient) SupportedVpnDevicesHandleResponse(re
 
 // SupportedVpnDevicesHandleError handles the SupportedVpnDevices error response.
 func (client *VirtualNetworkGatewaysClient) SupportedVpnDevicesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1592,8 +1532,8 @@ func (client *VirtualNetworkGatewaysClient) BeginUpdateTags(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -1649,9 +1589,6 @@ func (client *VirtualNetworkGatewaysClient) UpdateTagsHandleResponse(resp *azcor
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VirtualNetworkGatewaysClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -1669,8 +1606,8 @@ func (client *VirtualNetworkGatewaysClient) VpnDeviceConfigurationScript(ctx con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.VpnDeviceConfigurationScriptHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.VpnDeviceConfigurationScriptHandleError(resp)
 	}
 	result, err := client.VpnDeviceConfigurationScriptHandleResponse(resp)
 	if err != nil {
@@ -1704,9 +1641,6 @@ func (client *VirtualNetworkGatewaysClient) VpnDeviceConfigurationScriptHandleRe
 
 // VpnDeviceConfigurationScriptHandleError handles the VpnDeviceConfigurationScript error response.
 func (client *VirtualNetworkGatewaysClient) VpnDeviceConfigurationScriptHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings.go
@@ -59,6 +59,9 @@ func (client *VirtualNetworkPeeringsClient) BeginCreateOrUpdate(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *VirtualNetworkPeeringsClient) CreateOrUpdateCreateRequest(ctx cont
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *VirtualNetworkPeeringsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*VirtualNetworkPeeringPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &VirtualNetworkPeeringPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualNetworkPeeringsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *VirtualNetworkPeeringsClient) BeginDelete(ctx context.Context, res
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *VirtualNetworkPeeringsClient) DeleteCreateRequest(ctx context.Cont
 
 // DeleteHandleResponse handles the Delete response.
 func (client *VirtualNetworkPeeringsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualNetworkPeeringsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *VirtualNetworkPeeringsClient) Get(ctx context.Context, resourceGro
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *VirtualNetworkPeeringsClient) GetCreateRequest(ctx context.Context
 
 // GetHandleResponse handles the Get response.
 func (client *VirtualNetworkPeeringsClient) GetHandleResponse(resp *azcore.Response) (*VirtualNetworkPeeringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VirtualNetworkPeeringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetworkPeering)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VirtualNetworkPeeringsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,7 @@ func (client *VirtualNetworkPeeringsClient) List(resourceGroupName string, virtu
 			return client.ListCreateRequest(ctx, resourceGroupName, virtualNetworkName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *VirtualNetworkPeeringListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkPeeringListResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *VirtualNetworkPeeringsClient) ListCreateRequest(ctx context.Contex
 
 // ListHandleResponse handles the List response.
 func (client *VirtualNetworkPeeringsClient) ListHandleResponse(resp *azcore.Response) (*VirtualNetworkPeeringListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := VirtualNetworkPeeringListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetworkPeeringListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *VirtualNetworkPeeringsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings.go
@@ -59,8 +59,8 @@ func (client *VirtualNetworkPeeringsClient) BeginCreateOrUpdate(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *VirtualNetworkPeeringsClient) CreateOrUpdateHandleResponse(resp *a
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualNetworkPeeringsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *VirtualNetworkPeeringsClient) BeginDelete(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *VirtualNetworkPeeringsClient) DeleteHandleResponse(resp *azcore.Re
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualNetworkPeeringsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *VirtualNetworkPeeringsClient) Get(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *VirtualNetworkPeeringsClient) GetHandleResponse(resp *azcore.Respo
 
 // GetHandleError handles the Get error response.
 func (client *VirtualNetworkPeeringsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *VirtualNetworkPeeringsClient) ListHandleResponse(resp *azcore.Resp
 
 // ListHandleError handles the List error response.
 func (client *VirtualNetworkPeeringsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks.go
@@ -66,8 +66,8 @@ func (client *VirtualNetworksClient) CheckIPAddressAvailability(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CheckIPAddressAvailabilityHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.CheckIPAddressAvailabilityHandleError(resp)
 	}
 	result, err := client.CheckIPAddressAvailabilityHandleResponse(resp)
 	if err != nil {
@@ -102,9 +102,6 @@ func (client *VirtualNetworksClient) CheckIPAddressAvailabilityHandleResponse(re
 
 // CheckIPAddressAvailabilityHandleError handles the CheckIPAddressAvailability error response.
 func (client *VirtualNetworksClient) CheckIPAddressAvailabilityHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -123,8 +120,8 @@ func (client *VirtualNetworksClient) BeginCreateOrUpdate(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -180,9 +177,6 @@ func (client *VirtualNetworksClient) CreateOrUpdateHandleResponse(resp *azcore.R
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualNetworksClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -201,8 +195,8 @@ func (client *VirtualNetworksClient) BeginDelete(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -258,9 +252,6 @@ func (client *VirtualNetworksClient) DeleteHandleResponse(resp *azcore.Response)
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualNetworksClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -278,8 +269,8 @@ func (client *VirtualNetworksClient) Get(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -316,9 +307,6 @@ func (client *VirtualNetworksClient) GetHandleResponse(resp *azcore.Response) (*
 
 // GetHandleError handles the Get error response.
 func (client *VirtualNetworksClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -365,9 +353,6 @@ func (client *VirtualNetworksClient) ListHandleResponse(resp *azcore.Response) (
 
 // ListHandleError handles the List error response.
 func (client *VirtualNetworksClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -413,9 +398,6 @@ func (client *VirtualNetworksClient) ListAllHandleResponse(resp *azcore.Response
 
 // ListAllHandleError handles the ListAll error response.
 func (client *VirtualNetworksClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -463,9 +445,6 @@ func (client *VirtualNetworksClient) ListUsageHandleResponse(resp *azcore.Respon
 
 // ListUsageHandleError handles the ListUsage error response.
 func (client *VirtualNetworksClient) ListUsageHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -483,8 +462,8 @@ func (client *VirtualNetworksClient) UpdateTags(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -518,9 +497,6 @@ func (client *VirtualNetworksClient) UpdateTagsHandleResponse(resp *azcore.Respo
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VirtualNetworksClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks.go
@@ -66,6 +66,9 @@ func (client *VirtualNetworksClient) CheckIPAddressAvailability(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CheckIPAddressAvailabilityHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CheckIPAddressAvailabilityHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -93,15 +96,15 @@ func (client *VirtualNetworksClient) CheckIPAddressAvailabilityCreateRequest(ctx
 
 // CheckIPAddressAvailabilityHandleResponse handles the CheckIPAddressAvailability response.
 func (client *VirtualNetworksClient) CheckIPAddressAvailabilityHandleResponse(resp *azcore.Response) (*IPAddressAvailabilityResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.CheckIPAddressAvailabilityHandleError(resp)
-	}
 	result := IPAddressAvailabilityResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.IPAddressAvailabilityResult)
 }
 
 // CheckIPAddressAvailabilityHandleError handles the CheckIPAddressAvailability error response.
 func (client *VirtualNetworksClient) CheckIPAddressAvailabilityHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -118,6 +121,9 @@ func (client *VirtualNetworksClient) BeginCreateOrUpdate(ctx context.Context, re
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
@@ -169,14 +175,14 @@ func (client *VirtualNetworksClient) CreateOrUpdateCreateRequest(ctx context.Con
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *VirtualNetworksClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*VirtualNetworkPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &VirtualNetworkPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualNetworksClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -193,6 +199,9 @@ func (client *VirtualNetworksClient) BeginDelete(ctx context.Context, resourceGr
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -244,14 +253,14 @@ func (client *VirtualNetworksClient) DeleteCreateRequest(ctx context.Context, re
 
 // DeleteHandleResponse handles the Delete response.
 func (client *VirtualNetworksClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualNetworksClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -267,6 +276,9 @@ func (client *VirtualNetworksClient) Get(ctx context.Context, resourceGroupName 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -298,15 +310,15 @@ func (client *VirtualNetworksClient) GetCreateRequest(ctx context.Context, resou
 
 // GetHandleResponse handles the Get response.
 func (client *VirtualNetworksClient) GetHandleResponse(resp *azcore.Response) (*VirtualNetworkResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VirtualNetworkResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetwork)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VirtualNetworksClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -322,6 +334,7 @@ func (client *VirtualNetworksClient) List(resourceGroupName string) VirtualNetwo
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *VirtualNetworkListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkListResult.NextLink)
 		},
@@ -346,15 +359,15 @@ func (client *VirtualNetworksClient) ListCreateRequest(ctx context.Context, reso
 
 // ListHandleResponse handles the List response.
 func (client *VirtualNetworksClient) ListHandleResponse(resp *azcore.Response) (*VirtualNetworkListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := VirtualNetworkListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetworkListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *VirtualNetworksClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -370,6 +383,7 @@ func (client *VirtualNetworksClient) ListAll() VirtualNetworkListResultPager {
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *VirtualNetworkListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkListResult.NextLink)
 		},
@@ -393,15 +407,15 @@ func (client *VirtualNetworksClient) ListAllCreateRequest(ctx context.Context) (
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *VirtualNetworksClient) ListAllHandleResponse(resp *azcore.Response) (*VirtualNetworkListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := VirtualNetworkListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetworkListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *VirtualNetworksClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -417,6 +431,7 @@ func (client *VirtualNetworksClient) ListUsage(resourceGroupName string, virtual
 			return client.ListUsageCreateRequest(ctx, resourceGroupName, virtualNetworkName)
 		},
 		responder: client.ListUsageHandleResponse,
+		errorer:   client.ListUsageHandleError,
 		advancer: func(ctx context.Context, resp *VirtualNetworkListUsageResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkListUsageResult.NextLink)
 		},
@@ -442,15 +457,15 @@ func (client *VirtualNetworksClient) ListUsageCreateRequest(ctx context.Context,
 
 // ListUsageHandleResponse handles the ListUsage response.
 func (client *VirtualNetworksClient) ListUsageHandleResponse(resp *azcore.Response) (*VirtualNetworkListUsageResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListUsageHandleError(resp)
-	}
 	result := VirtualNetworkListUsageResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetworkListUsageResult)
 }
 
 // ListUsageHandleError handles the ListUsage error response.
 func (client *VirtualNetworksClient) ListUsageHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -466,6 +481,9 @@ func (client *VirtualNetworksClient) UpdateTags(ctx context.Context, resourceGro
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -494,15 +512,15 @@ func (client *VirtualNetworksClient) UpdateTagsCreateRequest(ctx context.Context
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *VirtualNetworksClient) UpdateTagsHandleResponse(resp *azcore.Response) (*VirtualNetworkResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := VirtualNetworkResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetwork)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VirtualNetworksClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps.go
@@ -63,8 +63,8 @@ func (client *VirtualNetworkTapsClient) BeginCreateOrUpdate(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *VirtualNetworkTapsClient) CreateOrUpdateHandleResponse(resp *azcor
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualNetworkTapsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *VirtualNetworkTapsClient) BeginDelete(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *VirtualNetworkTapsClient) DeleteHandleResponse(resp *azcore.Respon
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualNetworkTapsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *VirtualNetworkTapsClient) Get(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -253,9 +247,6 @@ func (client *VirtualNetworkTapsClient) GetHandleResponse(resp *azcore.Response)
 
 // GetHandleError handles the Get error response.
 func (client *VirtualNetworkTapsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -301,9 +292,6 @@ func (client *VirtualNetworkTapsClient) ListAllHandleResponse(resp *azcore.Respo
 
 // ListAllHandleError handles the ListAll error response.
 func (client *VirtualNetworkTapsClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -350,9 +338,6 @@ func (client *VirtualNetworkTapsClient) ListByResourceGroupHandleResponse(resp *
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *VirtualNetworkTapsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -370,8 +355,8 @@ func (client *VirtualNetworkTapsClient) UpdateTags(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -405,9 +390,6 @@ func (client *VirtualNetworkTapsClient) UpdateTagsHandleResponse(resp *azcore.Re
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VirtualNetworkTapsClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps.go
@@ -63,6 +63,9 @@ func (client *VirtualNetworkTapsClient) BeginCreateOrUpdate(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *VirtualNetworkTapsClient) CreateOrUpdateCreateRequest(ctx context.
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *VirtualNetworkTapsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*VirtualNetworkTapPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &VirtualNetworkTapPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualNetworkTapsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *VirtualNetworkTapsClient) BeginDelete(ctx context.Context, resourc
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *VirtualNetworkTapsClient) DeleteCreateRequest(ctx context.Context,
 
 // DeleteHandleResponse handles the Delete response.
 func (client *VirtualNetworkTapsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualNetworkTapsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *VirtualNetworkTapsClient) Get(ctx context.Context, resourceGroupNa
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -238,15 +247,15 @@ func (client *VirtualNetworkTapsClient) GetCreateRequest(ctx context.Context, re
 
 // GetHandleResponse handles the Get response.
 func (client *VirtualNetworkTapsClient) GetHandleResponse(resp *azcore.Response) (*VirtualNetworkTapResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VirtualNetworkTapResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetworkTap)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VirtualNetworkTapsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -262,6 +271,7 @@ func (client *VirtualNetworkTapsClient) ListAll() VirtualNetworkTapListResultPag
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *VirtualNetworkTapListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkTapListResult.NextLink)
 		},
@@ -285,15 +295,15 @@ func (client *VirtualNetworkTapsClient) ListAllCreateRequest(ctx context.Context
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *VirtualNetworkTapsClient) ListAllHandleResponse(resp *azcore.Response) (*VirtualNetworkTapListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := VirtualNetworkTapListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetworkTapListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *VirtualNetworkTapsClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -309,6 +319,7 @@ func (client *VirtualNetworkTapsClient) ListByResourceGroup(resourceGroupName st
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *VirtualNetworkTapListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkTapListResult.NextLink)
 		},
@@ -333,15 +344,15 @@ func (client *VirtualNetworkTapsClient) ListByResourceGroupCreateRequest(ctx con
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *VirtualNetworkTapsClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*VirtualNetworkTapListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := VirtualNetworkTapListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetworkTapListResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *VirtualNetworkTapsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -357,6 +368,9 @@ func (client *VirtualNetworkTapsClient) UpdateTags(ctx context.Context, resource
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -385,15 +399,15 @@ func (client *VirtualNetworkTapsClient) UpdateTagsCreateRequest(ctx context.Cont
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *VirtualNetworkTapsClient) UpdateTagsHandleResponse(resp *azcore.Response) (*VirtualNetworkTapResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := VirtualNetworkTapResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualNetworkTap)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VirtualNetworkTapsClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings.go
@@ -59,8 +59,8 @@ func (client *VirtualRouterPeeringsClient) BeginCreateOrUpdate(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *VirtualRouterPeeringsClient) CreateOrUpdateHandleResponse(resp *az
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualRouterPeeringsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *VirtualRouterPeeringsClient) BeginDelete(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *VirtualRouterPeeringsClient) DeleteHandleResponse(resp *azcore.Res
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualRouterPeeringsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *VirtualRouterPeeringsClient) Get(ctx context.Context, resourceGrou
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *VirtualRouterPeeringsClient) GetHandleResponse(resp *azcore.Respon
 
 // GetHandleError handles the Get error response.
 func (client *VirtualRouterPeeringsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *VirtualRouterPeeringsClient) ListHandleResponse(resp *azcore.Respo
 
 // ListHandleError handles the List error response.
 func (client *VirtualRouterPeeringsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings.go
@@ -59,6 +59,9 @@ func (client *VirtualRouterPeeringsClient) BeginCreateOrUpdate(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *VirtualRouterPeeringsClient) CreateOrUpdateCreateRequest(ctx conte
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *VirtualRouterPeeringsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*VirtualRouterPeeringPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &VirtualRouterPeeringPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualRouterPeeringsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *VirtualRouterPeeringsClient) BeginDelete(ctx context.Context, reso
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *VirtualRouterPeeringsClient) DeleteCreateRequest(ctx context.Conte
 
 // DeleteHandleResponse handles the Delete response.
 func (client *VirtualRouterPeeringsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualRouterPeeringsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *VirtualRouterPeeringsClient) Get(ctx context.Context, resourceGrou
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *VirtualRouterPeeringsClient) GetCreateRequest(ctx context.Context,
 
 // GetHandleResponse handles the Get response.
 func (client *VirtualRouterPeeringsClient) GetHandleResponse(resp *azcore.Response) (*VirtualRouterPeeringResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VirtualRouterPeeringResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualRouterPeering)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VirtualRouterPeeringsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,7 @@ func (client *VirtualRouterPeeringsClient) List(resourceGroupName string, virtua
 			return client.ListCreateRequest(ctx, resourceGroupName, virtualRouterName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *VirtualRouterPeeringListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualRouterPeeringListResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *VirtualRouterPeeringsClient) ListCreateRequest(ctx context.Context
 
 // ListHandleResponse handles the List response.
 func (client *VirtualRouterPeeringsClient) ListHandleResponse(resp *azcore.Response) (*VirtualRouterPeeringListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := VirtualRouterPeeringListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualRouterPeeringListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *VirtualRouterPeeringsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters.go
@@ -61,6 +61,9 @@ func (client *VirtualRoutersClient) BeginCreateOrUpdate(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -110,14 +113,14 @@ func (client *VirtualRoutersClient) CreateOrUpdateCreateRequest(ctx context.Cont
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *VirtualRoutersClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*VirtualRouterPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &VirtualRouterPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualRoutersClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,6 +137,9 @@ func (client *VirtualRoutersClient) BeginDelete(ctx context.Context, resourceGro
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *VirtualRoutersClient) DeleteCreateRequest(ctx context.Context, res
 
 // DeleteHandleResponse handles the Delete response.
 func (client *VirtualRoutersClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualRoutersClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *VirtualRoutersClient) Get(ctx context.Context, resourceGroupName s
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -239,15 +248,15 @@ func (client *VirtualRoutersClient) GetCreateRequest(ctx context.Context, resour
 
 // GetHandleResponse handles the Get response.
 func (client *VirtualRoutersClient) GetHandleResponse(resp *azcore.Response) (*VirtualRouterResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VirtualRouterResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualRouter)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VirtualRoutersClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -263,6 +272,7 @@ func (client *VirtualRoutersClient) List() VirtualRouterListResultPager {
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *VirtualRouterListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualRouterListResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *VirtualRoutersClient) ListCreateRequest(ctx context.Context) (*azc
 
 // ListHandleResponse handles the List response.
 func (client *VirtualRoutersClient) ListHandleResponse(resp *azcore.Response) (*VirtualRouterListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := VirtualRouterListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualRouterListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *VirtualRoutersClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -310,6 +320,7 @@ func (client *VirtualRoutersClient) ListByResourceGroup(resourceGroupName string
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *VirtualRouterListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualRouterListResult.NextLink)
 		},
@@ -334,15 +345,15 @@ func (client *VirtualRoutersClient) ListByResourceGroupCreateRequest(ctx context
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *VirtualRoutersClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*VirtualRouterListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := VirtualRouterListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualRouterListResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *VirtualRoutersClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters.go
@@ -61,8 +61,8 @@ func (client *VirtualRoutersClient) BeginCreateOrUpdate(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -118,9 +118,6 @@ func (client *VirtualRoutersClient) CreateOrUpdateHandleResponse(resp *azcore.Re
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualRoutersClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -139,8 +136,8 @@ func (client *VirtualRoutersClient) BeginDelete(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *VirtualRoutersClient) DeleteHandleResponse(resp *azcore.Response) 
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualRoutersClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *VirtualRoutersClient) Get(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -254,9 +248,6 @@ func (client *VirtualRoutersClient) GetHandleResponse(resp *azcore.Response) (*V
 
 // GetHandleError handles the Get error response.
 func (client *VirtualRoutersClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *VirtualRoutersClient) ListHandleResponse(resp *azcore.Response) (*
 
 // ListHandleError handles the List error response.
 func (client *VirtualRoutersClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -351,9 +339,6 @@ func (client *VirtualRoutersClient) ListByResourceGroupHandleResponse(resp *azco
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *VirtualRoutersClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err Error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualwans.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualwans.go
@@ -63,8 +63,8 @@ func (client *VirtualWansClient) BeginCreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *VirtualWansClient) CreateOrUpdateHandleResponse(resp *azcore.Respo
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualWansClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *VirtualWansClient) BeginDelete(ctx context.Context, resourceGroupN
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *VirtualWansClient) DeleteHandleResponse(resp *azcore.Response) (*H
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualWansClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *VirtualWansClient) Get(ctx context.Context, resourceGroupName stri
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -253,9 +247,6 @@ func (client *VirtualWansClient) GetHandleResponse(resp *azcore.Response) (*Virt
 
 // GetHandleError handles the Get error response.
 func (client *VirtualWansClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -301,9 +292,6 @@ func (client *VirtualWansClient) ListHandleResponse(resp *azcore.Response) (*Lis
 
 // ListHandleError handles the List error response.
 func (client *VirtualWansClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -350,9 +338,6 @@ func (client *VirtualWansClient) ListByResourceGroupHandleResponse(resp *azcore.
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *VirtualWansClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -370,8 +355,8 @@ func (client *VirtualWansClient) UpdateTags(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -405,9 +390,6 @@ func (client *VirtualWansClient) UpdateTagsHandleResponse(resp *azcore.Response)
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VirtualWansClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualwans.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualwans.go
@@ -63,6 +63,9 @@ func (client *VirtualWansClient) BeginCreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *VirtualWansClient) CreateOrUpdateCreateRequest(ctx context.Context
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *VirtualWansClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*VirtualWanPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &VirtualWanPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualWansClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *VirtualWansClient) BeginDelete(ctx context.Context, resourceGroupN
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *VirtualWansClient) DeleteCreateRequest(ctx context.Context, resour
 
 // DeleteHandleResponse handles the Delete response.
 func (client *VirtualWansClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *VirtualWansClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *VirtualWansClient) Get(ctx context.Context, resourceGroupName stri
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -238,15 +247,15 @@ func (client *VirtualWansClient) GetCreateRequest(ctx context.Context, resourceG
 
 // GetHandleResponse handles the Get response.
 func (client *VirtualWansClient) GetHandleResponse(resp *azcore.Response) (*VirtualWanResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VirtualWanResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualWan)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VirtualWansClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -262,6 +271,7 @@ func (client *VirtualWansClient) List() ListVirtualWaNsResultPager {
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ListVirtualWaNsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVirtualWaNsResult.NextLink)
 		},
@@ -285,15 +295,15 @@ func (client *VirtualWansClient) ListCreateRequest(ctx context.Context) (*azcore
 
 // ListHandleResponse handles the List response.
 func (client *VirtualWansClient) ListHandleResponse(resp *azcore.Response) (*ListVirtualWaNsResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ListVirtualWaNsResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListVirtualWaNsResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *VirtualWansClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -309,6 +319,7 @@ func (client *VirtualWansClient) ListByResourceGroup(resourceGroupName string) L
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *ListVirtualWaNsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVirtualWaNsResult.NextLink)
 		},
@@ -333,15 +344,15 @@ func (client *VirtualWansClient) ListByResourceGroupCreateRequest(ctx context.Co
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *VirtualWansClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*ListVirtualWaNsResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := ListVirtualWaNsResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListVirtualWaNsResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *VirtualWansClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -357,6 +368,9 @@ func (client *VirtualWansClient) UpdateTags(ctx context.Context, resourceGroupNa
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -385,15 +399,15 @@ func (client *VirtualWansClient) UpdateTagsCreateRequest(ctx context.Context, re
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *VirtualWansClient) UpdateTagsHandleResponse(resp *azcore.Response) (*VirtualWanResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := VirtualWanResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VirtualWan)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VirtualWansClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections.go
@@ -59,8 +59,8 @@ func (client *VpnConnectionsClient) BeginCreateOrUpdate(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -117,9 +117,6 @@ func (client *VpnConnectionsClient) CreateOrUpdateHandleResponse(resp *azcore.Re
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VpnConnectionsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -138,8 +135,8 @@ func (client *VpnConnectionsClient) BeginDelete(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -196,9 +193,6 @@ func (client *VpnConnectionsClient) DeleteHandleResponse(resp *azcore.Response) 
 
 // DeleteHandleError handles the Delete error response.
 func (client *VpnConnectionsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -216,8 +210,8 @@ func (client *VpnConnectionsClient) Get(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -252,9 +246,6 @@ func (client *VpnConnectionsClient) GetHandleResponse(resp *azcore.Response) (*V
 
 // GetHandleError handles the Get error response.
 func (client *VpnConnectionsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -302,9 +293,6 @@ func (client *VpnConnectionsClient) ListByVpnGatewayHandleResponse(resp *azcore.
 
 // ListByVpnGatewayHandleError handles the ListByVpnGateway error response.
 func (client *VpnConnectionsClient) ListByVpnGatewayHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections.go
@@ -59,6 +59,9 @@ func (client *VpnConnectionsClient) BeginCreateOrUpdate(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -109,14 +112,14 @@ func (client *VpnConnectionsClient) CreateOrUpdateCreateRequest(ctx context.Cont
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *VpnConnectionsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*VpnConnectionPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &VpnConnectionPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VpnConnectionsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -133,6 +136,9 @@ func (client *VpnConnectionsClient) BeginDelete(ctx context.Context, resourceGro
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -185,14 +191,14 @@ func (client *VpnConnectionsClient) DeleteCreateRequest(ctx context.Context, res
 
 // DeleteHandleResponse handles the Delete response.
 func (client *VpnConnectionsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *VpnConnectionsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -208,6 +214,9 @@ func (client *VpnConnectionsClient) Get(ctx context.Context, resourceGroupName s
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -237,15 +246,15 @@ func (client *VpnConnectionsClient) GetCreateRequest(ctx context.Context, resour
 
 // GetHandleResponse handles the Get response.
 func (client *VpnConnectionsClient) GetHandleResponse(resp *azcore.Response) (*VpnConnectionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VpnConnectionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VpnConnection)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VpnConnectionsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -261,6 +270,7 @@ func (client *VpnConnectionsClient) ListByVpnGateway(resourceGroupName string, g
 			return client.ListByVpnGatewayCreateRequest(ctx, resourceGroupName, gatewayName)
 		},
 		responder: client.ListByVpnGatewayHandleResponse,
+		errorer:   client.ListByVpnGatewayHandleError,
 		advancer: func(ctx context.Context, resp *ListVpnConnectionsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnConnectionsResult.NextLink)
 		},
@@ -286,15 +296,15 @@ func (client *VpnConnectionsClient) ListByVpnGatewayCreateRequest(ctx context.Co
 
 // ListByVpnGatewayHandleResponse handles the ListByVpnGateway response.
 func (client *VpnConnectionsClient) ListByVpnGatewayHandleResponse(resp *azcore.Response) (*ListVpnConnectionsResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByVpnGatewayHandleError(resp)
-	}
 	result := ListVpnConnectionsResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListVpnConnectionsResult)
 }
 
 // ListByVpnGatewayHandleError handles the ListByVpnGateway error response.
 func (client *VpnConnectionsClient) ListByVpnGatewayHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpngateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpngateways.go
@@ -67,6 +67,9 @@ func (client *VpnGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -116,14 +119,14 @@ func (client *VpnGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *VpnGatewaysClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*VpnGatewayPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &VpnGatewayPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VpnGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -140,6 +143,9 @@ func (client *VpnGatewaysClient) BeginDelete(ctx context.Context, resourceGroupN
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -191,14 +197,14 @@ func (client *VpnGatewaysClient) DeleteCreateRequest(ctx context.Context, resour
 
 // DeleteHandleResponse handles the Delete response.
 func (client *VpnGatewaysClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *VpnGatewaysClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -214,6 +220,9 @@ func (client *VpnGatewaysClient) Get(ctx context.Context, resourceGroupName stri
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -242,15 +251,15 @@ func (client *VpnGatewaysClient) GetCreateRequest(ctx context.Context, resourceG
 
 // GetHandleResponse handles the Get response.
 func (client *VpnGatewaysClient) GetHandleResponse(resp *azcore.Response) (*VpnGatewayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VpnGatewayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VpnGateway)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VpnGatewaysClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -266,6 +275,7 @@ func (client *VpnGatewaysClient) List() ListVpnGatewaysResultPager {
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ListVpnGatewaysResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnGatewaysResult.NextLink)
 		},
@@ -289,15 +299,15 @@ func (client *VpnGatewaysClient) ListCreateRequest(ctx context.Context) (*azcore
 
 // ListHandleResponse handles the List response.
 func (client *VpnGatewaysClient) ListHandleResponse(resp *azcore.Response) (*ListVpnGatewaysResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ListVpnGatewaysResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListVpnGatewaysResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *VpnGatewaysClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -313,6 +323,7 @@ func (client *VpnGatewaysClient) ListByResourceGroup(resourceGroupName string) L
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *ListVpnGatewaysResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnGatewaysResult.NextLink)
 		},
@@ -337,15 +348,15 @@ func (client *VpnGatewaysClient) ListByResourceGroupCreateRequest(ctx context.Co
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *VpnGatewaysClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*ListVpnGatewaysResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := ListVpnGatewaysResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListVpnGatewaysResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *VpnGatewaysClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -362,6 +373,9 @@ func (client *VpnGatewaysClient) BeginReset(ctx context.Context, resourceGroupNa
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResetHandleResponse(resp)
@@ -413,14 +427,14 @@ func (client *VpnGatewaysClient) ResetCreateRequest(ctx context.Context, resourc
 
 // ResetHandleResponse handles the Reset response.
 func (client *VpnGatewaysClient) ResetHandleResponse(resp *azcore.Response) (*VpnGatewayPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.ResetHandleError(resp)
-	}
 	return &VpnGatewayPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // ResetHandleError handles the Reset error response.
 func (client *VpnGatewaysClient) ResetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -436,6 +450,9 @@ func (client *VpnGatewaysClient) UpdateTags(ctx context.Context, resourceGroupNa
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -464,15 +481,15 @@ func (client *VpnGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, re
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *VpnGatewaysClient) UpdateTagsHandleResponse(resp *azcore.Response) (*VpnGatewayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := VpnGatewayResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VpnGateway)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VpnGatewaysClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpngateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpngateways.go
@@ -67,8 +67,8 @@ func (client *VpnGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -124,9 +124,6 @@ func (client *VpnGatewaysClient) CreateOrUpdateHandleResponse(resp *azcore.Respo
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VpnGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -145,8 +142,8 @@ func (client *VpnGatewaysClient) BeginDelete(ctx context.Context, resourceGroupN
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -202,9 +199,6 @@ func (client *VpnGatewaysClient) DeleteHandleResponse(resp *azcore.Response) (*H
 
 // DeleteHandleError handles the Delete error response.
 func (client *VpnGatewaysClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -222,8 +216,8 @@ func (client *VpnGatewaysClient) Get(ctx context.Context, resourceGroupName stri
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -257,9 +251,6 @@ func (client *VpnGatewaysClient) GetHandleResponse(resp *azcore.Response) (*VpnG
 
 // GetHandleError handles the Get error response.
 func (client *VpnGatewaysClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -305,9 +296,6 @@ func (client *VpnGatewaysClient) ListHandleResponse(resp *azcore.Response) (*Lis
 
 // ListHandleError handles the List error response.
 func (client *VpnGatewaysClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -354,9 +342,6 @@ func (client *VpnGatewaysClient) ListByResourceGroupHandleResponse(resp *azcore.
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *VpnGatewaysClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -375,8 +360,8 @@ func (client *VpnGatewaysClient) BeginReset(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.ResetHandleError(resp)
 	}
 	result, err := client.ResetHandleResponse(resp)
 	if err != nil {
@@ -432,9 +417,6 @@ func (client *VpnGatewaysClient) ResetHandleResponse(resp *azcore.Response) (*Vp
 
 // ResetHandleError handles the Reset error response.
 func (client *VpnGatewaysClient) ResetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -452,8 +434,8 @@ func (client *VpnGatewaysClient) UpdateTags(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -487,9 +469,6 @@ func (client *VpnGatewaysClient) UpdateTagsHandleResponse(resp *azcore.Response)
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VpnGatewaysClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections.go
@@ -44,6 +44,7 @@ func (client *VpnLinkConnectionsClient) ListByVpnConnection(resourceGroupName st
 			return client.ListByVpnConnectionCreateRequest(ctx, resourceGroupName, gatewayName, connectionName)
 		},
 		responder: client.ListByVpnConnectionHandleResponse,
+		errorer:   client.ListByVpnConnectionHandleError,
 		advancer: func(ctx context.Context, resp *ListVpnSiteLinkConnectionsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnSiteLinkConnectionsResult.NextLink)
 		},
@@ -70,15 +71,15 @@ func (client *VpnLinkConnectionsClient) ListByVpnConnectionCreateRequest(ctx con
 
 // ListByVpnConnectionHandleResponse handles the ListByVpnConnection response.
 func (client *VpnLinkConnectionsClient) ListByVpnConnectionHandleResponse(resp *azcore.Response) (*ListVpnSiteLinkConnectionsResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByVpnConnectionHandleError(resp)
-	}
 	result := ListVpnSiteLinkConnectionsResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListVpnSiteLinkConnectionsResult)
 }
 
 // ListByVpnConnectionHandleError handles the ListByVpnConnection error response.
 func (client *VpnLinkConnectionsClient) ListByVpnConnectionHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections.go
@@ -77,9 +77,6 @@ func (client *VpnLinkConnectionsClient) ListByVpnConnectionHandleResponse(resp *
 
 // ListByVpnConnectionHandleError handles the ListByVpnConnection error response.
 func (client *VpnLinkConnectionsClient) ListByVpnConnectionHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations.go
@@ -63,8 +63,8 @@ func (client *VpnServerConfigurationsClient) BeginCreateOrUpdate(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *VpnServerConfigurationsClient) CreateOrUpdateHandleResponse(resp *
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VpnServerConfigurationsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *VpnServerConfigurationsClient) BeginDelete(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *VpnServerConfigurationsClient) DeleteHandleResponse(resp *azcore.R
 
 // DeleteHandleError handles the Delete error response.
 func (client *VpnServerConfigurationsClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *VpnServerConfigurationsClient) Get(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -253,9 +247,6 @@ func (client *VpnServerConfigurationsClient) GetHandleResponse(resp *azcore.Resp
 
 // GetHandleError handles the Get error response.
 func (client *VpnServerConfigurationsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -301,9 +292,6 @@ func (client *VpnServerConfigurationsClient) ListHandleResponse(resp *azcore.Res
 
 // ListHandleError handles the List error response.
 func (client *VpnServerConfigurationsClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -350,9 +338,6 @@ func (client *VpnServerConfigurationsClient) ListByResourceGroupHandleResponse(r
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *VpnServerConfigurationsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -370,8 +355,8 @@ func (client *VpnServerConfigurationsClient) UpdateTags(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -405,9 +390,6 @@ func (client *VpnServerConfigurationsClient) UpdateTagsHandleResponse(resp *azco
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VpnServerConfigurationsClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations.go
@@ -63,6 +63,9 @@ func (client *VpnServerConfigurationsClient) BeginCreateOrUpdate(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *VpnServerConfigurationsClient) CreateOrUpdateCreateRequest(ctx con
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *VpnServerConfigurationsClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*VpnServerConfigurationPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &VpnServerConfigurationPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VpnServerConfigurationsClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *VpnServerConfigurationsClient) BeginDelete(ctx context.Context, re
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *VpnServerConfigurationsClient) DeleteCreateRequest(ctx context.Con
 
 // DeleteHandleResponse handles the Delete response.
 func (client *VpnServerConfigurationsClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *VpnServerConfigurationsClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *VpnServerConfigurationsClient) Get(ctx context.Context, resourceGr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -238,15 +247,15 @@ func (client *VpnServerConfigurationsClient) GetCreateRequest(ctx context.Contex
 
 // GetHandleResponse handles the Get response.
 func (client *VpnServerConfigurationsClient) GetHandleResponse(resp *azcore.Response) (*VpnServerConfigurationResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VpnServerConfigurationResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VpnServerConfiguration)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VpnServerConfigurationsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -262,6 +271,7 @@ func (client *VpnServerConfigurationsClient) List() ListVpnServerConfigurationsR
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ListVpnServerConfigurationsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnServerConfigurationsResult.NextLink)
 		},
@@ -285,15 +295,15 @@ func (client *VpnServerConfigurationsClient) ListCreateRequest(ctx context.Conte
 
 // ListHandleResponse handles the List response.
 func (client *VpnServerConfigurationsClient) ListHandleResponse(resp *azcore.Response) (*ListVpnServerConfigurationsResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ListVpnServerConfigurationsResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListVpnServerConfigurationsResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *VpnServerConfigurationsClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -309,6 +319,7 @@ func (client *VpnServerConfigurationsClient) ListByResourceGroup(resourceGroupNa
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *ListVpnServerConfigurationsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnServerConfigurationsResult.NextLink)
 		},
@@ -333,15 +344,15 @@ func (client *VpnServerConfigurationsClient) ListByResourceGroupCreateRequest(ct
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *VpnServerConfigurationsClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*ListVpnServerConfigurationsResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := ListVpnServerConfigurationsResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListVpnServerConfigurationsResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *VpnServerConfigurationsClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -357,6 +368,9 @@ func (client *VpnServerConfigurationsClient) UpdateTags(ctx context.Context, res
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -385,15 +399,15 @@ func (client *VpnServerConfigurationsClient) UpdateTagsCreateRequest(ctx context
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *VpnServerConfigurationsClient) UpdateTagsHandleResponse(resp *azcore.Response) (*VpnServerConfigurationResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := VpnServerConfigurationResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VpnServerConfiguration)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VpnServerConfigurationsClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan.go
@@ -51,8 +51,8 @@ func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) BeginList(c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.ListHandleError(resp)
 	}
 	result, err := client.ListHandleResponse(resp)
 	if err != nil {
@@ -108,9 +108,6 @@ func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) ListHandleR
 
 // ListHandleError handles the List error response.
 func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan.go
@@ -51,6 +51,9 @@ func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) BeginList(c
 	if err != nil {
 		return nil, err
 	}
+	if err := client.ListHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.ListHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -100,14 +103,14 @@ func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) ListCreateR
 
 // ListHandleResponse handles the List response.
 func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) ListHandleResponse(resp *azcore.Response) (*VpnServerConfigurationsResponsePollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.ListHandleError(resp)
-	}
 	return &VpnServerConfigurationsResponsePollerResponse{RawResponse: resp.Response}, nil
 }
 
 // ListHandleError handles the List error response.
 func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections.go
@@ -46,8 +46,8 @@ func (client *VpnSiteLinkConnectionsClient) Get(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -83,9 +83,6 @@ func (client *VpnSiteLinkConnectionsClient) GetHandleResponse(resp *azcore.Respo
 
 // GetHandleError handles the Get error response.
 func (client *VpnSiteLinkConnectionsClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections.go
@@ -46,6 +46,9 @@ func (client *VpnSiteLinkConnectionsClient) Get(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -74,15 +77,15 @@ func (client *VpnSiteLinkConnectionsClient) GetCreateRequest(ctx context.Context
 
 // GetHandleResponse handles the Get response.
 func (client *VpnSiteLinkConnectionsClient) GetHandleResponse(resp *azcore.Response) (*VpnSiteLinkConnectionResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VpnSiteLinkConnectionResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VpnSiteLinkConnection)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VpnSiteLinkConnectionsClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks.go
@@ -48,8 +48,8 @@ func (client *VpnSiteLinksClient) Get(ctx context.Context, resourceGroupName str
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -84,9 +84,6 @@ func (client *VpnSiteLinksClient) GetHandleResponse(resp *azcore.Response) (*Vpn
 
 // GetHandleError handles the Get error response.
 func (client *VpnSiteLinksClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -134,9 +131,6 @@ func (client *VpnSiteLinksClient) ListByVpnSiteHandleResponse(resp *azcore.Respo
 
 // ListByVpnSiteHandleError handles the ListByVpnSite error response.
 func (client *VpnSiteLinksClient) ListByVpnSiteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks.go
@@ -48,6 +48,9 @@ func (client *VpnSiteLinksClient) Get(ctx context.Context, resourceGroupName str
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -75,15 +78,15 @@ func (client *VpnSiteLinksClient) GetCreateRequest(ctx context.Context, resource
 
 // GetHandleResponse handles the Get response.
 func (client *VpnSiteLinksClient) GetHandleResponse(resp *azcore.Response) (*VpnSiteLinkResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VpnSiteLinkResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VpnSiteLink)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VpnSiteLinksClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -99,6 +102,7 @@ func (client *VpnSiteLinksClient) ListByVpnSite(resourceGroupName string, vpnSit
 			return client.ListByVpnSiteCreateRequest(ctx, resourceGroupName, vpnSiteName)
 		},
 		responder: client.ListByVpnSiteHandleResponse,
+		errorer:   client.ListByVpnSiteHandleError,
 		advancer: func(ctx context.Context, resp *ListVpnSiteLinksResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnSiteLinksResult.NextLink)
 		},
@@ -124,15 +128,15 @@ func (client *VpnSiteLinksClient) ListByVpnSiteCreateRequest(ctx context.Context
 
 // ListByVpnSiteHandleResponse handles the ListByVpnSite response.
 func (client *VpnSiteLinksClient) ListByVpnSiteHandleResponse(resp *azcore.Response) (*ListVpnSiteLinksResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByVpnSiteHandleError(resp)
-	}
 	result := ListVpnSiteLinksResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListVpnSiteLinksResult)
 }
 
 // ListByVpnSiteHandleError handles the ListByVpnSite error response.
 func (client *VpnSiteLinksClient) ListByVpnSiteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsites.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsites.go
@@ -63,8 +63,8 @@ func (client *VpnSitesClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -120,9 +120,6 @@ func (client *VpnSitesClient) CreateOrUpdateHandleResponse(resp *azcore.Response
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VpnSitesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -141,8 +138,8 @@ func (client *VpnSitesClient) BeginDelete(ctx context.Context, resourceGroupName
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -198,9 +195,6 @@ func (client *VpnSitesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTP
 
 // DeleteHandleError handles the Delete error response.
 func (client *VpnSitesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -218,8 +212,8 @@ func (client *VpnSitesClient) Get(ctx context.Context, resourceGroupName string,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -253,9 +247,6 @@ func (client *VpnSitesClient) GetHandleResponse(resp *azcore.Response) (*VpnSite
 
 // GetHandleError handles the Get error response.
 func (client *VpnSitesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -301,9 +292,6 @@ func (client *VpnSitesClient) ListHandleResponse(resp *azcore.Response) (*ListVp
 
 // ListHandleError handles the List error response.
 func (client *VpnSitesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -350,9 +338,6 @@ func (client *VpnSitesClient) ListByResourceGroupHandleResponse(resp *azcore.Res
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *VpnSitesClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -370,8 +355,8 @@ func (client *VpnSitesClient) UpdateTags(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateTagsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateTagsHandleError(resp)
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
 	if err != nil {
@@ -405,9 +390,6 @@ func (client *VpnSitesClient) UpdateTagsHandleResponse(resp *azcore.Response) (*
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VpnSitesClient) UpdateTagsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsites.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsites.go
@@ -63,6 +63,9 @@ func (client *VpnSitesClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -112,14 +115,14 @@ func (client *VpnSitesClient) CreateOrUpdateCreateRequest(ctx context.Context, r
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *VpnSitesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*VpnSitePollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	return &VpnSitePollerResponse{RawResponse: resp.Response}, nil
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VpnSitesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -136,6 +139,9 @@ func (client *VpnSitesClient) BeginDelete(ctx context.Context, resourceGroupName
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -187,14 +193,14 @@ func (client *VpnSitesClient) DeleteCreateRequest(ctx context.Context, resourceG
 
 // DeleteHandleResponse handles the Delete response.
 func (client *VpnSitesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *VpnSitesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -210,6 +216,9 @@ func (client *VpnSitesClient) Get(ctx context.Context, resourceGroupName string,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -238,15 +247,15 @@ func (client *VpnSitesClient) GetCreateRequest(ctx context.Context, resourceGrou
 
 // GetHandleResponse handles the Get response.
 func (client *VpnSitesClient) GetHandleResponse(resp *azcore.Response) (*VpnSiteResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := VpnSiteResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VpnSite)
 }
 
 // GetHandleError handles the Get error response.
 func (client *VpnSitesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -262,6 +271,7 @@ func (client *VpnSitesClient) List() ListVpnSitesResultPager {
 			return client.ListCreateRequest(ctx)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *ListVpnSitesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnSitesResult.NextLink)
 		},
@@ -285,15 +295,15 @@ func (client *VpnSitesClient) ListCreateRequest(ctx context.Context) (*azcore.Re
 
 // ListHandleResponse handles the List response.
 func (client *VpnSitesClient) ListHandleResponse(resp *azcore.Response) (*ListVpnSitesResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := ListVpnSitesResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListVpnSitesResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *VpnSitesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -309,6 +319,7 @@ func (client *VpnSitesClient) ListByResourceGroup(resourceGroupName string) List
 			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
+		errorer:   client.ListByResourceGroupHandleError,
 		advancer: func(ctx context.Context, resp *ListVpnSitesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnSitesResult.NextLink)
 		},
@@ -333,15 +344,15 @@ func (client *VpnSitesClient) ListByResourceGroupCreateRequest(ctx context.Conte
 
 // ListByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client *VpnSitesClient) ListByResourceGroupHandleResponse(resp *azcore.Response) (*ListVpnSitesResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListByResourceGroupHandleError(resp)
-	}
 	result := ListVpnSitesResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.ListVpnSitesResult)
 }
 
 // ListByResourceGroupHandleError handles the ListByResourceGroup error response.
 func (client *VpnSitesClient) ListByResourceGroupHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -357,6 +368,9 @@ func (client *VpnSitesClient) UpdateTags(ctx context.Context, resourceGroupName 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateTagsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateTagsHandleResponse(resp)
@@ -385,15 +399,15 @@ func (client *VpnSitesClient) UpdateTagsCreateRequest(ctx context.Context, resou
 
 // UpdateTagsHandleResponse handles the UpdateTags response.
 func (client *VpnSitesClient) UpdateTagsHandleResponse(resp *azcore.Response) (*VpnSiteResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateTagsHandleError(resp)
-	}
 	result := VpnSiteResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.VpnSite)
 }
 
 // UpdateTagsHandleError handles the UpdateTags error response.
 func (client *VpnSitesClient) UpdateTagsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration.go
@@ -51,8 +51,8 @@ func (client *VpnSitesConfigurationClient) BeginDownload(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DownloadHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.DownloadHandleError(resp)
 	}
 	result, err := client.DownloadHandleResponse(resp)
 	if err != nil {
@@ -108,9 +108,6 @@ func (client *VpnSitesConfigurationClient) DownloadHandleResponse(resp *azcore.R
 
 // DownloadHandleError handles the Download error response.
 func (client *VpnSitesConfigurationClient) DownloadHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration.go
@@ -51,6 +51,9 @@ func (client *VpnSitesConfigurationClient) BeginDownload(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
+	if err := client.DownloadHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.DownloadHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -100,14 +103,14 @@ func (client *VpnSitesConfigurationClient) DownloadCreateRequest(ctx context.Con
 
 // DownloadHandleResponse handles the Download response.
 func (client *VpnSitesConfigurationClient) DownloadHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DownloadHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DownloadHandleError handles the Download error response.
 func (client *VpnSitesConfigurationClient) DownloadHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies.go
@@ -58,8 +58,8 @@ func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdate(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateOrUpdateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil, client.CreateOrUpdateHandleError(resp)
 	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
@@ -93,9 +93,6 @@ func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdateHandleResponse
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -114,8 +111,8 @@ func (client *WebApplicationFirewallPoliciesClient) BeginDelete(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -171,9 +168,6 @@ func (client *WebApplicationFirewallPoliciesClient) DeleteHandleResponse(resp *a
 
 // DeleteHandleError handles the Delete error response.
 func (client *WebApplicationFirewallPoliciesClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -191,8 +185,8 @@ func (client *WebApplicationFirewallPoliciesClient) Get(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetHandleError(resp)
 	}
 	result, err := client.GetHandleResponse(resp)
 	if err != nil {
@@ -226,9 +220,6 @@ func (client *WebApplicationFirewallPoliciesClient) GetHandleResponse(resp *azco
 
 // GetHandleError handles the Get error response.
 func (client *WebApplicationFirewallPoliciesClient) GetHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -275,9 +266,6 @@ func (client *WebApplicationFirewallPoliciesClient) ListHandleResponse(resp *azc
 
 // ListHandleError handles the List error response.
 func (client *WebApplicationFirewallPoliciesClient) ListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -323,9 +311,6 @@ func (client *WebApplicationFirewallPoliciesClient) ListAllHandleResponse(resp *
 
 // ListAllHandleError handles the ListAll error response.
 func (client *WebApplicationFirewallPoliciesClient) ListAllHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies.go
@@ -58,6 +58,9 @@ func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdate(ctx context.C
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateOrUpdateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateOrUpdateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -84,15 +87,15 @@ func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdateCreateRequest(
 
 // CreateOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdateHandleResponse(resp *azcore.Response) (*WebApplicationFirewallPolicyResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
-		return nil, client.CreateOrUpdateHandleError(resp)
-	}
 	result := WebApplicationFirewallPolicyResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.WebApplicationFirewallPolicy)
 }
 
 // CreateOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -109,6 +112,9 @@ func (client *WebApplicationFirewallPoliciesClient) BeginDelete(ctx context.Cont
 	// send the first request to initialize the poller
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -160,14 +166,14 @@ func (client *WebApplicationFirewallPoliciesClient) DeleteCreateRequest(ctx cont
 
 // DeleteHandleResponse handles the Delete response.
 func (client *WebApplicationFirewallPoliciesClient) DeleteHandleResponse(resp *azcore.Response) (*HTTPPollerResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	return &HTTPPollerResponse{RawResponse: resp.Response}, nil
 }
 
 // DeleteHandleError handles the Delete error response.
 func (client *WebApplicationFirewallPoliciesClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -183,6 +189,9 @@ func (client *WebApplicationFirewallPoliciesClient) Get(ctx context.Context, res
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetHandleResponse(resp)
@@ -211,15 +220,15 @@ func (client *WebApplicationFirewallPoliciesClient) GetCreateRequest(ctx context
 
 // GetHandleResponse handles the Get response.
 func (client *WebApplicationFirewallPoliciesClient) GetHandleResponse(resp *azcore.Response) (*WebApplicationFirewallPolicyResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetHandleError(resp)
-	}
 	result := WebApplicationFirewallPolicyResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.WebApplicationFirewallPolicy)
 }
 
 // GetHandleError handles the Get error response.
 func (client *WebApplicationFirewallPoliciesClient) GetHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -235,6 +244,7 @@ func (client *WebApplicationFirewallPoliciesClient) List(resourceGroupName strin
 			return client.ListCreateRequest(ctx, resourceGroupName)
 		},
 		responder: client.ListHandleResponse,
+		errorer:   client.ListHandleError,
 		advancer: func(ctx context.Context, resp *WebApplicationFirewallPolicyListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.WebApplicationFirewallPolicyListResult.NextLink)
 		},
@@ -259,15 +269,15 @@ func (client *WebApplicationFirewallPoliciesClient) ListCreateRequest(ctx contex
 
 // ListHandleResponse handles the List response.
 func (client *WebApplicationFirewallPoliciesClient) ListHandleResponse(resp *azcore.Response) (*WebApplicationFirewallPolicyListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListHandleError(resp)
-	}
 	result := WebApplicationFirewallPolicyListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.WebApplicationFirewallPolicyListResult)
 }
 
 // ListHandleError handles the List error response.
 func (client *WebApplicationFirewallPoliciesClient) ListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
@@ -283,6 +293,7 @@ func (client *WebApplicationFirewallPoliciesClient) ListAll() WebApplicationFire
 			return client.ListAllCreateRequest(ctx)
 		},
 		responder: client.ListAllHandleResponse,
+		errorer:   client.ListAllHandleError,
 		advancer: func(ctx context.Context, resp *WebApplicationFirewallPolicyListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.WebApplicationFirewallPolicyListResult.NextLink)
 		},
@@ -306,15 +317,15 @@ func (client *WebApplicationFirewallPoliciesClient) ListAllCreateRequest(ctx con
 
 // ListAllHandleResponse handles the ListAll response.
 func (client *WebApplicationFirewallPoliciesClient) ListAllHandleResponse(resp *azcore.Response) (*WebApplicationFirewallPolicyListResultResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListAllHandleError(resp)
-	}
 	result := WebApplicationFirewallPolicyListResultResponse{RawResponse: resp.Response}
 	return &result, resp.UnmarshalAsJSON(&result.WebApplicationFirewallPolicyListResult)
 }
 
 // ListAllHandleError handles the ListAll error response.
 func (client *WebApplicationFirewallPoliciesClient) ListAllHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err CloudError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err

--- a/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
@@ -51,6 +51,9 @@ func (client *appendBlobClient) AppendBlock(ctx context.Context, contentLength i
 	if err != nil {
 		return nil, err
 	}
+	if err := client.AppendBlockHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.AppendBlockHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -117,9 +120,6 @@ func (client *appendBlobClient) AppendBlockCreateRequest(ctx context.Context, co
 
 // AppendBlockHandleResponse handles the AppendBlock response.
 func (client *appendBlobClient) AppendBlockHandleResponse(resp *azcore.Response) (*AppendBlobAppendBlockResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.AppendBlockHandleError(resp)
-	}
 	result := AppendBlobAppendBlockResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -190,6 +190,9 @@ func (client *appendBlobClient) AppendBlockHandleResponse(resp *azcore.Response)
 
 // AppendBlockHandleError handles the AppendBlock error response.
 func (client *appendBlobClient) AppendBlockHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -205,6 +208,9 @@ func (client *appendBlobClient) AppendBlockFromURL(ctx context.Context, sourceUr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.AppendBlockFromURLHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.AppendBlockFromURLHandleResponse(resp)
@@ -292,9 +298,6 @@ func (client *appendBlobClient) AppendBlockFromURLCreateRequest(ctx context.Cont
 
 // AppendBlockFromURLHandleResponse handles the AppendBlockFromURL response.
 func (client *appendBlobClient) AppendBlockFromURLHandleResponse(resp *azcore.Response) (*AppendBlobAppendBlockFromURLResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.AppendBlockFromURLHandleError(resp)
-	}
 	result := AppendBlobAppendBlockFromURLResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -362,6 +365,9 @@ func (client *appendBlobClient) AppendBlockFromURLHandleResponse(resp *azcore.Re
 
 // AppendBlockFromURLHandleError handles the AppendBlockFromURL error response.
 func (client *appendBlobClient) AppendBlockFromURLHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -377,6 +383,9 @@ func (client *appendBlobClient) Create(ctx context.Context, contentLength int64,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CreateHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CreateHandleResponse(resp)
@@ -456,9 +465,6 @@ func (client *appendBlobClient) CreateCreateRequest(ctx context.Context, content
 
 // CreateHandleResponse handles the Create response.
 func (client *appendBlobClient) CreateHandleResponse(resp *azcore.Response) (*AppendBlobCreateResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.CreateHandleError(resp)
-	}
 	result := AppendBlobCreateResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -511,6 +517,9 @@ func (client *appendBlobClient) CreateHandleResponse(resp *azcore.Response) (*Ap
 
 // CreateHandleError handles the Create error response.
 func (client *appendBlobClient) CreateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err

--- a/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
@@ -51,8 +51,8 @@ func (client *appendBlobClient) AppendBlock(ctx context.Context, contentLength i
 	if err != nil {
 		return nil, err
 	}
-	if err := client.AppendBlockHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.AppendBlockHandleError(resp)
 	}
 	result, err := client.AppendBlockHandleResponse(resp)
 	if err != nil {
@@ -190,9 +190,6 @@ func (client *appendBlobClient) AppendBlockHandleResponse(resp *azcore.Response)
 
 // AppendBlockHandleError handles the AppendBlock error response.
 func (client *appendBlobClient) AppendBlockHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -210,8 +207,8 @@ func (client *appendBlobClient) AppendBlockFromURL(ctx context.Context, sourceUr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.AppendBlockFromURLHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.AppendBlockFromURLHandleError(resp)
 	}
 	result, err := client.AppendBlockFromURLHandleResponse(resp)
 	if err != nil {
@@ -365,9 +362,6 @@ func (client *appendBlobClient) AppendBlockFromURLHandleResponse(resp *azcore.Re
 
 // AppendBlockFromURLHandleError handles the AppendBlockFromURL error response.
 func (client *appendBlobClient) AppendBlockFromURLHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -385,8 +379,8 @@ func (client *appendBlobClient) Create(ctx context.Context, contentLength int64,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.CreateHandleError(resp)
 	}
 	result, err := client.CreateHandleResponse(resp)
 	if err != nil {
@@ -517,9 +511,6 @@ func (client *appendBlobClient) CreateHandleResponse(resp *azcore.Response) (*Ap
 
 // CreateHandleError handles the Create error response.
 func (client *appendBlobClient) CreateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err

--- a/test/storage/2019-07-07/azblob/zz_generated_blob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blob.go
@@ -87,8 +87,8 @@ func (client *blobClient) AbortCopyFromURL(ctx context.Context, copyId string, b
 	if err != nil {
 		return nil, err
 	}
-	if err := client.AbortCopyFromURLHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusNoContent) {
+		return nil, client.AbortCopyFromURLHandleError(resp)
 	}
 	result, err := client.AbortCopyFromURLHandleResponse(resp)
 	if err != nil {
@@ -146,9 +146,6 @@ func (client *blobClient) AbortCopyFromURLHandleResponse(resp *azcore.Response) 
 
 // AbortCopyFromURLHandleError handles the AbortCopyFromURL error response.
 func (client *blobClient) AbortCopyFromURLHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusNoContent) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -166,8 +163,8 @@ func (client *blobClient) AcquireLease(ctx context.Context, blobAcquireLeaseOpti
 	if err != nil {
 		return nil, err
 	}
-	if err := client.AcquireLeaseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.AcquireLeaseHandleError(resp)
 	}
 	result, err := client.AcquireLeaseHandleResponse(resp)
 	if err != nil {
@@ -252,9 +249,6 @@ func (client *blobClient) AcquireLeaseHandleResponse(resp *azcore.Response) (*Bl
 
 // AcquireLeaseHandleError handles the AcquireLease error response.
 func (client *blobClient) AcquireLeaseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -272,8 +266,8 @@ func (client *blobClient) BreakLease(ctx context.Context, blobBreakLeaseOptions 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.BreakLeaseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.BreakLeaseHandleError(resp)
 	}
 	result, err := client.BreakLeaseHandleResponse(resp)
 	if err != nil {
@@ -360,9 +354,6 @@ func (client *blobClient) BreakLeaseHandleResponse(resp *azcore.Response) (*Blob
 
 // BreakLeaseHandleError handles the BreakLease error response.
 func (client *blobClient) BreakLeaseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -380,8 +371,8 @@ func (client *blobClient) ChangeLease(ctx context.Context, leaseId string, propo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ChangeLeaseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ChangeLeaseHandleError(resp)
 	}
 	result, err := client.ChangeLeaseHandleResponse(resp)
 	if err != nil {
@@ -462,9 +453,6 @@ func (client *blobClient) ChangeLeaseHandleResponse(resp *azcore.Response) (*Blo
 
 // ChangeLeaseHandleError handles the ChangeLease error response.
 func (client *blobClient) ChangeLeaseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -482,8 +470,8 @@ func (client *blobClient) CopyFromURL(ctx context.Context, copySource url.URL, b
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CopyFromURLHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.CopyFromURLHandleError(resp)
 	}
 	result, err := client.CopyFromURLHandleResponse(resp)
 	if err != nil {
@@ -605,9 +593,6 @@ func (client *blobClient) CopyFromURLHandleResponse(resp *azcore.Response) (*Blo
 
 // CopyFromURLHandleError handles the CopyFromURL error response.
 func (client *blobClient) CopyFromURLHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -625,8 +610,8 @@ func (client *blobClient) CreateSnapshot(ctx context.Context, blobCreateSnapshot
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateSnapshotHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.CreateSnapshotHandleError(resp)
 	}
 	result, err := client.CreateSnapshotHandleResponse(resp)
 	if err != nil {
@@ -728,9 +713,6 @@ func (client *blobClient) CreateSnapshotHandleResponse(resp *azcore.Response) (*
 
 // CreateSnapshotHandleError handles the CreateSnapshot error response.
 func (client *blobClient) CreateSnapshotHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -748,8 +730,8 @@ func (client *blobClient) Delete(ctx context.Context, blobDeleteOptions *BlobDel
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -822,9 +804,6 @@ func (client *blobClient) DeleteHandleResponse(resp *azcore.Response) (*BlobDele
 
 // DeleteHandleError handles the Delete error response.
 func (client *blobClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -842,8 +821,8 @@ func (client *blobClient) Download(ctx context.Context, blobDownloadOptions *Blo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DownloadHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusPartialContent) {
+		return nil, client.DownloadHandleError(resp)
 	}
 	result, err := client.DownloadHandleResponse(resp)
 	if err != nil {
@@ -1058,9 +1037,6 @@ func (client *blobClient) DownloadHandleResponse(resp *azcore.Response) (*BlobDo
 
 // DownloadHandleError handles the Download error response.
 func (client *blobClient) DownloadHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusPartialContent) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1078,8 +1054,8 @@ func (client *blobClient) GetAccessControl(ctx context.Context, blobGetAccessCon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetAccessControlHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetAccessControlHandleError(resp)
 	}
 	result, err := client.GetAccessControlHandleResponse(resp)
 	if err != nil {
@@ -1169,9 +1145,6 @@ func (client *blobClient) GetAccessControlHandleResponse(resp *azcore.Response) 
 
 // GetAccessControlHandleError handles the GetAccessControl error response.
 func (client *blobClient) GetAccessControlHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1189,8 +1162,8 @@ func (client *blobClient) GetAccountInfo(ctx context.Context) (*BlobGetAccountIn
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetAccountInfoHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetAccountInfoHandleError(resp)
 	}
 	result, err := client.GetAccountInfoHandleResponse(resp)
 	if err != nil {
@@ -1244,9 +1217,6 @@ func (client *blobClient) GetAccountInfoHandleResponse(resp *azcore.Response) (*
 
 // GetAccountInfoHandleError handles the GetAccountInfo error response.
 func (client *blobClient) GetAccountInfoHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1264,8 +1234,8 @@ func (client *blobClient) GetProperties(ctx context.Context, blobGetPropertiesOp
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetPropertiesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetPropertiesHandleError(resp)
 	}
 	result, err := client.GetPropertiesHandleResponse(resp)
 	if err != nil {
@@ -1490,9 +1460,6 @@ func (client *blobClient) GetPropertiesHandleResponse(resp *azcore.Response) (*B
 
 // GetPropertiesHandleError handles the GetProperties error response.
 func (client *blobClient) GetPropertiesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1510,8 +1477,8 @@ func (client *blobClient) ReleaseLease(ctx context.Context, leaseId string, blob
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ReleaseLeaseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ReleaseLeaseHandleError(resp)
 	}
 	result, err := client.ReleaseLeaseHandleResponse(resp)
 	if err != nil {
@@ -1588,9 +1555,6 @@ func (client *blobClient) ReleaseLeaseHandleResponse(resp *azcore.Response) (*Bl
 
 // ReleaseLeaseHandleError handles the ReleaseLease error response.
 func (client *blobClient) ReleaseLeaseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1608,8 +1572,8 @@ func (client *blobClient) Rename(ctx context.Context, renameSource string, blobR
 	if err != nil {
 		return nil, err
 	}
-	if err := client.RenameHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.RenameHandleError(resp)
 	}
 	result, err := client.RenameHandleResponse(resp)
 	if err != nil {
@@ -1736,9 +1700,6 @@ func (client *blobClient) RenameHandleResponse(resp *azcore.Response) (*BlobRena
 
 // RenameHandleError handles the Rename error response.
 func (client *blobClient) RenameHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1756,8 +1717,8 @@ func (client *blobClient) RenewLease(ctx context.Context, leaseId string, blobRe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.RenewLeaseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.RenewLeaseHandleError(resp)
 	}
 	result, err := client.RenewLeaseHandleResponse(resp)
 	if err != nil {
@@ -1837,9 +1798,6 @@ func (client *blobClient) RenewLeaseHandleResponse(resp *azcore.Response) (*Blob
 
 // RenewLeaseHandleError handles the RenewLease error response.
 func (client *blobClient) RenewLeaseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1857,8 +1815,8 @@ func (client *blobClient) SetAccessControl(ctx context.Context, blobSetAccessCon
 	if err != nil {
 		return nil, err
 	}
-	if err := client.SetAccessControlHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.SetAccessControlHandleError(resp)
 	}
 	result, err := client.SetAccessControlHandleResponse(resp)
 	if err != nil {
@@ -1945,9 +1903,6 @@ func (client *blobClient) SetAccessControlHandleResponse(resp *azcore.Response) 
 
 // SetAccessControlHandleError handles the SetAccessControl error response.
 func (client *blobClient) SetAccessControlHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1965,8 +1920,8 @@ func (client *blobClient) SetHTTPHeaders(ctx context.Context, blobSetHttpHeaders
 	if err != nil {
 		return nil, err
 	}
-	if err := client.SetHTTPHeadersHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.SetHTTPHeadersHandleError(resp)
 	}
 	result, err := client.SetHTTPHeadersHandleResponse(resp)
 	if err != nil {
@@ -2069,9 +2024,6 @@ func (client *blobClient) SetHTTPHeadersHandleResponse(resp *azcore.Response) (*
 
 // SetHTTPHeadersHandleError handles the SetHTTPHeaders error response.
 func (client *blobClient) SetHTTPHeadersHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -2089,8 +2041,8 @@ func (client *blobClient) SetMetadata(ctx context.Context, blobSetMetadataOption
 	if err != nil {
 		return nil, err
 	}
-	if err := client.SetMetadataHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.SetMetadataHandleError(resp)
 	}
 	result, err := client.SetMetadataHandleResponse(resp)
 	if err != nil {
@@ -2195,9 +2147,6 @@ func (client *blobClient) SetMetadataHandleResponse(resp *azcore.Response) (*Blo
 
 // SetMetadataHandleError handles the SetMetadata error response.
 func (client *blobClient) SetMetadataHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -2215,8 +2164,8 @@ func (client *blobClient) SetTier(ctx context.Context, tier AccessTier, blobSetT
 	if err != nil {
 		return nil, err
 	}
-	if err := client.SetTierHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil, client.SetTierHandleError(resp)
 	}
 	result, err := client.SetTierHandleResponse(resp)
 	if err != nil {
@@ -2269,9 +2218,6 @@ func (client *blobClient) SetTierHandleResponse(resp *azcore.Response) (*BlobSet
 
 // SetTierHandleError handles the SetTier error response.
 func (client *blobClient) SetTierHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -2289,8 +2235,8 @@ func (client *blobClient) StartCopyFromURL(ctx context.Context, copySource url.U
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StartCopyFromURLHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.StartCopyFromURLHandleError(resp)
 	}
 	result, err := client.StartCopyFromURLHandleResponse(resp)
 	if err != nil {
@@ -2397,9 +2343,6 @@ func (client *blobClient) StartCopyFromURLHandleResponse(resp *azcore.Response) 
 
 // StartCopyFromURLHandleError handles the StartCopyFromURL error response.
 func (client *blobClient) StartCopyFromURLHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -2417,8 +2360,8 @@ func (client *blobClient) Undelete(ctx context.Context, blobUndeleteOptions *Blo
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UndeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UndeleteHandleError(resp)
 	}
 	result, err := client.UndeleteHandleResponse(resp)
 	if err != nil {
@@ -2471,9 +2414,6 @@ func (client *blobClient) UndeleteHandleResponse(resp *azcore.Response) (*BlobUn
 
 // UndeleteHandleError handles the Undelete error response.
 func (client *blobClient) UndeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err

--- a/test/storage/2019-07-07/azblob/zz_generated_blob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blob.go
@@ -87,6 +87,9 @@ func (client *blobClient) AbortCopyFromURL(ctx context.Context, copyId string, b
 	if err != nil {
 		return nil, err
 	}
+	if err := client.AbortCopyFromURLHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.AbortCopyFromURLHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -121,9 +124,6 @@ func (client *blobClient) AbortCopyFromURLCreateRequest(ctx context.Context, cop
 
 // AbortCopyFromURLHandleResponse handles the AbortCopyFromURL response.
 func (client *blobClient) AbortCopyFromURLHandleResponse(resp *azcore.Response) (*BlobAbortCopyFromURLResponse, error) {
-	if !resp.HasStatusCode(http.StatusNoContent) {
-		return nil, client.AbortCopyFromURLHandleError(resp)
-	}
 	result := BlobAbortCopyFromURLResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -146,6 +146,9 @@ func (client *blobClient) AbortCopyFromURLHandleResponse(resp *azcore.Response) 
 
 // AbortCopyFromURLHandleError handles the AbortCopyFromURL error response.
 func (client *blobClient) AbortCopyFromURLHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusNoContent) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -161,6 +164,9 @@ func (client *blobClient) AcquireLease(ctx context.Context, blobAcquireLeaseOpti
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.AcquireLeaseHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.AcquireLeaseHandleResponse(resp)
@@ -211,9 +217,6 @@ func (client *blobClient) AcquireLeaseCreateRequest(ctx context.Context, blobAcq
 
 // AcquireLeaseHandleResponse handles the AcquireLease response.
 func (client *blobClient) AcquireLeaseHandleResponse(resp *azcore.Response) (*BlobAcquireLeaseResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.AcquireLeaseHandleError(resp)
-	}
 	result := BlobAcquireLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -249,6 +252,9 @@ func (client *blobClient) AcquireLeaseHandleResponse(resp *azcore.Response) (*Bl
 
 // AcquireLeaseHandleError handles the AcquireLease error response.
 func (client *blobClient) AcquireLeaseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -264,6 +270,9 @@ func (client *blobClient) BreakLease(ctx context.Context, blobBreakLeaseOptions 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.BreakLeaseHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.BreakLeaseHandleResponse(resp)
@@ -311,9 +320,6 @@ func (client *blobClient) BreakLeaseCreateRequest(ctx context.Context, blobBreak
 
 // BreakLeaseHandleResponse handles the BreakLease response.
 func (client *blobClient) BreakLeaseHandleResponse(resp *azcore.Response) (*BlobBreakLeaseResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, client.BreakLeaseHandleError(resp)
-	}
 	result := BlobBreakLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -354,6 +360,9 @@ func (client *blobClient) BreakLeaseHandleResponse(resp *azcore.Response) (*Blob
 
 // BreakLeaseHandleError handles the BreakLease error response.
 func (client *blobClient) BreakLeaseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -369,6 +378,9 @@ func (client *blobClient) ChangeLease(ctx context.Context, leaseId string, propo
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ChangeLeaseHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ChangeLeaseHandleResponse(resp)
@@ -415,9 +427,6 @@ func (client *blobClient) ChangeLeaseCreateRequest(ctx context.Context, leaseId 
 
 // ChangeLeaseHandleResponse handles the ChangeLease response.
 func (client *blobClient) ChangeLeaseHandleResponse(resp *azcore.Response) (*BlobChangeLeaseResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ChangeLeaseHandleError(resp)
-	}
 	result := BlobChangeLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -453,6 +462,9 @@ func (client *blobClient) ChangeLeaseHandleResponse(resp *azcore.Response) (*Blo
 
 // ChangeLeaseHandleError handles the ChangeLease error response.
 func (client *blobClient) ChangeLeaseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -468,6 +480,9 @@ func (client *blobClient) CopyFromURL(ctx context.Context, copySource url.URL, b
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CopyFromURLHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CopyFromURLHandleResponse(resp)
@@ -538,9 +553,6 @@ func (client *blobClient) CopyFromURLCreateRequest(ctx context.Context, copySour
 
 // CopyFromURLHandleResponse handles the CopyFromURL response.
 func (client *blobClient) CopyFromURLHandleResponse(resp *azcore.Response) (*BlobCopyFromURLResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, client.CopyFromURLHandleError(resp)
-	}
 	result := BlobCopyFromURLResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -593,6 +605,9 @@ func (client *blobClient) CopyFromURLHandleResponse(resp *azcore.Response) (*Blo
 
 // CopyFromURLHandleError handles the CopyFromURL error response.
 func (client *blobClient) CopyFromURLHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -608,6 +623,9 @@ func (client *blobClient) CreateSnapshot(ctx context.Context, blobCreateSnapshot
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CreateSnapshotHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CreateSnapshotHandleResponse(resp)
@@ -668,9 +686,6 @@ func (client *blobClient) CreateSnapshotCreateRequest(ctx context.Context, blobC
 
 // CreateSnapshotHandleResponse handles the CreateSnapshot response.
 func (client *blobClient) CreateSnapshotHandleResponse(resp *azcore.Response) (*BlobCreateSnapshotResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.CreateSnapshotHandleError(resp)
-	}
 	result := BlobCreateSnapshotResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-snapshot"); val != "" {
 		result.Snapshot = &val
@@ -713,6 +728,9 @@ func (client *blobClient) CreateSnapshotHandleResponse(resp *azcore.Response) (*
 
 // CreateSnapshotHandleError handles the CreateSnapshot error response.
 func (client *blobClient) CreateSnapshotHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -728,6 +746,9 @@ func (client *blobClient) Delete(ctx context.Context, blobDeleteOptions *BlobDel
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -779,9 +800,6 @@ func (client *blobClient) DeleteCreateRequest(ctx context.Context, blobDeleteOpt
 
 // DeleteHandleResponse handles the Delete response.
 func (client *blobClient) DeleteHandleResponse(resp *azcore.Response) (*BlobDeleteResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	result := BlobDeleteResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -804,6 +822,9 @@ func (client *blobClient) DeleteHandleResponse(resp *azcore.Response) (*BlobDele
 
 // DeleteHandleError handles the Delete error response.
 func (client *blobClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -819,6 +840,9 @@ func (client *blobClient) Download(ctx context.Context, blobDownloadOptions *Blo
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DownloadHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DownloadHandleResponse(resp)
@@ -883,9 +907,6 @@ func (client *blobClient) DownloadCreateRequest(ctx context.Context, blobDownloa
 
 // DownloadHandleResponse handles the Download response.
 func (client *blobClient) DownloadHandleResponse(resp *azcore.Response) (*BlobDownloadResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusPartialContent) {
-		return nil, client.DownloadHandleError(resp)
-	}
 	result := BlobDownloadResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
@@ -1037,6 +1058,9 @@ func (client *blobClient) DownloadHandleResponse(resp *azcore.Response) (*BlobDo
 
 // DownloadHandleError handles the Download error response.
 func (client *blobClient) DownloadHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusPartialContent) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1052,6 +1076,9 @@ func (client *blobClient) GetAccessControl(ctx context.Context, blobGetAccessCon
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetAccessControlHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetAccessControlHandleResponse(resp)
@@ -1101,9 +1128,6 @@ func (client *blobClient) GetAccessControlCreateRequest(ctx context.Context, blo
 
 // GetAccessControlHandleResponse handles the GetAccessControl response.
 func (client *blobClient) GetAccessControlHandleResponse(resp *azcore.Response) (*BlobGetAccessControlResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetAccessControlHandleError(resp)
-	}
 	result := BlobGetAccessControlResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
@@ -1145,6 +1169,9 @@ func (client *blobClient) GetAccessControlHandleResponse(resp *azcore.Response) 
 
 // GetAccessControlHandleError handles the GetAccessControl error response.
 func (client *blobClient) GetAccessControlHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1160,6 +1187,9 @@ func (client *blobClient) GetAccountInfo(ctx context.Context) (*BlobGetAccountIn
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetAccountInfoHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetAccountInfoHandleResponse(resp)
@@ -1186,9 +1216,6 @@ func (client *blobClient) GetAccountInfoCreateRequest(ctx context.Context) (*azc
 
 // GetAccountInfoHandleResponse handles the GetAccountInfo response.
 func (client *blobClient) GetAccountInfoHandleResponse(resp *azcore.Response) (*BlobGetAccountInfoResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetAccountInfoHandleError(resp)
-	}
 	result := BlobGetAccountInfoResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -1217,6 +1244,9 @@ func (client *blobClient) GetAccountInfoHandleResponse(resp *azcore.Response) (*
 
 // GetAccountInfoHandleError handles the GetAccountInfo error response.
 func (client *blobClient) GetAccountInfoHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1232,6 +1262,9 @@ func (client *blobClient) GetProperties(ctx context.Context, blobGetPropertiesOp
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetPropertiesHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetPropertiesHandleResponse(resp)
@@ -1286,9 +1319,6 @@ func (client *blobClient) GetPropertiesCreateRequest(ctx context.Context, blobGe
 
 // GetPropertiesHandleResponse handles the GetProperties response.
 func (client *blobClient) GetPropertiesHandleResponse(resp *azcore.Response) (*BlobGetPropertiesResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetPropertiesHandleError(resp)
-	}
 	result := BlobGetPropertiesResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
@@ -1460,6 +1490,9 @@ func (client *blobClient) GetPropertiesHandleResponse(resp *azcore.Response) (*B
 
 // GetPropertiesHandleError handles the GetProperties error response.
 func (client *blobClient) GetPropertiesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1475,6 +1508,9 @@ func (client *blobClient) ReleaseLease(ctx context.Context, leaseId string, blob
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ReleaseLeaseHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ReleaseLeaseHandleResponse(resp)
@@ -1520,9 +1556,6 @@ func (client *blobClient) ReleaseLeaseCreateRequest(ctx context.Context, leaseId
 
 // ReleaseLeaseHandleResponse handles the ReleaseLease response.
 func (client *blobClient) ReleaseLeaseHandleResponse(resp *azcore.Response) (*BlobReleaseLeaseResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ReleaseLeaseHandleError(resp)
-	}
 	result := BlobReleaseLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -1555,6 +1588,9 @@ func (client *blobClient) ReleaseLeaseHandleResponse(resp *azcore.Response) (*Bl
 
 // ReleaseLeaseHandleError handles the ReleaseLease error response.
 func (client *blobClient) ReleaseLeaseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1570,6 +1606,9 @@ func (client *blobClient) Rename(ctx context.Context, renameSource string, blobR
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.RenameHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.RenameHandleResponse(resp)
@@ -1658,9 +1697,6 @@ func (client *blobClient) RenameCreateRequest(ctx context.Context, renameSource 
 
 // RenameHandleResponse handles the Rename response.
 func (client *blobClient) RenameHandleResponse(resp *azcore.Response) (*BlobRenameResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.RenameHandleError(resp)
-	}
 	result := BlobRenameResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -1700,6 +1736,9 @@ func (client *blobClient) RenameHandleResponse(resp *azcore.Response) (*BlobRena
 
 // RenameHandleError handles the Rename error response.
 func (client *blobClient) RenameHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1715,6 +1754,9 @@ func (client *blobClient) RenewLease(ctx context.Context, leaseId string, blobRe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.RenewLeaseHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.RenewLeaseHandleResponse(resp)
@@ -1760,9 +1802,6 @@ func (client *blobClient) RenewLeaseCreateRequest(ctx context.Context, leaseId s
 
 // RenewLeaseHandleResponse handles the RenewLease response.
 func (client *blobClient) RenewLeaseHandleResponse(resp *azcore.Response) (*BlobRenewLeaseResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.RenewLeaseHandleError(resp)
-	}
 	result := BlobRenewLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -1798,6 +1837,9 @@ func (client *blobClient) RenewLeaseHandleResponse(resp *azcore.Response) (*Blob
 
 // RenewLeaseHandleError handles the RenewLease error response.
 func (client *blobClient) RenewLeaseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1813,6 +1855,9 @@ func (client *blobClient) SetAccessControl(ctx context.Context, blobSetAccessCon
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.SetAccessControlHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.SetAccessControlHandleResponse(resp)
@@ -1871,9 +1916,6 @@ func (client *blobClient) SetAccessControlCreateRequest(ctx context.Context, blo
 
 // SetAccessControlHandleResponse handles the SetAccessControl response.
 func (client *blobClient) SetAccessControlHandleResponse(resp *azcore.Response) (*BlobSetAccessControlResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.SetAccessControlHandleError(resp)
-	}
 	result := BlobSetAccessControlResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
@@ -1903,6 +1945,9 @@ func (client *blobClient) SetAccessControlHandleResponse(resp *azcore.Response) 
 
 // SetAccessControlHandleError handles the SetAccessControl error response.
 func (client *blobClient) SetAccessControlHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1918,6 +1963,9 @@ func (client *blobClient) SetHTTPHeaders(ctx context.Context, blobSetHttpHeaders
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.SetHTTPHeadersHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.SetHTTPHeadersHandleResponse(resp)
@@ -1982,9 +2030,6 @@ func (client *blobClient) SetHTTPHeadersCreateRequest(ctx context.Context, blobS
 
 // SetHTTPHeadersHandleResponse handles the SetHTTPHeaders response.
 func (client *blobClient) SetHTTPHeadersHandleResponse(resp *azcore.Response) (*BlobSetHTTPHeadersResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.SetHTTPHeadersHandleError(resp)
-	}
 	result := BlobSetHTTPHeadersResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -2024,6 +2069,9 @@ func (client *blobClient) SetHTTPHeadersHandleResponse(resp *azcore.Response) (*
 
 // SetHTTPHeadersHandleError handles the SetHTTPHeaders error response.
 func (client *blobClient) SetHTTPHeadersHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -2039,6 +2087,9 @@ func (client *blobClient) SetMetadata(ctx context.Context, blobSetMetadataOption
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.SetMetadataHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.SetMetadataHandleResponse(resp)
@@ -2099,9 +2150,6 @@ func (client *blobClient) SetMetadataCreateRequest(ctx context.Context, blobSetM
 
 // SetMetadataHandleResponse handles the SetMetadata response.
 func (client *blobClient) SetMetadataHandleResponse(resp *azcore.Response) (*BlobSetMetadataResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.SetMetadataHandleError(resp)
-	}
 	result := BlobSetMetadataResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -2147,6 +2195,9 @@ func (client *blobClient) SetMetadataHandleResponse(resp *azcore.Response) (*Blo
 
 // SetMetadataHandleError handles the SetMetadata error response.
 func (client *blobClient) SetMetadataHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -2162,6 +2213,9 @@ func (client *blobClient) SetTier(ctx context.Context, tier AccessTier, blobSetT
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.SetTierHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.SetTierHandleResponse(resp)
@@ -2200,9 +2254,6 @@ func (client *blobClient) SetTierCreateRequest(ctx context.Context, tier AccessT
 
 // SetTierHandleResponse handles the SetTier response.
 func (client *blobClient) SetTierHandleResponse(resp *azcore.Response) (*BlobSetTierResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
-		return nil, client.SetTierHandleError(resp)
-	}
 	result := BlobSetTierResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -2218,6 +2269,9 @@ func (client *blobClient) SetTierHandleResponse(resp *azcore.Response) (*BlobSet
 
 // SetTierHandleError handles the SetTier error response.
 func (client *blobClient) SetTierHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -2233,6 +2287,9 @@ func (client *blobClient) StartCopyFromURL(ctx context.Context, copySource url.U
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.StartCopyFromURLHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.StartCopyFromURLHandleResponse(resp)
@@ -2302,9 +2359,6 @@ func (client *blobClient) StartCopyFromURLCreateRequest(ctx context.Context, cop
 
 // StartCopyFromURLHandleResponse handles the StartCopyFromURL response.
 func (client *blobClient) StartCopyFromURLHandleResponse(resp *azcore.Response) (*BlobStartCopyFromURLResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, client.StartCopyFromURLHandleError(resp)
-	}
 	result := BlobStartCopyFromURLResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -2343,6 +2397,9 @@ func (client *blobClient) StartCopyFromURLHandleResponse(resp *azcore.Response) 
 
 // StartCopyFromURLHandleError handles the StartCopyFromURL error response.
 func (client *blobClient) StartCopyFromURLHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -2358,6 +2415,9 @@ func (client *blobClient) Undelete(ctx context.Context, blobUndeleteOptions *Blo
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UndeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UndeleteHandleResponse(resp)
@@ -2389,9 +2449,6 @@ func (client *blobClient) UndeleteCreateRequest(ctx context.Context, blobUndelet
 
 // UndeleteHandleResponse handles the Undelete response.
 func (client *blobClient) UndeleteHandleResponse(resp *azcore.Response) (*BlobUndeleteResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UndeleteHandleError(resp)
-	}
 	result := BlobUndeleteResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -2414,6 +2471,9 @@ func (client *blobClient) UndeleteHandleResponse(resp *azcore.Response) (*BlobUn
 
 // UndeleteHandleError handles the Undelete error response.
 func (client *blobClient) UndeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err

--- a/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
@@ -55,6 +55,9 @@ func (client *blockBlobClient) CommitBlockList(ctx context.Context, blocks Block
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CommitBlockListHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CommitBlockListHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -140,9 +143,6 @@ func (client *blockBlobClient) CommitBlockListCreateRequest(ctx context.Context,
 
 // CommitBlockListHandleResponse handles the CommitBlockList response.
 func (client *blockBlobClient) CommitBlockListHandleResponse(resp *azcore.Response) (*BlockBlobCommitBlockListResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.CommitBlockListHandleError(resp)
-	}
 	result := BlockBlobCommitBlockListResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -202,6 +202,9 @@ func (client *blockBlobClient) CommitBlockListHandleResponse(resp *azcore.Respon
 
 // CommitBlockListHandleError handles the CommitBlockList error response.
 func (client *blockBlobClient) CommitBlockListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -217,6 +220,9 @@ func (client *blockBlobClient) GetBlockList(ctx context.Context, listType BlockL
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetBlockListHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetBlockListHandleResponse(resp)
@@ -255,9 +261,6 @@ func (client *blockBlobClient) GetBlockListCreateRequest(ctx context.Context, li
 
 // GetBlockListHandleResponse handles the GetBlockList response.
 func (client *blockBlobClient) GetBlockListHandleResponse(resp *azcore.Response) (*BlockListResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetBlockListHandleError(resp)
-	}
 	result := BlockListResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
@@ -300,6 +303,9 @@ func (client *blockBlobClient) GetBlockListHandleResponse(resp *azcore.Response)
 
 // GetBlockListHandleError handles the GetBlockList error response.
 func (client *blockBlobClient) GetBlockListHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -315,6 +321,9 @@ func (client *blockBlobClient) StageBlock(ctx context.Context, blockId string, c
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.StageBlockHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.StageBlockHandleResponse(resp)
@@ -366,9 +375,6 @@ func (client *blockBlobClient) StageBlockCreateRequest(ctx context.Context, bloc
 
 // StageBlockHandleResponse handles the StageBlock response.
 func (client *blockBlobClient) StageBlockHandleResponse(resp *azcore.Response) (*BlockBlobStageBlockResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.StageBlockHandleError(resp)
-	}
 	result := BlockBlobStageBlockResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Content-MD5"); val != "" {
 		contentMd5, err := base64.StdEncoding.DecodeString(val)
@@ -418,6 +424,9 @@ func (client *blockBlobClient) StageBlockHandleResponse(resp *azcore.Response) (
 
 // StageBlockHandleError handles the StageBlock error response.
 func (client *blockBlobClient) StageBlockHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -433,6 +442,9 @@ func (client *blockBlobClient) StageBlockFromURL(ctx context.Context, blockId st
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.StageBlockFromURLHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.StageBlockFromURLHandleResponse(resp)
@@ -500,9 +512,6 @@ func (client *blockBlobClient) StageBlockFromURLCreateRequest(ctx context.Contex
 
 // StageBlockFromURLHandleResponse handles the StageBlockFromURL response.
 func (client *blockBlobClient) StageBlockFromURLHandleResponse(resp *azcore.Response) (*BlockBlobStageBlockFromURLResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.StageBlockFromURLHandleError(resp)
-	}
 	result := BlockBlobStageBlockFromURLResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Content-MD5"); val != "" {
 		contentMd5, err := base64.StdEncoding.DecodeString(val)
@@ -552,6 +561,9 @@ func (client *blockBlobClient) StageBlockFromURLHandleResponse(resp *azcore.Resp
 
 // StageBlockFromURLHandleError handles the StageBlockFromURL error response.
 func (client *blockBlobClient) StageBlockFromURLHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -567,6 +579,9 @@ func (client *blockBlobClient) Upload(ctx context.Context, contentLength int64, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UploadHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UploadHandleResponse(resp)
@@ -652,9 +667,6 @@ func (client *blockBlobClient) UploadCreateRequest(ctx context.Context, contentL
 
 // UploadHandleResponse handles the Upload response.
 func (client *blockBlobClient) UploadHandleResponse(resp *azcore.Response) (*BlockBlobUploadResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.UploadHandleError(resp)
-	}
 	result := BlockBlobUploadResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -707,6 +719,9 @@ func (client *blockBlobClient) UploadHandleResponse(resp *azcore.Response) (*Blo
 
 // UploadHandleError handles the Upload error response.
 func (client *blockBlobClient) UploadHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err

--- a/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
@@ -55,8 +55,8 @@ func (client *blockBlobClient) CommitBlockList(ctx context.Context, blocks Block
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CommitBlockListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.CommitBlockListHandleError(resp)
 	}
 	result, err := client.CommitBlockListHandleResponse(resp)
 	if err != nil {
@@ -202,9 +202,6 @@ func (client *blockBlobClient) CommitBlockListHandleResponse(resp *azcore.Respon
 
 // CommitBlockListHandleError handles the CommitBlockList error response.
 func (client *blockBlobClient) CommitBlockListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -222,8 +219,8 @@ func (client *blockBlobClient) GetBlockList(ctx context.Context, listType BlockL
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetBlockListHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetBlockListHandleError(resp)
 	}
 	result, err := client.GetBlockListHandleResponse(resp)
 	if err != nil {
@@ -303,9 +300,6 @@ func (client *blockBlobClient) GetBlockListHandleResponse(resp *azcore.Response)
 
 // GetBlockListHandleError handles the GetBlockList error response.
 func (client *blockBlobClient) GetBlockListHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -323,8 +317,8 @@ func (client *blockBlobClient) StageBlock(ctx context.Context, blockId string, c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StageBlockHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.StageBlockHandleError(resp)
 	}
 	result, err := client.StageBlockHandleResponse(resp)
 	if err != nil {
@@ -424,9 +418,6 @@ func (client *blockBlobClient) StageBlockHandleResponse(resp *azcore.Response) (
 
 // StageBlockHandleError handles the StageBlock error response.
 func (client *blockBlobClient) StageBlockHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -444,8 +435,8 @@ func (client *blockBlobClient) StageBlockFromURL(ctx context.Context, blockId st
 	if err != nil {
 		return nil, err
 	}
-	if err := client.StageBlockFromURLHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.StageBlockFromURLHandleError(resp)
 	}
 	result, err := client.StageBlockFromURLHandleResponse(resp)
 	if err != nil {
@@ -561,9 +552,6 @@ func (client *blockBlobClient) StageBlockFromURLHandleResponse(resp *azcore.Resp
 
 // StageBlockFromURLHandleError handles the StageBlockFromURL error response.
 func (client *blockBlobClient) StageBlockFromURLHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -581,8 +569,8 @@ func (client *blockBlobClient) Upload(ctx context.Context, contentLength int64, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UploadHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.UploadHandleError(resp)
 	}
 	result, err := client.UploadHandleResponse(resp)
 	if err != nil {
@@ -719,9 +707,6 @@ func (client *blockBlobClient) UploadHandleResponse(resp *azcore.Response) (*Blo
 
 // UploadHandleError handles the Upload error response.
 func (client *blockBlobClient) UploadHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err

--- a/test/storage/2019-07-07/azblob/zz_generated_container.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_container.go
@@ -74,6 +74,9 @@ func (client *containerClient) AcquireLease(ctx context.Context, containerAcquir
 	if err != nil {
 		return nil, err
 	}
+	if err := client.AcquireLeaseHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.AcquireLeaseHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -117,9 +120,6 @@ func (client *containerClient) AcquireLeaseCreateRequest(ctx context.Context, co
 
 // AcquireLeaseHandleResponse handles the AcquireLease response.
 func (client *containerClient) AcquireLeaseHandleResponse(resp *azcore.Response) (*ContainerAcquireLeaseResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.AcquireLeaseHandleError(resp)
-	}
 	result := ContainerAcquireLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -155,6 +155,9 @@ func (client *containerClient) AcquireLeaseHandleResponse(resp *azcore.Response)
 
 // AcquireLeaseHandleError handles the AcquireLease error response.
 func (client *containerClient) AcquireLeaseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -170,6 +173,9 @@ func (client *containerClient) BreakLease(ctx context.Context, containerBreakLea
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.BreakLeaseHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.BreakLeaseHandleResponse(resp)
@@ -212,9 +218,6 @@ func (client *containerClient) BreakLeaseCreateRequest(ctx context.Context, cont
 
 // BreakLeaseHandleResponse handles the BreakLease response.
 func (client *containerClient) BreakLeaseHandleResponse(resp *azcore.Response) (*ContainerBreakLeaseResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, client.BreakLeaseHandleError(resp)
-	}
 	result := ContainerBreakLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -255,6 +258,9 @@ func (client *containerClient) BreakLeaseHandleResponse(resp *azcore.Response) (
 
 // BreakLeaseHandleError handles the BreakLease error response.
 func (client *containerClient) BreakLeaseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -270,6 +276,9 @@ func (client *containerClient) ChangeLease(ctx context.Context, leaseId string, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ChangeLeaseHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ChangeLeaseHandleResponse(resp)
@@ -311,9 +320,6 @@ func (client *containerClient) ChangeLeaseCreateRequest(ctx context.Context, lea
 
 // ChangeLeaseHandleResponse handles the ChangeLease response.
 func (client *containerClient) ChangeLeaseHandleResponse(resp *azcore.Response) (*ContainerChangeLeaseResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ChangeLeaseHandleError(resp)
-	}
 	result := ContainerChangeLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -349,6 +355,9 @@ func (client *containerClient) ChangeLeaseHandleResponse(resp *azcore.Response) 
 
 // ChangeLeaseHandleError handles the ChangeLease error response.
 func (client *containerClient) ChangeLeaseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -364,6 +373,9 @@ func (client *containerClient) Create(ctx context.Context, containerCreateOption
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CreateHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CreateHandleResponse(resp)
@@ -409,9 +421,6 @@ func (client *containerClient) CreateCreateRequest(ctx context.Context, containe
 
 // CreateHandleResponse handles the Create response.
 func (client *containerClient) CreateHandleResponse(resp *azcore.Response) (*ContainerCreateResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.CreateHandleError(resp)
-	}
 	result := ContainerCreateResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -444,6 +453,9 @@ func (client *containerClient) CreateHandleResponse(resp *azcore.Response) (*Con
 
 // CreateHandleError handles the Create error response.
 func (client *containerClient) CreateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -459,6 +471,9 @@ func (client *containerClient) Delete(ctx context.Context, containerDeleteOption
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -499,9 +514,6 @@ func (client *containerClient) DeleteCreateRequest(ctx context.Context, containe
 
 // DeleteHandleResponse handles the Delete response.
 func (client *containerClient) DeleteHandleResponse(resp *azcore.Response) (*ContainerDeleteResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	result := ContainerDeleteResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -524,6 +536,9 @@ func (client *containerClient) DeleteHandleResponse(resp *azcore.Response) (*Con
 
 // DeleteHandleError handles the Delete error response.
 func (client *containerClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -539,6 +554,9 @@ func (client *containerClient) GetAccessPolicy(ctx context.Context, containerGet
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetAccessPolicyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetAccessPolicyHandleResponse(resp)
@@ -574,9 +592,6 @@ func (client *containerClient) GetAccessPolicyCreateRequest(ctx context.Context,
 
 // GetAccessPolicyHandleResponse handles the GetAccessPolicy response.
 func (client *containerClient) GetAccessPolicyHandleResponse(resp *azcore.Response) (*SignedIDentifierArrayResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetAccessPolicyHandleError(resp)
-	}
 	result := SignedIDentifierArrayResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-blob-public-access"); val != "" {
 		result.BlobPublicAccess = (*PublicAccessType)(&val)
@@ -612,6 +627,9 @@ func (client *containerClient) GetAccessPolicyHandleResponse(resp *azcore.Respon
 
 // GetAccessPolicyHandleError handles the GetAccessPolicy error response.
 func (client *containerClient) GetAccessPolicyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -627,6 +645,9 @@ func (client *containerClient) GetAccountInfo(ctx context.Context) (*ContainerGe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetAccountInfoHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetAccountInfoHandleResponse(resp)
@@ -653,9 +674,6 @@ func (client *containerClient) GetAccountInfoCreateRequest(ctx context.Context) 
 
 // GetAccountInfoHandleResponse handles the GetAccountInfo response.
 func (client *containerClient) GetAccountInfoHandleResponse(resp *azcore.Response) (*ContainerGetAccountInfoResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetAccountInfoHandleError(resp)
-	}
 	result := ContainerGetAccountInfoResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -684,6 +702,9 @@ func (client *containerClient) GetAccountInfoHandleResponse(resp *azcore.Respons
 
 // GetAccountInfoHandleError handles the GetAccountInfo error response.
 func (client *containerClient) GetAccountInfoHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -699,6 +720,9 @@ func (client *containerClient) GetProperties(ctx context.Context, containerGetPr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetPropertiesHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetPropertiesHandleResponse(resp)
@@ -733,9 +757,6 @@ func (client *containerClient) GetPropertiesCreateRequest(ctx context.Context, c
 
 // GetPropertiesHandleResponse handles the GetProperties response.
 func (client *containerClient) GetPropertiesHandleResponse(resp *azcore.Response) (*ContainerGetPropertiesResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetPropertiesHandleError(resp)
-	}
 	result := ContainerGetPropertiesResponse{RawResponse: resp.Response}
 	for hh := range resp.Header {
 		if strings.HasPrefix(hh, "x-ms-meta-") {
@@ -812,6 +833,9 @@ func (client *containerClient) GetPropertiesHandleResponse(resp *azcore.Response
 
 // GetPropertiesHandleError handles the GetProperties error response.
 func (client *containerClient) GetPropertiesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -827,6 +851,7 @@ func (client *containerClient) ListBlobFlatSegment(containerListBlobFlatSegmentO
 			return client.ListBlobFlatSegmentCreateRequest(ctx, containerListBlobFlatSegmentOptions)
 		},
 		responder: client.ListBlobFlatSegmentHandleResponse,
+		errorer:   client.ListBlobFlatSegmentHandleError,
 		advancer: func(ctx context.Context, resp *ListBlobsFlatSegmentResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.EnumerationResults.NextMarker)
 		},
@@ -868,9 +893,6 @@ func (client *containerClient) ListBlobFlatSegmentCreateRequest(ctx context.Cont
 
 // ListBlobFlatSegmentHandleResponse handles the ListBlobFlatSegment response.
 func (client *containerClient) ListBlobFlatSegmentHandleResponse(resp *azcore.Response) (*ListBlobsFlatSegmentResponseResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListBlobFlatSegmentHandleError(resp)
-	}
 	result := ListBlobsFlatSegmentResponseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val
@@ -896,6 +918,9 @@ func (client *containerClient) ListBlobFlatSegmentHandleResponse(resp *azcore.Re
 
 // ListBlobFlatSegmentHandleError handles the ListBlobFlatSegment error response.
 func (client *containerClient) ListBlobFlatSegmentHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -911,6 +936,7 @@ func (client *containerClient) ListBlobHierarchySegment(delimiter string, contai
 			return client.ListBlobHierarchySegmentCreateRequest(ctx, delimiter, containerListBlobHierarchySegmentOptions)
 		},
 		responder: client.ListBlobHierarchySegmentHandleResponse,
+		errorer:   client.ListBlobHierarchySegmentHandleError,
 		advancer: func(ctx context.Context, resp *ListBlobsHierarchySegmentResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.EnumerationResults.NextMarker)
 		},
@@ -953,9 +979,6 @@ func (client *containerClient) ListBlobHierarchySegmentCreateRequest(ctx context
 
 // ListBlobHierarchySegmentHandleResponse handles the ListBlobHierarchySegment response.
 func (client *containerClient) ListBlobHierarchySegmentHandleResponse(resp *azcore.Response) (*ListBlobsHierarchySegmentResponseResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListBlobHierarchySegmentHandleError(resp)
-	}
 	result := ListBlobsHierarchySegmentResponseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val
@@ -981,6 +1004,9 @@ func (client *containerClient) ListBlobHierarchySegmentHandleResponse(resp *azco
 
 // ListBlobHierarchySegmentHandleError handles the ListBlobHierarchySegment error response.
 func (client *containerClient) ListBlobHierarchySegmentHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -996,6 +1022,9 @@ func (client *containerClient) ReleaseLease(ctx context.Context, leaseId string,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ReleaseLeaseHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ReleaseLeaseHandleResponse(resp)
@@ -1036,9 +1065,6 @@ func (client *containerClient) ReleaseLeaseCreateRequest(ctx context.Context, le
 
 // ReleaseLeaseHandleResponse handles the ReleaseLease response.
 func (client *containerClient) ReleaseLeaseHandleResponse(resp *azcore.Response) (*ContainerReleaseLeaseResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ReleaseLeaseHandleError(resp)
-	}
 	result := ContainerReleaseLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -1071,6 +1097,9 @@ func (client *containerClient) ReleaseLeaseHandleResponse(resp *azcore.Response)
 
 // ReleaseLeaseHandleError handles the ReleaseLease error response.
 func (client *containerClient) ReleaseLeaseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1086,6 +1115,9 @@ func (client *containerClient) RenewLease(ctx context.Context, leaseId string, c
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.RenewLeaseHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.RenewLeaseHandleResponse(resp)
@@ -1126,9 +1158,6 @@ func (client *containerClient) RenewLeaseCreateRequest(ctx context.Context, leas
 
 // RenewLeaseHandleResponse handles the RenewLease response.
 func (client *containerClient) RenewLeaseHandleResponse(resp *azcore.Response) (*ContainerRenewLeaseResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.RenewLeaseHandleError(resp)
-	}
 	result := ContainerRenewLeaseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -1164,6 +1193,9 @@ func (client *containerClient) RenewLeaseHandleResponse(resp *azcore.Response) (
 
 // RenewLeaseHandleError handles the RenewLease error response.
 func (client *containerClient) RenewLeaseHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1179,6 +1211,9 @@ func (client *containerClient) SetAccessPolicy(ctx context.Context, containerSet
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.SetAccessPolicyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.SetAccessPolicyHandleResponse(resp)
@@ -1230,9 +1265,6 @@ func (client *containerClient) SetAccessPolicyCreateRequest(ctx context.Context,
 
 // SetAccessPolicyHandleResponse handles the SetAccessPolicy response.
 func (client *containerClient) SetAccessPolicyHandleResponse(resp *azcore.Response) (*ContainerSetAccessPolicyResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.SetAccessPolicyHandleError(resp)
-	}
 	result := ContainerSetAccessPolicyResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -1265,6 +1297,9 @@ func (client *containerClient) SetAccessPolicyHandleResponse(resp *azcore.Respon
 
 // SetAccessPolicyHandleError handles the SetAccessPolicy error response.
 func (client *containerClient) SetAccessPolicyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1280,6 +1315,9 @@ func (client *containerClient) SetMetadata(ctx context.Context, containerSetMeta
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.SetMetadataHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.SetMetadataHandleResponse(resp)
@@ -1323,9 +1361,6 @@ func (client *containerClient) SetMetadataCreateRequest(ctx context.Context, con
 
 // SetMetadataHandleResponse handles the SetMetadata response.
 func (client *containerClient) SetMetadataHandleResponse(resp *azcore.Response) (*ContainerSetMetadataResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.SetMetadataHandleError(resp)
-	}
 	result := ContainerSetMetadataResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -1358,6 +1393,9 @@ func (client *containerClient) SetMetadataHandleResponse(resp *azcore.Response) 
 
 // SetMetadataHandleError handles the SetMetadata error response.
 func (client *containerClient) SetMetadataHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err

--- a/test/storage/2019-07-07/azblob/zz_generated_container.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_container.go
@@ -74,8 +74,8 @@ func (client *containerClient) AcquireLease(ctx context.Context, containerAcquir
 	if err != nil {
 		return nil, err
 	}
-	if err := client.AcquireLeaseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.AcquireLeaseHandleError(resp)
 	}
 	result, err := client.AcquireLeaseHandleResponse(resp)
 	if err != nil {
@@ -155,9 +155,6 @@ func (client *containerClient) AcquireLeaseHandleResponse(resp *azcore.Response)
 
 // AcquireLeaseHandleError handles the AcquireLease error response.
 func (client *containerClient) AcquireLeaseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -175,8 +172,8 @@ func (client *containerClient) BreakLease(ctx context.Context, containerBreakLea
 	if err != nil {
 		return nil, err
 	}
-	if err := client.BreakLeaseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.BreakLeaseHandleError(resp)
 	}
 	result, err := client.BreakLeaseHandleResponse(resp)
 	if err != nil {
@@ -258,9 +255,6 @@ func (client *containerClient) BreakLeaseHandleResponse(resp *azcore.Response) (
 
 // BreakLeaseHandleError handles the BreakLease error response.
 func (client *containerClient) BreakLeaseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -278,8 +272,8 @@ func (client *containerClient) ChangeLease(ctx context.Context, leaseId string, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ChangeLeaseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ChangeLeaseHandleError(resp)
 	}
 	result, err := client.ChangeLeaseHandleResponse(resp)
 	if err != nil {
@@ -355,9 +349,6 @@ func (client *containerClient) ChangeLeaseHandleResponse(resp *azcore.Response) 
 
 // ChangeLeaseHandleError handles the ChangeLease error response.
 func (client *containerClient) ChangeLeaseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -375,8 +366,8 @@ func (client *containerClient) Create(ctx context.Context, containerCreateOption
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.CreateHandleError(resp)
 	}
 	result, err := client.CreateHandleResponse(resp)
 	if err != nil {
@@ -453,9 +444,6 @@ func (client *containerClient) CreateHandleResponse(resp *azcore.Response) (*Con
 
 // CreateHandleError handles the Create error response.
 func (client *containerClient) CreateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -473,8 +461,8 @@ func (client *containerClient) Delete(ctx context.Context, containerDeleteOption
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -536,9 +524,6 @@ func (client *containerClient) DeleteHandleResponse(resp *azcore.Response) (*Con
 
 // DeleteHandleError handles the Delete error response.
 func (client *containerClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -556,8 +541,8 @@ func (client *containerClient) GetAccessPolicy(ctx context.Context, containerGet
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetAccessPolicyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetAccessPolicyHandleError(resp)
 	}
 	result, err := client.GetAccessPolicyHandleResponse(resp)
 	if err != nil {
@@ -627,9 +612,6 @@ func (client *containerClient) GetAccessPolicyHandleResponse(resp *azcore.Respon
 
 // GetAccessPolicyHandleError handles the GetAccessPolicy error response.
 func (client *containerClient) GetAccessPolicyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -647,8 +629,8 @@ func (client *containerClient) GetAccountInfo(ctx context.Context) (*ContainerGe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetAccountInfoHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetAccountInfoHandleError(resp)
 	}
 	result, err := client.GetAccountInfoHandleResponse(resp)
 	if err != nil {
@@ -702,9 +684,6 @@ func (client *containerClient) GetAccountInfoHandleResponse(resp *azcore.Respons
 
 // GetAccountInfoHandleError handles the GetAccountInfo error response.
 func (client *containerClient) GetAccountInfoHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -722,8 +701,8 @@ func (client *containerClient) GetProperties(ctx context.Context, containerGetPr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetPropertiesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetPropertiesHandleError(resp)
 	}
 	result, err := client.GetPropertiesHandleResponse(resp)
 	if err != nil {
@@ -833,9 +812,6 @@ func (client *containerClient) GetPropertiesHandleResponse(resp *azcore.Response
 
 // GetPropertiesHandleError handles the GetProperties error response.
 func (client *containerClient) GetPropertiesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -918,9 +894,6 @@ func (client *containerClient) ListBlobFlatSegmentHandleResponse(resp *azcore.Re
 
 // ListBlobFlatSegmentHandleError handles the ListBlobFlatSegment error response.
 func (client *containerClient) ListBlobFlatSegmentHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1004,9 +977,6 @@ func (client *containerClient) ListBlobHierarchySegmentHandleResponse(resp *azco
 
 // ListBlobHierarchySegmentHandleError handles the ListBlobHierarchySegment error response.
 func (client *containerClient) ListBlobHierarchySegmentHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1024,8 +994,8 @@ func (client *containerClient) ReleaseLease(ctx context.Context, leaseId string,
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ReleaseLeaseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ReleaseLeaseHandleError(resp)
 	}
 	result, err := client.ReleaseLeaseHandleResponse(resp)
 	if err != nil {
@@ -1097,9 +1067,6 @@ func (client *containerClient) ReleaseLeaseHandleResponse(resp *azcore.Response)
 
 // ReleaseLeaseHandleError handles the ReleaseLease error response.
 func (client *containerClient) ReleaseLeaseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1117,8 +1084,8 @@ func (client *containerClient) RenewLease(ctx context.Context, leaseId string, c
 	if err != nil {
 		return nil, err
 	}
-	if err := client.RenewLeaseHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.RenewLeaseHandleError(resp)
 	}
 	result, err := client.RenewLeaseHandleResponse(resp)
 	if err != nil {
@@ -1193,9 +1160,6 @@ func (client *containerClient) RenewLeaseHandleResponse(resp *azcore.Response) (
 
 // RenewLeaseHandleError handles the RenewLease error response.
 func (client *containerClient) RenewLeaseHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1213,8 +1177,8 @@ func (client *containerClient) SetAccessPolicy(ctx context.Context, containerSet
 	if err != nil {
 		return nil, err
 	}
-	if err := client.SetAccessPolicyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.SetAccessPolicyHandleError(resp)
 	}
 	result, err := client.SetAccessPolicyHandleResponse(resp)
 	if err != nil {
@@ -1297,9 +1261,6 @@ func (client *containerClient) SetAccessPolicyHandleResponse(resp *azcore.Respon
 
 // SetAccessPolicyHandleError handles the SetAccessPolicy error response.
 func (client *containerClient) SetAccessPolicyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1317,8 +1278,8 @@ func (client *containerClient) SetMetadata(ctx context.Context, containerSetMeta
 	if err != nil {
 		return nil, err
 	}
-	if err := client.SetMetadataHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.SetMetadataHandleError(resp)
 	}
 	result, err := client.SetMetadataHandleResponse(resp)
 	if err != nil {
@@ -1393,9 +1354,6 @@ func (client *containerClient) SetMetadataHandleResponse(resp *azcore.Response) 
 
 // SetMetadataHandleError handles the SetMetadata error response.
 func (client *containerClient) SetMetadataHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err

--- a/test/storage/2019-07-07/azblob/zz_generated_directory.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_directory.go
@@ -54,6 +54,9 @@ func (client *directoryClient) Create(ctx context.Context, directoryCreateOption
 	if err != nil {
 		return nil, err
 	}
+	if err := client.CreateHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.CreateHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -122,9 +125,6 @@ func (client *directoryClient) CreateCreateRequest(ctx context.Context, director
 
 // CreateHandleResponse handles the Create response.
 func (client *directoryClient) CreateHandleResponse(resp *azcore.Response) (*DirectoryCreateResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.CreateHandleError(resp)
-	}
 	result := DirectoryCreateResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -164,6 +164,9 @@ func (client *directoryClient) CreateHandleResponse(resp *azcore.Response) (*Dir
 
 // CreateHandleError handles the Create error response.
 func (client *directoryClient) CreateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -179,6 +182,9 @@ func (client *directoryClient) Delete(ctx context.Context, recursiveDirectoryDel
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.DeleteHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.DeleteHandleResponse(resp)
@@ -228,9 +234,6 @@ func (client *directoryClient) DeleteCreateRequest(ctx context.Context, recursiv
 
 // DeleteHandleResponse handles the Delete response.
 func (client *directoryClient) DeleteHandleResponse(resp *azcore.Response) (*DirectoryDeleteResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.DeleteHandleError(resp)
-	}
 	result := DirectoryDeleteResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-continuation"); val != "" {
 		result.Marker = &val
@@ -256,6 +259,9 @@ func (client *directoryClient) DeleteHandleResponse(resp *azcore.Response) (*Dir
 
 // DeleteHandleError handles the Delete error response.
 func (client *directoryClient) DeleteHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -271,6 +277,9 @@ func (client *directoryClient) GetAccessControl(ctx context.Context, directoryGe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetAccessControlHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetAccessControlHandleResponse(resp)
@@ -320,9 +329,6 @@ func (client *directoryClient) GetAccessControlCreateRequest(ctx context.Context
 
 // GetAccessControlHandleResponse handles the GetAccessControl response.
 func (client *directoryClient) GetAccessControlHandleResponse(resp *azcore.Response) (*DirectoryGetAccessControlResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetAccessControlHandleError(resp)
-	}
 	result := DirectoryGetAccessControlResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
@@ -364,6 +370,9 @@ func (client *directoryClient) GetAccessControlHandleResponse(resp *azcore.Respo
 
 // GetAccessControlHandleError handles the GetAccessControl error response.
 func (client *directoryClient) GetAccessControlHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -379,6 +388,9 @@ func (client *directoryClient) Rename(ctx context.Context, renameSource string, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.RenameHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.RenameHandleResponse(resp)
@@ -470,9 +482,6 @@ func (client *directoryClient) RenameCreateRequest(ctx context.Context, renameSo
 
 // RenameHandleResponse handles the Rename response.
 func (client *directoryClient) RenameHandleResponse(resp *azcore.Response) (*DirectoryRenameResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.RenameHandleError(resp)
-	}
 	result := DirectoryRenameResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-continuation"); val != "" {
 		result.Marker = &val
@@ -515,6 +524,9 @@ func (client *directoryClient) RenameHandleResponse(resp *azcore.Response) (*Dir
 
 // RenameHandleError handles the Rename error response.
 func (client *directoryClient) RenameHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -530,6 +542,9 @@ func (client *directoryClient) SetAccessControl(ctx context.Context, directorySe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.SetAccessControlHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.SetAccessControlHandleResponse(resp)
@@ -588,9 +603,6 @@ func (client *directoryClient) SetAccessControlCreateRequest(ctx context.Context
 
 // SetAccessControlHandleResponse handles the SetAccessControl response.
 func (client *directoryClient) SetAccessControlHandleResponse(resp *azcore.Response) (*DirectorySetAccessControlResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.SetAccessControlHandleError(resp)
-	}
 	result := DirectorySetAccessControlResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
@@ -620,6 +632,9 @@ func (client *directoryClient) SetAccessControlHandleResponse(resp *azcore.Respo
 
 // SetAccessControlHandleError handles the SetAccessControl error response.
 func (client *directoryClient) SetAccessControlHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err

--- a/test/storage/2019-07-07/azblob/zz_generated_directory.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_directory.go
@@ -54,8 +54,8 @@ func (client *directoryClient) Create(ctx context.Context, directoryCreateOption
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.CreateHandleError(resp)
 	}
 	result, err := client.CreateHandleResponse(resp)
 	if err != nil {
@@ -164,9 +164,6 @@ func (client *directoryClient) CreateHandleResponse(resp *azcore.Response) (*Dir
 
 // CreateHandleError handles the Create error response.
 func (client *directoryClient) CreateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -184,8 +181,8 @@ func (client *directoryClient) Delete(ctx context.Context, recursiveDirectoryDel
 	if err != nil {
 		return nil, err
 	}
-	if err := client.DeleteHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.DeleteHandleError(resp)
 	}
 	result, err := client.DeleteHandleResponse(resp)
 	if err != nil {
@@ -259,9 +256,6 @@ func (client *directoryClient) DeleteHandleResponse(resp *azcore.Response) (*Dir
 
 // DeleteHandleError handles the Delete error response.
 func (client *directoryClient) DeleteHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -279,8 +273,8 @@ func (client *directoryClient) GetAccessControl(ctx context.Context, directoryGe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetAccessControlHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetAccessControlHandleError(resp)
 	}
 	result, err := client.GetAccessControlHandleResponse(resp)
 	if err != nil {
@@ -370,9 +364,6 @@ func (client *directoryClient) GetAccessControlHandleResponse(resp *azcore.Respo
 
 // GetAccessControlHandleError handles the GetAccessControl error response.
 func (client *directoryClient) GetAccessControlHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -390,8 +381,8 @@ func (client *directoryClient) Rename(ctx context.Context, renameSource string, 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.RenameHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.RenameHandleError(resp)
 	}
 	result, err := client.RenameHandleResponse(resp)
 	if err != nil {
@@ -524,9 +515,6 @@ func (client *directoryClient) RenameHandleResponse(resp *azcore.Response) (*Dir
 
 // RenameHandleError handles the Rename error response.
 func (client *directoryClient) RenameHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -544,8 +532,8 @@ func (client *directoryClient) SetAccessControl(ctx context.Context, directorySe
 	if err != nil {
 		return nil, err
 	}
-	if err := client.SetAccessControlHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.SetAccessControlHandleError(resp)
 	}
 	result, err := client.SetAccessControlHandleResponse(resp)
 	if err != nil {
@@ -632,9 +620,6 @@ func (client *directoryClient) SetAccessControlHandleResponse(resp *azcore.Respo
 
 // SetAccessControlHandleError handles the SetAccessControl error response.
 func (client *directoryClient) SetAccessControlHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err DataLakeStorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err

--- a/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
@@ -63,6 +63,9 @@ func (client *pageBlobClient) ClearPages(ctx context.Context, contentLength int6
 	if err != nil {
 		return nil, err
 	}
+	if err := client.ClearPagesHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.ClearPagesHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -130,9 +133,6 @@ func (client *pageBlobClient) ClearPagesCreateRequest(ctx context.Context, conte
 
 // ClearPagesHandleResponse handles the ClearPages response.
 func (client *pageBlobClient) ClearPagesHandleResponse(resp *azcore.Response) (*PageBlobClearPagesResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.ClearPagesHandleError(resp)
-	}
 	result := PageBlobClearPagesResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -186,6 +186,9 @@ func (client *pageBlobClient) ClearPagesHandleResponse(resp *azcore.Response) (*
 
 // ClearPagesHandleError handles the ClearPages error response.
 func (client *pageBlobClient) ClearPagesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -201,6 +204,9 @@ func (client *pageBlobClient) CopyIncremental(ctx context.Context, copySource ur
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CopyIncrementalHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CopyIncrementalHandleResponse(resp)
@@ -245,9 +251,6 @@ func (client *pageBlobClient) CopyIncrementalCreateRequest(ctx context.Context, 
 
 // CopyIncrementalHandleResponse handles the CopyIncremental response.
 func (client *pageBlobClient) CopyIncrementalHandleResponse(resp *azcore.Response) (*PageBlobCopyIncrementalResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, client.CopyIncrementalHandleError(resp)
-	}
 	result := PageBlobCopyIncrementalResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -286,6 +289,9 @@ func (client *pageBlobClient) CopyIncrementalHandleResponse(resp *azcore.Respons
 
 // CopyIncrementalHandleError handles the CopyIncremental error response.
 func (client *pageBlobClient) CopyIncrementalHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -301,6 +307,9 @@ func (client *pageBlobClient) Create(ctx context.Context, contentLength int64, b
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.CreateHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.CreateHandleResponse(resp)
@@ -387,9 +396,6 @@ func (client *pageBlobClient) CreateCreateRequest(ctx context.Context, contentLe
 
 // CreateHandleResponse handles the Create response.
 func (client *pageBlobClient) CreateHandleResponse(resp *azcore.Response) (*PageBlobCreateResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.CreateHandleError(resp)
-	}
 	result := PageBlobCreateResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -442,6 +448,9 @@ func (client *pageBlobClient) CreateHandleResponse(resp *azcore.Response) (*Page
 
 // CreateHandleError handles the Create error response.
 func (client *pageBlobClient) CreateHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -457,6 +466,9 @@ func (client *pageBlobClient) GetPageRanges(ctx context.Context, pageBlobGetPage
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetPageRangesHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetPageRangesHandleResponse(resp)
@@ -509,9 +521,6 @@ func (client *pageBlobClient) GetPageRangesCreateRequest(ctx context.Context, pa
 
 // GetPageRangesHandleResponse handles the GetPageRanges response.
 func (client *pageBlobClient) GetPageRangesHandleResponse(resp *azcore.Response) (*PageListResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetPageRangesHandleError(resp)
-	}
 	result := PageListResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
@@ -551,6 +560,9 @@ func (client *pageBlobClient) GetPageRangesHandleResponse(resp *azcore.Response)
 
 // GetPageRangesHandleError handles the GetPageRanges error response.
 func (client *pageBlobClient) GetPageRangesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -566,6 +578,9 @@ func (client *pageBlobClient) GetPageRangesDiff(ctx context.Context, pageBlobGet
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetPageRangesDiffHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetPageRangesDiffHandleResponse(resp)
@@ -624,9 +639,6 @@ func (client *pageBlobClient) GetPageRangesDiffCreateRequest(ctx context.Context
 
 // GetPageRangesDiffHandleResponse handles the GetPageRangesDiff response.
 func (client *pageBlobClient) GetPageRangesDiffHandleResponse(resp *azcore.Response) (*PageListResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetPageRangesDiffHandleError(resp)
-	}
 	result := PageListResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
@@ -666,6 +678,9 @@ func (client *pageBlobClient) GetPageRangesDiffHandleResponse(resp *azcore.Respo
 
 // GetPageRangesDiffHandleError handles the GetPageRangesDiff error response.
 func (client *pageBlobClient) GetPageRangesDiffHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -681,6 +696,9 @@ func (client *pageBlobClient) Resize(ctx context.Context, blobContentLength int6
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.ResizeHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.ResizeHandleResponse(resp)
@@ -737,9 +755,6 @@ func (client *pageBlobClient) ResizeCreateRequest(ctx context.Context, blobConte
 
 // ResizeHandleResponse handles the Resize response.
 func (client *pageBlobClient) ResizeHandleResponse(resp *azcore.Response) (*PageBlobResizeResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ResizeHandleError(resp)
-	}
 	result := PageBlobResizeResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -779,6 +794,9 @@ func (client *pageBlobClient) ResizeHandleResponse(resp *azcore.Response) (*Page
 
 // ResizeHandleError handles the Resize error response.
 func (client *pageBlobClient) ResizeHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -794,6 +812,9 @@ func (client *pageBlobClient) UpdateSequenceNumber(ctx context.Context, sequence
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UpdateSequenceNumberHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UpdateSequenceNumberHandleResponse(resp)
@@ -844,9 +865,6 @@ func (client *pageBlobClient) UpdateSequenceNumberCreateRequest(ctx context.Cont
 
 // UpdateSequenceNumberHandleResponse handles the UpdateSequenceNumber response.
 func (client *pageBlobClient) UpdateSequenceNumberHandleResponse(resp *azcore.Response) (*PageBlobUpdateSequenceNumberResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.UpdateSequenceNumberHandleError(resp)
-	}
 	result := PageBlobUpdateSequenceNumberResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -886,6 +904,9 @@ func (client *pageBlobClient) UpdateSequenceNumberHandleResponse(resp *azcore.Re
 
 // UpdateSequenceNumberHandleError handles the UpdateSequenceNumber error response.
 func (client *pageBlobClient) UpdateSequenceNumberHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -901,6 +922,9 @@ func (client *pageBlobClient) UploadPages(ctx context.Context, contentLength int
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UploadPagesHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UploadPagesHandleResponse(resp)
@@ -976,9 +1000,6 @@ func (client *pageBlobClient) UploadPagesCreateRequest(ctx context.Context, cont
 
 // UploadPagesHandleResponse handles the UploadPages response.
 func (client *pageBlobClient) UploadPagesHandleResponse(resp *azcore.Response) (*PageBlobUploadPagesResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.UploadPagesHandleError(resp)
-	}
 	result := PageBlobUploadPagesResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -1045,6 +1066,9 @@ func (client *pageBlobClient) UploadPagesHandleResponse(resp *azcore.Response) (
 
 // UploadPagesHandleError handles the UploadPages error response.
 func (client *pageBlobClient) UploadPagesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1060,6 +1084,9 @@ func (client *pageBlobClient) UploadPagesFromURL(ctx context.Context, sourceUrl 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.UploadPagesFromURLHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.UploadPagesFromURLHandleResponse(resp)
@@ -1147,9 +1174,6 @@ func (client *pageBlobClient) UploadPagesFromURLCreateRequest(ctx context.Contex
 
 // UploadPagesFromURLHandleResponse handles the UploadPagesFromURL response.
 func (client *pageBlobClient) UploadPagesFromURLHandleResponse(resp *azcore.Response) (*PageBlobUploadPagesFromURLResponse, error) {
-	if !resp.HasStatusCode(http.StatusCreated) {
-		return nil, client.UploadPagesFromURLHandleError(resp)
-	}
 	result := PageBlobUploadPagesFromURLResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -1213,6 +1237,9 @@ func (client *pageBlobClient) UploadPagesFromURLHandleResponse(resp *azcore.Resp
 
 // UploadPagesFromURLHandleError handles the UploadPagesFromURL error response.
 func (client *pageBlobClient) UploadPagesFromURLHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusCreated) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err

--- a/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
@@ -63,8 +63,8 @@ func (client *pageBlobClient) ClearPages(ctx context.Context, contentLength int6
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ClearPagesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.ClearPagesHandleError(resp)
 	}
 	result, err := client.ClearPagesHandleResponse(resp)
 	if err != nil {
@@ -186,9 +186,6 @@ func (client *pageBlobClient) ClearPagesHandleResponse(resp *azcore.Response) (*
 
 // ClearPagesHandleError handles the ClearPages error response.
 func (client *pageBlobClient) ClearPagesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -206,8 +203,8 @@ func (client *pageBlobClient) CopyIncremental(ctx context.Context, copySource ur
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CopyIncrementalHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.CopyIncrementalHandleError(resp)
 	}
 	result, err := client.CopyIncrementalHandleResponse(resp)
 	if err != nil {
@@ -289,9 +286,6 @@ func (client *pageBlobClient) CopyIncrementalHandleResponse(resp *azcore.Respons
 
 // CopyIncrementalHandleError handles the CopyIncremental error response.
 func (client *pageBlobClient) CopyIncrementalHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -309,8 +303,8 @@ func (client *pageBlobClient) Create(ctx context.Context, contentLength int64, b
 	if err != nil {
 		return nil, err
 	}
-	if err := client.CreateHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.CreateHandleError(resp)
 	}
 	result, err := client.CreateHandleResponse(resp)
 	if err != nil {
@@ -448,9 +442,6 @@ func (client *pageBlobClient) CreateHandleResponse(resp *azcore.Response) (*Page
 
 // CreateHandleError handles the Create error response.
 func (client *pageBlobClient) CreateHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -468,8 +459,8 @@ func (client *pageBlobClient) GetPageRanges(ctx context.Context, pageBlobGetPage
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetPageRangesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetPageRangesHandleError(resp)
 	}
 	result, err := client.GetPageRangesHandleResponse(resp)
 	if err != nil {
@@ -560,9 +551,6 @@ func (client *pageBlobClient) GetPageRangesHandleResponse(resp *azcore.Response)
 
 // GetPageRangesHandleError handles the GetPageRanges error response.
 func (client *pageBlobClient) GetPageRangesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -580,8 +568,8 @@ func (client *pageBlobClient) GetPageRangesDiff(ctx context.Context, pageBlobGet
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetPageRangesDiffHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetPageRangesDiffHandleError(resp)
 	}
 	result, err := client.GetPageRangesDiffHandleResponse(resp)
 	if err != nil {
@@ -678,9 +666,6 @@ func (client *pageBlobClient) GetPageRangesDiffHandleResponse(resp *azcore.Respo
 
 // GetPageRangesDiffHandleError handles the GetPageRangesDiff error response.
 func (client *pageBlobClient) GetPageRangesDiffHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -698,8 +683,8 @@ func (client *pageBlobClient) Resize(ctx context.Context, blobContentLength int6
 	if err != nil {
 		return nil, err
 	}
-	if err := client.ResizeHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.ResizeHandleError(resp)
 	}
 	result, err := client.ResizeHandleResponse(resp)
 	if err != nil {
@@ -794,9 +779,6 @@ func (client *pageBlobClient) ResizeHandleResponse(resp *azcore.Response) (*Page
 
 // ResizeHandleError handles the Resize error response.
 func (client *pageBlobClient) ResizeHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -814,8 +796,8 @@ func (client *pageBlobClient) UpdateSequenceNumber(ctx context.Context, sequence
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UpdateSequenceNumberHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.UpdateSequenceNumberHandleError(resp)
 	}
 	result, err := client.UpdateSequenceNumberHandleResponse(resp)
 	if err != nil {
@@ -904,9 +886,6 @@ func (client *pageBlobClient) UpdateSequenceNumberHandleResponse(resp *azcore.Re
 
 // UpdateSequenceNumberHandleError handles the UpdateSequenceNumber error response.
 func (client *pageBlobClient) UpdateSequenceNumberHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -924,8 +903,8 @@ func (client *pageBlobClient) UploadPages(ctx context.Context, contentLength int
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UploadPagesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.UploadPagesHandleError(resp)
 	}
 	result, err := client.UploadPagesHandleResponse(resp)
 	if err != nil {
@@ -1066,9 +1045,6 @@ func (client *pageBlobClient) UploadPagesHandleResponse(resp *azcore.Response) (
 
 // UploadPagesHandleError handles the UploadPages error response.
 func (client *pageBlobClient) UploadPagesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -1086,8 +1062,8 @@ func (client *pageBlobClient) UploadPagesFromURL(ctx context.Context, sourceUrl 
 	if err != nil {
 		return nil, err
 	}
-	if err := client.UploadPagesFromURLHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusCreated) {
+		return nil, client.UploadPagesFromURLHandleError(resp)
 	}
 	result, err := client.UploadPagesFromURLHandleResponse(resp)
 	if err != nil {
@@ -1237,9 +1213,6 @@ func (client *pageBlobClient) UploadPagesFromURLHandleResponse(resp *azcore.Resp
 
 // UploadPagesFromURLHandleError handles the UploadPagesFromURL error response.
 func (client *pageBlobClient) UploadPagesFromURLHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusCreated) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err

--- a/test/storage/2019-07-07/azblob/zz_generated_pagers.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_pagers.go
@@ -25,6 +25,8 @@ type ListBlobsFlatSegmentResponsePager interface {
 
 type listBlobsFlatSegmentResponseCreateRequest func(context.Context) (*azcore.Request, error)
 
+type listBlobsFlatSegmentResponseHandleError func(*azcore.Response) error
+
 type listBlobsFlatSegmentResponseHandleResponse func(*azcore.Response) (*ListBlobsFlatSegmentResponseResponse, error)
 
 type listBlobsFlatSegmentResponseAdvancePage func(context.Context, *ListBlobsFlatSegmentResponseResponse) (*azcore.Request, error)
@@ -34,6 +36,8 @@ type listBlobsFlatSegmentResponsePager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester listBlobsFlatSegmentResponseCreateRequest
+	// callback for handling response errors
+	errorer listBlobsFlatSegmentResponseHandleError
 	// callback for handling the HTTP response
 	responder listBlobsFlatSegmentResponseHandleResponse
 	// callback for advancing to the next page
@@ -64,6 +68,13 @@ func (p *listBlobsFlatSegmentResponsePager) NextPage(ctx context.Context) bool {
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -92,6 +103,8 @@ type ListBlobsHierarchySegmentResponsePager interface {
 
 type listBlobsHierarchySegmentResponseCreateRequest func(context.Context) (*azcore.Request, error)
 
+type listBlobsHierarchySegmentResponseHandleError func(*azcore.Response) error
+
 type listBlobsHierarchySegmentResponseHandleResponse func(*azcore.Response) (*ListBlobsHierarchySegmentResponseResponse, error)
 
 type listBlobsHierarchySegmentResponseAdvancePage func(context.Context, *ListBlobsHierarchySegmentResponseResponse) (*azcore.Request, error)
@@ -101,6 +114,8 @@ type listBlobsHierarchySegmentResponsePager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester listBlobsHierarchySegmentResponseCreateRequest
+	// callback for handling response errors
+	errorer listBlobsHierarchySegmentResponseHandleError
 	// callback for handling the HTTP response
 	responder listBlobsHierarchySegmentResponseHandleResponse
 	// callback for advancing to the next page
@@ -131,6 +146,13 @@ func (p *listBlobsHierarchySegmentResponsePager) NextPage(ctx context.Context) b
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err
@@ -159,6 +181,8 @@ type ListContainersSegmentResponsePager interface {
 
 type listContainersSegmentResponseCreateRequest func(context.Context) (*azcore.Request, error)
 
+type listContainersSegmentResponseHandleError func(*azcore.Response) error
+
 type listContainersSegmentResponseHandleResponse func(*azcore.Response) (*ListContainersSegmentResponseResponse, error)
 
 type listContainersSegmentResponseAdvancePage func(context.Context, *ListContainersSegmentResponseResponse) (*azcore.Request, error)
@@ -168,6 +192,8 @@ type listContainersSegmentResponsePager struct {
 	pipeline azcore.Pipeline
 	// creates the initial request (non-LRO case)
 	requester listContainersSegmentResponseCreateRequest
+	// callback for handling response errors
+	errorer listContainersSegmentResponseHandleError
 	// callback for handling the HTTP response
 	responder listContainersSegmentResponseHandleResponse
 	// callback for advancing to the next page
@@ -198,6 +224,13 @@ func (p *listContainersSegmentResponsePager) NextPage(ctx context.Context) bool 
 		return false
 	}
 	resp, err := p.pipeline.Do(req)
+	if err != nil {
+		p.err = err
+		return false
+	}
+	if p.err = p.errorer(resp); p.err != nil {
+		return false
+	}
 	result, err := p.responder(resp)
 	if err != nil {
 		p.err = err

--- a/test/storage/2019-07-07/azblob/zz_generated_pagers.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_pagers.go
@@ -8,6 +8,7 @@ package azblob
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"net/http"
 )
 
 // ListBlobsFlatSegmentResponsePager provides iteration over ListBlobsFlatSegmentResponse pages.
@@ -72,7 +73,8 @@ func (p *listBlobsFlatSegmentResponsePager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -150,7 +152,8 @@ func (p *listBlobsHierarchySegmentResponsePager) NextPage(ctx context.Context) b
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)
@@ -228,7 +231,8 @@ func (p *listContainersSegmentResponsePager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	if p.err = p.errorer(resp); p.err != nil {
+	if !resp.HasStatusCode(http.StatusOK) {
+		p.err = p.errorer(resp)
 		return false
 	}
 	result, err := p.responder(resp)

--- a/test/storage/2019-07-07/azblob/zz_generated_service.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_service.go
@@ -57,8 +57,8 @@ func (client *serviceClient) GetAccountInfo(ctx context.Context) (*ServiceGetAcc
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetAccountInfoHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetAccountInfoHandleError(resp)
 	}
 	result, err := client.GetAccountInfoHandleResponse(resp)
 	if err != nil {
@@ -112,9 +112,6 @@ func (client *serviceClient) GetAccountInfoHandleResponse(resp *azcore.Response)
 
 // GetAccountInfoHandleError handles the GetAccountInfo error response.
 func (client *serviceClient) GetAccountInfoHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -132,8 +129,8 @@ func (client *serviceClient) GetProperties(ctx context.Context, serviceGetProper
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetPropertiesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetPropertiesHandleError(resp)
 	}
 	result, err := client.GetPropertiesHandleResponse(resp)
 	if err != nil {
@@ -180,9 +177,6 @@ func (client *serviceClient) GetPropertiesHandleResponse(resp *azcore.Response) 
 
 // GetPropertiesHandleError handles the GetProperties error response.
 func (client *serviceClient) GetPropertiesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -200,8 +194,8 @@ func (client *serviceClient) GetStatistics(ctx context.Context, serviceGetStatis
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetStatisticsHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetStatisticsHandleError(resp)
 	}
 	result, err := client.GetStatisticsHandleResponse(resp)
 	if err != nil {
@@ -255,9 +249,6 @@ func (client *serviceClient) GetStatisticsHandleResponse(resp *azcore.Response) 
 
 // GetStatisticsHandleError handles the GetStatistics error response.
 func (client *serviceClient) GetStatisticsHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -275,8 +266,8 @@ func (client *serviceClient) GetUserDelegationKey(ctx context.Context, keyInfo K
 	if err != nil {
 		return nil, err
 	}
-	if err := client.GetUserDelegationKeyHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.GetUserDelegationKeyHandleError(resp)
 	}
 	result, err := client.GetUserDelegationKeyHandleResponse(resp)
 	if err != nil {
@@ -330,9 +321,6 @@ func (client *serviceClient) GetUserDelegationKeyHandleResponse(resp *azcore.Res
 
 // GetUserDelegationKeyHandleError handles the GetUserDelegationKey error response.
 func (client *serviceClient) GetUserDelegationKeyHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -401,9 +389,6 @@ func (client *serviceClient) ListContainersSegmentHandleResponse(resp *azcore.Re
 
 // ListContainersSegmentHandleError handles the ListContainersSegment error response.
 func (client *serviceClient) ListContainersSegmentHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -421,8 +406,8 @@ func (client *serviceClient) SetProperties(ctx context.Context, storageServicePr
 	if err != nil {
 		return nil, err
 	}
-	if err := client.SetPropertiesHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusAccepted) {
+		return nil, client.SetPropertiesHandleError(resp)
 	}
 	result, err := client.SetPropertiesHandleResponse(resp)
 	if err != nil {
@@ -469,9 +454,6 @@ func (client *serviceClient) SetPropertiesHandleResponse(resp *azcore.Response) 
 
 // SetPropertiesHandleError handles the SetProperties error response.
 func (client *serviceClient) SetPropertiesHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusAccepted) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -489,8 +471,8 @@ func (client *serviceClient) SubmitBatch(ctx context.Context, contentLength int6
 	if err != nil {
 		return nil, err
 	}
-	if err := client.SubmitBatchHandleError(resp); err != nil {
-		return nil, err
+	if !resp.HasStatusCode(http.StatusOK) {
+		return nil, client.SubmitBatchHandleError(resp)
 	}
 	result, err := client.SubmitBatchHandleResponse(resp)
 	if err != nil {
@@ -539,9 +521,6 @@ func (client *serviceClient) SubmitBatchHandleResponse(resp *azcore.Response) (*
 
 // SubmitBatchHandleError handles the SubmitBatch error response.
 func (client *serviceClient) SubmitBatchHandleError(resp *azcore.Response) error {
-	if resp.HasStatusCode(http.StatusOK) {
-		return nil
-	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err

--- a/test/storage/2019-07-07/azblob/zz_generated_service.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_service.go
@@ -57,6 +57,9 @@ func (client *serviceClient) GetAccountInfo(ctx context.Context) (*ServiceGetAcc
 	if err != nil {
 		return nil, err
 	}
+	if err := client.GetAccountInfoHandleError(resp); err != nil {
+		return nil, err
+	}
 	result, err := client.GetAccountInfoHandleResponse(resp)
 	if err != nil {
 		return nil, err
@@ -81,9 +84,6 @@ func (client *serviceClient) GetAccountInfoCreateRequest(ctx context.Context) (*
 
 // GetAccountInfoHandleResponse handles the GetAccountInfo response.
 func (client *serviceClient) GetAccountInfoHandleResponse(resp *azcore.Response) (*ServiceGetAccountInfoResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetAccountInfoHandleError(resp)
-	}
 	result := ServiceGetAccountInfoResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -112,6 +112,9 @@ func (client *serviceClient) GetAccountInfoHandleResponse(resp *azcore.Response)
 
 // GetAccountInfoHandleError handles the GetAccountInfo error response.
 func (client *serviceClient) GetAccountInfoHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -127,6 +130,9 @@ func (client *serviceClient) GetProperties(ctx context.Context, serviceGetProper
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetPropertiesHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetPropertiesHandleResponse(resp)
@@ -159,9 +165,6 @@ func (client *serviceClient) GetPropertiesCreateRequest(ctx context.Context, ser
 
 // GetPropertiesHandleResponse handles the GetProperties response.
 func (client *serviceClient) GetPropertiesHandleResponse(resp *azcore.Response) (*StorageServicePropertiesResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetPropertiesHandleError(resp)
-	}
 	result := StorageServicePropertiesResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -177,6 +180,9 @@ func (client *serviceClient) GetPropertiesHandleResponse(resp *azcore.Response) 
 
 // GetPropertiesHandleError handles the GetProperties error response.
 func (client *serviceClient) GetPropertiesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -192,6 +198,9 @@ func (client *serviceClient) GetStatistics(ctx context.Context, serviceGetStatis
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetStatisticsHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetStatisticsHandleResponse(resp)
@@ -224,9 +233,6 @@ func (client *serviceClient) GetStatisticsCreateRequest(ctx context.Context, ser
 
 // GetStatisticsHandleResponse handles the GetStatistics response.
 func (client *serviceClient) GetStatisticsHandleResponse(resp *azcore.Response) (*StorageServiceStatsResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetStatisticsHandleError(resp)
-	}
 	result := StorageServiceStatsResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -249,6 +255,9 @@ func (client *serviceClient) GetStatisticsHandleResponse(resp *azcore.Response) 
 
 // GetStatisticsHandleError handles the GetStatistics error response.
 func (client *serviceClient) GetStatisticsHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -264,6 +273,9 @@ func (client *serviceClient) GetUserDelegationKey(ctx context.Context, keyInfo K
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.GetUserDelegationKeyHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.GetUserDelegationKeyHandleResponse(resp)
@@ -296,9 +308,6 @@ func (client *serviceClient) GetUserDelegationKeyCreateRequest(ctx context.Conte
 
 // GetUserDelegationKeyHandleResponse handles the GetUserDelegationKey response.
 func (client *serviceClient) GetUserDelegationKeyHandleResponse(resp *azcore.Response) (*UserDelegationKeyResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.GetUserDelegationKeyHandleError(resp)
-	}
 	result := UserDelegationKeyResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -321,6 +330,9 @@ func (client *serviceClient) GetUserDelegationKeyHandleResponse(resp *azcore.Res
 
 // GetUserDelegationKeyHandleError handles the GetUserDelegationKey error response.
 func (client *serviceClient) GetUserDelegationKeyHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -336,6 +348,7 @@ func (client *serviceClient) ListContainersSegment(serviceListContainersSegmentO
 			return client.ListContainersSegmentCreateRequest(ctx, serviceListContainersSegmentOptions)
 		},
 		responder: client.ListContainersSegmentHandleResponse,
+		errorer:   client.ListContainersSegmentHandleError,
 		advancer: func(ctx context.Context, resp *ListContainersSegmentResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.EnumerationResults.NextMarker)
 		},
@@ -373,9 +386,6 @@ func (client *serviceClient) ListContainersSegmentCreateRequest(ctx context.Cont
 
 // ListContainersSegmentHandleResponse handles the ListContainersSegment response.
 func (client *serviceClient) ListContainersSegmentHandleResponse(resp *azcore.Response) (*ListContainersSegmentResponseResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.ListContainersSegmentHandleError(resp)
-	}
 	result := ListContainersSegmentResponseResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -391,6 +401,9 @@ func (client *serviceClient) ListContainersSegmentHandleResponse(resp *azcore.Re
 
 // ListContainersSegmentHandleError handles the ListContainersSegment error response.
 func (client *serviceClient) ListContainersSegmentHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -406,6 +419,9 @@ func (client *serviceClient) SetProperties(ctx context.Context, storageServicePr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.SetPropertiesHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.SetPropertiesHandleResponse(resp)
@@ -438,9 +454,6 @@ func (client *serviceClient) SetPropertiesCreateRequest(ctx context.Context, sto
 
 // SetPropertiesHandleResponse handles the SetProperties response.
 func (client *serviceClient) SetPropertiesHandleResponse(resp *azcore.Response) (*ServiceSetPropertiesResponse, error) {
-	if !resp.HasStatusCode(http.StatusAccepted) {
-		return nil, client.SetPropertiesHandleError(resp)
-	}
 	result := ServiceSetPropertiesResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -456,6 +469,9 @@ func (client *serviceClient) SetPropertiesHandleResponse(resp *azcore.Response) 
 
 // SetPropertiesHandleError handles the SetProperties error response.
 func (client *serviceClient) SetPropertiesHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusAccepted) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
@@ -471,6 +487,9 @@ func (client *serviceClient) SubmitBatch(ctx context.Context, contentLength int6
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.SubmitBatchHandleError(resp); err != nil {
 		return nil, err
 	}
 	result, err := client.SubmitBatchHandleResponse(resp)
@@ -505,9 +524,6 @@ func (client *serviceClient) SubmitBatchCreateRequest(ctx context.Context, conte
 
 // SubmitBatchHandleResponse handles the SubmitBatch response.
 func (client *serviceClient) SubmitBatchHandleResponse(resp *azcore.Response) (*ServiceSubmitBatchResponse, error) {
-	if !resp.HasStatusCode(http.StatusOK) {
-		return nil, client.SubmitBatchHandleError(resp)
-	}
 	result := ServiceSubmitBatchResponse{RawResponse: resp.Response}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val
@@ -523,6 +539,9 @@ func (client *serviceClient) SubmitBatchHandleResponse(resp *azcore.Response) (*
 
 // SubmitBatchHandleError handles the SubmitBatch error response.
 func (client *serviceClient) SubmitBatchHandleError(resp *azcore.Response) error {
+	if resp.HasStatusCode(http.StatusOK) {
+		return nil
+	}
 	var err StorageError
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err


### PR DESCRIPTION
Moved call to error handler out of the response handler and into the API
body.  The method now returns nil on success.
Added errorer field to pagers to be called for checking response, along
with errHandler to pager-pollers.
Omitted response handler for methods that don't return a model.
Added missing error check in pagers NextPage() method.
Function generateResponseUnmarshaller() was moved out of
createProtocolResponse(), its implementation did not change.