### PR TITLE
Include non-required header and query param constants

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -458,8 +458,6 @@ function createProtocolRequest(codeModel: CodeModel, op: Operation, imports: Imp
       let qpText = '';
       if (qp.required === true) {
         qpText = `\t${setter}\n`;
-      } else if (qp.schema.type === SchemaType.Constant) {
-        // omit this query param. TODO once non-required constants are fixed
       } else if (qp.implementation === ImplementationLocation.Client) {
         // global optional param
         qpText = `\tif client.${qp.language.go!.name} != nil {\n`;
@@ -529,8 +527,6 @@ function createProtocolRequest(codeModel: CodeModel, op: Operation, imports: Imp
     }
     if (header.required) {
       text += emitHeaderSet(header, '\t');
-    } else if (header.schema.type === SchemaType.Constant) {
-      // omit this header. TODO once non-required constants are fixed
     } else {
       text += emitParamGroupCheck(<GroupProperty>header.language.go!.paramGroup, header);
       text += emitHeaderSet(header, '\t\t');
@@ -592,8 +588,7 @@ function createProtocolRequest(codeModel: CodeModel, op: Operation, imports: Imp
       text += '\t}\n';
       body = 'aux';
     }
-    // TODO once non-required constants are fixed
-    if (bodyParam!.required || bodyParam?.schema.type === SchemaType.Constant) {
+    if (bodyParam!.required || bodyParam!.schema.type === SchemaType.Constant) {
       text += `\treturn req, req.MarshalAs${getMediaFormat(bodyParam!.schema, mediaType, body)}\n`;
     } else {
       const paramGroup = <GroupProperty>bodyParam!.language.go!.paramGroup;

--- a/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
@@ -95,6 +95,9 @@ func (client *appendBlobClient) AppendBlockCreateRequest(ctx context.Context, co
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
 	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
+	}
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)
 	}
@@ -248,6 +251,9 @@ func (client *appendBlobClient) AppendBlockFromURLCreateRequest(ctx context.Cont
 	}
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
+	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
 	}
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)
@@ -433,6 +439,9 @@ func (client *appendBlobClient) CreateCreateRequest(ctx context.Context, content
 	}
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
+	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
 	}
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)

--- a/test/storage/2019-07-07/azblob/zz_generated_blob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blob.go
@@ -643,6 +643,9 @@ func (client *blobClient) CreateSnapshotCreateRequest(ctx context.Context, blobC
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
 	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
+	}
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)
 	}
@@ -863,6 +866,9 @@ func (client *blobClient) DownloadCreateRequest(ctx context.Context, blobDownloa
 	}
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
+	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
 		req.Header.Set("If-Modified-Since", modifiedAccessConditions.IfModifiedSince.Format(time.RFC1123))
@@ -1266,6 +1272,9 @@ func (client *blobClient) GetPropertiesCreateRequest(ctx context.Context, blobGe
 	}
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
+	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
 		req.Header.Set("If-Modified-Since", modifiedAccessConditions.IfModifiedSince.Format(time.RFC1123))
@@ -2076,6 +2085,9 @@ func (client *blobClient) SetMetadataCreateRequest(ctx context.Context, blobSetM
 	}
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
+	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
 	}
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)

--- a/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
@@ -115,6 +115,9 @@ func (client *blockBlobClient) CommitBlockListCreateRequest(ctx context.Context,
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
 	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
+	}
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)
 	}
@@ -356,6 +359,9 @@ func (client *blockBlobClient) StageBlockCreateRequest(ctx context.Context, bloc
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
 	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
+	}
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)
 	}
@@ -474,6 +480,9 @@ func (client *blockBlobClient) StageBlockFromURLCreateRequest(ctx context.Contex
 	}
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
+	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
 	}
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)
@@ -626,6 +635,9 @@ func (client *blockBlobClient) UploadCreateRequest(ctx context.Context, contentL
 	}
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
+	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
 	}
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)

--- a/test/storage/2019-07-07/azblob/zz_generated_models.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_models.go
@@ -3214,6 +3214,8 @@ type ServiceGetUserDelegationKeyOptions struct {
 
 // ServiceListContainersSegmentOptions contains the optional parameters for the Service.ListContainersSegment method.
 type ServiceListContainersSegmentOptions struct {
+	// Include this parameter to specify that the container's metadata be returned as part of the response body.
+	Include *string
 	// A string value that identifies the portion of the list of containers to be returned with the next listing operation. The
 	// operation returns the NextMarker value within the response body if the listing operation did not return all containers
 	// remaining to be listed with the current page. The NextMarker value can be used as the value for the marker parameter in

--- a/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
@@ -99,6 +99,9 @@ func (client *pageBlobClient) ClearPagesCreateRequest(ctx context.Context, conte
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
 	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
+	}
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)
 	}
@@ -360,6 +363,9 @@ func (client *pageBlobClient) CreateCreateRequest(ctx context.Context, contentLe
 	}
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
+	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
 	}
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)
@@ -714,6 +720,9 @@ func (client *pageBlobClient) ResizeCreateRequest(ctx context.Context, blobConte
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
 	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
+	}
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)
 	}
@@ -945,6 +954,9 @@ func (client *pageBlobClient) UploadPagesCreateRequest(ctx context.Context, cont
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
 	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
+	}
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)
 	}
@@ -1100,6 +1112,9 @@ func (client *pageBlobClient) UploadPagesFromURLCreateRequest(ctx context.Contex
 	}
 	if cpkInfo != nil && cpkInfo.EncryptionKeySha256 != nil {
 		req.Header.Set("x-ms-encryption-key-sha256", *cpkInfo.EncryptionKeySha256)
+	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Header.Set("x-ms-encryption-algorithm", "AES256")
 	}
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)

--- a/test/storage/2019-07-07/azblob/zz_generated_service.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_service.go
@@ -360,6 +360,9 @@ func (client *serviceClient) ListContainersSegmentCreateRequest(ctx context.Cont
 	if serviceListContainersSegmentOptions != nil && serviceListContainersSegmentOptions.Maxresults != nil {
 		query.Set("maxresults", strconv.FormatInt(int64(*serviceListContainersSegmentOptions.Maxresults), 10))
 	}
+	if serviceListContainersSegmentOptions != nil && serviceListContainersSegmentOptions.Include != nil {
+		query.Set("include", "metadata")
+	}
 	if serviceListContainersSegmentOptions != nil && serviceListContainersSegmentOptions.Timeout != nil {
 		query.Set("timeout", strconv.FormatInt(int64(*serviceListContainersSegmentOptions.Timeout), 10))
 	}


### PR DESCRIPTION
Storage, and other services, contain optional header and query params
that are constants so include them in codegen.
Replaced 'TODO' type descriptions with actual descriptions.  They aren't
actually used but cleans up noise when searching for TODO comments.